### PR TITLE
Fix system_getAddrInfo to behave more like the real version

### DIFF
--- a/src/plugin/shd-system.c
+++ b/src/plugin/shd-system.c
@@ -733,10 +733,11 @@ gint system_getAddrInfo(gchar *name, const gchar *service,
 		/* application will expect it in network order */
 		// sa->sin_addr.s_addr = (in_addr_t) htonl((guint32)(*addr));
 		sa->sin_addr.s_addr = address;
+		sa->sin_family = AF_INET; /* libcurl expects this to be set */
 
 		struct addrinfo* ai_out = g_malloc(sizeof(struct addrinfo));
 		ai_out->ai_addr = (struct sockaddr*) sa;
-		ai_out->ai_addrlen = sizeof(in_addr_t);
+		ai_out->ai_addrlen =  sizeof(struct sockaddr_in);
 		ai_out->ai_canonname = NULL;
 		ai_out->ai_family = AF_INET;
 		ai_out->ai_flags = 0;


### PR DESCRIPTION
Libcurl fails to resolve a hostname with the current version of system_getAddrInfo. This seems be caused by two things:
1. ai_out->ai_addrlen is too small. According to the man page [getaddrinfo(3)](http://www.kernel.org/doc/man-pages/online/pages/man3/getaddrinfo.3.html) it should contain the size of the sockaddr-object pointed at by ai_addr. The type is of sockaddr_in and not in_addr though.
2. sa->sin_family is not set. Libcurl expects this, though its kinda redundant with ai_out->ai_family. Nevertheless the actual implementation seems to do this as well.
