### PR TITLE
Make path where pcap files are saved customizable

### DIFF
--- a/src/configuration/shd-parser.c
+++ b/src/configuration/shd-parser.c
@@ -43,7 +43,7 @@ static const gchar* ParserAttributeStrings[] = {
 	"plugin", "software", "cluster", "clusters",
 	"bandwidthdown", "bandwidthup", "latency", "jitter", "packetloss",
 	"cpufrequency", "time", "quantity", "arguments", "heartbeatfrequency",
-	"heartbeatloglevel", "loglevel", "logpcap",
+	"heartbeatloglevel", "loglevel", "logpcap", "pcapdir",
 };
 
 /* NOTE - they MUST be synced with ParserAttributeStrings */
@@ -70,6 +70,7 @@ typedef enum {
 	ATTRIBUTE_HEARTBEATLOGLEVEL,
 	ATTRIBUTE_LOGLEVEL,
 	ATTRIBUTE_LOGPCAP,
+	ATTRIBUTE_PCAPDIR,
 } ParserAttributes;
 
 struct _Parser {
@@ -124,6 +125,8 @@ struct _ParserValues {
 	GString* heartbeatLogLevel;
 	/* node-specific pcap logging */
 	GString* logPcap;
+	/* node-specific directory for pcap files */
+	GString* pcapDir;
 	MAGIC_DECLARE;
 };
 
@@ -185,6 +188,8 @@ static ParserValues* _parser_getValues(const gchar *element_name,
 			values->logLevel = g_string_new(*value_cursor);
 		} else if(g_ascii_strcasecmp(*name_cursor, ParserAttributeStrings[ATTRIBUTE_LOGPCAP]) == 0) {
 			values->logPcap = g_string_new(*value_cursor);
+		} else if(g_ascii_strcasecmp(*name_cursor, ParserAttributeStrings[ATTRIBUTE_PCAPDIR]) == 0) {
+			values->pcapDir = g_string_new(*value_cursor);
 		} else {
 			warning("unrecognized attribute '%s' for element '%s' while parsing topology. ignoring.", *name_cursor, element_name);
 		}
@@ -219,7 +224,9 @@ static void _parser_freeValues(ParserValues* values) {
 		g_string_free(values->logLevel, TRUE);
 	if(values->logPcap)
 		g_string_free(values->logPcap, TRUE);
-
+	if(values->pcapDir)
+		g_string_free(values->pcapDir, TRUE);
+	
 	MAGIC_CLEAR(values);
 	g_free(values);
 }
@@ -403,7 +410,7 @@ static void _parser_handleElement(GMarkupParseContext *context,
 		if(_parser_validateNode(parser, values)) {
 			a = (Action*) createnodes_new(values->id, values->software, values->cluster,
 					values->bandwidthdown, values->bandwidthup, values->quantity, values->cpufrequency,
-					values->heartbeatIntervalSeconds, values->heartbeatLogLevel, values->logLevel, values->logPcap);
+					values->heartbeatIntervalSeconds, values->heartbeatLogLevel, values->logLevel, values->logPcap, values->pcapDir);
 			a->priority = 5;
 		}
 	} else if(g_ascii_strcasecmp(element_name, ParserElementStrings[ELEMENT_KILL]) == 0) {

--- a/src/node/shd-network-interface.h
+++ b/src/node/shd-network-interface.h
@@ -27,7 +27,7 @@
 typedef struct _NetworkInterface NetworkInterface;
 
 NetworkInterface* networkinterface_new(Network* network, GQuark address, gchar* name,
-		guint64 bwDownKiBps, guint64 bwUpKiBps, gboolean logPcap);
+		guint64 bwDownKiBps, guint64 bwUpKiBps, gboolean logPcap, gchar* pcapDir);
 void networkinterface_free(NetworkInterface* interface);
 
 in_addr_t networkinterface_getIPAddress(NetworkInterface* interface);

--- a/src/node/shd-node.h
+++ b/src/node/shd-node.h
@@ -31,7 +31,7 @@ typedef struct _Node Node;
 Node* node_new(GQuark id, Network* network, Software* software, guint32 ip,
 		GString* hostname, guint64 bwDownKiBps, guint64 bwUpKiBps, guint cpuFrequency, gint cpuThreshold,
 		guint nodeSeed, SimulationTime heartbeatInterval, GLogLevelFlags heartbeatLogLevel,
-		GLogLevelFlags logLevel, gchar logPcap);
+		GLogLevelFlags logLevel, gboolean logPcap, gchar* pcapDir);
 void node_free(gpointer data);
 
 void node_lock(Node* node);

--- a/src/runnable/action/shd-create-node.h
+++ b/src/runnable/action/shd-create-node.h
@@ -29,7 +29,7 @@ typedef struct _CreateNodesAction CreateNodesAction;
 CreateNodesAction* createnodes_new(GString* name, GString* software, GString* cluster,
 		guint64 bandwidthdown, guint64 bandwidthup, guint64 quantity, guint64 cpuFrequency,
 		guint64 heartbeatIntervalSeconds, GString* heartbeatLogLevelString,
-		GString* logLevelString, GString* logPcapString);
+		GString* logLevelString, GString* logPcapString, GString* pcapDirString);
 void createnodes_run(CreateNodesAction* action);
 void createnodes_free(CreateNodesAction* action);
 

--- a/src/topology/shd-internetwork.c
+++ b/src/topology/shd-internetwork.c
@@ -183,7 +183,7 @@ gpointer internetwork_createNode(Internetwork* internet, GQuark nodeID,
 		Network* network, Software* software, GString* hostname,
 		guint64 bwDownKiBps, guint64 bwUpKiBps, guint cpuFrequency, gint cpuThreshold,
 		guint nodeSeed, SimulationTime heartbeatInterval, GLogLevelFlags heartbeatLogLevel,
-		GLogLevelFlags logLevel, gchar logPcap) {
+		GLogLevelFlags logLevel, gboolean logPcap, gchar* pcapDir) {
 	MAGIC_ASSERT(internet);
 	g_assert(!internet->isReadOnly);
 
@@ -191,7 +191,7 @@ gpointer internetwork_createNode(Internetwork* internet, GQuark nodeID,
 	ip = (guint32) nodeID;
 	Node* node = node_new(nodeID, network, software, ip, hostname, bwDownKiBps, bwUpKiBps,
 			cpuFrequency, cpuThreshold, nodeSeed, heartbeatInterval, heartbeatLogLevel,
-			logLevel, logPcap);
+			logLevel, logPcap, pcapDir);
 	g_hash_table_replace(internet->nodes, GUINT_TO_POINTER((guint)nodeID), node);
 
 	gchar* mapName = g_strdup((const gchar*) hostname->str);

--- a/src/topology/shd-internetwork.h
+++ b/src/topology/shd-internetwork.h
@@ -105,7 +105,7 @@ gpointer internetwork_createNode(Internetwork* internet, GQuark nodeID,
 		guint64 bwDownKiBps, guint64 bwUpKiBps, guint cpuFrequency,
 		gint cpuThreshold, guint nodeSeed,
 		SimulationTime heartbeatInterval, GLogLevelFlags heartbeatLogLevel,
-		GLogLevelFlags logLevel, gchar logPcap); /* XXX: return type is "Node*" */
+		GLogLevelFlags logLevel, gboolean logPcap, gchar* pcapDir); /* XXX: return type is "Node*" */
 
 /**
  * Marks the given internet as read-only, so no additional nodes or networks may


### PR DESCRIPTION
Per default Shadow saves pcap files in `data/pcapdata/` relative to the current working directory if `logpcap` is set to true for a node. It can however become difficult to manage all the pcap files generated. If I change my working directory to a new folder for each experiment I have to create `data/pcapdata` in each one too, if I don't do that it becomes messy. The attached commit add the attribute `pcapdir` to nodes to customize the path. If `pcapdir` is not set the directory will default to `data/pcapdata`.
