### PR TITLE
Call tidy functions of embedded plug-ins in _scallion_free()

### DIFF
--- a/src/library/scallion/scallion-plugin.c
+++ b/src/library/scallion/scallion-plugin.c
@@ -474,7 +474,6 @@ static void _scallion_new(gint argc, gchar* argv[]) {
 
 static void _scallion_free() {
 	scallion.shadowlibFuncs->log(G_LOG_LEVEL_DEBUG, __FUNCTION__, "scallion_free called");
-	scalliontor_free(scallion.stor);
 	
 	if (scallion.sfgEpoll) {
 		service_filegetter_stop(&scallion.sfg);
@@ -488,7 +487,7 @@ static void _scallion_free() {
 		torrentService_stop(&scallion.tsvc);
 	}
 	
-
+	scalliontor_free(scallion.stor);
 }
 
 static void _scallion_notify() {


### PR DESCRIPTION
This calls `service_filegetter_stop()`, `browser_free()` and `torrentService_stop()` from `_scallion_free()` if a plug-in was used over scallion.
