### PR TITLE
Fixed TCP congestion control, no longer relies on packet drop event hack.

### DIFF
--- a/src/host/descriptor/shd-tcp-aimd.c
+++ b/src/host/descriptor/shd-tcp-aimd.c
@@ -35,7 +35,7 @@ void aimd_congestionAvoidance(AIMD* aimd, gint inFlight, gint packetsAcked, gint
     }
 }
 
-void aimd_packetLoss(AIMD* aimd) {
+guint aimd_packetLoss(AIMD* aimd) {
 	MAGIC_ASSERT(aimd);
     TCPCongestion* congestion = (TCPCongestion*)aimd;
 
@@ -56,9 +56,8 @@ void aimd_packetLoss(AIMD* aimd) {
    	 *  increase window when the congestion window is larger than SMSS*SMSS.
    	 *  If the above formula yields 0, the result SHOULD be rounded up to 1 byte."
 	 */
-	if(congestion->window == 0) {
-		congestion->window = 1;
-	}
+
+    return MAX(congestion->window, 1);
 }
 
 static void _aimd_free(AIMD* aimd) {

--- a/src/host/descriptor/shd-tcp-congestion.c
+++ b/src/host/descriptor/shd-tcp-congestion.c
@@ -37,10 +37,10 @@ void tcpCongestion_avoidance(TCPCongestion* congestion, gint inFlight, gint pack
     congestion->funcTable->avoidance(congestion, inFlight, packetsAcked, ack);
 }
 
-void tcpCongestion_packetLoss(TCPCongestion* congestion) {
+guint tcpCongestion_packetLoss(TCPCongestion* congestion) {
     MAGIC_ASSERT(congestion);
     MAGIC_ASSERT(congestion->funcTable);
-    congestion->funcTable->packetLoss(congestion);
+    return congestion->funcTable->packetLoss(congestion);
 }
 
 void tcpCongestion_free(TCPCongestion* congestion) {

--- a/src/host/descriptor/shd-tcp-congestion.h
+++ b/src/host/descriptor/shd-tcp-congestion.h
@@ -31,7 +31,7 @@ typedef struct _TCPCongestion TCPCongestion;
 typedef struct _TCPCongestionFunctionTable TCPCongestionFunctionTable;
 
 typedef void (*TCPCongestionAvoidanceFunc)(TCPCongestion* congestion, gint inFlight, gint packetsAcked, gint ack);
-typedef void (*TCPCongestionPacketLossFunc)(TCPCongestion* congestion);
+typedef guint (*TCPCongestionPacketLossFunc)(TCPCongestion* congestion);
 typedef void (*TCPCongestionFreeFunc)(TCPCongestion* congsetion);
 
 struct _TCPCongestionFunctionTable {
@@ -62,7 +62,7 @@ struct _TCPCongestion {
 
 void tcpCongestion_init(TCPCongestion* congestion, TCPCongestionFunctionTable* funcTable,TCPCongestionType type,  gint window, gint threshold);
 void tcpCongestion_avoidance(TCPCongestion* congestion, gint inFlight, gint packetsAcked, gint ack);
-void tcpCongestion_packetLoss(TCPCongestion* congestion);
+guint tcpCongestion_packetLoss(TCPCongestion* congestion);
 void tcpCongestion_free(TCPCongestion* congestion);
 
 TCPCongestionType tcpCongestion_getType(gchar* type);

--- a/src/host/descriptor/shd-tcp-reno.c
+++ b/src/host/descriptor/shd-tcp-reno.c
@@ -39,7 +39,7 @@ void reno_congestionAvoidance(Reno* reno, gint inFlight, gint packetsAcked, gint
     }
 }
 
-void reno_packetLoss(Reno* reno) {
+guint reno_packetLoss(Reno* reno) {
 	MAGIC_ASSERT(reno);
     TCPCongestion* congestion = (TCPCongestion*)reno;
 
@@ -63,8 +63,7 @@ void reno_packetLoss(Reno* reno) {
 	if(reno->window == 0) {
 		reno->window = 1;
 	}
-
-    congestion->window = reno->window;
+    return reno->window;
 }
 
 static void _reno_free(Reno* reno) {

--- a/src/host/descriptor/shd-tcp-scoreboard.h
+++ b/src/host/descriptor/shd-tcp-scoreboard.h
@@ -14,7 +14,7 @@ typedef struct _ScoreBoard ScoreBoard;
 ScoreBoard* scoreboard_new();
 void scoreboard_free(ScoreBoard* scoreboard);
 
-gboolean scoreboard_update(ScoreBoard* scoreboard, GList* selectiveACKs, gint unacked);
+TCPProcessFlags scoreboard_update(ScoreBoard* scoreboard, GList* selectiveACKs, gint unacked);
 void scoreboard_clear(ScoreBoard* scoreboard);
 gint scoreboard_getNextRetransmit(ScoreBoard* scoreboard);
 void scoreboard_markRetransmitted(ScoreBoard* scoreboard, gint sequence, gint sendNext);

--- a/src/host/descriptor/shd-tcp.h
+++ b/src/host/descriptor/shd-tcp.h
@@ -11,6 +11,15 @@
 
 typedef struct _TCP TCP;
 
+typedef enum TCPProcessFlags TCPProcessFlags;
+enum TCPProcessFlags {
+    TCP_PF_NONE = 0,
+    TCP_PF_PROCESSED = 1 << 0,
+    TCP_PF_DATA_ACKED = 1 << 1,
+    TCP_PF_DATA_SACKED = 1 << 2,
+    TCP_PF_DATA_LOST = 1 << 3,
+};
+
 TCP* tcp_new(gint handle, guint receiveBufferSize, guint sendBufferSize);
 gint tcp_getConnectError(TCP* tcp);
 void tcp_getInfo(TCP* tcp, struct tcp_info *tcpinfo);


### PR DESCRIPTION
Removed hack in shd-worker.c which ensures that only around 10% of lost packets gets triggered by a timer expiration (using the packet drop event).

CUBIC congestion control algorithm now has a minimum congestion window of 2.  This allows for more ACKs to be sent making detection of packet loss easier.

Cleaned up tcp_processPacket function -- data and ACK processing now have their own function.

NOTE: With these changes, we no longer track the results from network simulator (NS2) as closely.  Here are the results with 0-20% packet loss and zoomed in at 0-1% packet loss:

![times-vs-ploss-large](https://cloud.githubusercontent.com/assets/349679/2715978/a4f6f364-c51b-11e3-98a0-bd0bcb785786.png)
![times-vs-ploss-small](https://cloud.githubusercontent.com/assets/349679/2715979/a4f75a8e-c51b-11e3-8d6b-2938d467ee29.png)

This could be caused by the fact that we still do not drop control packets (packets of length 0).  If this is removed shadow cannot perform ANY downloads past somewhere around 5-10%.  I believe NS also does not drop control packets, but this was only from observations after the run, never confirmed in the source code.  It could just be that control packets are rarely dropped, as the packets are short and, with very high probability, will fit into the network queue that NS uses.
