### PR TITLE
Bug in compare functions for double and SimulationTime

### DIFF
--- a/src/utility/shd-utility.c
+++ b/src/utility/shd-utility.c
@@ -37,7 +37,7 @@ gboolean utility_int16Equal(gconstpointer value1, gconstpointer value2) {
 gint utility_doubleCompare(const gdouble* value1, const gdouble* value2, gpointer userData) {
 	utility_assert(value1 && value2);
 	/* return neg if first before second, pos if second before first, 0 if equal */
-	return *value1 == *value2 ? 0 : *value1 < *value2 ? -1 : +1;
+	return (*value1) == (*value2) ? 0 : (*value1) < (*value2) ? -1 : +1;
 }
 
 gint utility_simulationTimeCompare(const SimulationTime* value1, const SimulationTime* value2,


### PR DESCRIPTION
The compare functions for double and SimulationTime are passed pointers, but the comparison function doesn't dereference them, so the comparison is done on the memory address instead of the actual value.

This is one of the causes of indeterminate runs.  The retransmission timer functions use a priority queue to store retransmission timers, causing retransmissions to get scheduled out of order.
