### PR TITLE
search for rpath in DT_RPATH or DT_RUNPATH

### DIFF
--- a/src/main/core/shd-main.c
+++ b/src/main/core/shd-main.c
@@ -25,7 +25,7 @@ static gchar* _main_getRPath() {
     const ElfW(Dyn) *rpath = NULL;
     const gchar *strtab = NULL;
     for (; dyn->d_tag != DT_NULL; ++dyn) {
-        if (dyn->d_tag == DT_RPATH) {
+        if (dyn->d_tag == DT_RPATH || dyn->d_tag == DT_RUNPATH) {
             rpath = dyn;
         } else if (dyn->d_tag == DT_STRTAB) {
             strtab = (const gchar *) dyn->d_un.d_val;


### PR DESCRIPTION
DT_RPATH is, strictly speaking, deprecated by DT_RUNPATH, but still supported.
Different compilers/linkers will use different tags, so just look for both.
Fixes (partially) Ubuntu 17.04 build.