### PR TITLE
support glibc 2.25/2.26, Ubuntu 17.10, and Solus

### DIFF
--- a/src/external/elf-loader/CMakeLists.txt
+++ b/src/external/elf-loader/CMakeLists.txt
@@ -38,6 +38,8 @@ if( ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" )
         set(LIBDL_FILE /lib/x86_64-linux-gnu/libdl.so.2)
     elseif(EXISTS /lib64/libdl.so.2)
         set(LIBDL_FILE /lib64/libdl.so.2)
+    elseif(EXISTS /usr/lib64/libdl.so.2)
+        set(LIBDL_FILE /usr/lib64/libdl.so.2)
     endif()
     message(STATUS "LIBDL = ${LIBDL_FILE}")
 

--- a/src/external/elf-loader/extract-system-config.py
+++ b/src/external/elf-loader/extract-system-config.py
@@ -254,9 +254,9 @@ def main(argv):
     config.write ('#define CONFIG_RTLD_DL_CLKTCK_OFFSET ' + str(data.data) + '\n')
 
     data = debug.get_struct_member_offset ('rtld_global', '_dl_error_catch_tsd')
-    if data is None:
-        sys.exit (1)
-    config.write ('#define CONFIG_DL_ERROR_CATCH_TSD_OFFSET ' + str(data.data) + '\n')
+    # field was removed in glibc 2.25
+    if data is not None:
+        config.write ('#define CONFIG_DL_ERROR_CATCH_TSD_OFFSET ' + str(data.data) + '\n')
 
     data = debug.get_struct_size ('pthread')
     if data is None:

--- a/src/external/elf-loader/extract-system-config.py
+++ b/src/external/elf-loader/extract-system-config.py
@@ -175,6 +175,9 @@ def search_debug_file():
                     # ubuntu 1610
                     '/usr/lib/debug/lib/x86_64-linux-gnu/ld-2.24.so',
                     '/usr/lib/debug/lib/i386-linux-gnu/ld-2.24.so',
+                    # ubuntu 1710
+                    '/usr/lib/debug/lib/x86_64-linux-gnu/ld-2.26.so',
+                    '/usr/lib/debug/lib/i386-linux-gnu/ld-2.26.so',
                     # debian 9
                     find_build_id('/lib/x86_64-linux-gnu/ld-2.24.so'),
                     find_build_id('/lib/i386-linux-gnu/ld-2.24.so'),

--- a/src/external/elf-loader/extract-system-config.py
+++ b/src/external/elf-loader/extract-system-config.py
@@ -105,7 +105,7 @@ class DebugData:
         sub_item = self.read_one ()
         while sub_item is not None:
             if sub_item.level == parent.level:
-                self.write_back_one ()
+                self.write_back_one (sub_item)
                 return None
             if sub_item.type.strip() == 'DW_TAG_member' and \
                     sub_item.attributes.has_key ('DW_AT_name') and \
@@ -187,12 +187,14 @@ def search_debug_file():
 
         if os.path.isfile (file):
             return file
-    
+
     raise CouldNotFindFile ()
 
 def list_lib_path():
     paths = []
     re_lib = re.compile ('(?<=^#)')
+    if not os.path.isdir("/etc/ld.so.conf.d/"):
+        return ''
     for filename in os.listdir("/etc/ld.so.conf.d/"):
         try:
             for line in open ("/etc/ld.so.conf.d/" + filename, 'r'):
@@ -202,13 +204,14 @@ def list_lib_path():
         except:
             continue
     return ':'.join(paths)
-        
+
 def usage():
     print ''
 
 def main(argv):
     config_filename = ''
     debug_filename = ''
+    build_dir = ''
     try:
         opts, args = getopt.getopt(argv, 'hc:d:b:',
                                    ['help', 'config=', 'debug=', 'builddir='])
@@ -293,4 +296,3 @@ def main(argv):
 
 if __name__ == "__main__":
     main(sys.argv[1:])
-

--- a/src/external/elf-loader/glibc.c
+++ b/src/external/elf-loader/glibc.c
@@ -80,6 +80,38 @@ EXPORT char **_dl_argv;
 //_r_debug;
 //__libc_memalign;
 
+// XXX: tunables were added in 2.25. They allow customization of glibc
+// behavior via environment variables in a more (though not completely)
+// standardized manner. A good place to start to understand them is here:
+// https://siddhesh.in/posts/the-story-of-tunables.html
+// Unfortunately, they are implemented in the dynamic loader, and while
+// they currently aren't heavily used, that's likely to change. For now,
+// we get away with some stub code that seems to get us far enough, but
+// what we really need to do is copy the entire implementation here.
+typedef enum
+{
+  // XXX: These are the currently used tunables in glibc 2.25 and 2.26.
+  // They are likely to change, so we should be getting them from the debug
+  // symbols instead, via extract-system-config.py.
+  glibc_malloc_arena_max, glibc_malloc_mmap_max, glibc_malloc_mmap_threshold,
+  glibc_malloc_check, glibc_malloc_perturb, glibc_malloc_trim_threshold,
+  glibc_malloc_arena_test, glibc_malloc_top_pad
+} tunable_id_t;
+typedef union
+{
+  // the types of supported tunables
+  int64_t numval;
+  const char *str;
+} tunable_val_t;
+typedef void (*tunable_callback_t) (tunable_val_t *);
+EXPORT void
+__tunable_set_val (tunable_id_t id, void *valp, tunable_callback_t callback)
+{
+  // XXX: Currently the only tunable function I've seen called in practice,
+  // and it just sets them, so an empty stub is fine. Once anything really
+  // makes use of them though, we need to reimplement ~the whole system.
+  return;
+}
 
 static void **
 vdl_dl_error_catch_tsd (void)

--- a/src/external/elf-loader/glibc.c
+++ b/src/external/elf-loader/glibc.c
@@ -219,9 +219,12 @@ glibc_startup_finished (void)
 void
 glibc_initialize (int clktck)
 {
+  // _dl_error_catch_tsd only exists in glibc versions <2.25
+#ifdef CONFIG_DL_ERROR_CATCH_TSD_OFFSET
   void **(*fn) (void) = vdl_dl_error_catch_tsd;
   char *dst = &_rtld_local[CONFIG_DL_ERROR_CATCH_TSD_OFFSET];
   vdl_memcpy ((void *) dst, &fn, sizeof (fn));
+#endif
   char *off = &_rtld_local_ro[CONFIG_RTLD_DL_PAGESIZE_OFFSET];
   int pgsz = system_getpagesize ();
   vdl_memcpy (off, &pgsz, sizeof (pgsz));

--- a/src/external/elf-loader/test/CMakeLists.txt
+++ b/src/external/elf-loader/test/CMakeLists.txt
@@ -211,5 +211,5 @@ target_link_libraries(test27 -ldl)
 add_test(NAME elfloader-test27 COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/runtest.sh test27 ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(test28 test28.c)
-target_link_libraries(test28 -lpthread -ldl)
+target_link_libraries(test28 vdl -lpthread -ldl)
 add_test(NAME elfloader-test28 COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/runtest.sh test28 ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/external/elf-loader/x86_64/stage0.S
+++ b/src/external/elf-loader/x86_64/stage0.S
@@ -22,7 +22,14 @@ L1:	lea -L1(%rdi),%rdi
 	push %rdi
 	# pass pointer to TrampolineInformation to stage1
 	lea 8(%rsp),%rdi
+        # save the stack pointer for when we come back
+        # (r12 is preserved by functions and syscalls)
+        movq %rsp, %r12
+        # align the stack to 16 bytes
+        andq $-16, %rsp
 	call stage1
+        # get the stack pointer back
+        movq %r12, %rsp
 	# read dl_fini field of TrampolineInformation
 	mov 32(%rsp),%rdx
 	# read entry_point field of TrampolineInformation
@@ -35,4 +42,3 @@ L1:	lea -L1(%rdi),%rdi
 	# trick from glibc: crash if we return here. Should not
 	# happen ever
 	hlt
-	

--- a/src/test/tcp/shd-test-tcp.c
+++ b/src/test/tcp/shd-test-tcp.c
@@ -19,6 +19,7 @@
 #include <sys/epoll.h>
 #include <sys/select.h>
 #include <fcntl.h>
+#include <sys/uio.h>
 
 #define USAGE "USAGE: 'shd-test-tcp iomode type'; iomode=('blocking'|'nonblocking-poll'|'nonblocking-epoll'|'nonblocking-select') type=('client' server_ip|'server')"
 #define MYLOG(...) _mylog(__FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)


### PR DESCRIPTION
The most important of the commits in the long run is 2598799232f0e0e143169b3597d2cc1b20b23a77 because the underlying feature still needs implementing (the stub code it adds works for now though).

The other major commit is e5d9b95fa635efc46288e7640b07501a55fcc6c2 which I think does a pretty good job at making future changes to this ABI easy to fix.

fixes #350 
Tested on Ubuntu 16.04, Ubuntu 17.10, and a Solus VM.