### PR TITLE
reduce collisions in readonly-cache map

### DIFF
--- a/src/external/elf-loader/vdl-map.c
+++ b/src/external/elf-loader/vdl-map.c
@@ -654,7 +654,7 @@ readonly_cache_map (const char *filename, const struct VdlFileMap *map,
 
   char *section = vdl_utils_itoa (map->file_start_align);
   char *hashname = vdl_utils_strconcat (filename, section);
-  unsigned long hash = vdl_gnu_hash (filename);
+  unsigned long hash = vdl_gnu_hash (hashname);
   vdl_alloc_free (section);
   vdl_alloc_free (hashname);
   int cfd = readonly_cache_find (filename, map, hash);


### PR DESCRIPTION
In d9abe9709b75b92acf5fdf45c494a1027eb26474 I tried to make collisions in a hashmap less frequent by using something more unique than the filename. It looks like I forgot to actually make use of this name though.