### PR TITLE
mark the main executable as using static TLS

### DIFF
--- a/src/external/elf-loader/vdl-tls.c
+++ b/src/external/elf-loader/vdl-tls.c
@@ -42,7 +42,7 @@ file_initialize (struct VdlFile *file)
   file->tls_align = pt_tls->p_align;
   file->tls_index = g_vdl.tls_next_index;
   vdl_hashmap_insert (g_vdl.module_map, file->tls_index, file);
-  file->tls_is_static = (dt_flags & DF_STATIC_TLS) ? 1 : 0;
+  file->tls_is_static = (dt_flags & DF_STATIC_TLS) || file->is_executable;
   file->tls_tmpl_gen = g_vdl.tls_gen;
   // XXX: the next_index increment code below is bad for many reasons.
   // Instead, we should try to reuse tls indexes that are not used anymore


### PR DESCRIPTION
This fixes the failing tests on Centos7 with -O3. See the commit message for a full writeup on what exactly this is really fixing, and how it still technically isn't the "right thing". The tests were failing when compiled with -O3 because they started aligning their TLS allocations to 0x10 bytes instead of 0x04, which made it use just enough extra memory to interfere with the parts of glibc's static TLS that are actually used every time.