### PR TITLE
disable mmx and sse in elf-loader

### DIFF
--- a/src/external/elf-loader/CMakeLists.txt
+++ b/src/external/elf-loader/CMakeLists.txt
@@ -147,6 +147,7 @@ add_library(ldso SHARED ${ldso_srcs} ${as_srcs})
 add_dependencies(ldso vdlconfig ldsoversion)
 target_link_libraries(ldso -lgcc)
 set_target_properties(ldso PROPERTIES
+    COMPILE_FLAGS "-mno-mmx -mno-sse"
     LINK_FLAGS "-fvisibility=hidden -nostartfiles -nostdlib -Wl,--entry=stage0,--version-script=${CMAKE_CURRENT_BINARY_DIR}/ldso.version,-Bstatic"
     PREFIX ""
     SUFFIX ""


### PR DESCRIPTION
We can't use mmx or sse registers in ldso, because we don't push them to the
stack when doing a PLT lookup. They're fine in the dynamic loader (libvdl)
though, because those are just relatively normal function calls. It's possible
SSE instructions are enough of a performance advantage to make it worth it to
move those registers onto the stack when doing the PLT lookup, but it's a non-
trivial operation, because PUSH doesn't work on those registers. Knowing which
is better would require some benchmarking, which might be worth looking into
eventually, since PLT lookups are fairly frequent.

fixes #366