### PR TITLE
Fix topology completeness function

### DIFF
--- a/src/main/routing/shd-topology.c
+++ b/src/main/routing/shd-topology.c
@@ -144,7 +144,7 @@ static gboolean _topology_isComplete(Topology* top, gboolean *result) {
      *   - if less than the number of vertexes, it isn't a complete graph
      * - otherwise the graph is complete
      *
-     * Notice: In order to be considerd complete, every vertex must have an
+     * Notice: In order to be considered complete, every vertex must have an
      * edge beginning and ending at itself too.
      */
     /* vert selector. We wall all verts */


### PR DESCRIPTION
Consider an undirected graph. Consider a vertex with an edge that begins and
ends at itself. That edge counts as two outgoing edges from that vertex.

The function that determines whether or not a topology is complete counts
outgoing edges from each vertex and makes sure it is at least as large as the
number of vertexes. These "self-loop" edges cause the number of edges to be
inflated by one. Thus, tiny topologies where the number of vertexes is close
to one were sometimes determined to be complete when they actually weren't.

This commit subtracts one from the outgoing edge count for vertexes in an
undirected graph if a self-loop is present.

Fixes #389