### PR TITLE
updates to elf-loader tests

### DIFF
--- a/src/external/elf-loader/test/CMakeLists.txt
+++ b/src/external/elf-loader/test/CMakeLists.txt
@@ -214,6 +214,8 @@ add_executable(test28 test28.c)
 target_link_libraries(test28 vdl -lpthread -ldl)
 add_test(NAME elfloader-test28 COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/runtest.sh test28 ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_test(NAME elfloader-registers COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/registers.sh)
+
 set_tests_properties(
         elfloader-test15
         PROPERTIES RUN_SERIAL true

--- a/src/external/elf-loader/test/CMakeLists.txt
+++ b/src/external/elf-loader/test/CMakeLists.txt
@@ -202,9 +202,9 @@ add_executable(test25 test25.c)
 target_link_libraries(test25 -lpthread -ldl)
 add_test(NAME elfloader-test25 COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/runtest.sh test25 ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_executable(test26 test26.c)
-target_link_libraries(test26 -lpthread -ldl)
-add_test(NAME elfloader-test26 COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/runtest.sh test26 ${CMAKE_CURRENT_SOURCE_DIR})
+#add_executable(test26 test26.c)
+#target_link_libraries(test26 -lpthread -ldl)
+#add_test(NAME elfloader-test26 COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/runtest.sh test26 ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(test27 test27.c)
 target_link_libraries(test27 -ldl)

--- a/src/external/elf-loader/test/registers.sh
+++ b/src/external/elf-loader/test/registers.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# The AMD64 System V ABI (i.e. x86-64 ELF standard) lists a small set of
+# registers preserved across function calls -- also known as "callee-saved
+# registers", because it's the job of the called function to save them before
+# using them. The rest of the registers ("caller-saved registers") implictly
+# have no guarantees. Except they do: They can't be modified by a PLT lookup.
+# This means we need to make sure our ld.so binary doesn't modify these
+# registers (either pushing them to stack first, or simply not using them).
+# The original elf-loader people assumed this would be easy, but compilers are
+# getting smarter and making use of more obscure registers as time goes on,
+# especially with -O3 enabled. So this script tests that all the registers in
+# the ld.so executable are calle-saved, or one of the few we push ourselves in
+# x86_64/resolv.S
+
+if [ ! -z "$1" ]; then
+   ldso=$1
+else
+   ldso='../ldso'
+fi
+
+objdump -d $ldso |
+    grep -v "nop" | # nops are just used for data priming, no need to worry
+    egrep -o "%[[:alnum:]][[:alnum:]][[:alnum:]]?" | # get all the registers
+    # remove everything pushed:
+    grep -v "\
+%ah\|%al\|%ax\|%eax\|%rax\|\
+%ch\|%cl\|%cx\|%ecx\|%rcx\|\
+%dh\|%dl\|%dx\|%edx\|%rdx\|\
+%si\|%esi\|%rsi\|\
+%di\|%edi\|%rdi\|\
+%r8\|%r9\|%r10\|%r11\
+"| # remove everything callee-saved:
+    grep -v "\
+%bh\|%bl\|%bx\|%ebx\|%rbx\|\
+%bpl\|bp\|%ebp\|%rbp\|\
+%r12\|%r13\|%r14\|%r15\|\
+%rsp\
+"| # these are neither, but we (presumably) know what we're doing:
+    grep -qv "%rip\|%fs"
+# if grep found anything else, the test has failed
+if test $? -eq 1; then
+    echo "***** PASS registers *****"
+    exit 0
+else
+    echo "***** FAIL registers *****"
+    exit 1
+fi

--- a/src/external/elf-loader/test/registers.sh
+++ b/src/external/elf-loader/test/registers.sh
@@ -19,8 +19,8 @@ else
 fi
 
 objdump -d $ldso |
-    grep -v "nop" | # nops are just used for data priming, no need to worry
-    egrep -o "%[[:alnum:]][[:alnum:]][[:alnum:]]?" | # get all the registers
+    grep -v "nop" | # nops are just used for cache priming, no need to worry
+    egrep -o "%[[:alnum:]][[:alnum:]][[:alnum:]]*" | # get all the registers
     # remove everything pushed:
     grep -v "\
 %ah\|%al\|%ax\|%eax\|%rax\|\


### PR DESCRIPTION
The first commit adds a new test for any registers we don't take care of in elf-loader, to prevent any future repeats of #366/#388.

The second commit removes test26 again, until #371 is fixed.

edit: change wording so PR doesn't close any bugs