### PR TITLE
Start sims at a time that isn't the 1970s

### DIFF
--- a/src/main/core/shd-worker.c
+++ b/src/main/core/shd-worker.c
@@ -240,7 +240,7 @@ void worker_sendPacket(Packet* packet) {
 
 static void _worker_bootHost(Host* host, Worker* worker) {
     worker_setActiveHost(host);
-    worker->clock.now = 0;
+    worker->clock.now = SIMTIME_MIN;
     host_continueExecutionTimer(host);
     host_boot(host);
     host_stopExecutionTimer(host);

--- a/src/main/core/support/shd-configuration.c
+++ b/src/main/core/support/shd-configuration.c
@@ -491,7 +491,7 @@ static GError* _parser_handleKillAttributes(Parser* parser, const gchar** attrib
         debug("found attribute '%s=%s'", name, value);
 
         if (!g_ascii_strcasecmp(name, "time")) {
-            killTime = g_ascii_strtoull(value, NULL, 10);
+            killTime = g_ascii_strtoull(value, NULL, 10) + (SIMTIME_MIN / SIMTIME_ONE_SECOND);
             isSet = TRUE;
         } else {
             error = g_error_new(G_MARKUP_ERROR, G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE,
@@ -651,7 +651,13 @@ static GError* _parser_handleShadowAttributes(Parser* parser, const gchar** attr
             shadow->environment.string = g_string_new(value);
             shadow->environment.isSet = TRUE;
         } else if(!shadow->stoptime.isSet && !g_ascii_strcasecmp(name, "stoptime")) {
-            shadow->stoptime.integer = g_ascii_strtoull(value, NULL, 10);
+            /* At one point, Shadow considered secs_since_1970 and
+             * secs_since_simulation_start to be the same. That's no longer the
+             * case. We don't expect the user to know that, and we epxect them
+             * to specify the stoptime relative to the simulation start, not
+             * relative to the unix epoch. Thus we add SIMTIME_MIN to the value
+             * they specified. */
+            shadow->stoptime.integer = g_ascii_strtoull(value, NULL, 10) + (SIMTIME_MIN / SIMTIME_ONE_SECOND);
             shadow->stoptime.isSet = TRUE;
         } else {
             error = g_error_new(G_MARKUP_ERROR, G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE,

--- a/src/main/core/support/shd-configuration.c
+++ b/src/main/core/support/shd-configuration.c
@@ -548,10 +548,10 @@ static GError* _parser_handleProcessAttributes(Parser* parser, const gchar** att
             process->arguments.isSet = TRUE;
         } else if (!process->starttime.isSet && (!g_ascii_strcasecmp(name, "starttime") ||
                 !g_ascii_strcasecmp(name, "time"))) { /* TODO deprecate 'time' */
-            process->starttime.integer = g_ascii_strtoull(value, NULL, 10);
+            process->starttime.integer = g_ascii_strtoull(value, NULL, 10) + (SIMTIME_MIN / SIMTIME_ONE_SECOND);
             process->starttime.isSet = TRUE;
         } else if (!process->stoptime.isSet && !g_ascii_strcasecmp(name, "stoptime")) {
-            process->stoptime.integer = g_ascii_strtoull(value, NULL, 10);
+            process->stoptime.integer = g_ascii_strtoull(value, NULL, 10) + (SIMTIME_MIN / SIMTIME_ONE_SECOND);
             process->stoptime.isSet = TRUE;
         } else if(!process->preload.isSet && !g_ascii_strcasecmp(name, "preload")) {
             process->preload.string = g_string_new(value);

--- a/src/main/core/support/shd-definitions.h
+++ b/src/main/core/support/shd-definitions.h
@@ -23,12 +23,6 @@ typedef guint ShadowID;
 #define SIMTIME_INVALID G_MAXUINT64
 
 /**
- * Maximum and minimum valid values.
- */
-#define SIMTIME_MAX (G_MAXUINT64-1)
-#define SIMTIME_MIN 0
-
-/**
  * Represents one nanosecond in simulation time.
  */
 #define SIMTIME_ONE_NANOSECOND G_GUINT64_CONSTANT(1)
@@ -57,6 +51,15 @@ typedef guint ShadowID;
  * Represents one hour in simulation time.
  */
 #define SIMTIME_ONE_HOUR G_GUINT64_CONSTANT(3600000000000)
+
+/**
+ * Maximum and minimum valid values.
+ */
+#define SIMTIME_MAX (G_MAXUINT64-1)
+/* 792,892,800 is 16 Feb 1995. It is also about 220,248 hours since the 1970
+ * epoch. Some programs assume the current time is not that close to 1970, so
+ * start simulations at something arbitrary, but not close to 1970. */
+#define SIMTIME_MIN (792892800 * SIMTIME_ONE_SECOND)
 
 #ifdef DEBUG
 /**


### PR DESCRIPTION
For better or worse, some programs assume the current time is adequately farther
foward than 1 Jan 1970. Before this patch, Shadow simluations would start with
time == 0.

But not anymore! This patch starts simulations at an arbitrary time (16 Feb
1995) that should be far enough away from 1970 for most applications.

A simple test program called `time()`, `clock_gettime()` (with both `REAL` and `MONOTONIC`), and `gettimeofday()` to verify that they all respect the changes.

The user is still able to specify a kill/stop time as a number of seconds since simulation start.