### PR TITLE
elf-loader valgrind support

### DIFF
--- a/setup
+++ b/setup
@@ -93,6 +93,11 @@ def main():
         action="store_true", dest="disable_tgen",
         default=False)
 
+    parser_build.add_argument('--loader-valgrind',
+        help="build in support for valgrind in elf-loader, instead of just Shadow",
+        action="store_true", dest="do_valgrind",
+        default=False)
+
     # configure test subcommand
     parser_test = subparsers_main.add_parser('test', help='run Shadow tests',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -145,6 +150,7 @@ def build(args):
     if args.do_profile: cmake_cmd += " -DSHADOW_PROFILE=ON"
     if args.export_libraries: cmake_cmd += " -DSHADOW_EXPORT=ON"
     if args.disable_tgen: cmake_cmd += " -DBUILD_TGEN=OFF"
+    if args.do_valgrind: cmake_cmd += " -DLOADER_VALGRIND=ON"
 
     # we will run from build directory
     calledDirectory = os.getcwd()

--- a/src/external/elf-loader/CMakeLists.txt
+++ b/src/external/elf-loader/CMakeLists.txt
@@ -4,8 +4,14 @@ add_definitions(-DMALLOC_DEBUG_ENABLE)
 add_definitions(-D_GNU_SOURCE)
 add_definitions(-DLDSO_SONAME=\"ldso\")
 
+if(LOADER_VALGRIND STREQUAL ON)
+  add_definitions(-DHAVE_VALGRIND_H)
+  include_directories("/usr/include/")
+else()
+  add_cflags(-O3)
+endif()
+
 add_cflags(-g3)
-add_cflags(-O3)
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56888
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
   add_cflags(-fno-tree-loop-distribute-patterns)

--- a/src/external/elf-loader/internal-tests.cc
+++ b/src/external/elf-loader/internal-tests.cc
@@ -59,6 +59,10 @@ extern "C" void *vdl_alloc_malloc (size_t size)
 {
   return malloc (size);
 }
+extern "C" void *vdl_alloc_global(size_t size)
+{
+  return malloc (size);
+}
 extern "C" void vdl_alloc_free (void *buffer)
 {
   return free (buffer);

--- a/src/external/elf-loader/stage1.c
+++ b/src/external/elf-loader/stage1.c
@@ -121,7 +121,7 @@ global_initialize (unsigned long interpreter_load_base)
   vdl->n_removed = 0;
   vdl->module_map = vdl_hashmap_new ();
   vdl->preloads = vdl_list_new ();
-  vdl->address_ranges = vdl_rbnew (map_address_compare, nodup, norel);
+  vdl->address_ranges = vdl_rbnew (map_address_compare, nodup, vdl_alloc_free);
   vdl->readonly_cache = vdl_hashmap_new ();
   vdl->ro_cache_futex = futex_new ();
   vdl->shm_path = make_shm_name ();

--- a/src/external/elf-loader/stage2.c
+++ b/src/external/elf-loader/stage2.c
@@ -132,6 +132,7 @@ ld_preload_lists (struct VdlList *preload_files, struct VdlList *preload_deps,
     }
 
   // save preload list for searching when in other contexts
+  vdl_list_delete(g_vdl.preloads);
   g_vdl.preloads = preload_files;
 error:
   vdl_utils_str_list_delete (preload_names);

--- a/src/external/elf-loader/vdl-alloc.h
+++ b/src/external/elf-loader/vdl-alloc.h
@@ -2,8 +2,7 @@
 #define VDL_ALLOC_H
 
 /**
- * A thin wrapper around the global variable which holds the 
- * allocator state.
+ * Abstraction layer for handling allocators
  */
 
 #include <unistd.h> // for size_t
@@ -14,6 +13,7 @@ extern "C" {
 
 void vdl_alloc_initialize (void);
 void vdl_alloc_destroy (void);
+void *vdl_alloc_allocator (void);
 
 void *vdl_alloc_malloc (size_t size);
 void vdl_alloc_free (void *buffer);
@@ -21,6 +21,9 @@ void vdl_alloc_free (void *buffer);
   (type *) vdl_alloc_malloc (sizeof (type))
 #define vdl_alloc_delete(v) \
   vdl_alloc_free (v)
+
+// used for managing the allocators, try to avoid using
+void *vdl_alloc_global (size_t size);
 
 #ifdef __cplusplus
 }

--- a/src/external/elf-loader/vdl-dl.c
+++ b/src/external/elf-loader/vdl-dl.c
@@ -460,11 +460,6 @@ vdl_dlclose (void *handle)
 
   vdl_tls_file_deinitialize (call_fini);
 
-  // update the linkmap before unmapping
-  vdl_linkmap_remove_range (call_fini,
-                            vdl_list_begin (call_fini),
-                            vdl_list_end (call_fini));
-
   // now, unmap
   vdl_unmap (call_fini, true);
 

--- a/src/external/elf-loader/vdl-hashmap.c
+++ b/src/external/elf-loader/vdl-hashmap.c
@@ -182,7 +182,8 @@ vdl_hashmap_delete (struct VdlHashMap *map)
   for (i = 0; i <= map->n_buckets; i++)
     {
       struct VdlList *bucket = map->buckets[i];
-      vdl_list_delete (bucket);
+      if(bucket)
+        vdl_list_delete (bucket);
     }
   vdl_alloc_free (map->buckets);
   rwlock_delete (map->lock);

--- a/src/external/elf-loader/vdl-hashmap.c
+++ b/src/external/elf-loader/vdl-hashmap.c
@@ -116,6 +116,7 @@ vdl_hashmap_remove (struct VdlHashMap *map, uint32_t hash, void *data)
       if (data == item->data)
         {
           vdl_list_remove (items, item);
+          vdl_alloc_delete (item);
           map->load--;
           break;
         }

--- a/src/external/elf-loader/vdl-linkmap.c
+++ b/src/external/elf-loader/vdl-linkmap.c
@@ -43,7 +43,7 @@ vdl_linkmap_append_range (struct VdlList *list, void **begin, void **end)
 }
 
 static void
-vdl_linkmap_remove (struct VdlFile *file)
+vdl_linkmap_remove_internal (struct VdlFile *file)
 {
   // first, remove them from the global link_map
   struct VdlFile *next = file->next;
@@ -77,13 +77,21 @@ vdl_linkmap_remove (struct VdlFile *file)
 }
 
 void
+vdl_linkmap_remove (struct VdlFile *file)
+{
+  write_lock (g_vdl.link_map_lock);
+  vdl_linkmap_remove_internal (file);
+  write_unlock (g_vdl.link_map_lock);
+}
+
+void
 vdl_linkmap_remove_range (struct VdlList *list, void **begin, void **end)
 {
   void **i;
   write_lock (g_vdl.link_map_lock);
   for (i = begin; i != end; i = vdl_list_next (list, i))
     {
-      vdl_linkmap_remove (*i);
+      vdl_linkmap_remove_internal (*i);
     }
   write_unlock (g_vdl.link_map_lock);
 }

--- a/src/external/elf-loader/vdl-linkmap.h
+++ b/src/external/elf-loader/vdl-linkmap.h
@@ -6,6 +6,7 @@ struct VdlList;
 
 void vdl_linkmap_append (struct VdlFile *file);
 void vdl_linkmap_append_range (struct VdlList *list, void **begin, void **end);
+void vdl_linkmap_remove (struct VdlFile *file);
 void vdl_linkmap_remove_range (struct VdlList *list, void **begin, void **end);
 struct VdlList *vdl_linkmap_copy (void);
 void vdl_linkmap_print (void);

--- a/src/external/elf-loader/vdl-list.c
+++ b/src/external/elf-loader/vdl-list.c
@@ -1,8 +1,6 @@
 #include "vdl-list.h"
 #include "vdl-alloc.h"
 
-
-
 struct VdlList *
 vdl_list_new (void)
 {
@@ -269,6 +267,21 @@ vdl_list_push_back (struct VdlList *list, void *data)
 {
   write_lock (list->lock);
   vdl_list_insert_internal (list, (void **) &list->tail, data);
+  write_unlock (list->lock);
+}
+
+void
+vdl_list_global_push_back (struct VdlList *list, void *data)
+{
+  write_lock (list->lock);
+  struct VdlListItem *after = &list->tail;
+  struct VdlListItem *item = vdl_alloc_global (sizeof(struct VdlListItem));
+  item->data = data;
+  item->next = after;
+  item->prev = after->prev;
+  after->prev = item;
+  item->prev->next = item;
+  list->size++;
   write_unlock (list->lock);
 }
 

--- a/src/external/elf-loader/vdl-list.h
+++ b/src/external/elf-loader/vdl-list.h
@@ -90,6 +90,9 @@ void vdl_list_iterate (struct VdlList *list,
 void *vdl_list_search_on (struct VdlList *list, void *aux,
                           void *(*iterator) (void *data, void *aux));
 
+// globally allocated list operations, for use by the allocator itself
+void vdl_list_global_push_back (struct VdlList *list, void *data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/external/elf-loader/vdl-sort.c
+++ b/src/external/elf-loader/vdl-sort.c
@@ -47,6 +47,7 @@ vdl_sort_increasing_depth (struct VdlList *files)
           cur = vdl_list_next (input, cur);
         }
     }
+  vdl_list_delete (input);
   return output;
 }
 

--- a/src/external/elf-loader/vdl-tls.c
+++ b/src/external/elf-loader/vdl-tls.c
@@ -325,8 +325,7 @@ vdl_tls_dtv_allocate (unsigned long tcb)
   if (!current_dtv)
     {
       local_tls = vdl_alloc_new (struct LocalTLS);
-      local_tls->allocator = vdl_alloc_new (struct Alloc);
-      alloc_initialize (local_tls->allocator);
+      local_tls->allocator = vdl_alloc_allocator ();
     }
   else
     {

--- a/src/external/elf-loader/vdl-tls.c
+++ b/src/external/elf-loader/vdl-tls.c
@@ -364,6 +364,7 @@ vdl_tls_dtv_allocate (unsigned long tcb)
           DTV_MIGRATE_SHADOW(new_dtv, current_dtv, module);
         }
       // clear the old dtv
+      DTV_FREE_SHADOW(current_dtv);
       vdl_alloc_free (&current_dtv[-2]);
     }
 }
@@ -416,7 +417,7 @@ vdl_tls_get_local_tls (void)
       dtv_t *dtv = get_current_dtv (tp);
       if (dtv)
         {
-          return (struct LocalTLS *) DTV_LOCAL_TLS(dtv);
+          return DTV_LOCAL_TLS(dtv);
         }
     }
   return 0;

--- a/src/external/elf-loader/vdl-unmap.c
+++ b/src/external/elf-loader/vdl-unmap.c
@@ -1,6 +1,7 @@
 #include "vdl-unmap.h"
 #include "vdl-map.h"
 #include "vdl-context.h"
+#include "vdl-linkmap.h"
 #include "vdl-file.h"
 #include "vdl-utils.h"
 #include "vdl-log.h"
@@ -13,6 +14,7 @@ static void
 file_delete (struct VdlFile *file, bool mapping)
 {
   vdl_context_remove_file (file->context, file);
+  vdl_linkmap_remove (file);
 
   if (mapping)
     {
@@ -26,7 +28,6 @@ file_delete (struct VdlFile *file, bool mapping)
           address->key = map->mem_start_align;
           ret = vdl_rbfind (g_vdl.address_ranges, address);
           vdl_rberase (g_vdl.address_ranges, ret);
-          vdl_alloc_delete (ret);
           vdl_alloc_delete (address);
           int status = system_munmap ((void *) map->mem_start_align,
                                       map->mem_size_align);

--- a/src/external/elf-loader/vdl.h
+++ b/src/external/elf-loader/vdl.h
@@ -97,6 +97,8 @@ struct Vdl
   struct Futex *ro_cache_futex;
   // the unique ephemeral path we use for our shared memory mappings
   char* shm_path;
+  // list of thread-local allocators for cleanup
+  struct VdlList *allocators;
 };
 
 extern struct Vdl g_vdl;


### PR DESCRIPTION
These commits
 - fix some bugs in elf-loader for supporting valgrind
 - adds a setup script option for building elf-loader with support for valgrind on elf-loader (Shadow doesn't need this option for valgrind support, unless you want to look at elf-loader's allocations too)
 - fixes some memory leaks in elf-loader

This makes valgrind mostly work. It can be a bit rough around the edges in some places, especially as it relates to threads and shutting down, but is good enough for basic profiling.