### PR TITLE
add support for specifying the plugin start symbol in the config

### DIFF
--- a/src/main/core/shd-master.c
+++ b/src/main/core/shd-master.c
@@ -245,7 +245,8 @@ static void _master_registerPluginCallback(ConfigurationPluginElement* pe, Maste
     utility_assert(pe);
     MAGIC_ASSERT(master);
     utility_assert(pe->id.isSet && pe->id.string);
-    slave_addNewProgram(master->slave, pe->id.string->str, pe->path.string->str);
+    slave_addNewProgram(master->slave, pe->id.string->str, pe->path.string->str,
+                        pe->startsymbol.isSet ? pe->startsymbol.string->str : NULL);
 }
 
 static void _master_registerPlugins(Master* master) {

--- a/src/main/core/shd-slave.h
+++ b/src/main/core/shd-slave.h
@@ -48,7 +48,7 @@ void slave_run(Slave*);
 gboolean slave_schedulerIsRunning(Slave* slave);
 
 /* info received from master to set up the simulation */
-void slave_addNewProgram(Slave* slave, const gchar* name, const gchar* path);
+void slave_addNewProgram(Slave* slave, const gchar* name, const gchar* path, const gchar* startSymbol);
 void slave_addNewVirtualHost(Slave* slave, HostParameters* params);
 void slave_addNewVirtualProcess(Slave* slave, gchar* hostName, gchar* pluginName, gchar* preloadName,
         SimulationTime startTime, SimulationTime stopTime, gchar* arguments);

--- a/src/main/core/support/shd-configuration.c
+++ b/src/main/core/support/shd-configuration.c
@@ -139,6 +139,10 @@ static void _parser_freePluginElement(ConfigurationPluginElement* plugin) {
         utility_assert(plugin->id.string != NULL);
         g_string_free(plugin->id.string, TRUE);
     }
+    if(plugin->startsymbol.isSet) {
+        utility_assert(plugin->startsymbol.string != NULL);
+        g_string_free(plugin->startsymbol.string, TRUE);
+    }
 
     g_free(plugin);
 }
@@ -341,6 +345,9 @@ static GError* _parser_handlePluginAttributes(Parser* parser, const gchar** attr
             plugin->path.string = g_string_new(homePath);
             g_free(homePath);
             plugin->path.isSet = TRUE;
+        } else if (!plugin->startsymbol.isSet && !g_ascii_strcasecmp(name, "startsymbol")) {
+            plugin->startsymbol.string = g_string_new(value);
+            plugin->startsymbol.isSet = TRUE;
         } else {
             error = g_error_new(G_MARKUP_ERROR, G_MARKUP_ERROR_UNKNOWN_ATTRIBUTE,
                             "unknown 'plugin' attribute '%s'", name);

--- a/src/main/core/support/shd-configuration.h
+++ b/src/main/core/support/shd-configuration.h
@@ -39,6 +39,7 @@ struct _ConfigurationPluginElement {
     ConfigurationStringAttribute id;
     ConfigurationStringAttribute path;
     /* optional*/
+    ConfigurationStringAttribute startsymbol;
 };
 
 typedef struct _ConfigurationTopologyElement ConfigurationTopologyElement;

--- a/src/main/host/shd-host.c
+++ b/src/main/host/shd-host.c
@@ -308,11 +308,11 @@ void host_boot(Host* host) {
 }
 
 void host_addApplication(Host* host, SimulationTime startTime, SimulationTime stopTime,
-        const gchar* pluginName, const gchar* pluginPath,
+        const gchar* pluginName, const gchar* pluginPath, const gchar* pluginSymbol,
         const gchar* preloadName, const gchar* preloadPath, gchar* arguments) {
     MAGIC_ASSERT(host);
     guint processID = host->processIDCounter++;
-    Process* proc = process_new(host, processID, startTime, stopTime, pluginName, pluginPath, preloadName, preloadPath, arguments);
+    Process* proc = process_new(host, processID, startTime, stopTime, pluginName, pluginPath, pluginSymbol, preloadName, preloadPath, arguments);
     g_queue_push_tail(host->processes, proc);
 }
 

--- a/src/main/host/shd-host.h
+++ b/src/main/host/shd-host.h
@@ -55,7 +55,7 @@ void host_boot(Host* host);
 void host_shutdown(Host* host);
 
 void host_addApplication(Host* host, SimulationTime startTime, SimulationTime stopTime,
-        const gchar* pluginName, const gchar* pluginPath,
+        const gchar* pluginName, const gchar* pluginPath, const gchar* pluginSymbol,
         const gchar* preloadName, const gchar* preloadPath, gchar* arguments);
 void host_freeAllApplications(Host* host);
 

--- a/src/main/host/shd-process.h
+++ b/src/main/host/shd-process.h
@@ -73,8 +73,8 @@ typedef off_t off64_t;
 
 Process* process_new(gpointer host, guint processID,
         SimulationTime startTime, SimulationTime stopTime, const gchar* pluginName,
-        const gchar* pluginPath, const gchar* preloadName, const gchar* preloadPath,
-        gchar* arguments);
+        const gchar* pluginPath, const gchar* pluginSymbol, const gchar* preloadName, 
+        const gchar* preloadPath, gchar* arguments);
 void process_ref(Process* proc);
 void process_unref(Process* proc);
 

--- a/src/test/dynlink/manual-test/plugin.c
+++ b/src/test/dynlink/manual-test/plugin.c
@@ -1,3 +1,7 @@
 int main(int argc, char* argv[]) {
     return 0;
 }
+
+int main2(int argc, char* argv[]) {
+    return 0;
+}

--- a/src/test/dynlink/manual-test/test.c
+++ b/src/test/dynlink/manual-test/test.c
@@ -10,6 +10,7 @@
 #define NUM_LOADS 500
 #define PLUGIN_PATH "libplugin.so"
 #define PLUGIN_SYM "main"
+#define PLUGIN_SYM2 "main2"
 
 // new info type we've added
 #define RTLD_DI_STATIC_TLS_SIZE 127
@@ -60,10 +61,11 @@ int run(void) {
         dlerror();
 
         /* lookup a function symbol in the plugin we just loaded */
-        void* func = dlsym(handles[i], PLUGIN_SYM);
+        char* startSymbol = (i % 2) ? PLUGIN_SYM : PLUGIN_SYM2;
+        void* func = dlsym(handles[i], startSymbol);
         if(!func) {
             fprintf(stdout, "dlsym() for symbol '%s' returned NULL, dlerror is '%s'\n",
-                    PLUGIN_SYM, dlerror());
+                    startSymbol, dlerror());
             return EXIT_FAILURE;
         }
     }

--- a/src/test/dynlink/shd-test-dynlink-plugin.c
+++ b/src/test/dynlink/shd-test-dynlink-plugin.c
@@ -20,3 +20,7 @@ int plugin_value = 0;
 int main(int argc, char* argv[]) {
     return ++plugin_value + lib_increment();
 }
+
+int main2(int argc, char* argv[]) {
+    return ++plugin_value + lib_increment();
+}

--- a/src/test/dynlink/shd-test-dynlink.c
+++ b/src/test/dynlink/shd-test-dynlink.c
@@ -38,6 +38,7 @@
 #define PLUGIN_PATH "libshadow-test-dynlink-plugin.so"
 
 #define PLUGIN_MAIN_SYMBOL "main"
+#define PLUGIN_MAIN_SYMBOL2 "main2"
 typedef int (*MainFunc)(int argc, char* argv[]);
 
 int global_num_dlmopens = 0;
@@ -113,10 +114,11 @@ int _test_linker_loader_single(int use_dlmopen) {
         /* clear dlerror */
         dlerror();
 
-        funcs[i] = dlsym(handles[i], PLUGIN_MAIN_SYMBOL);
+        char* startSymbol = (i % 2) ? PLUGIN_MAIN_SYMBOL : PLUGIN_MAIN_SYMBOL2;
+        funcs[i] = dlsym(handles[i], startSymbol);
         if(!funcs[i]) {
             fprintf(stdout, "dlsym() for symbol '%s' returned NULL, dlerror is '%s'\n",
-                    PLUGIN_MAIN_SYMBOL, dlerror());
+                    startSymbol, dlerror());
             return EXIT_FAILURE;
         }
     }


### PR DESCRIPTION
I am researching using Shadow to simulate blockchain networks and wanted to try and see if I could get it to run a Rust executable.  It turns out that the Rust compiler doesn't allow the creation of a C callable dynamic linked library with the "main" symbol exported.  To get around this, I modified Shadow to add a "startsymbol" attribute to the plugin tags in the config.  If it isn't specified, it defaults to "main" so the existing behavior is preserved.  I also modified a few tests to verify it works.  I think this may also be useful for other situations also.