### PR TITLE
gdb performance improvements

### DIFF
--- a/src/external/elf-loader/gdb.c
+++ b/src/external/elf-loader/gdb.c
@@ -5,7 +5,7 @@
 #include <link.h>
 
 static
-ElfW (Dyn) *
+ElfW(Dyn) *
 file_get_dynamic (const struct VdlFile *file, long tag)
 {
   ElfW (Dyn) * cur = (ElfW (Dyn) *) file->dynamic;
@@ -43,7 +43,7 @@ gdb_initialize (struct VdlFile *file)
   // in the DT_DEBUG entry of the main executable dynamic section
   // because this is where gdb goes to look to find the pointer and
   // lookup an inferior's linkmap.
-  ElfW (Dyn) * dt_debug = file_get_dynamic (file, DT_DEBUG);
+  ElfW(Dyn) *dt_debug = file_get_dynamic (file, DT_DEBUG);
   unsigned long *p = (unsigned long *) &(dt_debug->d_un.d_ptr);
   *p = (unsigned long) &g_vdl;
 }
@@ -52,5 +52,8 @@ void
 gdb_notify (void)
 {
   g_vdl.state = VDL_CONSISTENT;
-  g_vdl.breakpoint ();
+  if (g_vdl.breakpoint)
+    {
+      g_vdl.breakpoint ();
+    }
 }

--- a/src/external/elf-loader/stage1.c
+++ b/src/external/elf-loader/stage1.c
@@ -98,6 +98,7 @@ global_initialize (unsigned long interpreter_load_base)
 
   vdl->version = 1;
   vdl->link_map = 0;
+  vdl->shadow_link_map = vdl_list_new();
   vdl->link_map_lock = rwlock_new ();
   vdl->breakpoint = 0;
   vdl->state = VDL_CONSISTENT;
@@ -241,6 +242,7 @@ stage1_freeres (void)
   vdl_utils_str_list_delete (g_vdl.search_dirs);
   vdl_hashmap_delete (g_vdl.files);
   vdl_hashmap_delete (g_vdl.contexts);
+  vdl_list_delete (g_vdl.shadow_link_map);
   futex_delete (g_vdl.ro_cache_futex);
   rwlock_delete (g_vdl.global_lock);
   rwlock_delete (g_vdl.tls_lock);
@@ -280,7 +282,7 @@ stage1 (struct Stage1InputOutput *input_output)
   extern ElfW(Dyn) _DYNAMIC[] __attribute__ ((visibility ("hidden")));
   extern const ElfW(Addr) _GLOBAL_OFFSET_TABLE_[] __attribute__ ((visibility ("hidden")));
   ElfW(Addr) load_base = (ElfW(Addr)) &_DYNAMIC - (unsigned long)_GLOBAL_OFFSET_TABLE_[0];
-  
+
   relocate_dt_rel (load_base);
 
   // Now that access to global variables is possible, we initialize

--- a/src/external/elf-loader/stage2.c
+++ b/src/external/elf-loader/stage2.c
@@ -124,10 +124,7 @@ ld_preload_lists (struct VdlList *preload_files, struct VdlList *preload_deps,
       result.requested->count++;
       result.requested->is_interposer = 1;
       vdl_list_push_back (preload_files, result.requested);
-      vdl_list_insert_range (preload_deps, vdl_list_end (preload_deps),
-                             result.newly_mapped,
-                             vdl_list_begin (result.newly_mapped),
-                             vdl_list_end (result.newly_mapped));
+      vdl_list_append_list (preload_deps, result.newly_mapped);
       vdl_list_delete (result.newly_mapped);
     }
 
@@ -286,15 +283,10 @@ stage2_initialize (struct Stage2Input input)
   // then, the dependencies from the ld preload entries
   vdl_linkmap_append (main_file);
   vdl_linkmap_append (interp);
-  vdl_linkmap_append_range (ld_preload,
-                            vdl_list_begin (ld_preload),
-                            vdl_list_end (ld_preload));
-  vdl_linkmap_append_range (main_result.newly_mapped,
-                            vdl_list_begin (main_result.newly_mapped),
-                            vdl_list_end (main_result.newly_mapped));
-  vdl_linkmap_append_range (preload_deps,
-                            vdl_list_begin (preload_deps),
-                            vdl_list_end (preload_deps));
+  vdl_linkmap_append_list (ld_preload);
+  vdl_linkmap_append_list (main_result.newly_mapped);
+  vdl_linkmap_append_list (preload_deps);
+  vdl_linkmap_abi_update ();
   vdl_list_delete (main_result.newly_mapped);
   main_result.newly_mapped = 0;
 
@@ -305,20 +297,10 @@ stage2_initialize (struct Stage2Input input)
   // binaries).
   vdl_list_push_back (context->global_scope, main_file);
   // of course, the ld_preload binaries must be in there if needed.
-  vdl_list_insert_range (context->global_scope,
-                         vdl_list_end (context->global_scope),
-                         ld_preload,
-                         vdl_list_begin (ld_preload),
-                         vdl_list_end (ld_preload));
+  vdl_list_append_list (context->global_scope, ld_preload);
   struct VdlList *all_deps = vdl_sort_deps_breadth_first (main_file);
-  vdl_list_insert_range (context->global_scope,
-                         vdl_list_end (context->global_scope), all_deps,
-                         vdl_list_begin (all_deps), vdl_list_end (all_deps));
-  vdl_list_insert_range (context->global_scope,
-                         vdl_list_end (context->global_scope),
-                         preload_deps,
-                         vdl_list_begin (preload_deps),
-                         vdl_list_end (preload_deps));
+  vdl_list_append_list (context->global_scope, all_deps);
+  vdl_list_append_list (context->global_scope, preload_deps);
   vdl_list_delete (all_deps);
   vdl_list_unicize (context->global_scope);
 

--- a/src/external/elf-loader/test/CMakeLists.txt
+++ b/src/external/elf-loader/test/CMakeLists.txt
@@ -214,6 +214,11 @@ add_executable(test28 test28.c)
 target_link_libraries(test28 vdl -lpthread -ldl)
 add_test(NAME elfloader-test28 COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/runtest.sh test28 ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_executable(test29 test29.c)
+target_link_libraries(test29 vdl -lpthread -ldl)
+add_test(NAME elfloader-test29 COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/runtest.sh test29 ${CMAKE_CURRENT_SOURCE_DIR})
+set_property(TEST elfloader-test29 PROPERTY ENVIRONMENT LD_STATIC_TLS_EXTRA=1000000)
+
 add_test(NAME elfloader-registers COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/registers.sh)
 
 set_tests_properties(

--- a/src/external/elf-loader/test/output/test29.ref
+++ b/src/external/elf-loader/test/output/test29.ref
@@ -1,0 +1,4 @@
+libtest29 constructor
+enter main
+leave main
+libtest29 destructor

--- a/src/external/elf-loader/test/test29.c
+++ b/src/external/elf-loader/test/test29.c
@@ -1,0 +1,57 @@
+#include <dlfcn.h>
+#include <stdio.h>
+#include "test.h"
+
+LIB(test29)
+
+// this test tests large dlmopen counts
+#define DLMOPEN_COUNT 1000
+
+int main (__attribute__((unused)) int argc,
+          __attribute__((unused)) char *argv[])
+{
+  printf ("enter main\n");
+  void *handles[DLMOPEN_COUNT];
+  dlerror();
+  for (int i = 0; i < DLMOPEN_COUNT; i++)
+    {
+      handles[i] = dlmopen(LM_ID_NEWLM, "./libr.so", RTLD_LAZY);
+      if (!handles[i])
+        {
+          printf ("failed to open handle %d: %s\n", i, dlerror());
+          return 1;
+        }
+      Lmid_t lmid;
+      if(dlinfo (handles[i], RTLD_DI_LMID, &lmid))
+        {
+          printf ("dlinfo failed on iteration %d: %s\n", i, dlerror());
+          return 1;
+        }
+      // make sure we actually use some TLS in every namespace,
+      // even though there are no other threads
+      int (*fn1)(void) = dlsym (handles[i], "get_b");
+      if (!fn1)
+        {
+          printf ("failed to find %d get_b(): %s\n", i, dlerror());
+          return 1;
+        }
+      int b = fn1();
+      void (*fn2)(int) = dlsym (handles[i], "set_b");
+      if (!fn1)
+        {
+          printf ("failed to find %d set_b(): %s\n", i, dlerror());
+          return 1;
+        }
+      fn2 (b+1);
+    }
+  for (int i = 0; i < DLMOPEN_COUNT; i++)
+    {
+      if(dlclose (handles[i]))
+        {
+          printf ("failed to close %d: %s\n", i, dlerror());
+          return 1;
+        }
+    }
+  printf ("leave main\n");
+  return 0;
+}

--- a/src/external/elf-loader/vdl-dl.h
+++ b/src/external/elf-loader/vdl-dl.h
@@ -24,6 +24,7 @@ void *vdl_dlvsym_with_flags (void *handle, const char *symbol,
 int vdl_dlinfo (void *handle, int request, void *p);
 void *vdl_dlmopen (Lmid_t lmid, const char *filename, int flag);
 struct VdlFile *vdl_addr_to_file (unsigned long addr);
+struct VdlFile *vdl_search_file (void *handle);
 // create a new linkmap
 Lmid_t vdl_dl_lmid_new (int argc, char **argv, char **envp);
 void vdl_dl_lmid_delete (Lmid_t lmid);

--- a/src/external/elf-loader/vdl-file.h
+++ b/src/external/elf-loader/vdl-file.h
@@ -111,8 +111,10 @@ struct VdlFile
   // indicates if we patched this file for some
   // nastly glibc-isms.
   uint32_t patched:1;
-  // indicates if we have inserted into the global linkmap
+  // indicates if we have inserted into the ABI linkmap
   uint32_t in_linkmap:1;
+  // indicates if we have inserted into the shadow linkmap
+  uint32_t in_shadow_linkmap:1;
   // indicates if this represents the main executable.
   uint32_t is_executable:1;
   // indicates if this is an interposing file

--- a/src/external/elf-loader/vdl-hashmap.c
+++ b/src/external/elf-loader/vdl-hashmap.c
@@ -98,13 +98,24 @@ vdl_hashmap_get (struct VdlHashMap *map, uint32_t hash, void *key,
   return 0;
 }
 
+static void *
+vdl_hashmap_search_iter (void **data, void *aux)
+{
+  struct VdlHashMapItem *item = *data;
+  if (item->data == aux)
+    {
+      return data;
+    }
+  return NULL;
+}
+
 void
 vdl_hashmap_remove (struct VdlHashMap *map, uint32_t hash, void *data)
 {
   write_lock (map->lock);
   struct VdlList *items = map->buckets[hash & (map->n_buckets - 1)];
-  void **found = vdl_list_find (items, data);
-  if(found != vdl_list_end(items))
+  void **found = vdl_list_search_on (items, data, vdl_hashmap_search_iter);
+  if (found)
     {
       struct VdlHashMapItem *item = *found;
       vdl_list_erase (items, found);

--- a/src/external/elf-loader/vdl-linkmap.c
+++ b/src/external/elf-loader/vdl-linkmap.c
@@ -6,16 +6,16 @@
 #include "vdl-hashmap.h"
 #include "vdl-utils.h"
 #include "futex.h"
+#include "gdb.h"
 
-void
-vdl_linkmap_append (struct VdlFile *file)
+static void
+vdl_linkmap_abi_append (void *data)
 {
+  struct VdlFile *file = data;
   if (file->in_linkmap)
     {
       return;
     }
-  uint32_t hash = vdl_int_hash ((unsigned long) file);
-  vdl_hashmap_insert (g_vdl.files, hash, file);
   file->in_linkmap = 1;
   if (g_vdl.link_map == 0)
     {
@@ -27,25 +27,30 @@ vdl_linkmap_append (struct VdlFile *file)
   file->prev = g_vdl.link_map_tail;
   g_vdl.link_map_tail = file;
   file->next = 0;
-  g_vdl.n_added++;
 }
 
-void
-vdl_linkmap_append_range (struct VdlList *list, void **begin, void **end)
-{
-  void **i;
-  write_lock (g_vdl.link_map_lock);
-  for (i = begin; i != end; i = vdl_list_next (list, i))
-    {
-      vdl_linkmap_append (*i);
-    }
-  write_unlock (g_vdl.link_map_lock);
-}
-
+// afaik, gdb doesn't do anything special on removal,
+// so we can remove from both linkmaps at the same time
 static void
-vdl_linkmap_remove_internal (struct VdlFile *file)
+vdl_linkmap_remove_internal (void *data)
 {
-  // first, remove them from the global link_map
+  struct VdlFile *file = data;
+  // first, remove it from the shadow linkmap and other structures
+  vdl_list_remove (g_vdl.shadow_link_map, file);
+  file->in_shadow_linkmap = 0;
+  if (file->has_tls)
+    {
+      vdl_hashmap_remove (g_vdl.module_map, file->tls_index, file);
+    }
+  uint32_t hash = vdl_int_hash ((unsigned long) file);
+  vdl_hashmap_remove (g_vdl.files, hash, file);
+  g_vdl.n_removed++;
+  if (!file->in_linkmap)
+    {
+      return;
+    }
+
+  // it was put in the ABI linkmap, remove from that too
   struct VdlFile *next = file->next;
   struct VdlFile *prev = file->prev;
   file->next = 0;
@@ -67,13 +72,6 @@ vdl_linkmap_remove_internal (struct VdlFile *file)
     {
       g_vdl.link_map_tail = prev;
     }
-  if (file->has_tls)
-    {
-      vdl_hashmap_remove (g_vdl.module_map, file->tls_index, file);
-    }
-  uint32_t hash = vdl_int_hash ((unsigned long) file);
-  vdl_hashmap_remove (g_vdl.files, hash, file);
-  g_vdl.n_removed++;
 }
 
 void
@@ -81,37 +79,92 @@ vdl_linkmap_remove (struct VdlFile *file)
 {
   write_lock (g_vdl.link_map_lock);
   vdl_linkmap_remove_internal (file);
+  gdb_notify ();
   write_unlock (g_vdl.link_map_lock);
 }
 
 void
-vdl_linkmap_remove_range (struct VdlList *list, void **begin, void **end)
+vdl_linkmap_remove_list (struct VdlList *list)
 {
-  void **i;
   write_lock (g_vdl.link_map_lock);
-  for (i = begin; i != end; i = vdl_list_next (list, i))
-    {
-      vdl_linkmap_remove_internal (*i);
-    }
+  vdl_list_iterate (list, vdl_linkmap_remove_internal);
+  gdb_notify ();
   write_unlock (g_vdl.link_map_lock);
 }
 
 struct VdlList *
 vdl_linkmap_copy (void)
 {
-  struct VdlList *list = vdl_list_new ();
-  struct VdlFile *cur;
-  read_lock (g_vdl.link_map_lock);
-  for (cur = g_vdl.link_map; cur != 0; cur = cur->next)
-    {
-      vdl_list_push_back (list, cur);
-    }
-  read_unlock (g_vdl.link_map_lock);
-  return list;
+  return vdl_list_copy(g_vdl.shadow_link_map);
 }
 
 void
-vdl_linkmap_print (void)
+vdl_linkmap_abi_update (void)
+{
+  write_lock (g_vdl.link_map_lock);
+  vdl_list_iterate (g_vdl.shadow_link_map, vdl_linkmap_abi_append);
+  gdb_notify ();
+  write_unlock (g_vdl.link_map_lock);
+}
+
+void
+vdl_linkmap_append (struct VdlFile *file)
+{
+  if (file->in_shadow_linkmap)
+    {
+      return;
+    }
+  uint32_t hash = vdl_int_hash ((unsigned long) file);
+  vdl_hashmap_insert (g_vdl.files, hash, file);
+  vdl_list_push_back (g_vdl.shadow_link_map, file);
+  file->in_shadow_linkmap = 1;
+  __sync_fetch_and_add (&g_vdl.n_added, 1);
+}
+
+int
+vdl_linkmap_append_iterator (void *data)
+{
+  struct VdlFile *file = data;
+  if (file->in_shadow_linkmap)
+    {
+      return 0;
+    }
+  uint32_t hash = vdl_int_hash ((unsigned long) file);
+  vdl_hashmap_insert (g_vdl.files, hash, file);
+  file->in_shadow_linkmap = 1;
+  __sync_fetch_and_add (&g_vdl.n_added, 1);
+  return 1;
+}
+
+void
+vdl_linkmap_append_list (struct VdlList *list)
+{
+  struct VdlList *needed = vdl_list_get_all (list, vdl_linkmap_append_iterator);
+  vdl_list_append_list (g_vdl.shadow_link_map, needed);
+  vdl_list_delete (needed);
+}
+
+
+static void
+vdl_linkmap_shadow_print_iterator (void *data)
+{
+  struct VdlFile *file = data;
+  vdl_log_printf (VDL_LOG_PRINT,
+                  "load_base=0x%x , file=%s\n",
+                  file->load_base, file->filename);
+}
+
+// these are intended for debugging (e.g., you can call them from gdb)
+// don't commit any code that calls them
+
+void
+vdl_linkmap_shadow_print (void)
+{
+  vdl_list_iterate (g_vdl.shadow_link_map, vdl_linkmap_shadow_print_iterator);
+}
+
+void
+vdl_linkmap_abi_print (void)
 {
   struct VdlFile *cur;
   read_lock (g_vdl.link_map_lock);

--- a/src/external/elf-loader/vdl-linkmap.h
+++ b/src/external/elf-loader/vdl-linkmap.h
@@ -5,10 +5,10 @@ struct VdlFile;
 struct VdlList;
 
 void vdl_linkmap_append (struct VdlFile *file);
-void vdl_linkmap_append_range (struct VdlList *list, void **begin, void **end);
+void vdl_linkmap_append_list (struct VdlList *list);
 void vdl_linkmap_remove (struct VdlFile *file);
-void vdl_linkmap_remove_range (struct VdlList *list, void **begin, void **end);
+void vdl_linkmap_remove_list (struct VdlList *list);
 struct VdlList *vdl_linkmap_copy (void);
-void vdl_linkmap_print (void);
+void vdl_linkmap_abi_update (void);
 
 #endif /* VDL_LINKMAP_H */

--- a/src/external/elf-loader/vdl-list.c
+++ b/src/external/elf-loader/vdl-list.c
@@ -523,3 +523,24 @@ vdl_list_search_on (struct VdlList *list, void *aux,
   read_unlock (list->lock);
   return NULL;
 }
+
+struct VdlList *vdl_list_get_all (struct VdlList *list,
+                                  int (*iterator) (void *data))
+{
+  struct VdlList *ret = vdl_list_new ();
+  int is;
+  struct VdlListItem *i;
+  read_lock (list->lock);
+  for (i = list->head.next;
+       i != &list->tail;
+       i = i->next)
+    {
+      is = (*iterator) (i->data);
+      if (is)
+        {
+          vdl_list_insert_internal (ret, (void **) &ret->tail, i->data);
+        }
+    }
+  read_unlock (list->lock);
+  return ret;
+}

--- a/src/external/elf-loader/vdl-list.c
+++ b/src/external/elf-loader/vdl-list.c
@@ -504,7 +504,7 @@ vdl_list_iterate (struct VdlList *list, void (*iterator) (void *data))
 */
 void *
 vdl_list_search_on (struct VdlList *list, void *aux,
-                    void *(*iterator) (void *data, void *aux))
+                    void *(*iterator) (void **data, void *aux))
 {
   read_lock (list->lock);
   void *ret;
@@ -513,7 +513,7 @@ vdl_list_search_on (struct VdlList *list, void *aux,
        i != &list->tail;
        i = i->next)
     {
-      ret = (*iterator) (i->data, aux);
+      ret = (*iterator) ((void **)i, aux);
       if (ret)
         {
           read_unlock (list->lock);

--- a/src/external/elf-loader/vdl-list.h
+++ b/src/external/elf-loader/vdl-list.h
@@ -89,6 +89,8 @@ void vdl_list_iterate (struct VdlList *list,
                        void (*iterator) (void *data));
 void *vdl_list_search_on (struct VdlList *list, void *aux,
                           void *(*iterator) (void *data, void *aux));
+struct VdlList *vdl_list_get_all (struct VdlList *list,
+                                  int (*iterator) (void *data));
 
 // globally allocated list operations, for use by the allocator itself
 void vdl_list_global_push_back (struct VdlList *list, void *data);

--- a/src/external/elf-loader/vdl-list.h
+++ b/src/external/elf-loader/vdl-list.h
@@ -88,7 +88,7 @@ void **vdl_list_rprev (struct VdlList *list, void **i);
 void vdl_list_iterate (struct VdlList *list,
                        void (*iterator) (void *data));
 void *vdl_list_search_on (struct VdlList *list, void *aux,
-                          void *(*iterator) (void *data, void *aux));
+                          void *(*iterator) (void **data, void *aux));
 struct VdlList *vdl_list_get_all (struct VdlList *list,
                                   int (*iterator) (void *data));
 

--- a/src/external/elf-loader/vdl-lookup.c
+++ b/src/external/elf-loader/vdl-lookup.c
@@ -435,9 +435,10 @@ struct VdlLookupArgs
 
 /* designed to be the iterator on the list of files in the scope
  */
-static void *vdl_lookup_in_file (void *data, void *aux)
+static void *
+vdl_lookup_in_file (void **data, void *aux)
 {
-  struct VdlFile *item = data;
+  struct VdlFile *item = *data;
   struct VdlLookupArgs *args = aux;
   if (args->flags & VDL_LOOKUP_NO_EXEC && item->is_executable)
     {

--- a/src/external/elf-loader/vdl-map.c
+++ b/src/external/elf-loader/vdl-map.c
@@ -380,6 +380,7 @@ file_new (unsigned long load_base, unsigned long dynamic, struct VdlList *maps,
   file->reloced = 0;
   file->patched = 0;
   file->in_linkmap = 0;
+  file->in_shadow_linkmap = 0;
   file->is_executable = 0;
   file->is_interposer = 0;
   // no need to initialize gc_color because it is always

--- a/src/external/elf-loader/vdl-tls.c
+++ b/src/external/elf-loader/vdl-tls.c
@@ -680,10 +680,10 @@ struct SwapArgs
   dtv_t *dtv2;
 };
 
-void *
-vdl_tls_swap_file (void *data, void *aux)
+static void *
+vdl_tls_swap_file (void **data, void *aux)
 {
-  struct VdlFile *file = data;
+  struct VdlFile *file = *data;
   struct SwapArgs *args = aux;
 
   if (!file->has_tls)

--- a/src/external/elf-loader/vdl.h
+++ b/src/external/elf-loader/vdl.h
@@ -51,6 +51,8 @@ struct Vdl
   unsigned long interpreter_load_base;
   // end ABI-compatible fields
 
+  // we keep our internal link map here, then populate the ABI one when needed for gdb
+  struct VdlList *shadow_link_map;
   struct VdlFile *link_map_tail;
   struct RWLock *link_map_lock;
   // The list of directories to search for binaries in DT_NEEDED entries.


### PR DESCRIPTION
This partially fixes the problems in #381 by using the second option there. That is, with 
1aef9b0 in particular, elf-loader doesn't add dynamically loaded objects to the linkmap, preventing gdb from finding them. For shadow, this means that the performance of running in gdb or attaching gdb to a running experiment will be considerably faster, with the drawback that no debug symbols will be loaded for plugins and their dependencies. While there isn't a full solution in place (that would require patching gdb), there are some helper functions to address plugin debug symbols:

 - `vdl_linkmap_abi_update()` will add all objects to the linkmap and notify gdb, at what is probably only slightly faster than what it was before. This is useful for smaller experiments, or experiments where you're willing to be very patient.
 - `vdl_linkmap_abi_from_addr (addr)` will add to the linkmap the object either pointed to by `addr` or which has a map containing `addr`, and notify gdb. This is useful for things like stack traces, where you take the address of any frame without debug symbols and call this function on it.
- `vdl_linkmap_abi_from_addrs (count, ...)` will do the same, for `count` addresses passed in. It's useful for making gdb scripts a little shorter.
- `vdl_linkmap_shadow_print()` and `vdl_linkmap_abi_print()` print all the objects that have been dynamically linked/loaded, or have been added to the linkmap, respectively. The former is useful for seeing what is available to load debug symbols for, and the latter is to check what already has. The handles printed by these can be used in `vdl_linkmap_abi_from_addr (addr)`.

I'll need to document this on the wiki, along with some example gdb scripts for doing things like automatically loading all debug symbols for a segfault stacktrace.

Something this doesn't implement which might be useful is the ability to optionally run with the old behavior (update the linkmap on every load), since with this patch it's impossible to put a breakpoint in any object which hasn't been loaded yet.