### PR TITLE
unsupported pthread functions

### DIFF
--- a/src/main/host/shd-process-undefined.h
+++ b/src/main/host/shd-process-undefined.h
@@ -1,0 +1,47 @@
+/*
+ * The Shadow Simulator
+ * See LICENSE for licensing information
+ */
+
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_tryjoin_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_timedjoin_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_attr_getstack);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_attr_setstack);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_attr_setaffinity_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_attr_getaffinity_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_getattr_default_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_setattr_default_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_setschedprio);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_getname_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_setname_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_setaffinity_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_getaffinity_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_mutex_timedlock);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_mutex_consistent);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_mutex_consistent_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_mutexattr_getrobust);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_mutexattr_getrobust_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_mutexattr_setrobust);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_mutexattr_setrobust_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_rwlock_timedrdlock);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_rwlock_timedwrlock);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_rwlockattr_getkind_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_rwlockattr_setkind_np);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_spin_init);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_spin_destroy);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_spin_lock);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_spin_trylock);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_spin_unlock);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_barrier_init);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_barrier_destroy);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_barrier_wait);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_barrierattr_init);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_barrierattr_destroy);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_barrierattr_getpshared);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_barrierattr_setpshared);
+PROCESS_EMU_UNSUPPORTED(int, ENOSYS, pthread_getcpuclockid);
+PROCESS_EMU_UNSUPPORTED(void,      , __pthread_register_cancel);
+PROCESS_EMU_UNSUPPORTED(void,      , __pthread_unregister_cancel);
+PROCESS_EMU_UNSUPPORTED(void,      , __pthread_register_cancel_defer);
+PROCESS_EMU_UNSUPPORTED(void,      , __pthread_unregister_cancel_restore);
+PROCESS_EMU_UNSUPPORTED(void,      , __pthread_unwind_next);

--- a/src/main/host/shd-process.c
+++ b/src/main/host/shd-process.c
@@ -7432,3 +7432,16 @@ int process_emu_pthread_cond_timedwait(Process* proc, pthread_cond_t *cond, pthr
     _process_changeContext(proc, PCTX_SHADOW, prevCTX);
     return ret;
 }
+
+#define PROCESS_EMU_UNSUPPORTED(returntype, returnval, functionname) \
+    returntype process_emu_##functionname(Process* proc, ...) { \
+        ProcessContext prevCTX = _process_changeContext(proc, proc->activeContext, PCTX_SHADOW); \
+        warning(#functionname " is not supported by pth or by shadow"); \
+        _process_setErrno(proc, ENOSYS); \
+        _process_changeContext(proc, PCTX_SHADOW, prevCTX); \
+        return returnval; \
+    }
+
+#include "shd-process-undefined.h"
+
+#undef PROCESS_EMU_UNSUPPORTED

--- a/src/main/host/shd-process.c
+++ b/src/main/host/shd-process.c
@@ -82,7 +82,7 @@
 /**
  * We call this function to run the plugin executable. This is the default
  * symbol name when one isn't specified in the plugin configuration element.
- * A start symbol must exist or the dlsym lookup will fail. 
+ * A start symbol must exist or the dlsym lookup will fail.
  */
 #define PLUGIN_DEFAULT_SYMBOL "main"
 
@@ -556,7 +556,7 @@ static void _process_loadPlugin(Process* proc) {
 
 Process* process_new(gpointer host, guint processID,
         SimulationTime startTime, SimulationTime stopTime, const gchar* pluginName,
-        const gchar* pluginPath, const gchar* pluginSymbol, const gchar* preloadName, 
+        const gchar* pluginPath, const gchar* pluginSymbol, const gchar* preloadName,
         const gchar* preloadPath, gchar* arguments) {
     Process* proc = g_new0(Process, 1);
     MAGIC_INIT(proc);
@@ -5139,14 +5139,14 @@ int process_emu_pthread_getattr_np(Process* proc, pthread_t thread, pthread_attr
     if(prevCTX == PCTX_PLUGIN) {
         pth_t pt = NULL;
         memmove(&pt, &thread, sizeof(void*));
-        if(pt == NULL) {
+        if(pt == NULL || attr == NULL) {
             ret = EINVAL;
             _process_setErrno(proc, EINVAL);
         } else {
             _process_changeContext(proc, PCTX_SHADOW, PCTX_PTH);
             utility_assert(proc->tstate == pth_gctx_get());
             pth_attr_t na = NULL;
-            if(!pth_getattr_np(pt, (pth_attr_t)attr)) {
+            if(pth_getattr_np(pt, (pth_attr_t) attr)) {
                 ret = errno;
             }
             _process_changeContext(proc, PCTX_PTH, PCTX_SHADOW);
@@ -7432,4 +7432,3 @@ int process_emu_pthread_cond_timedwait(Process* proc, pthread_cond_t *cond, pthr
     _process_changeContext(proc, PCTX_SHADOW, prevCTX);
     return ret;
 }
-

--- a/src/main/host/shd-process.h
+++ b/src/main/host/shd-process.h
@@ -73,7 +73,7 @@ typedef off_t off64_t;
 
 Process* process_new(gpointer host, guint processID,
         SimulationTime startTime, SimulationTime stopTime, const gchar* pluginName,
-        const gchar* pluginPath, const gchar* pluginSymbol, const gchar* preloadName, 
+        const gchar* pluginPath, const gchar* pluginSymbol, const gchar* preloadName,
         const gchar* preloadPath, gchar* arguments);
 void process_ref(Process* proc);
 void process_unref(Process* proc);
@@ -292,6 +292,7 @@ int process_emu_pthread_attr_setname_np(Process* proc, pthread_attr_t *attr, cha
 int process_emu_pthread_attr_getname_np(Process* proc, const pthread_attr_t *attr, char **name);
 int process_emu_pthread_attr_setprio_np(Process* proc, pthread_attr_t *attr, int prio);
 int process_emu_pthread_attr_getprio_np(Process* proc, const pthread_attr_t *attr, int *prio);
+int process_emu_pthread_getattr_np(Process* proc, pthread_t thread, pthread_attr_t *attr);
 
 /* pthread threads */
 

--- a/src/main/host/shd-process.h
+++ b/src/main/host/shd-process.h
@@ -414,4 +414,11 @@ int process_emu_pselect(Process* proc, int nfds, fd_set *readfds, fd_set *writef
 int process_emu_poll(Process* proc, struct pollfd *pfd, nfds_t nfd, int timeout);
 int process_emu_ppoll(Process* proc, struct pollfd *fds, nfds_t nfds, const struct timespec *timeout_ts, const sigset_t *sigmask);
 
+#define PROCESS_EMU_UNSUPPORTED(returntype, returnval, functionname) \
+  returntype process_emu_##functionname(Process* proc, ...);
+
+#include "shd-process-undefined.h"
+
+#undef PROCESS_EMU_UNSUPPORTED
+
 #endif /* SHD_PROCESS_H_ */

--- a/src/preload/shd-preload-defs.h
+++ b/src/preload/shd-preload-defs.h
@@ -133,6 +133,7 @@ PRELOADDEF(return, int, clock_gettime, (clockid_t a, struct timespec *b), a, b);
 PRELOADDEF(return, int, gettimeofday, (struct timeval* a, struct timezone* b), a, b);
 PRELOADDEF(return, struct tm *, localtime, (const time_t *a), a);
 PRELOADDEF(return, struct tm *, localtime_r, (const time_t *a, struct tm *b), a, b);
+PRELOADDEF(return, int, pthread_getcpuclockid, (pthread_t a, clockid_t *b), a, b);
 
 /* name/address family */
 
@@ -198,6 +199,12 @@ PRELOADDEF(return, int, pthread_attr_setname_np, (pthread_attr_t *a, char *b), a
 PRELOADDEF(return, int, pthread_attr_getname_np, (const pthread_attr_t *a, char **b), a, b);
 PRELOADDEF(return, int, pthread_attr_setprio_np, (pthread_attr_t *a, int b), a, b);
 PRELOADDEF(return, int, pthread_attr_getprio_np, (const pthread_attr_t *a, int *b), a, b);
+PRELOADDEF(return, int, pthread_attr_getstack, (const pthread_attr_t *a, void **b, size_t *c), a, b, c);
+PRELOADDEF(return, int, pthread_attr_setstack, (pthread_attr_t *a, void *b, size_t c), a, b, c);
+PRELOADDEF(return, int, pthread_attr_setaffinity_np, (pthread_attr_t *a, size_t b, const cpu_set_t *c), a, b, c);
+PRELOADDEF(return, int, pthread_attr_getaffinity_np, (const pthread_attr_t *a, size_t b, cpu_set_t *c), a, b, c);
+PRELOADDEF(return, int, pthread_getattr_default_np, (pthread_attr_t *a), a);
+PRELOADDEF(return, int, pthread_setattr_default_np, (const pthread_attr_t *a), a);
 
 /* pthread threads */
 
@@ -213,6 +220,12 @@ PRELOADDEF(return, int, pthread_once, (pthread_once_t *a, void (*b)(void)), a, b
 PRELOADDEF(return, int, pthread_sigmask, (int a, const sigset_t *b, sigset_t *c), a, b, c);
 PRELOADDEF(return, int, pthread_kill, (pthread_t a, int b), a, b);
 PRELOADDEF(return, int, pthread_abort, (pthread_t a), a);
+PRELOADDEF(return, int, pthread_tryjoin_np, (pthread_t a, void **b), a, b);
+PRELOADDEF(return, int, pthread_timedjoin_np, (pthread_t a, void **b, const struct timespec *c), a, b, c);
+PRELOADDEF(return, int, pthread_getname_np, (pthread_t a, char *b, size_t c), a, b, c);
+PRELOADDEF(return, int, pthread_setname_np, (pthread_t a, const char *b), a, b);
+PRELOADDEF(return, int, pthread_setaffinity_np, (pthread_t a, size_t b, const cpu_set_t *c), a, b, c);
+PRELOADDEF(return, int, pthread_getaffinity_np, (pthread_t a, size_t b, cpu_set_t *c), a, b, c);
 
 /* concurrency */
 
@@ -237,11 +250,20 @@ PRELOADDEF(return, int, pthread_setcanceltype, (int a, int *b), a, b);
 
 PRELOADDEF(return, int, pthread_setschedparam, (pthread_t a, int b, const struct sched_param *c), a, b, c);
 PRELOADDEF(return, int, pthread_getschedparam, (pthread_t a, int *b, struct sched_param *c), a, b, c);
+PRELOADDEF(return, int, pthread_setschedprio, (pthread_t a, int b), a, b);
 
 /* pthread cleanup */
+/* the commented out PRELOADDEFs here are macros, so cannot be interposed */
 
 //PRELOADDEF(      , void, pthread_cleanup_push, (void (*a)(void *), void *b), a, b);
+PRELOADDEF(      , void, __pthread_register_cancel, (__pthread_unwind_buf_t *a), a);
 //PRELOADDEF(      , void, pthread_cleanup_pop, (int a), a, b);
+PRELOADDEF(      , void, __pthread_unregister_cancel, (__pthread_unwind_buf_t *a), a);
+//PRELOADDEF(      , void, pthread_cleanup_push_defer_np, (void (*a)(void *), void *b), a, b);
+PRELOADDEF(      , void, __pthread_register_cancel_defer, (__pthread_unwind_buf_t *a), a);
+//PRELOADDEF(      , void, pthread_cleanup_pop_restore_np, (int a), a, b);
+PRELOADDEF(      , void, __pthread_unregister_cancel_restore, (__pthread_unwind_buf_t *a), a);
+PRELOADDEF(      , void, __pthread_unwind_next, (__pthread_unwind_buf_t *a), a);
 
 /* forking */
 
@@ -259,6 +281,10 @@ PRELOADDEF(return, int, pthread_mutexattr_setpshared, (pthread_mutexattr_t *a, i
 PRELOADDEF(return, int, pthread_mutexattr_getpshared, (const pthread_mutexattr_t *a, int *b), a, b);
 PRELOADDEF(return, int, pthread_mutexattr_settype, (pthread_mutexattr_t *a, int b), a, b);
 PRELOADDEF(return, int, pthread_mutexattr_gettype, (const pthread_mutexattr_t *a, int *b), a, b);
+PRELOADDEF(return, int, pthread_mutexattr_getrobust, (const pthread_mutexattr_t *a, int *b), a, b);
+PRELOADDEF(return, int, pthread_mutexattr_getrobust_np, (const pthread_mutexattr_t *a, int *b), a, b);
+PRELOADDEF(return, int, pthread_mutexattr_setrobust, (pthread_mutexattr_t *a, int b), a, b);
+PRELOADDEF(return, int, pthread_mutexattr_setrobust_np, (pthread_mutexattr_t *a, int b), a, b);
 
 /* pthread mutex */
 
@@ -269,15 +295,20 @@ PRELOADDEF(return, int, pthread_mutex_getprioceiling, (const pthread_mutex_t *a,
 PRELOADDEF(return, int, pthread_mutex_lock, (pthread_mutex_t *a), a);
 PRELOADDEF(return, int, pthread_mutex_trylock, (pthread_mutex_t *a), a);
 PRELOADDEF(return, int, pthread_mutex_unlock, (pthread_mutex_t *a), a);
+PRELOADDEF(return, int, pthread_mutex_timedlock, (pthread_mutex_t *a, const struct timespec *b), a, b);
+PRELOADDEF(return, int, pthread_mutex_consistent, (pthread_mutex_t *a), a);
+PRELOADDEF(return, int, pthread_mutex_consistent_np, (pthread_mutex_t *a), a);
 
-/* pthread lock attributes */
+/* pthread read-write lock attributes */
 
 PRELOADDEF(return, int, pthread_rwlockattr_init, (pthread_rwlockattr_t *a), a);
 PRELOADDEF(return, int, pthread_rwlockattr_destroy, (pthread_rwlockattr_t *a), a);
 PRELOADDEF(return, int, pthread_rwlockattr_setpshared, (pthread_rwlockattr_t *a, int b), a, b);
 PRELOADDEF(return, int, pthread_rwlockattr_getpshared, (const pthread_rwlockattr_t *a, int *b), a, b);
+PRELOADDEF(return, int, pthread_rwlockattr_getkind_np, (const pthread_rwlockattr_t *a, int *b), a, b);
+PRELOADDEF(return, int, pthread_rwlockattr_setkind_np, (pthread_rwlockattr_t *a, int b), a, b);
 
-/* pthread locks */
+/* pthread read-write locks */
 
 PRELOADDEF(return, int, pthread_rwlock_init, (pthread_rwlock_t *a, const pthread_rwlockattr_t *b), a, b);
 PRELOADDEF(return, int, pthread_rwlock_destroy, (pthread_rwlock_t *a), a);
@@ -286,6 +317,29 @@ PRELOADDEF(return, int, pthread_rwlock_tryrdlock, (pthread_rwlock_t *a), a);
 PRELOADDEF(return, int, pthread_rwlock_wrlock, (pthread_rwlock_t *a), a);
 PRELOADDEF(return, int, pthread_rwlock_trywrlock, (pthread_rwlock_t *a), a);
 PRELOADDEF(return, int, pthread_rwlock_unlock, (pthread_rwlock_t *a), a);
+PRELOADDEF(return, int, pthread_rwlock_timedrdlock, (pthread_rwlock_t *a, const struct timespec *b), a, b);
+PRELOADDEF(return, int, pthread_rwlock_timedwrlock, (pthread_rwlock_t *a, const struct timespec *b), a, b);
+
+/* pthread spinlocks */
+
+PRELOADDEF(return, int, pthread_spin_init, (pthread_spinlock_t *a, int b), a, b);
+PRELOADDEF(return, int, pthread_spin_destroy, (pthread_spinlock_t *a), a);
+PRELOADDEF(return, int, pthread_spin_lock, (pthread_spinlock_t *a), a);
+PRELOADDEF(return, int, pthread_spin_trylock, (pthread_spinlock_t *a), a);
+PRELOADDEF(return, int, pthread_spin_unlock, (pthread_spinlock_t *a), a);
+
+/* pthread barrier attributes */
+
+PRELOADDEF(return, int, pthread_barrierattr_init, (pthread_barrierattr_t *a), a);
+PRELOADDEF(return, int, pthread_barrierattr_destroy, (pthread_barrierattr_t *a), a);
+PRELOADDEF(return, int, pthread_barrierattr_getpshared, (const pthread_barrierattr_t *a, int *b), a, b);
+PRELOADDEF(return, int, pthread_barrierattr_setpshared, (pthread_barrierattr_t *a, int b), a, b);
+
+/* pthread barriers */
+
+PRELOADDEF(return, int, pthread_barrier_init, (pthread_barrier_t *a, const pthread_barrierattr_t *b, unsigned int c), a, b, c);
+PRELOADDEF(return, int, pthread_barrier_destroy, (pthread_barrier_t *a), a);
+PRELOADDEF(return, int, pthread_barrier_wait, (pthread_barrier_t *a), a);
 
 /* pthread condition attributes */
 


### PR DESCRIPTION
The first commit makes a few minor bug fixes to my previous implementation of pthread_getattr_np.

The second commit adds all extern functions found in my system's /usr/include/pthread.h which weren't already implemented in Shadow, in the form of using a macro to generate a function definition for informing the user it isn't implemented. This should make identifying when these functions are used by plugins easier.