### PR TITLE
Add support for Debian testing

### DIFF
--- a/src/external/elf-loader/extract-system-config.py
+++ b/src/external/elf-loader/extract-system-config.py
@@ -181,6 +181,9 @@ def search_debug_file():
                     # debian 9
                     find_build_id('/lib/x86_64-linux-gnu/ld-2.24.so'),
                     find_build_id('/lib/i386-linux-gnu/ld-2.24.so'),
+                    # debian 10 (testing)
+                    find_build_id('/lib/x86_64-linux-gnu/ld-2.26.so'),
+                    find_build_id('/lib/i386-linux-gnu/ld-2.26.so'),
                     # solus - link points to latest version of ld
                     find_build_id('/usr/lib/ld-linux-x86-64.so.2'),
                     ]


### PR DESCRIPTION
I'm moving to using Shadow on my workstation, which is running Debian testing. I don't know if it makes sense to include this patch into Shadow itself as the ld version will probably change before Debian testing becomes the next stable.

Maybe it would make more sense to start matching on a glob here instead of matching on specific versions for the different distributions?