### PR TITLE
minor elf-loader changes

### DIFF
--- a/src/external/elf-loader/extract-system-config.py
+++ b/src/external/elf-loader/extract-system-config.py
@@ -5,24 +5,6 @@ import re
 import getopt
 import os
 
-
-def find_build_id(path):
-    if os.path.exists(path):
-        file = os.popen('readelf -n {}'.format(path), 'r')
-        lines = file.readlines()
-        regex = re.compile(r'^    Build ID: (\w+)$')
-
-        for line in lines:
-            result = regex.search(line)
-
-            if not result:
-                continue
-
-            h = result.group(1)
-            return "/usr/lib/debug/.build-id/{}/{}.debug".format(h[0:2], h[2:])
-
-    return None
-
 class Data:
     def __init__(self, data):
         self.data = data
@@ -145,55 +127,65 @@ class DebugData:
 class CouldNotFindFile:
     pass
 
+
+def find_build_id(path):
+    if not os.path.exists(path):
+        return None
+    file = os.popen('readelf -n {}'.format(path), 'r')
+    lines = file.readlines()
+    regex = re.compile(r'^    Build ID: (\w+)$')
+    for line in lines:
+        result = regex.search(line)
+        if result:
+            h = result.group(1)
+            return "/usr/lib/debug/.build-id/{}/{}.debug".format(h[0:2], h[2:])
+    return None
+
+def check_file_regex(directory, file_regex):
+    if not os.path.exists(directory):
+        return None
+    lines = os.listdir(directory)
+    regex = re.compile(file_regex)
+    for line in lines:
+        result = regex.search(line)
+        if result:
+            return directory + result.group()
+    return None
+
 def search_debug_file():
-    files_to_try = ['/usr/lib64/debug/lib64/ld-2.11.2.so.debug',
-                    '/usr/lib/debug/lib64/ld-linux-x86-64.so.2.debug',
-                    '/usr/lib/debug/ld-linux-x86-64.so.2',
-                    '/usr/lib/debug/lib/ld-linux.so.2.debug',
-                    '/usr/lib/debug/ld-linux.so.2',
-                    # ubuntu 1104/1110
-                    '/usr/lib/debug/lib/i386-linux-gnu/ld-2.13.so',
-                    '/usr/lib/debug/lib/x86_64-linux-gnu/ld-2.13.so',
-                    # for ubuntu 0910. braindead
-                    '/usr/lib/debug/lib/ld-2.10.1.so',
-                    # for ubuntu 1004.
-                    '/usr/lib/debug/lib/ld-2.11.1.so',
-                    # for ubuntu 1010.
-                    '/usr/lib/debug/lib/ld-2.12.1.so',
-                    # ubuntu 1204
-                    '/usr/lib/debug/lib/x86_64-linux-gnu/ld-2.15.so',
-                    '/usr/lib/debug/lib/i386-linux-gnu/ld-2.15.so',
-                    # ubuntu 1304
-                    '/usr/lib/debug/lib/x86_64-linux-gnu/ld-2.17.so',
-                    '/usr/lib/debug/lib/i386-linux-gnu/ld-2.17.so',
-                    # ubuntu 1404
-                    '/usr/lib/debug/lib/x86_64-linux-gnu/ld-2.19.so',
-                    '/usr/lib/debug/lib/i386-linux-gnu/ld-2.19.so',
-                    # ubuntu 1604
-                    '/usr/lib/debug/lib/x86_64-linux-gnu/ld-2.23.so',
-                    '/usr/lib/debug/lib/i386-linux-gnu/ld-2.23.so',
-                    # ubuntu 1610
-                    '/usr/lib/debug/lib/x86_64-linux-gnu/ld-2.24.so',
-                    '/usr/lib/debug/lib/i386-linux-gnu/ld-2.24.so',
-                    # ubuntu 1710
-                    '/usr/lib/debug/lib/x86_64-linux-gnu/ld-2.26.so',
-                    '/usr/lib/debug/lib/i386-linux-gnu/ld-2.26.so',
-                    # debian 9
-                    find_build_id('/lib/x86_64-linux-gnu/ld-2.24.so'),
-                    find_build_id('/lib/i386-linux-gnu/ld-2.24.so'),
-                    # debian 10 (testing)
-                    find_build_id('/lib/x86_64-linux-gnu/ld-2.26.so'),
-                    find_build_id('/lib/i386-linux-gnu/ld-2.26.so'),
-                    # solus - link points to latest version of ld
-                    find_build_id('/usr/lib/ld-linux-x86-64.so.2'),
-                    ]
-    for file in files_to_try:
+    debug_files = [ ('/usr/lib64/debug/lib64/', r'ld-[0-9.]+\.so.debug'),
+                    ('/usr/lib/debug/lib64/', r'ld-linux-x86-64\.so\.2\.debug'),
+                    ('/usr/lib/debug/', r'ld-linux-x86-64\.so\.2'),
+                    ('/usr/lib/debug/lib/', r'ld-linux\.so\.2\.debug'),
+                    ('/usr/lib/debug/', r'ld-linux\.so\.2'),
+                    # ubuntu 09.10-10.10
+                    ('/usr/lib/debug/lib/', r'ld-[0-9.]+\.so'),
+                    # ubuntu 11.04/11.10
+                    ('/usr/lib/debug/lib/i386-linux-gnu/', r'ld-[0-9.]+\.so'),
+                    ('/usr/lib/debug/lib/x86_64-linux-gnu/', r'ld-[0-9.]+\.so'),
+                    # ubuntu >12.04
+                    ('/usr/lib/debug/lib/x86_64-linux-gnu/', r'ld-[0-9.]+\.so'),
+                    ('/usr/lib/debug/lib/i386-linux-gnu/', r'ld-[0-9.]+\.so'),
+                  ]
+    build_ids = [ # debian
+                  ('/lib/x86_64-linux-gnu/', r'ld-[0-9.]+\.so'),
+                  ('/lib/i386-linux-gnu/', r'ld-[0-9.]+\.so'),
+                  # solus
+                  ('/usr/lib/', r'ld-linux-x86-64\.so\.2'),
+                ]
+    for file_tuple in debug_files:
+        file = check_file_regex(file_tuple[0], file_tuple[1])
         if not file:
             continue
-
         if os.path.isfile (file):
             return file
-
+    for file_tuple in build_ids:
+        library = check_file_regex(file_tuple[0], file_tuple[1])
+        file = find_build_id(library)
+        if not file:
+            continue
+        if os.path.isfile (file):
+            return file
     raise CouldNotFindFile ()
 
 def list_lib_path():

--- a/src/external/elf-loader/vdl-tls.c
+++ b/src/external/elf-loader/vdl-tls.c
@@ -215,8 +215,7 @@ vdl_tls_tcb_allocate (void)
 void
 vdl_tls_tcb_initialize (unsigned long tcb, unsigned long sysinfo)
 {
-  vdl_memcpy ((void *) (tcb + CONFIG_TCB_SYSINFO_OFFSET), &sysinfo,
-              sizeof (sysinfo));
+  *(unsigned long *)(tcb + CONFIG_TCB_SYSINFO_OFFSET) = sysinfo;
 }
 
 // The dtv_t structure needs to be compatible with the one used by the
@@ -302,15 +301,13 @@ typedef union shadowdtv
 static inline dtv_t *
 get_current_dtv (unsigned long tp)
 {
-  dtv_t *dtv;
-  vdl_memcpy (&dtv, (void *) (tp + CONFIG_TCB_DTV_OFFSET), sizeof (dtv));
-  return dtv;
+  return *(dtv_t **) (tp + CONFIG_TCB_DTV_OFFSET);
 }
 
 static inline void
 set_current_dtv (unsigned long tp, dtv_t *dtv)
 {
-  vdl_memcpy ((void *) (tp + CONFIG_TCB_DTV_OFFSET), &dtv, sizeof (dtv));
+  *(dtv_t **) (tp + CONFIG_TCB_DTV_OFFSET) = dtv;
 }
 
 void


### PR DESCRIPTION
The first commit 17817c1  switches to using regex to find ld.so debug files, which fixes #408 (I opted for regex over globs to be a bit stricter in what we match).

The second commit b40578a fixes what should be a minor performance problem (some code we inherited used memcpy when it could have just used assignment), but on closer inspection might be a non-trivial boost since it occurs in some of the most frequently used elf-loader code (outside of dynamic loading), is code that is often called from within a global lock, and this should allow for more significant compiler optimizations. I would have to do some measurements to say for sure though, and I don't think it will be *that* significant.

I was going to add a commit to fix a very minor memory leak as well, but since it involves switching out a linked list for a hash table and I don't have enough time today to give it enough testing to feel comfortable committing just yet, I'll hold off on that for now.