### PR TITLE
use /usr/bin/env in scripts

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -36,7 +36,7 @@ add_subdirectory(timerfd)
 ## For now, we just check the first 20 results so that some checking is in place.
 add_test(
 	NAME shadow-leakcheck-grep
-	COMMAND /usr/bin/bash ${CMAKE_SOURCE_DIR}/src/test/leakcheck.sh
+	COMMAND /usr/bin/env bash ${CMAKE_SOURCE_DIR}/src/test/leakcheck.sh
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 set_tests_properties(shadow-leakcheck-grep PROPERTIES DEPENDS "determinism1-shadow;determinism2-shadow;dynlink-shadow;preload-shadow-dl-run;preload-shadow-dl-env;bind-shadow;cpp-shadow;determinism-shadow-compare;epoll-shadow;epoll-writeable-shadow;epoll-shadow;file-shadow;phold-shadow;phold-threaded-shadow;pthreads-shadow;random-shadow;signal-shadow;sleep-shadow;sockbuf-shadow;tcp-blocking-loopback-shadow;tcp-blocking-lossless-shadow;tcp-blocking-lossy-shadow;tcp-nonblocking-poll-lossy-shadow;tcp-nonblocking-poll-lossless-shadow;tcp-nonblocking-poll-loopback-shadow;tcp-nonblocking-epoll-lossless-shadow;tcp-nonblocking-epoll-loopback-shadow;tcp-nonblocking-epoll-lossy-shadow;tcp-nonblocking-epoll-lossy-shadow;tcp-nonblocking-select-lossless-shadow;tcp-nonblocking-select-lossy-shadow;tcp-nonblocking-select-loopback-shadow;timerfd-shadow;tcp-iov-shadow")

--- a/src/test/leakcheck.sh
+++ b/src/test/leakcheck.sh
@@ -1,1 +1,1 @@
-/usr/bin/grep "ObjectCounter: counter diffs:" ../../Testing/Temporary/LastTest.log.tmp | head -n 20 | /usr/bin/cut -d' ' -f8- > leakcheck.log
+/usr/bin/env grep "ObjectCounter: counter diffs:" ../../Testing/Temporary/LastTest.log.tmp | head -n 20 | /usr/bin/env cut -d' ' -f8- > leakcheck.log


### PR DESCRIPTION
Some distros, e.g. Ubuntu, don't put crucial executables like bash in /usr/bin.