### PR TITLE
fix minor memory leak in elf-loader garbage collector

### DIFF
--- a/src/external/elf-loader/vdl-list.c
+++ b/src/external/elf-loader/vdl-list.c
@@ -445,6 +445,22 @@ vdl_list_sort (struct VdlList *list,
 }
 
 void
+vdl_list_sorted_insert (struct VdlList *list, void *value)
+{
+  write_lock (list->lock);
+  struct VdlListItem *i = list->head.next;
+  while (value < i->data && i != &list->tail)
+    {
+      i = i->next;
+    }
+  if (value != i->data)
+    {
+      vdl_list_insert_internal (list, i, value);
+    }
+  write_unlock (list->lock);
+}
+
+void
 vdl_list_unique (struct VdlList *list)
 {
   write_lock (list->lock);

--- a/src/external/elf-loader/vdl-list.h
+++ b/src/external/elf-loader/vdl-list.h
@@ -68,6 +68,7 @@ void vdl_list_sort (struct VdlList *list,
                     // true if a < b, false otherwise
                     bool (*is_strictly_lower) (void *a, void *b, void *context),
                     void *context);
+void vdl_list_sorted_insert (struct VdlList *list, void *value);
 void vdl_list_unique (struct VdlList *list);
 
 // Contrary to the std::list::unique method, this function

--- a/src/external/elf-loader/vdl-lookup.c
+++ b/src/external/elf-loader/vdl-lookup.c
@@ -464,7 +464,7 @@ vdl_lookup_in_file (void **data, void *aux)
           if (item != args->file && args->file != 0)
             {
               // The symbol has been resolved in another binary. Make note of this.
-              vdl_list_push_front (args->file->gc_symbols_resolved_in, item);
+              vdl_list_sorted_insert (args->file->gc_symbols_resolved_in, item);
             }
           struct VdlLookupResult *result = vdl_alloc_new (struct VdlLookupResult);
           result->file = item;
@@ -510,7 +510,7 @@ vdl_lookup_in_file (void **data, void *aux)
   if (final_item != args->file && args->file != 0)
     {
       // The symbol has been resolved in another binary. Make note of this.
-      vdl_list_push_front (args->file->gc_symbols_resolved_in, final_item);
+      vdl_list_sorted_insert (args->file->gc_symbols_resolved_in, final_item);
     }
   struct VdlLookupResult *result = vdl_alloc_new (struct VdlLookupResult);
   result->file = final_item;


### PR DESCRIPTION
This adds an operation which is linear in the number of files symbols are resolved from by a file, but my experiments with shadow-tor show this number never gets very large (<10 once the experiment is up and running).