### PR TITLE
various bug fixes

### DIFF
--- a/src/external/elf-loader/extract-system-config.py
+++ b/src/external/elf-loader/extract-system-config.py
@@ -181,6 +181,8 @@ def search_debug_file():
             return file
     for file_tuple in build_ids:
         library = check_file_regex(file_tuple[0], file_tuple[1])
+        if not library:
+            continue
         file = find_build_id(library)
         if not file:
             continue

--- a/src/external/elf-loader/vdl-hashmap.c
+++ b/src/external/elf-loader/vdl-hashmap.c
@@ -147,6 +147,8 @@ vdl_hashmap_insert (struct VdlHashMap *map, uint32_t hash, void *data)
       read_unlock (map->lock);
       struct VdlList *new_items = vdl_list_new ();
       write_lock (map->lock);
+      index = hash & (map->n_buckets - 1);
+      items = map->buckets[index];
       if (!items)
         {
           items = new_items;

--- a/src/external/elf-loader/vdl-list.c
+++ b/src/external/elf-loader/vdl-list.c
@@ -455,7 +455,7 @@ vdl_list_sorted_insert (struct VdlList *list, void *value)
     }
   if (value != i->data)
     {
-      vdl_list_insert_internal (list, i, value);
+      vdl_list_insert_internal (list, (void **) i, value);
     }
   write_unlock (list->lock);
 }

--- a/src/main/core/scheduler/shd-scheduler-policy-host-steal.c
+++ b/src/main/core/scheduler/shd-scheduler-policy-host-steal.c
@@ -323,12 +323,18 @@ static Event* _schedulerpolicyhoststeal_pop(SchedulerPolicy* policy, SimulationT
     HostStealThreadData* tdata = g_hash_table_lookup(data->threadToThreadDataMap, GUINT_TO_POINTER(pthread_self()));
     g_rw_lock_reader_unlock(&data->lock);
 
+    /* if there is no tdata, that means this thread didn't get any hosts assigned to it */
+    if(!tdata) {
+        /* this thread will remain idle */
+        return NULL;
+    }
+
     /* we only need to lock this thread's lock, since it's our own queue */
     g_timer_continue(tdata->popIdleTime);
     g_mutex_lock(&(tdata->lock));
     g_timer_stop(tdata->popIdleTime);
 
-    if(tdata != NULL && barrier > tdata->currentBarrier) {
+    if(barrier > tdata->currentBarrier) {
         tdata->currentBarrier = barrier;
 
         /* make sure all of the hosts that were processed last time get processed in the next round */

--- a/src/main/core/scheduler/shd-scheduler-policy.h
+++ b/src/main/core/scheduler/shd-scheduler-policy.h
@@ -49,6 +49,7 @@ struct _SchedulerPolicy {
 
 SchedulerPolicy* schedulerpolicyglobalsingle_new();
 SchedulerPolicy* schedulerpolicyhostsingle_new();
+SchedulerPolicy* schedulerpolicyhoststeal_new();
 SchedulerPolicy* schedulerpolicythreadsingle_new();
 SchedulerPolicy* schedulerpolicythreadperthread_new();
 SchedulerPolicy* schedulerpolicythreadperhost_new();

--- a/src/main/core/scheduler/shd-scheduler.c
+++ b/src/main/core/scheduler/shd-scheduler.c
@@ -135,7 +135,7 @@ Scheduler* scheduler_new(SchedulerPolicyType policyType, guint nWorkers, gpointe
             break;
         }
         case SP_PARALLEL_HOST_STEAL: {
-            scheduler->policy = schedulerpolicyhostsingle_new();
+            scheduler->policy = schedulerpolicyhoststeal_new();
             break;
         }
         case SP_PARALLEL_THREAD_SINGLE: {

--- a/src/main/host/shd-process.c
+++ b/src/main/host/shd-process.c
@@ -1371,7 +1371,7 @@ void process_migrate(Process* proc, gpointer threads) {
     struct ProcessMigrateArgs* ts = threads;
     if (!proc->lmid) {
         /* plugin hasn't been loaded into a namespace yet; nothing to do */
-        warning("can't migrate process before namespace is loaded");
+        info("can't migrate process before namespace is loaded");
         return;
     }
     if (!ts || !ts->t1 || !ts->t2) {


### PR DESCRIPTION
While working on getting shadow running on the new machine in CrySP, I've encountered various bugs. The most significant of these is that a typo was preventing the work-stealing scheduler from ever being used (when I was originally implementing/measuring it, my local shadow copy implemented it over the hostsingle policy). This also means the TLS swapping code hasn't been used with recent changes. I've done some pretty thorough testing on an Ubuntu 16.04 machine, as well as some testing on Ubuntu 17.10 and a Solus VM, so hopefully it doesn't introduce any new bugs, but you might want to test it before merging too.