### PR TITLE
logging improvements

### DIFF
--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -6,9 +6,7 @@ INCLUDE(ExternalProject)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(RPTH_DEBUG_SWITCH "--enable-debug=yes")
-    set(RPTH_OPT_SWITCH "--enable-optimize=no")
 else()
-    set(RPTH_DEBUG_SWITCH "--enable-debug=no")
     set(RPTH_OPT_SWITCH "--enable-optimize=yes")
 endif()
 

--- a/src/external/elf-loader/vdl-log.h
+++ b/src/external/elf-loader/vdl-log.h
@@ -4,6 +4,8 @@
 // for system_exit in VDL_LOG_ASSERT
 #include "system.h"
 
+extern uint32_t g_logging;
+
 enum VdlLog {
   VDL_LOG_FUNC     = (1<<0),
   VDL_LOG_DBG      = (1<<1),
@@ -15,7 +17,12 @@ enum VdlLog {
   VDL_LOG_PRINT    = (1<<7)
 };
 
-void vdl_log_printf (enum VdlLog log, const char *str, ...);
+void vdl_log_printf_func (const char *str, ...);
+
+#define vdl_log_printf(log, str, ...)           \
+  if (__builtin_expect(g_logging & log, 0))     \
+    vdl_log_printf_func(str, ##__VA_ARGS__)
+
 #ifdef DEBUG
 #define VDL_LOG_FUNCTION(str,...)                                       \
   vdl_log_printf (VDL_LOG_FUNC, "%s:%d, %s (" str ")\n",                \
@@ -44,7 +51,7 @@ void vdl_log_printf (enum VdlLog log, const char *str, ...);
   if (!(predicate))                                                     \
     {                                                                   \
       vdl_log_printf (VDL_LOG_AST, "%s:%d, %s, " str "\n",              \
-                      __FILE__, __LINE__, __FUNCTION__, ## __VA_ARGS__); \
+                      __FILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__); \
       {                                                                 \
         char *p = 0;                                                    \
         *p = 0;                                                         \

--- a/src/main/host/shd-process.c
+++ b/src/main/host/shd-process.c
@@ -301,7 +301,7 @@ static void _process_updateErrnoLocation(Process* proc) {
     gpointer symbol = dlsym(proc->plugin.handle, PLUGIN_ERRNOLOC_SYMBOL);
     if(symbol) {
         proc->plugin.errnoGetLocation = symbol;
-        message("found '%s' at %p", PLUGIN_ERRNOLOC_SYMBOL, symbol);
+        info("found '%s' at %p", PLUGIN_ERRNOLOC_SYMBOL, symbol);
 
         /* now that we just did the lookup, the errno location is no longer stale */
         proc->plugin.errnoGetLocationIsStale = FALSE;


### PR DESCRIPTION
This makes some minor improvements to a few points of logging:
 - elf-loader gets a lock on its logging function so that the output isn't a jumbled mess, and moves some of the logging into a macro so compiler optimizations can be more aggressive and branch prediction more accurate
 - rpth gets a fix to its debug option in the configure script, so that non-debug builds don't include the debug log macros
 - shadow gets the log message in _process_updateErrnoLocation moved from message to info, because
```
$ tail shadow.log -n 10000 | grep -vc "_process_updateErrnoLocation"
1876
```

This is a noticeable improvement on performance for tiny experiments (~30%), but probably insignificant for medium to large experiments (outside of file sizes).