### PR TITLE
handle soft dl(m)open failures gracefully

### DIFF
--- a/src/external/elf-loader/stage1.c
+++ b/src/external/elf-loader/stage1.c
@@ -126,6 +126,7 @@ global_initialize (unsigned long interpreter_load_base)
   vdl->readonly_cache = vdl_hashmap_new ();
   vdl->ro_cache_futex = futex_new ();
   vdl->shm_path = make_shm_name ();
+  vdl->gc_futex = futex_new ();
 }
 
 // relocate entries in DT_REL

--- a/src/external/elf-loader/vdl-dl.c
+++ b/src/external/elf-loader/vdl-dl.c
@@ -335,21 +335,22 @@ dlopen_with_context (struct VdlContext *context, const char *filename,
   return map.requested;
 
 error:
-  {
-    // we don't need to call_fini here because we have not yet
-    // called call_init.
-    struct VdlGcResult gc = vdl_gc_run ();
+  if (map.newly_mapped != 0)
+    {
+      // we don't need to call_fini here because we have not yet
+      // called call_init.
+      vdl_list_delete (map.newly_mapped);
+      struct VdlGcResult gc = vdl_gc_run ();
 
-    vdl_tls_file_deinitialize (gc.unload);
+      vdl_tls_file_deinitialize (gc.unload);
 
-    vdl_unmap (gc.unload, true);
+      vdl_unmap (gc.unload, true);
 
-    vdl_list_delete (gc.unload);
-    vdl_list_delete (gc.not_unload);
-
-    write_unlock (context->lock);
-    read_unlock (g_vdl.global_lock);
-  }
+      vdl_list_delete (gc.unload);
+      vdl_list_delete (gc.not_unload);
+    }
+  write_unlock (context->lock);
+  read_unlock (g_vdl.global_lock);
   return 0;
 }
 

--- a/src/external/elf-loader/vdl-gc.c
+++ b/src/external/elf-loader/vdl-gc.c
@@ -101,8 +101,9 @@ vdl_gc_white_list_new (struct VdlList *list)
 struct VdlGcResult
 vdl_gc_run (void)
 {
-  struct VdlList *global = vdl_linkmap_copy ();
   struct VdlList *unload = vdl_list_new ();
+  futex_lock (g_vdl.gc_futex);
+  struct VdlList *global = vdl_linkmap_copy ();
   struct VdlList *white = vdl_gc_white_list_new (global);
   while (!vdl_list_empty (white))
     {
@@ -123,6 +124,7 @@ vdl_gc_run (void)
       vdl_list_delete (white);
       white = vdl_gc_white_list_new (global);
     }
+  futex_unlock (g_vdl.gc_futex);
   vdl_list_delete (white);
   // copy global files left into not_unload list
   struct VdlGcResult result;

--- a/src/external/elf-loader/vdl-map.c
+++ b/src/external/elf-loader/vdl-map.c
@@ -1145,6 +1145,8 @@ vdl_map_from_filename (struct VdlContext *context, const char *filename)
     {
       result.error_string = single.error_string;
       vdl_list_delete (empty);
+      vdl_list_delete (result.newly_mapped);
+      result.newly_mapped = 0;
       return result;
     }
   if (single.newly_mapped)

--- a/src/external/elf-loader/vdl-map.h
+++ b/src/external/elf-loader/vdl-map.h
@@ -12,7 +12,8 @@ struct VdlMapResult
   // should be non-null if success, null otherwise.
   struct VdlFile *requested;
   // the list of files which were brought into memory
-  // by this map request. allocated by callee. caller must free.
+  // by this map request. allocated by callee. caller must free,
+  // unless null, which indicates nothing was mapped
   struct VdlList *newly_mapped;
   // if the mapping fails, a human-readable string
   // which indicates what went wrong.

--- a/src/external/elf-loader/vdl.h
+++ b/src/external/elf-loader/vdl.h
@@ -101,6 +101,8 @@ struct Vdl
   char* shm_path;
   // list of thread-local allocators for cleanup
   struct VdlList *allocators;
+  // the garbage collector spans multiple contexts, so needs a global futex
+  struct Futex *gc_futex;
 };
 
 extern struct Vdl g_vdl;


### PR DESCRIPTION
glibc or gcc has started inserting code that tests if an optional library is available by calling dlopen on it. We've been treating failing to find a requested library as a relatively untested failure case, which manifested as segfaults when doing this a lot in parallel.

This adds two commits to address this new use: abd3e16 fixes the underlying correctness bug by adding a futex to garbage collection, while c199c32 avoids needing to garbage collect at all when this particular case happens (since it will now apparently be very frequent).

Fixes #423 