### PR TITLE
Configure tgen's runtime behavior

### DIFF
--- a/src/plugin/shadow-plugin-tgen/CMakeLists.txt
+++ b/src/plugin/shadow-plugin-tgen/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 2.8.8 FATAL_ERROR)
 
 set(tgen_sources
     shd-tgen-action.c
+    shd-tgen-config.c
     shd-tgen-driver.c
     shd-tgen-generator.c
     shd-tgen-graph.c

--- a/src/plugin/shadow-plugin-tgen/shd-tgen-action.c
+++ b/src/plugin/shadow-plugin-tgen/shd-tgen-action.c
@@ -85,7 +85,7 @@ static GError* _tgenaction_handlePeer(const gchar* attributeName,
 
     /* dont add my own address to the server pool */
     char myname[128];
-    if (!gethostname(&myname[0], 128)
+    if (!tgenconfig_gethostname(&myname[0], 128)
             && !g_ascii_strcasecmp(myname, tokens[0])) {
         tgen_info("refusing to place my address in server pool for attribute '%s'", attributeName);
         return NULL;

--- a/src/plugin/shadow-plugin-tgen/shd-tgen-config.c
+++ b/src/plugin/shadow-plugin-tgen/shd-tgen-config.c
@@ -1,0 +1,14 @@
+#include "shd-tgen.h"
+
+gint tgenconfig_gethostname(gchar* name, size_t len) {
+    gchar* tgenip = getenv("TGENHOSTNAME");
+    if (tgenip != NULL) {
+        return -(g_snprintf(name, len, "%s", tgenip) < 0);
+    } else {
+        return gethostname(name, len);
+    }
+}
+
+gchar* tgenconfig_getIP() {
+    return getenv("TGENIP");
+}

--- a/src/plugin/shadow-plugin-tgen/shd-tgen-config.h
+++ b/src/plugin/shadow-plugin-tgen/shd-tgen-config.h
@@ -1,0 +1,7 @@
+#ifndef SHD_TGEN_CONFIG_H_
+#define SHD_TGEN_CONFIG_H_
+
+gint tgenconfig_gethostname(gchar* name, size_t len);
+gchar* tgenconfig_getIP();
+
+#endif /* SHD_TGEN_CONFIG_H_ */

--- a/src/plugin/shadow-plugin-tgen/shd-tgen-driver.c
+++ b/src/plugin/shadow-plugin-tgen/shd-tgen-driver.c
@@ -638,7 +638,7 @@ void tgendriver_unref(TGenDriver* driver) {
 //static gchar* _tgendriver_makeTempFile() {
 //    gchar nameBuffer[256];
 //    memset(nameBuffer, 0, 256);
-//    gethostname(nameBuffer, 255);
+//    tgenconfig_gethostname(nameBuffer, 255);
 //
 //    GString* templateBuffer = g_string_new("XXXXXX-shadow-tgen-");
 //    g_string_append_printf(templateBuffer, "%s.xml", nameBuffer);

--- a/src/plugin/shadow-plugin-tgen/shd-tgen-main.c
+++ b/src/plugin/shadow-plugin-tgen/shd-tgen-main.c
@@ -77,7 +77,7 @@ static gint _tgenmain_run(gint argc, gchar *argv[]) {
     /* get our hostname for logging */
     gchar hostname[128];
     memset(hostname, 0, 128);
-    gethostname(hostname, 128);
+    tgenconfig_gethostname(hostname, 128);
 
     /* default to message level log until we read config */
     tgen_message("Initializing traffic generator on host %s process id %i", hostname, (gint)getpid());

--- a/src/plugin/shadow-plugin-tgen/shd-tgen-server.c
+++ b/src/plugin/shadow-plugin-tgen/shd-tgen-server.c
@@ -108,7 +108,12 @@ TGenServer* tgenserver_new(in_port_t serverPort, TGenServer_notifyNewPeerFunc no
     struct sockaddr_in listener;
     memset(&listener, 0, sizeof(struct sockaddr_in));
     listener.sin_family = AF_INET;
-    listener.sin_addr.s_addr = htonl(INADDR_ANY);
+    char* tgenip = getenv("TGENIP");
+    if (tgenip != NULL) {
+        listener.sin_addr.s_addr = inet_addr(tgenip);
+    } else {
+        listener.sin_addr.s_addr = htonl(INADDR_ANY);
+    }
     listener.sin_port = serverPort;
 
     /* bind the socket to the server port */

--- a/src/plugin/shadow-plugin-tgen/shd-tgen-server.c
+++ b/src/plugin/shadow-plugin-tgen/shd-tgen-server.c
@@ -108,7 +108,7 @@ TGenServer* tgenserver_new(in_port_t serverPort, TGenServer_notifyNewPeerFunc no
     struct sockaddr_in listener;
     memset(&listener, 0, sizeof(struct sockaddr_in));
     listener.sin_family = AF_INET;
-    char* tgenip = getenv("TGENIP");
+    gchar* tgenip = tgenconfig_getIP();
     if (tgenip != NULL) {
         listener.sin_addr.s_addr = inet_addr(tgenip);
     } else {

--- a/src/plugin/shadow-plugin-tgen/shd-tgen-transfer.c
+++ b/src/plugin/shadow-plugin-tgen/shd-tgen-transfer.c
@@ -1695,7 +1695,7 @@ TGenTransfer* tgentransfer_new(const gchar* idStr, gsize count, TGenTransferType
 
     gchar nameBuffer[256];
     memset(nameBuffer, 0, 256);
-    transfer->hostname = (0 == gethostname(nameBuffer, 255)) ? g_strdup(nameBuffer) : NULL;
+    transfer->hostname = (0 == tgenconfig_gethostname(nameBuffer, 255)) ? g_strdup(nameBuffer) : NULL;
 
     if(type != TGEN_TYPE_NONE) {
         transfer->isCommander = TRUE;

--- a/src/plugin/shadow-plugin-tgen/shd-tgen-transport.c
+++ b/src/plugin/shadow-plugin-tgen/shd-tgen-transport.c
@@ -282,7 +282,7 @@ TGenTransport* tgentransport_newActive(TGenPeer* proxy, gchar* username, gchar* 
         return NULL;
     }
 
-    char* tgenip = getenv("TGENIP");
+    gchar* tgenip = tgenconfig_getIP();
     /* bind()'ing here is only neccessary if we specify our IP */
     if (tgenip != NULL) {
         struct sockaddr_in localaddr;

--- a/src/plugin/shadow-plugin-tgen/shd-tgen-transport.c
+++ b/src/plugin/shadow-plugin-tgen/shd-tgen-transport.c
@@ -282,6 +282,24 @@ TGenTransport* tgentransport_newActive(TGenPeer* proxy, gchar* username, gchar* 
         return NULL;
     }
 
+    char* tgenip = getenv("TGENIP");
+    /* bind()'ing here is only neccessary if we specify our IP */
+    if (tgenip != NULL) {
+        struct sockaddr_in localaddr;
+        memset(&localaddr, 0, sizeof(localaddr));
+        localaddr.sin_family = AF_INET;
+        localaddr.sin_addr.s_addr = inet_addr(tgenip);
+        localaddr.sin_port = 0;
+        gint result = bind(socketD, (struct sockaddr *) &localaddr, sizeof(localaddr));
+
+        if (result < 0) {
+            tgen_critical("bind(): socket %i returned %i error %i: %s",
+                    socketD, result, errno, g_strerror(errno));
+            close(socketD);
+            return NULL;
+        }
+    }
+
     /* connect to another host */
     struct sockaddr_in master;
     memset(&master, 0, sizeof(master));

--- a/src/plugin/shadow-plugin-tgen/shd-tgen.h
+++ b/src/plugin/shadow-plugin-tgen/shd-tgen.h
@@ -50,5 +50,6 @@ extern TGenLogFunc tgenLogFunc;
 #include "shd-tgen-generator.h"
 #include "shd-tgen-graph.h"
 #include "shd-tgen-driver.h"
+#include "shd-tgen-config.h"
 
 #endif /* SHD_TGEN_H_ */


### PR DESCRIPTION
These commits add some instance-specific configuration options that are useful in some non-Shadow contexts -- most notably, in NetMirage.

The first commit allows tgen to bind to a specific IP, set via the `TGENIP` environment variable.

The second commit allows tgen to use a specific hostname, set via the `TGENHOSTNAME` environment variable, and also creates new files `shd-tgen-config.c/h`, with the intention that they will be used for these and all future (non-graphml) configurations of tgen. The idea being, if at some point we switch environment variables to command line options, or move parameters from the config file to the invocation, there's an obvious place to do it.

I can change the names of any of these files or environment variables to something else, of course.