### PR TITLE
fix endianness issues when creating pcaps

### DIFF
--- a/src/main/host/shd-network-interface.c
+++ b/src/main/host/shd-network-interface.c
@@ -252,9 +252,9 @@ static void _networkinterface_capturePacket(NetworkInterface* interface, Packet*
     if(tcpHeader->flags & PTCP_FIN) pcapPacket->finFlag = TRUE;
 
     pcapPacket->seq = (guint32)tcpHeader->sequence;
-    pcapPacket->win = (guint32)tcpHeader->window;
+    pcapPacket->win = (guint16)tcpHeader->window;
     if(tcpHeader->flags & PTCP_ACK) {
-        pcapPacket->ack = (guint32)htonl(tcpHeader->acknowledgment);
+        pcapPacket->ack = (guint32)tcpHeader->acknowledgment;
     }
 
     pcapwriter_writePacket(interface->pcap, pcapPacket);

--- a/src/main/utility/shd-pcap-writer.c
+++ b/src/main/utility/shd-pcap-writer.c
@@ -98,7 +98,7 @@ void pcapwriter_writePacket(PCapWriter* pcap, PCapPacket* packet) {
     /* write the TCP header */
     guint16 sourcePort = packet->srcPort;
     guint16 destinationPort = packet->dstPort;
-    guint32 sequence = packet->seq;
+    guint32 sequence = htonl(packet->seq);
     guint32 acknowledgement = 0;
     if(packet->ackFlag) {
         acknowledgement = htonl(packet->ack);
@@ -109,7 +109,7 @@ void pcapwriter_writePacket(PCapWriter* pcap, PCapPacket* packet) {
     if(packet->synFlag) tcpFlags |= 0x02;
     if(packet->ackFlag) tcpFlags |= 0x10;
     if(packet->finFlag) tcpFlags |= 0x01;
-    guint16 window = (guint16)packet->win;
+    guint16 window = htons(packet->win);
     guint16 tcpChecksum = 0x0000;
     guint8 options[14] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 

--- a/src/main/utility/shd-pcap-writer.h
+++ b/src/main/utility/shd-pcap-writer.h
@@ -38,7 +38,7 @@ struct _PCapPacket {
     gboolean finFlag;
     guint32 seq;
     guint32 ack;
-    guint32 win;
+    guint16 win;
     guint headerSize;
     guint payloadLength;
     gpointer payload;


### PR DESCRIPTION
This doesn't fix Wireshark assuming the sequence numbers are bytes (instead of packet counts), but it at least makes the numbers correct.

For reference, IIRC Shadow uses full ints for window size, but this code casts to 16 bits because the pcap format assumes these are actual TCP packets. There may be a way to fake window scaling into this code, but it would be a little tricky and not actually reflective of the exact window size anyway.