### PR TITLE
Add return statement to operator overload

### DIFF
--- a/src/main/host/descriptor/shd-tcp-retransmit-tally.cc
+++ b/src/main/host/descriptor/shd-tcp-retransmit-tally.cc
@@ -294,6 +294,7 @@ RetransmitTally &RetransmitTally::operator=(RetransmitTally &&rhs) {
    sacked_ = std::move(rhs.sacked_);
    retransmitted_ = std::move(rhs.retransmitted_);
    lost_ = std::move(rhs.lost_);
+   return *this;
 }
 
 void RetransmitTally::compute_lost() {


### PR DESCRIPTION
The method has a reference to its class as return type, but does not actually
have a return statement. This has resulted in null-dereferences and segfaults
on Kali-Linux. This fix appears to resolve #699. The number of failed tests
has gone from 18 to 20 to only 1 and the functional tests exits successfully.