### PR TITLE
Fix to TCP RetransmitTally initialization

### DIFF
--- a/src/main/host/descriptor/shd-tcp-retransmit-tally.cc
+++ b/src/main/host/descriptor/shd-tcp-retransmit-tally.cc
@@ -22,13 +22,13 @@ static bool still_sorted_(const Ranges &r) {
 }
 
 static RetransmitTally *cast_and_assert(void *p) {
-   auto *rt = reinterpret_cast<RetransmitTally *>(p);
+   auto *rt = static_cast<RetransmitTally *>(p);
    assert(rt->magic_num_ == RetransmitTally::kMagicNum);
    return rt;
 }
 
 static const RetransmitTally *cast_and_assert(const void *p) {
-   auto *rt = reinterpret_cast<const RetransmitTally *>(p);
+   auto *rt = static_cast<const RetransmitTally *>(p);
    assert(rt->magic_num_ == RetransmitTally::kMagicNum);
    return rt;
 }
@@ -167,14 +167,13 @@ static Ranges ranges_subtract(const Ranges &lhs, const Ranges &rhs) {
 
 extern "C" {
 
-void retransmit_tally_init(void *p) {
-   std::fill_n(reinterpret_cast<std::uint8_t *>(p), sizeof(RetransmitTally), 0);
-   auto *rt = reinterpret_cast<RetransmitTally *>(p);
-   *rt = RetransmitTally{};
+void retransmit_tally_init(void **p) {
+   *p = new RetransmitTally{};
 }
 
 void retransmit_tally_destroy(void *p) {
-   auto *rt [[ gnu::unused ]] = cast_and_assert(p);
+   auto *rt = cast_and_assert(p);
+   delete rt;
 }
 
 size_t retransmit_tally_size_bytes() {

--- a/src/main/host/descriptor/shd-tcp-retransmit-tally.h
+++ b/src/main/host/descriptor/shd-tcp-retransmit-tally.h
@@ -27,7 +27,7 @@ enum TCPProcessFlags_ {
 extern "C" {
 #endif // __cplusplus
 
-void retransmit_tally_init(void *p);
+void retransmit_tally_init(void **p);
 void retransmit_tally_destroy(void *p);
 
 size_t retransmit_tally_size_bytes();

--- a/src/main/host/descriptor/shd-tcp.c
+++ b/src/main/host/descriptor/shd-tcp.c
@@ -2252,7 +2252,6 @@ void tcp_free(TCP* tcp) {
     tcpCongestion_free(tcp->congestion);
 
     retransmit_tally_destroy(tcp->retransmit.tally);
-    free(tcp->retransmit.tally);
 
     MAGIC_CLEAR(tcp);
     g_free(tcp);
@@ -2417,9 +2416,7 @@ TCP* tcp_new(gint handle, guint receiveBufferSize, guint sendBufferSize) {
     tcp->retransmit.queue =
             g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, (GDestroyNotify)packet_unref);
 
-    tcp->retransmit.tally = malloc(retransmit_tally_size_bytes());
-    assert(tcp->retransmit.tally != NULL);
-    retransmit_tally_init(tcp->retransmit.tally);
+    retransmit_tally_init(&tcp->retransmit.tally);
 
     tcp->retransmit.scheduledTimerExpirations =
             priorityqueue_new((GCompareDataFunc)utility_simulationTimeCompare, NULL, g_free);


### PR DESCRIPTION
Before this commit, the TCP retransmit tally was being constructed as follows--

        1. We mallocate sizeof(RetransmitTally)
        2. We pass a pointer of the allocated memory to the init function
        3. The init function zeroes the memory, constructs a new
           RetransmitTally on the stack, and then copy-assigns the
           stack-allocated RT to the zero'ed one of the heap.

I believe this behavior was causing issues for certain compiler
(probably due to undefined behavior, or maybe because the
copy-assignment operator wasn't implemented correctly).

The new init code takes a **RetransmitTally and will allocate and
initialize one directly using operator new.

Patch was tested and does not cause any additional test cases to fail.