### PR TITLE
Add automated testing with GitHub Actions:

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -5,9 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7]  # 3.8]
+        python-version: [2.7]  # , 3.8]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@master
+        with:
+          python-version: ${{ matrix.python-version }}
       - run: pip install flake8
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -3,6 +3,9 @@ on: [push, pull_request]
 jobs:
   lint_python:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7]  # 3.8]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@master

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,10 @@
+name: lint_python
+on: [push, pull_request]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+      - run: pip install flake8
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
Like #696 but running on GitHub's builtin https://github.com/shadow/shadow/actions

Let's use flake8 to find bug before our users do...

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.