### PR TITLE
Undefined name: 'e' --> Exception

### DIFF
--- a/src/external/elf-loader/test/run-valgrind.py
+++ b/src/external/elf-loader/test/run-valgrind.py
@@ -7,7 +7,7 @@ try:
     version = subprocess.Popen (['valgrind', '--version'],
                                 stdout = subprocess.PIPE,
                                 stderr = subprocess.PIPE)
-except e:
+except Exception:
     sys.exit(1)
 
 ver_re = re.compile('([0-9]+)\.([0-9]+)\.([0-9]+)')


### PR DESCRIPTION
`e` is an undefined name in this context so a NameError will always be raised instead of the actual exception.

Discovered by #704