### PR TITLE
Use dynamic port assignment for server ports in tests.

### DIFF
--- a/src/test/shd-test-common.h
+++ b/src/test/shd-test-common.h
@@ -9,9 +9,9 @@
 #include <netdb.h>
 
 /* calls common_setup_tcp_sockets and common_connect_tcp_sockets in sequence */
-int common_get_connected_tcp_sockets(in_port_t server_listener_port, int* server_listener_fd_out, int* server_fd_out, int* client_fd_out);
+int common_get_connected_tcp_sockets(int* server_listener_fd_out, int* server_fd_out, int* client_fd_out);
 
-int common_setup_tcp_sockets(int* server_listener_fd_out, int* client_fd_out, in_port_t server_listener_port);
+int common_setup_tcp_sockets(int* server_listener_fd_out, int* client_fd_out, in_port_t* server_listener_port_out);
 int common_connect_tcp_sockets(int server_listener_fd, int client_fd, int* server_fd_out, in_port_t server_listener_port);
 
 #endif /* SRC_TEST_SHD_TEST_COMMON_H_ */

--- a/src/test/shutdown/shd-test-shutdown.c
+++ b/src/test/shutdown/shd-test-shutdown.c
@@ -13,11 +13,12 @@
 
 #include <../shd-test-common.h>
 
-static int _test_shutdown_tcp(int call_connect, in_port_t server_port, int shut_client, int how) {
+static int _test_shutdown_tcp(int call_connect, int shut_client, int how) {
     int sd = 0, cd = 0, sd_child = 0;
+    in_port_t server_port = 0;
     int retval = EXIT_FAILURE;
 
-    if(common_setup_tcp_sockets(&sd, &cd, server_port) < 0) {
+    if(common_setup_tcp_sockets(&sd, &cd, &server_port) < 0) {
         goto fail;
     }
 
@@ -50,22 +51,21 @@ fail:
 static int _test_tcp_shutdown_before_connect(){
     printf("########## running _test_tcp_shutdown_before_connect\n");
 
-    int portctr = 30550;
     int result = 0;
 
-    result = _test_shutdown_tcp(0, (in_port_t)htons(portctr++), 1, SHUT_RDWR);
+    result = _test_shutdown_tcp(0, 1, SHUT_RDWR);
     if(result != ENOTCONN) {
         printf("Expecting shutdown(SHUT_RDWR) on unconnected socket to return ENOTCONN instead of %i\n", result);
         return EXIT_FAILURE;
     }
 
-    result = _test_shutdown_tcp(0, (in_port_t)htons(portctr++), 1, SHUT_RD);
+    result = _test_shutdown_tcp(0, 1, SHUT_RD);
     if(result != ENOTCONN) {
         printf("Expecting shutdown(SHUT_RD) on unconnected socket to return ENOTCONN instead of %i\n", result);
         return EXIT_FAILURE;
     }
 
-    result = _test_shutdown_tcp(0, (in_port_t)htons(portctr++), 1, SHUT_WR);
+    result = _test_shutdown_tcp(0, 1, SHUT_WR);
     if(result != ENOTCONN) {
         printf("Expecting shutdown(SHUT_WR) on unconnected socket to return ENOTCONN instead of %i\n", result);
         return EXIT_FAILURE;
@@ -77,46 +77,45 @@ static int _test_tcp_shutdown_before_connect(){
 static int _test_tcp_shutdown_after_connect(){
     printf("########## running _test_tcp_shutdown_after_connect\n");
 
-    int portctr = 30650;
     int result = 0;
 
-    result = _test_shutdown_tcp(1, (in_port_t)htons(portctr++), 1, SHUT_RDWR);
+    result = _test_shutdown_tcp(1, 1, SHUT_RDWR);
     if(result != 0) {
         printf("Expecting shutdown(SHUT_RDWR) on client socket to return 0 instead of %i\n", result);
         return EXIT_FAILURE;
     }
 
-    result = _test_shutdown_tcp(1, (in_port_t)htons(portctr++), 1, SHUT_RD);
+    result = _test_shutdown_tcp(1, 1, SHUT_RD);
     if(result != 0) {
         printf("Expecting shutdown(SHUT_RD) on client socket to return 0 instead of %i\n", result);
         return EXIT_FAILURE;
     }
 
-    result = _test_shutdown_tcp(1, (in_port_t)htons(portctr++), 1, SHUT_WR);
+    result = _test_shutdown_tcp(1, 1, SHUT_WR);
     if(result != 0) {
         printf("Expecting shutdown(SHUT_WR) on client socket to return 0 instead of %i\n", result);
         return EXIT_FAILURE;
     }
 
-    result = _test_shutdown_tcp(1, (in_port_t)htons(portctr++), 0, SHUT_RDWR);
+    result = _test_shutdown_tcp(1, 0, SHUT_RDWR);
     if(result != 0) {
         printf("Expecting shutdown(SHUT_RDWR) on server socket to return 0 instead of %i\n", result);
         return EXIT_FAILURE;
     }
 
-    result = _test_shutdown_tcp(1, (in_port_t)htons(portctr++), 0, SHUT_RD);
+    result = _test_shutdown_tcp(1, 0, SHUT_RD);
     if(result != 0) {
         printf("Expecting shutdown(SHUT_RD) on server socket to return 0 instead of %i\n", result);
         return EXIT_FAILURE;
     }
 
-    result = _test_shutdown_tcp(1, (in_port_t)htons(portctr++), 0, SHUT_WR);
+    result = _test_shutdown_tcp(1, 0, SHUT_WR);
     if(result != 0) {
         printf("Expecting shutdown(SHUT_WR) on server socket to return 0 instead of %i\n", result);
         return EXIT_FAILURE;
     }
 
-    result = _test_shutdown_tcp(1, (in_port_t)htons(portctr++), 1, 666);
+    result = _test_shutdown_tcp(1, 1, 666);
     if(result != -1 && errno != EINVAL) {
         printf("Expecting shutdown(SHUT_WR) on server socket to return -1(EINVAL) instead of %i\n", result);
         return EXIT_FAILURE;
@@ -135,7 +134,7 @@ static int _test_read_after_shutdown() {
 
     int sd = 0, cd = 0, sd_child = 0;
 
-    int result = common_get_connected_tcp_sockets((in_port_t)htons(30750), &sd, &sd_child, &cd);
+    int result = common_get_connected_tcp_sockets(&sd, &sd_child, &cd);
     if(result != EXIT_SUCCESS) {
         printf("Unable to get connected tcp sockets\n");
         goto fail;
@@ -233,7 +232,7 @@ static int _test_write_after_shutdown() {
 
     int sd = 0, cd = 0, sd_child = 0;
 
-    int result = common_get_connected_tcp_sockets((in_port_t)htons(30850), &sd, &sd_child, &cd);
+    int result = common_get_connected_tcp_sockets(&sd, &sd_child, &cd);
     if(result != EXIT_SUCCESS) {
         printf("Unable to get connected tcp sockets\n");
         goto fail;
@@ -321,7 +320,7 @@ static int _test_write_blocked_shutdown() {
 
     int sd = 0, cd = 0, sd_child = 0;
 
-    int result = common_get_connected_tcp_sockets((in_port_t)htons(30950), &sd, &sd_child, &cd);
+    int result = common_get_connected_tcp_sockets(&sd, &sd_child, &cd);
     if(result != EXIT_SUCCESS) {
         printf("Unable to get connected tcp sockets\n");
         goto fail;

--- a/src/test/sockbuf/shd-test-sockbuf.c
+++ b/src/test/sockbuf/shd-test-sockbuf.c
@@ -145,11 +145,12 @@ static int log_sizes(int fd, int get_len, char* str) {
     return 0;
 }
 
-int test_set_size_connect_helper(int call_connect, in_port_t server_port) {
+int test_set_size_connect_helper(int call_connect) {
     int sd = 0, cd = 0, sd_child = 0;
+    in_port_t server_port = 0;
     int result = 0;
 
-    if(common_setup_tcp_sockets(&sd, &cd, server_port) < 0) {
+    if(common_setup_tcp_sockets(&sd, &cd, &server_port) < 0) {
         goto fail;
     }
 
@@ -227,11 +228,12 @@ int do_send_receive_loop(int sd_child, int cd, int num_loops) {
     return 0;
 }
 
-int test_autotune_helper(int use_autotune, in_port_t server_port){
+int test_autotune_helper(int use_autotune) {
     int sd = 0, cd = 0, sd_child = 0;
+    in_port_t server_port = 0;
     int result = 0;
 
-    if(common_setup_tcp_sockets(&sd, &cd, server_port) < 0) {
+    if(common_setup_tcp_sockets(&sd, &cd, &server_port) < 0) {
         goto fail;
     }
 
@@ -333,22 +335,22 @@ fail:
 
 int test_set_size_before_connect(){
     printf("########## running test_set_size_before_connect\n");
-    return test_set_size_connect_helper(0, (in_port_t)htons(30001));
+    return test_set_size_connect_helper(0);
 }
 
 int test_set_size_after_connect(){
     printf("########## running test_set_size_after_connect\n");
-    return test_set_size_connect_helper(1, (in_port_t)htons(30002));
+    return test_set_size_connect_helper(1);
 }
 
 int test_set_size_to_disable_autotune() {
     printf("########## running test_set_size_to_disable_autotune\n");
-    return test_autotune_helper(0, (in_port_t)htons(30003));
+    return test_autotune_helper(0);
 }
 
 int test_autotune_increases_size() {
     printf("########## running test_autotune_increases_size\n");
-    return test_autotune_helper(1, (in_port_t)htons(30004));
+    return test_autotune_helper(1);
 }
 
 int run() {


### PR DESCRIPTION
This fixes the bug where the shutdown test fails if run multiple
times, and generally prevents the possibility of tests failing
in the case that a hard-coded port number happens to already
be in use.