### PR TITLE
suppress NULL argument warning for dlinfo with RTLD_DI_STATIC_TLS_SIZE

### DIFF
--- a/src/external/elf-loader/dl.h
+++ b/src/external/elf-loader/dl.h
@@ -16,3 +16,6 @@ int dl_lmid_swap_tls (Lmid_t lmid, pthread_t *t1, pthread_t *t2);
 // dlinfo() flag. Populates info field with the size of the currently used
 // static TLS.
 #define RTLD_DI_STATIC_TLS_SIZE 127
+// Pass as first argument when using RTLD_DI_STATIC_TLS_SIZE, to avoid
+// a NULL argument warning.
+#define RTLD_DI_STATIC_TLS_SIZE_DOESNT_REQUIRE_HANDLE ((void*)0x1)

--- a/src/main/core/shd-main.c
+++ b/src/main/core/shd-main.c
@@ -97,7 +97,7 @@ static gulong _main_computeLoadSize(Lmid_t lmid, const gchar* pluginPath, const 
     dlerror();
 
     /* get the initial TLS size used */
-    result = dlinfo(NULL, RTLD_DI_STATIC_TLS_SIZE, &tlsSizeStart);
+    result = dlinfo(RTLD_DI_STATIC_TLS_SIZE_DOESNT_REQUIRE_HANDLE, RTLD_DI_STATIC_TLS_SIZE, &tlsSizeStart);
 
     if (result != 0) {
         warning("error in dlinfo() while computing TLS start size, dlerror is '%s'", dlerror());
@@ -129,7 +129,7 @@ static gulong _main_computeLoadSize(Lmid_t lmid, const gchar* pluginPath, const 
         }
     }
 
-    result = dlinfo(NULL, RTLD_DI_STATIC_TLS_SIZE, &tlsSizeEnd);
+    result = dlinfo(RTLD_DI_STATIC_TLS_SIZE_DOESNT_REQUIRE_HANDLE, RTLD_DI_STATIC_TLS_SIZE, &tlsSizeEnd);
 
     if (result != 0) {
         warning("error in dlinfo() while computing TLS end size, dlerror is '%s'", dlerror());


### PR DESCRIPTION
Linux's `dlinfo` is annotated with `nonnull`, but the custom
vdl loader has an extension RTLD_DI_STATIC_TLS_SIZE, for which
a null handle is allowed. So, suppress the warning just for
those call sites by using a non-null (but likely invalid) address
RTLD_DI_STATIC_TLS_SIZE_DOESNT_REQUIRE_HANDLE.

This is one step toward unblocking compiling with -Werror (GH-711)