### PR TITLE
return pid from getpid and getppid

### DIFF
--- a/src/preload/shd-preload-defs.h
+++ b/src/preload/shd-preload-defs.h
@@ -176,8 +176,8 @@ PRELOADDEF(return, int, srandom_r, (unsigned int a, struct random_data *b), a, b
 
 /* pid */
 
-PRELOADDEF(      , pid_t, getpid, (void));
-PRELOADDEF(      , pid_t, getppid, (void));
+PRELOADDEF(return, pid_t, getpid, (void));
+PRELOADDEF(return, pid_t, getppid, (void));
 
 /* signals */
 


### PR DESCRIPTION
Resolves a warning when compiling with clang (GH-711).

As far as I can tell this was a real bug, and getpid callers
would've just been getting some arbitrary value from the stack.
It looks like current tests would have passed as long as it
was a *consistent* arbitrary value.

Considered adding a regression test that does something
with the returned pid, but it's not clear
how shadow does or ought to handle a process that does much in the
way of process manipulation. Other functions that do process
manipulation (e.g. kill) aren't overridden at all.