### PR TITLE
Add yum-utils dependency for Fedora

### DIFF
--- a/docs/1.1-Shadow.md
+++ b/docs/1.1-Shadow.md
@@ -25,10 +25,31 @@ This page describes how to setup and install Shadow from a bare-bones Linux inst
 In more recent versions of Fedora (and maybe at some point CentOS), `yum` can be exchanged for `dnf` in these commands.
 
 ```bash
-sudo yum install -y gcc gcc-c++ python make cmake glib2 glib2-devel igraph igraph-devel xz xz-devel python-pyelftools
+sudo yum install -y \
+    cmake \
+    gcc \
+    gcc-c++ \
+    glib2 \
+    glib2-devel \
+    igraph \
+    igraph-devel \
+    make \
+    python \
+    python-pyelftools \
+    xz \
+    xz-devel
 sudo yum debuginfo-install glibc
-sudo yum install -y numpy scipy python-matplotlib python-networkx python-lxml
-sudo yum install -y git dstat screen htop
+sudo yum install -y \
+    numpy \
+    python-lxml \
+    python-matplotlib \
+    python-networkx \
+    scipy
+sudo yum install -y \
+    dstat \
+    git \
+    htop \
+    screen
 ```
 
 #### APT (Debian/Ubuntu):
@@ -36,10 +57,30 @@ sudo yum install -y git dstat screen htop
 Ubuntu renamed libigraph0 to libigraph0v5 sometime between 14.04 and 16.04. Therefore when using a version of Ubuntu older than 16.04, you should replace `libigraph0v5` with `libigraph0`.
 
 ```bash
-sudo apt-get install -y gcc g++ python libglib2.0-0 libglib2.0-dev libigraph0v5 libigraph0-dev cmake make xz-utils python-pyelftools
+sudo apt-get install -y \
+    cmake \
+    g++ \
+    gcc \
+    libglib2.0-0 \
+    libglib2.0-dev \
+    libigraph0-dev \
+    libigraph0v5 \
+    make \
+    python \
+    python-pyelftools \
+    xz-utils
 sudo apt-get install libc-dbg
-sudo apt-get install -y python-matplotlib python-numpy python-scipy python-networkx python-lxml
-sudo apt-get install -y git dstat screen htop
+sudo apt-get install -y \
+    python-lxml \
+    python-matplotlib \
+    python-networkx \
+    python-numpy \
+    python-scipy
+sudo apt-get install -y \
+    dstat \
+    git \
+    htop \
+    screen
 ```
 
 ## Shadow Setup

--- a/docs/1.1-Shadow.md
+++ b/docs/1.1-Shadow.md
@@ -37,7 +37,8 @@ sudo yum install -y \
     python \
     python-pyelftools \
     xz \
-    xz-devel
+    xz-devel \
+    yum-utils
 sudo yum debuginfo-install glibc
 sudo yum install -y \
     numpy \


### PR DESCRIPTION
In particular noticed this was needed on Fedora 31.
Also split dependency lists across lines and sort.