### PR TITLE
Pass link flags only to link steps.

### DIFF
--- a/cmake/ShadowTools.cmake
+++ b/cmake/ShadowTools.cmake
@@ -41,3 +41,14 @@ macro(add_cflags)
 endmacro(add_cflags)
 
 ######################################################################################################
+## ADD_LDFLAGS                                                                                       ##
+######################################################################################################
+
+macro(add_ldflags)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${ARGN}")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${ARGN}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ARGN}")
+    set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} ${ARGN}")
+endmacro(add_ldflags)
+
+######################################################################################################

--- a/src/external/elf-loader/test/CMakeLists.txt
+++ b/src/external/elf-loader/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_cflags("-Wl,--warn-unresolved-symbols -L. -Wl,--no-as-needed")
+add_ldflags("-Wl,--warn-unresolved-symbols -L. -Wl,--no-as-needed")
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
 


### PR DESCRIPTION
* Adds a macro add_ldflags analagous to add_cflags.
* Uses that macro to fix a "unused-command-line-argument" warning in
  clang, where link flags were being passed to compile steps.

Progress on GH-711.