### PR TITLE
Bump version: 1.13.2 → 1.14.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.13.2
+current_version = 1.14.0
 commit = False
 tag = False
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 ## set build parameters
 project(Shadow)
-set(SHADOW_VERSION_FULL 1.13.2)
+set(SHADOW_VERSION_FULL 1.14.0)
 
 message(STATUS "System name: ${CMAKE_SYSTEM_NAME}")
 message(STATUS "System version: ${CMAKE_SYSTEM_VERSION}")


### PR DESCRIPTION
This commit was created with:

```
bumpversion --tag --commit minor
```

Will also push the corresponding tag after this is merged.