### PR TITLE
Fix CI's package management

### DIFF
--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -20,6 +20,9 @@ jobs:
       matrix:
         cc: ['gcc', 'clang']
     steps:
+      - name: Update packages
+        run: sudo apt-get update
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -46,6 +49,9 @@ jobs:
       CC: ${{ matrix.cc }}
 
     steps:
+      - name: Update packages
+        run: sudo apt-get update
+
       - name: Checkout shadow
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: sudo apt install -y ${{ matrix.cc }} g++ cmake make xz-utils python libglib2.0-0 libglib2.0-dev libigraph0v5 libigraph0-dev libc-dbg python-pyelftools
+        run: sudo apt-get install -y ${{ matrix.cc }} g++ cmake make xz-utils python libglib2.0-0 libglib2.0-dev libigraph0v5 libigraph0-dev libc-dbg python-pyelftools
 
       - name: Build
         run: CC=${{ matrix.cc }} python setup build --clean --test --werror


### PR DESCRIPTION
CI has been failing because one of the packages it's trying to fetch is no longer available on the server, so it gets a 404.

This change updates the package cache before trying to install dependencies, which seems to fix it.

That does introduce an unfortunate possibility of things breaking out from under us when dependencies introduce breaking changes, but that seems like a lesser problem than packages completely going away out from under us.

If and when we get Shadow working under Docker again we can create a custom image with our dependencies already installed and run everything on that.