### PR TITLE
Build and test debug mode too

### DIFF
--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         cc: ['gcc', 'clang']
+        buildtype: ['debug', 'release']
     steps:
       - name: Update packages
         run: sudo apt-get update
@@ -28,7 +29,12 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install -y ${{ matrix.cc }} g++ cmake make xz-utils python libglib2.0-0 libglib2.0-dev libigraph0v5 libigraph0-dev libc-dbg python-pyelftools
 
-      - name: Build
+      - name: Build Debug
+        if: ${{ matrix.buildtype == 'debug' }}
+        run: CC=${{ matrix.cc }} python setup build --clean --test --werror --debug
+
+      - name: Build Release
+        if: ${{ matrix.buildtype == 'release' }}
         run: CC=${{ matrix.cc }} python setup build --clean --test --werror
 
       - name: Install

--- a/src/external/elf-loader/CMakeLists.txt
+++ b/src/external/elf-loader/CMakeLists.txt
@@ -78,6 +78,10 @@ endif()
 # https://github.com/shadow/shadow/issues/715
 set_source_files_properties(glibc.c PROPERTIES COMPILE_FLAGS -Wno-unneeded-internal-declaration)
 
+# There are some internal debugging functions that currently have no callers,
+# but are probably better to keep around.
+set_source_files_properties(stage2.c PROPERTIES COMPILE_FLAGS -Wno-unused-function)
+
 set(ldso_srcs
     alloc.c
     avprintf-cb.c


### PR DESCRIPTION
Just came across the --werror --debug build getting broken in res/phantom. While that particular breakage was fairly innocuous, in general it's a good idea to test the debug build too.