### PR TITLE
File glibtest

### DIFF
--- a/src/test/file/CMakeLists.txt
+++ b/src/test/file/CMakeLists.txt
@@ -1,3 +1,7 @@
+find_package(GLIB REQUIRED)
+include_directories(${GLIB_INCLUDES})
+link_libraries(${GLIB_LIBRARIES})
+
 ## build the test as a dynamic executable that plugs into shadow
 add_shadow_plugin(shadow-plugin-test-file shd-test-file.c)
 


### PR DESCRIPTION
Enables individual file tests to be turned on and off independently, so that we can enable them incrementally in the phantom branch.

Migrates to glib's test framework so that we can filter which tests run from the command-line. This also makes the test code more succinct and give better failure reporting.

Modifies subtests to be independent of each-other; i.e. not depend on earlier tests to have created or modified a test file.