### PR TITLE
Test udp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,8 @@ if(POLICY  CMP0026)
     cmake_policy(SET  CMP0026  OLD)
 endif()
 
+include_directories(${CMAKE_SOURCE_DIR}/src)
+
 ## recurse our project tree
 add_subdirectory(${CMAKE_SOURCE_DIR}/resource/)
 add_subdirectory(${CMAKE_SOURCE_DIR}/src/)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -31,6 +31,7 @@ add_subdirectory(sleep)
 add_subdirectory(sockbuf)
 add_subdirectory(tcp)
 add_subdirectory(timerfd)
+add_subdirectory(udp)
 
 ## FIXME - the LastTest.log.tmp file does not contain all output when we do
 ## the grep above, so we get an inconsistent number of results in the output.

--- a/src/test/file/shd-test-file.c
+++ b/src/test/file/shd-test-file.c
@@ -17,27 +17,7 @@
 #include <sys/uio.h>
 #include <errno.h>
 
-// Similar to g_assert_true, but include stringified errno on failure.
-#define assert_true_errno(c)                                                   \
-    if (!(c)) {                                                                \
-        g_error("!(%s): %s", #c, strerror(errno));                             \
-        g_test_fail();                                                         \
-    }
-
-#define assert_nonnull_errno(p) assert_true_errno((p) != NULL)
-#define assert_nonneg_errno(p) assert_true_errno((p) >= 0)
-
-// Assert that errno is the expected value.
-#define assert_errno_is(e)                                                     \
-    {                                                                          \
-        int _errno = errno;                                                    \
-        int _e = e;                                                            \
-        if (_e != _errno) {                                                    \
-            g_error("Got errno %d (%s) instead of %d (%s)", _errno,            \
-                    strerror(_errno), _e, strerror(_e));                       \
-            g_test_fail();                                                     \
-        }                                                                      \
-    }
+#include "test/shd-test-glib-helpers.h"
 
 // For use in conjunction with g_auto for a file that will delete itself on
 // function exit.

--- a/src/test/shd-test-glib-helpers.h
+++ b/src/test/shd-test-glib-helpers.h
@@ -4,13 +4,15 @@
 #include <glib.h>
 #include <unistd.h>
 
-// Similar to g_assert_true, but include stringified errno on failure.
-#define assert_true_errno(c)                                                   \
+#define assert_true_errstring(c, s)                                            \
     if (!(c)) {                                                                \
-        g_error("!(%s): %s", #c, strerror(errno));                             \
+        g_error("!(%s): %s", #c, (s));                                         \
         g_test_fail();                                                         \
+        exit(EXIT_FAILURE);                                                    \
     }
 
+// Similar to g_assert_true, but include stringified errno on failure.
+#define assert_true_errno(c) assert_true_errstring(c, strerror(errno))
 #define assert_nonnull_errno(p) assert_true_errno((p) != NULL)
 #define assert_nonneg_errno(p) assert_true_errno((p) >= 0)
 
@@ -23,7 +25,9 @@
             g_error("Got errno %d (%s) instead of %d (%s)", _errno,            \
                     strerror(_errno), _e, strerror(_e));                       \
             g_test_fail();                                                     \
+            exit(EXIT_FAILURE);                                                \
         }                                                                      \
     }
+
 
 #endif

--- a/src/test/shd-test-glib-helpers.h
+++ b/src/test/shd-test-glib-helpers.h
@@ -1,0 +1,29 @@
+#ifndef SHD_TEST_GLIB_HELPERS_H
+#define SHD_TEST_GLIB_HELPERS_H
+
+#include <glib.h>
+#include <unistd.h>
+
+// Similar to g_assert_true, but include stringified errno on failure.
+#define assert_true_errno(c)                                                   \
+    if (!(c)) {                                                                \
+        g_error("!(%s): %s", #c, strerror(errno));                             \
+        g_test_fail();                                                         \
+    }
+
+#define assert_nonnull_errno(p) assert_true_errno((p) != NULL)
+#define assert_nonneg_errno(p) assert_true_errno((p) >= 0)
+
+// Assert that errno is the expected value.
+#define assert_errno_is(e)                                                     \
+    {                                                                          \
+        int _errno = errno;                                                    \
+        int _e = e;                                                            \
+        if (_e != _errno) {                                                    \
+            g_error("Got errno %d (%s) instead of %d (%s)", _errno,            \
+                    strerror(_errno), _e, strerror(_e));                       \
+            g_test_fail();                                                     \
+        }                                                                      \
+    }
+
+#endif

--- a/src/test/udp/CMakeLists.txt
+++ b/src/test/udp/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(GLIB REQUIRED)
+include_directories(${GLIB_INCLUDES})
+link_libraries(${GLIB_LIBRARIES})
+
+## build the test as a dynamic executable that plugs into shadow
+add_shadow_exe(test-udp shd-test-udp.c)
+
+## register the tests
+add_test(NAME udp COMMAND /bin/bash -c "rm -f udp-fifo && mkfifo udp-fifo && ../shadow-test-launcher test-udp client 0 udp-fifo : test-udp server 0 udp-fifo")
+add_test(NAME udp-shadow COMMAND /bin/bash -c "rm -f udp-shadow-fifo && mkfifo udp-shadow-fifo && ${CMAKE_BINARY_DIR}/src/main/shadow -l debug -d udp.shadow.data ${CMAKE_CURRENT_SOURCE_DIR}/udp.test.shadow.config.xml")

--- a/src/test/udp/shd-test-udp.c
+++ b/src/test/udp/shd-test-udp.c
@@ -1,0 +1,214 @@
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <glib.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "test/shd-test-glib-helpers.h"
+
+// Send `i` over a fifo(7) named `pipename`.
+static void fifo_send_u16(const char* pipename, uint16_t i) {
+    FILE* f = fopen(pipename, "w");
+    assert_nonnull_errno(f);
+
+    char buf[10];
+    int len = snprintf(buf, 10, "%d", i);
+    g_assert(len < sizeof(buf));
+
+    int count = fwrite(buf, 1, len, f);
+    assert_true_errno(count == len);
+    fclose(f);
+}
+
+// Recv a u16 from a fifo(7) named `pipename`.
+static short fifo_recv_u16(const char* pipename) {
+    FILE* f = fopen(pipename, "r");
+    assert_nonnull_errno(f);
+    char buf[10] = {0};
+    int count = fread(buf, 1, sizeof(buf)-1, f);
+    assert_true_errstring(count != 0, feof(f) ? "Unexpected end of file"
+                                              : strerror(ferror(f)));
+    fclose(f);
+
+    guint64 val;
+    GError *error = NULL;
+    g_ascii_string_to_unsigned(buf, /* base= */ 10, /* min= */ 0,
+                                    /* max= */ UINT16_MAX, &val, &error);
+    g_assert_no_error(error);
+    return val;
+}
+
+// Creates and returns a client UDP socket to localhost at `port`, and sets
+// `addr` and `len` to the server address. If `port` is 0, reads the port number
+// over the fifo(7) `fifo_name`.
+int connect_client(struct sockaddr* addr, socklen_t* len, uint16_t port,
+                   const char* fifo_name) {
+    struct addrinfo hints = {
+        .ai_family = AF_INET,
+        .ai_socktype = SOCK_DGRAM,
+    };
+    if (port == 0) {
+        port = fifo_recv_u16(fifo_name);
+    }
+    gchar* port_string = g_strdup_printf("%u", port);
+    struct addrinfo* addrs = NULL;
+    int rv;
+    assert_true_errstring(
+        (rv = getaddrinfo(NULL, port_string, &hints, &addrs)) == 0,
+        gai_strerror(rv));
+    g_assert_nonnull(addrs);
+    g_assert_cmpint(addrs->ai_addrlen, <=, *len);
+    *addr = *addrs->ai_addr;
+    *len = addrs->ai_addrlen;
+    freeaddrinfo(addrs);
+
+    int sock;
+    assert_nonneg_errno(sock = socket(AF_INET, SOCK_DGRAM, 0));
+    return sock;
+}
+
+// Creates and returns a UDP listening on `port`. If `port` is 0, uses an
+// automatically assigned port number and writes it to the fifo(7) `fifo_name`.
+int connect_server(uint16_t port, const char* fifo_name) {
+    int sock;
+    assert_nonneg_errno(sock = socket(AF_INET, SOCK_DGRAM, 0));
+    struct addrinfo hints = {
+        .ai_family = AF_INET,
+        .ai_socktype = SOCK_DGRAM,
+        .ai_flags = AI_PASSIVE,
+    };
+    gchar* port_string = g_strdup_printf("%u", port);
+    struct addrinfo* addrs = NULL;
+    int rv;
+    assert_true_errstring(
+        (rv = getaddrinfo(NULL, port_string, &hints, &addrs)) == 0,
+        gai_strerror(rv));
+    g_free(port_string);
+    port_string =  NULL;
+    g_assert_nonnull(addrs);
+    assert_nonneg_errno(bind(sock, addrs->ai_addr, addrs->ai_addrlen));
+    freeaddrinfo(addrs);
+    addrs = NULL;
+    if (port == 0) {
+        // Tell the client side what port we ended up with.
+        struct sockaddr_in bound_addr;
+        socklen_t bound_addr_len = sizeof(bound_addr);
+        assert_nonneg_errno(getsockname(sock, &bound_addr, &bound_addr_len));
+        g_assert(bound_addr_len <= sizeof(bound_addr));
+        fifo_send_u16(fifo_name, ntohs(bound_addr.sin_port));
+    }
+    return sock;
+}
+
+typedef enum { CLIENT, SERVER } Type;
+typedef struct {
+    Type type;
+    uint16_t port;
+    const char* fifo_name;
+} TestParams;
+
+void test_sendto_one_byte(const void* void_params) {
+    const TestParams* params = void_params;
+    const char data[] = {42};
+    if (params->type == CLIENT) {
+        struct sockaddr_in server_addr = {};
+        socklen_t server_addr_len = sizeof(server_addr);
+        int sock =
+            connect_client((struct sockaddr*)&server_addr, &server_addr_len,
+                           params->port, params->fifo_name);
+        ssize_t sent;
+        assert_nonneg_errno(sent = sendto(sock, data, sizeof(data), 0,
+                                          &server_addr, server_addr_len));
+        g_assert_cmpint(sent, ==, sizeof(data));
+    } else {
+        int sock = connect_server(params->port, params->fifo_name);
+        char recv_buf[10];
+        struct sockaddr recvfrom_addr = {};
+        socklen_t recvfrom_addr_len = sizeof(recvfrom_addr);
+        ssize_t recvd;
+        assert_nonneg_errno(recvd =
+                                recvfrom(sock, recv_buf, sizeof(recv_buf), 0,
+                                         &recvfrom_addr, &recvfrom_addr_len));
+        g_assert_cmpmem(recv_buf, recvd, data, sizeof(data));
+        /*
+        g_assert_cmpmem(&recvfrom_addr, recvfrom_addr_len, &server_addr,
+                        server_addr_len);
+                        */
+    }
+}
+
+int main(int argc, char* argv[]) {
+    // Parses any arguments that glib understands and strips them out.
+    // We tell it *not* to set the program name because we do that ourselves
+    // later, and it may only be done once.
+    g_test_init(&argc, &argv, "no_g_set_prgname", NULL);
+
+    // Consume first argument (program name)
+    const char* binname = argv[0];
+    --argc;
+    ++argv;
+
+    // Get type (server|client)
+    if(argc < 1) {
+        g_error("Missing type name");
+    }
+    Type type;
+    if(!g_strcmp0(argv[0], "client")) {
+        type = CLIENT;
+    } else if (!g_strcmp0(argv[0], "server")) {
+        type = SERVER;
+    } else {
+        g_error("Bad type name: %s", argv[0]);
+    }
+    char *prgname = g_strdup_printf("%s:%s", binname, argv[0]);
+    g_set_prgname(prgname);
+    g_free(prgname);
+    --argc;
+    ++argv;
+
+    // Get port number to use, or 0 to use dynamic assignment.
+    if(argc < 1) {
+        g_error("Missing port number");
+        return EXIT_FAILURE;
+    }
+    guint64 port64;
+    GError* error = NULL;
+    if (!g_ascii_string_to_unsigned(argv[0], /* base= */ 10, /* min= */ 0,
+                                    /* max= */ UINT16_MAX, &port64, &error)) {
+        g_error("Parsing port '%s': %s", argv[1], error->message);
+        return EXIT_FAILURE;
+    }
+    in_port_t port = port64;
+    --argc;
+    ++argv;
+
+    // If port is zero, get the fifo to use to communicate the port.
+    const char* fifo_name = NULL;
+    if (port == 0) {
+        if (argc < 1) {
+            g_error("Missing fifo name");
+        }
+        fifo_name = argv[0];
+        --argc;
+        ++argv;
+    }
+
+    TestParams test_params = {
+        .type = type,
+        .port = port,
+        .fifo_name = fifo_name,
+    };
+
+    g_test_add_data_func("/udp/sendto_one_byte", &test_params, test_sendto_one_byte);
+    g_test_run();
+    return EXIT_SUCCESS;
+}

--- a/src/test/udp/udp.test.shadow.config.xml
+++ b/src/test/udp/udp.test.shadow.config.xml
@@ -1,0 +1,30 @@
+<shadow>
+  <topology><![CDATA[<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+  <key attr.name="packetloss" attr.type="double" for="edge" id="d4" />
+  <key attr.name="latency" attr.type="double" for="edge" id="d3" />
+  <key attr.name="bandwidthup" attr.type="int" for="node" id="d2" />
+  <key attr.name="bandwidthdown" attr.type="int" for="node" id="d1" />
+  <key attr.name="countrycode" attr.type="string" for="node" id="d0" />
+  <graph edgedefault="undirected">
+    <node id="poi-1">
+      <data key="d0">US</data>
+      <data key="d1">10240</data>
+      <data key="d2">10240</data>
+    </node>
+    <edge source="poi-1" target="poi-1">
+      <data key="d3">50.0</data>
+      <data key="d4">0.0</data>
+    </edge>
+  </graph>
+</graphml>
+]]></topology>
+  <kill time="5"/>
+  <plugin id="testudp" path="test-udp"/>
+  <node id="testclient" quantity="1">
+    <application plugin="testudp" starttime="1" arguments="client 5678"/>
+  </node>
+  <node id="testserver" quantity="1">
+    <application plugin="testudp" starttime="1" arguments="server 5678"/>
+  </node>
+</shadow>
+


### PR DESCRIPTION
This is mostly getting in place a framework for UDP tests; particularly
for using dynamically assigned ports when not running under Shadow and
communicating them via a fifo(7). I'll flesh out some more tests in a
follow-up.

Initially I tried doing the same under Shadow as well, but it doesn't
deal well with blocking on an `open` call. I got it to sort of work if I
opened the fifo in nonblocking mode and looped, but decided it'd be
cleaner to just use hard-coded ports under Shadow for now. I expect that
the blocking `open` call won't be an issue under Phantom, so we can
perhaps switch it over there.