### PR TITLE
Add test timeouts and verbose output

### DIFF
--- a/setup
+++ b/setup
@@ -115,6 +115,15 @@ def main():
         action="store", dest="njobs",
         default=4)#multiprocessing.cpu_count())
 
+    # TODO: Ideally make the default more like 1s, and add more individual
+    # exceptions as needed (using e.g. `set_tests_properties(slow_test_name
+    # PROPERTIES TIMEOUT 30)`
+    parser_test.add_argument('-t', '--timeout',
+        help="default test timeout, in seconds",
+        metavar="s", type=int,
+        action="store", dest="timeout",
+        default=20)
+
     # configure install subcommand
     parser_install = subparsers_main.add_parser('install', help='install Shadow',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -237,7 +246,7 @@ def run_tests(testdir, args):
     os.chdir(testdir)
 
     # test, wait for it to finish
-    testcmd = "ctest -j{0}".format(args.njobs)
+    testcmd = "ctest -j{0} --timeout {1}".format(args.njobs, args.timeout)
 
     logging.info("calling \'"+testcmd+"\'")
     retcode = subprocess.call(testcmd.strip().split())

--- a/setup
+++ b/setup
@@ -124,6 +124,11 @@ def main():
         action="store", dest="timeout",
         default=20)
 
+    parser_test.add_argument('-v', '--verbose',
+        help="print verbose test output",
+        action="store_true", dest="do_verbose",
+        default=False)
+
     # configure install subcommand
     parser_install = subparsers_main.add_parser('install', help='install Shadow',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -246,7 +251,9 @@ def run_tests(testdir, args):
     os.chdir(testdir)
 
     # test, wait for it to finish
-    testcmd = "ctest -j{0} --timeout {1}".format(args.njobs, args.timeout)
+    testcmd = "ctest --output-on-failure -j{0} --timeout {1}".format(args.njobs, args.timeout)
+    if args.do_verbose:
+        testcmd += " --verbose"
 
     logging.info("calling \'"+testcmd+"\'")
     retcode = subprocess.call(testcmd.strip().split())

--- a/src/test/epoll/CMakeLists.txt
+++ b/src/test/epoll/CMakeLists.txt
@@ -9,3 +9,6 @@ add_executable(test-epoll shd-test-epoll.c)
 add_test(NAME epoll COMMAND test-epoll)
 add_test(NAME epoll-shadow COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow -l debug -d epoll.shadow.data ${CMAKE_CURRENT_SOURCE_DIR}/epoll.test.shadow.config.xml)
 add_test(NAME epoll-writeable-shadow COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow -l debug -d epoll-writeable.shadow.data ${CMAKE_CURRENT_SOURCE_DIR}/epoll-writeable.test.shadow.config.xml)
+
+# TODO: See https://github.com/shadow/shadow/issues/756
+set_tests_properties(epoll-writeable-shadow PROPERTIES TIMEOUT 200)


### PR DESCRIPTION
Timeouts should help prevent a misbehaving test from running forever, and helps prevent
large unexpected regressions such as #756.

Verbose output is helpful for debugging, especially in CI without having to rerun again locally.