### PR TITLE
Clarify 'node', 'cluster', 'edge' terminology

### DIFF
--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -25,7 +25,7 @@ environment="OPENSSL_ia32cap=~0x200000200000000;EVENT_NOSELECT=1;EVENT_NOPOLL=1;
 **Optional attributes**: _path_  
 **Optional child element**: `<![CDATA[TEXT]]>`
 
-The _topology_ element must hold either a collection of vertices and edges that represent a network topology as the TEXT in a `<![CDATA[TEXT]]>` style element, or a _path_ to a file holding such data. The TEXT data should be in graphml format, and hold an undirected, complete, connected graph with certain attributes specified on the vertices and links. For more information on how to structure this data, see the [Topology Format](3.2-Network-Config.md).
+The _topology_ element must hold either a collection of nodes and edges that represent a network topology as the TEXT in a `<![CDATA[TEXT]]>` style element, or a _path_ to a file holding such data. The TEXT data should be in graphml format, and hold an undirected, complete, connected graph with certain attributes specified on the nodes and edges. For more information on how to structure this data, see the [Topology Format](3.2-Network-Config.md).
 
 ### The _plugin_ element
 ```xml
@@ -50,21 +50,21 @@ Preload plug-ins are used in the _process_ element and provides a way to interpo
 **Optional attributes**: _iphint_, _geocodehint_, _typehint_, _quantity_, _bandwidthdown_, _bandwidthup_, _interfacebuffer_, _socketrecvbuffer_, _socketsendbuffer_, _loglevel_, _heartbeatloglevel_, _heartbeatloginfo_, _heartbeatfrequency_, _cpufrequency_, _logpcap_, _pcapdir_  
 **Required child element**: \<process\>  
 
-The _host_ element represents a node or virtual host in the simulation. The _id_ attribute identifies this _host_ and must be a string that is unique among all _id_ attributes for any element in the XML file. _id_ will also be used as the network hostname of this _host_.
+The _host_ element represents a virtual host in the simulation. The _id_ attribute identifies this _host_ and must be a string that is unique among all _id_ attributes for any element in the XML file. _id_ will also be used as the network hostname of this _host_.
 
-The _iphint_, _geocodehint_, and _typehint_ attributes provide hints to Shadow's name and routing system on where to attach this host to the topology. These hints will be matched based on the values of the _ip_, _geocode_, and _type_ of the vertices as specified in the topology file.
+Shadow assigns each _host_ to a _node_ in the [_topology_](3.2-Network-Config.md). The _iphint_, _geocodehint_, and _typehint_ attributes provide hints to Shadow's name and routing system for which _node_ to assign the given _host_ to. These hints will be matched based on the values of the _ip_, _geocode_, and _type_ of the nodes as specified in the topology file.
 
 The _quantity_ attribute specifies the number of hosts of this type to start. If _quantity_ is greater than 1, each host's hostname will be prefixed with a counter. For example, a _host_ with an _id_ of `host` and _quantity_=2 would produce nodes with hostnames `1.host` and `2.host`.
 
-_bandwidthdown_ and _bandwidthup_ optionally specify the downstream and upstream bandwidth capacities for this _host_, and override any default bandwidth values set in the _cluster_ element corresponding to the _cluster_ attribute. If not given, the default bandwidth values from the assigned _cluster_ element are used.
+_bandwidthdown_ and _bandwidthup_ optionally specify the downstream and upstream bandwidth capacities for this _host_, and override any default bandwidth values set in the assigned topology _node_.
 
 _interfacebuffer_ controls the size of the interface receive buffer that accepts packets from the network. _socketrecvbuffer_ and _socketsendbuffer_ control the initial size of the socket buffers that hold packets to and from the process. Note that these sizes may be adjusted by auto-tuning, in order fill the channel capacity as defined by the bandwidth-delay product between two hosts. These values can instead be set globally for all hosts with the Shadow command line options `--interface-buffer`, `--socket-recv-buffer`, and `--socket-send-buffer` (see `shadow --help-network` for more info).
 
-_loglevel_ and _heartbeatloglevel_ are host-specific overrides for the simulator default log levels (the defaults are adjustable with shadow arguments `--log-level` and `--heartbeat-log-level`). Valid strings include 'error', 'critical', 'warning', 'message', 'info', and 'debug'. _heartbeatloginfo_ is a host-specific override for the type of information that will get logged for this node during the heartbeat. Valid values are 'node', 'socket', and 'ram'. _heartbeatfrequency_ is a host-specific override for the default number of seconds between which heartbeat messages are logged (the default is adjustable with shadow argument `--heartbeat-frequency`). Each heartbeat message contains useful statistics about the _node_.
+_loglevel_ and _heartbeatloglevel_ are host-specific overrides for the simulator default log levels (the defaults are adjustable with shadow arguments `--log-level` and `--heartbeat-log-level`). Valid strings include 'error', 'critical', 'warning', 'message', 'info', and 'debug'. _heartbeatloginfo_ is a host-specific override for the type of information that will get logged for this host during the heartbeat. Valid values are 'node', 'socket', and 'ram'. _heartbeatfrequency_ is a host-specific override for the default number of seconds between which heartbeat messages are logged (the default is adjustable with shadow argument `--heartbeat-frequency`). Each heartbeat message contains useful statistics about the _host_.
 
 _cpufrequency_ is the speed of this _host's_ virtual CPU in kilohertz. Along with the CPU processing requirements of the plug-in process, this determines how often events for this _host_ are delayed during simulation.
 
-_logpcap_ is a case insensitive boolean string (e.g. "true") that specifies that Shadow should log all network input and output for this _node_ in PCAP format (for viewing in e.g. wireshark). _pcapdir_ is the directory to which the logs should be saved for this _host_.
+_logpcap_ is a case insensitive boolean string (e.g. "true") that specifies that Shadow should log all network input and output for this _host_ in PCAP format (for viewing in e.g. wireshark). _pcapdir_ is the directory to which the logs should be saved for this _host_.
 
 Hosts must have at least one child \<process\> (see below), and may have more than one.
 

--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -56,7 +56,7 @@ Shadow assigns each _host_ to a _node_ in the [_topology_](3.2-Network-Config.md
 
 The _quantity_ attribute specifies the number of hosts of this type to start. If _quantity_ is greater than 1, each host's hostname will be prefixed with a counter. For example, a _host_ with an _id_ of `host` and _quantity_=2 would produce nodes with hostnames `1.host` and `2.host`.
 
-_bandwidthdown_ and _bandwidthup_ optionally specify the downstream and upstream bandwidth capacities for this _host_, and override any default bandwidth values set in the assigned topology _node_.
+_bandwidthdown_ and _bandwidthup_ optionally specify the downstream and upstream bandwidth capacities for this _host_ in KiB, and override any default bandwidth values set in the assigned topology _node_.
 
 _interfacebuffer_ controls the size of the interface receive buffer that accepts packets from the network. _socketrecvbuffer_ and _socketsendbuffer_ control the initial size of the socket buffers that hold packets to and from the process. Note that these sizes may be adjusted by auto-tuning, in order fill the channel capacity as defined by the bandwidth-delay product between two hosts. These values can instead be set globally for all hosts with the Shadow command line options `--interface-buffer`, `--socket-recv-buffer`, and `--socket-send-buffer` (see `shadow --help-network` for more info).
 

--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -41,18 +41,18 @@ Preload plug-ins are used in the _process_ element and provides a way to interpo
 
 ### The _host_ element
 ```xml
-<host id="STRING" iphint="STRING" geocodehint="STRING" typehint="STRING" quantity="INTEGER" bandwidthdown="INTEGER" bandwidthup="INTEGER" interfacebuffer="INTEGER" socketrecvbuffer="INTEGER" socketsendbuffer="INTEGER" loglevel="STRING" heartbeatloglevel="STRING" heartbeatloginfo="STRING" heartbeatfrequency="INTEGER" cpufrequency="INTEGER" logpcap="STRING" pcapdir="STRING">
+<host id="STRING" iphint="STRING" countrycodehint="STRING" typehint="STRING" quantity="INTEGER" bandwidthdown="INTEGER" bandwidthup="INTEGER" interfacebuffer="INTEGER" socketrecvbuffer="INTEGER" socketsendbuffer="INTEGER" loglevel="STRING" heartbeatloglevel="STRING" heartbeatloginfo="STRING" heartbeatfrequency="INTEGER" cpufrequency="INTEGER" logpcap="STRING" pcapdir="STRING">
   <process ... />
   ...
 </host>
 ```
 **Required attributes**: _id_  
-**Optional attributes**: _iphint_, _geocodehint_, _typehint_, _quantity_, _bandwidthdown_, _bandwidthup_, _interfacebuffer_, _socketrecvbuffer_, _socketsendbuffer_, _loglevel_, _heartbeatloglevel_, _heartbeatloginfo_, _heartbeatfrequency_, _cpufrequency_, _logpcap_, _pcapdir_  
+**Optional attributes**: _iphint_, _countrycodehint_, _typehint_, _quantity_, _bandwidthdown_, _bandwidthup_, _interfacebuffer_, _socketrecvbuffer_, _socketsendbuffer_, _loglevel_, _heartbeatloglevel_, _heartbeatloginfo_, _heartbeatfrequency_, _cpufrequency_, _logpcap_, _pcapdir_  
 **Required child element**: \<process\>  
 
 The _host_ element represents a virtual host in the simulation. The _id_ attribute identifies this _host_ and must be a string that is unique among all _id_ attributes for any element in the XML file. _id_ will also be used as the network hostname of this _host_.
 
-Shadow assigns each _host_ to a _node_ in the [_topology_](3.2-Network-Config.md). The _iphint_, _geocodehint_, and _typehint_ attributes provide hints to Shadow's name and routing system for which _node_ to assign the given _host_ to. These hints will be matched based on the values of the _ip_, _geocode_, and _type_ of the nodes as specified in the topology file.
+Shadow assigns each _host_ to a _node_ in the [_topology_](3.2-Network-Config.md). The _iphint_, _countrycodehint_, and _typehint_ attributes provide hints to Shadow's name and routing system for which _node_ to assign the given _host_ to. These hints will be matched based on the values of the _ip_, _countrycode_, and _type_ of the nodes as specified in the topology file.
 
 The _quantity_ attribute specifies the number of hosts of this type to start. If _quantity_ is greater than 1, each host's hostname will be prefixed with a counter. For example, a _host_ with an _id_ of `host` and _quantity_=2 would produce nodes with hostnames `1.host` and `2.host`.
 


### PR DESCRIPTION
Remove references to "clusters". A cluster is now a "node in the topology".

Don't refer to hosts as nodes, since this could cause them to be confused with topology nodes.

Use "node" instead of "vertice" and "edge" instead of "link", since those are the concrete terms used in the topology.

Progress on #776 