### PR TITLE
Block fixup commits

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,20 @@
+# Syntax reference:
+# https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+name: Git Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  # Fixup commits are OK in pull requests, but should generally be squashed
+  # before merging to master, e.g. using `git rebase -i --autosquash master`.
+  # See https://github.com/marketplace/actions/block-autosquash-commits
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+        - name: Block autosquash commits
+          uses: xt0rted/block-autosquash-commits-action@master
+          with:
+            repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -15,6 +15,6 @@ jobs:
 
     steps:
         - name: Block autosquash commits
-          uses: xt0rted/block-autosquash-commits-action@master
+          uses: xt0rted/block-autosquash-commits-action@3c9ba6760eba3c160eead6ed4b6449024ec406ad
           with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
"fixup!" and "squash!" commits are generally created using the `--fixup`
and `--squash` flags to `git commit`, and are intended to be squashed
into another commit before merging, generally using the `--autosquash`
flag with `git rebase`. They are a useful alternative to
amending/rebasing commits immediately, especially for a pull request
that's in the middle of review.

Without a check like this one though, it's easy to forget to `git rebase
--autosquash` them away before merging. e.g.
3787852.