### PR TITLE
Save shadow logs on CI failure

### DIFF
--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -88,7 +88,7 @@ jobs:
         run: shadow-plugin-tor/tools/continuous_integration_test.sh
 
       - name: Upload simulation logs
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: simulation-output

--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Test
         run: python setup test
 
+      - name: Upload shadow logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: shadow-data
+          path: build/**/*shadow.data/*
+
+
   shadow-plugin-tor-ci:
     runs-on: ubuntu-latest
     strategy:

--- a/setup
+++ b/setup
@@ -227,7 +227,7 @@ def test(args):
 
     if not os.path.exists(testdir+'/CTestTestfile.cmake'):
         logging.error("please run './setup build --test' before testing!")
-        return
+        return -1
 
     # go to build dir and install from makefile
     calledDirectory = os.getcwd()
@@ -250,7 +250,7 @@ def install(args):
     builddir=getfullpath(BUILD_PREFIX)
     if not os.path.exists(builddir):
         logging.error("please build before installing!")
-        return
+        return -1
 
     # go to build dir and install from makefile
     calledDirectory = os.getcwd()


### PR DESCRIPTION
Some other minor cleanup while in here:
* Bump upload-artifact action version
* Have setup script return failure when it aborts