### PR TITLE
Grab build dir on failure

### DIFF
--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -47,8 +47,8 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: shadow-data
-          path: build/**/*shadow.data/*
+          name: shadow-build
+          path: build
 
 
   shadow-plugin-tor-ci:

--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -41,7 +41,7 @@ jobs:
         run: python setup install
 
       - name: Test
-        run: python setup test
+        run: ulimit -c unlimited && python setup test
 
       - name: Upload shadow logs
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Some of the sporadic test failures I've been seeing don't have anything useful in the logs. Grab the whole build directory on test failures, including binaries and any generated core files, to facilitate debugging.