### PR TITLE
Rerun failed

### DIFF
--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -41,7 +41,10 @@ jobs:
         run: python setup install
 
       - name: Test
-        run: python setup test
+        # For now, if the first batch of tests fails, rerun the failing tests
+        # and continue on if they then pass. This is to work around sporadic
+        # and difficult to debug errors such as #798
+        run: python setup test || python setup test --rerun-failed
 
       - name: Upload shadow logs
         uses: actions/upload-artifact@v2

--- a/setup
+++ b/setup
@@ -115,6 +115,11 @@ def main():
         action="store", dest="njobs",
         default=4)#multiprocessing.cpu_count())
 
+    parser_test.add_argument('-r', '--rerun-failed',
+        help="Run only the tests that failed previously",
+        action="store_true", dest="rerun_failed",
+        default=False)
+
     # TODO: Ideally make the default more like 1s, and add more individual
     # exceptions as needed (using e.g. `set_tests_properties(slow_test_name
     # PROPERTIES TIMEOUT 30)`
@@ -237,6 +242,9 @@ def test(args):
     testcmd = "ctest --output-on-failure -j{0} --timeout {1}".format(args.njobs, args.timeout)
     if args.do_verbose:
         testcmd += " --verbose"
+
+    if args.rerun_failed:
+        testcmd += " --rerun-failed"
 
     logging.info("calling \'"+testcmd+"\'")
     retcode = subprocess.call(testcmd.strip().split())


### PR DESCRIPTION
We unfortunately have some difficult to debug, nondeterministic failures (e.g. #798). Eventually it'd be good to fix these, but I don't think it makes sense to block other work on it at the moment. Right now the only recourse is to manually click the "rerun all workflows" button, which reruns *all* the tests in *all* configurations, including the slow shadow-plugin-tor-ci.

This PR adds an option to ./setup to rerun tests that failed in the last run, and modifies the CI script to try rerunning failing tests once before failing the CI workflow.