### PR TITLE
Logger improvements

### DIFF
--- a/src/main/core/logger/shadow_logger.c
+++ b/src/main/core/logger/shadow_logger.c
@@ -25,7 +25,6 @@ typedef struct _LoggerThreadData LoggerThreadData;
 struct _LoggerThreadData {
     /* keep wall time without relying on main logger data */
     GTimer* runTimer;
-    gdouble loggerRunOffset;
 
     /* local temporary store for this threads log records */
     GQueue* localRecordBundle;
@@ -67,7 +66,6 @@ static LoggerThreadData* _loggerthreaddata_new(GTimer* loggerTimer) {
     MAGIC_INIT(threadData);
 
     threadData->runTimer = g_timer_new();
-    threadData->loggerRunOffset = g_timer_elapsed(loggerTimer, NULL);
 
     threadData->localRecordBundle = g_queue_new();
     threadData->remoteLogHelperMailbox = g_async_queue_new();

--- a/src/main/core/logger/shadow_logger.c
+++ b/src/main/core/logger/shadow_logger.c
@@ -126,10 +126,6 @@ void shadow_logger_setEnableBuffering(ShadowLogger* logger, gboolean enabled) {
     logger->shouldBuffer = enabled;
 }
 
-static gdouble _logger_elapsed_double() {
-    return (double)logger_elapsed_micros() / G_USEC_PER_SEC;
-}
-
 static void _logger_sendRegisterCommandToHelper(ShadowLogger* logger,
                                                 LoggerThreadData* threadData) {
     LoggerHelperCommand* command = loggerhelpercommand_new(
@@ -179,7 +175,7 @@ void shadow_logger_logVA(ShadowLogger* logger, LogLevel level,
         logger->threadToDataMap, GUINT_TO_POINTER(pthread_self()));
     MAGIC_ASSERT(threadData);
 
-    gdouble timespan = _logger_elapsed_double();
+    gdouble timespan = (double)logger_elapsed_micros() / G_USEC_PER_SEC;
 
     LogRecord* record =
         logrecord_new(level, timespan, fileName, functionName, lineNumber);
@@ -293,7 +289,7 @@ static gchar* _logger_getNewRunTimeStr(ShadowLogger* logger) {
     MAGIC_ASSERT(logger);
 
     /* compute our run time */
-    guint64 elapsed = _logger_elapsed_double();
+    guint64 elapsed = logger_elapsed_micros() / G_USEC_PER_SEC;
     guint64 hours = elapsed / 3600;
     elapsed %= 3600;
     guint64 minutes = elapsed / 60;

--- a/src/main/core/logger/shadow_logger.c
+++ b/src/main/core/logger/shadow_logger.c
@@ -5,6 +5,7 @@
 
 #include "main/core/logger/shadow_logger.h"
 
+#include <glib.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -126,8 +127,7 @@ void shadow_logger_setEnableBuffering(ShadowLogger* logger, gboolean enabled) {
 }
 
 static gdouble _logger_elapsed_double() {
-    struct timeval elapsed = logger_get_global_elapsed_time();
-    return elapsed.tv_sec + elapsed.tv_usec/1000000.0;
+    return (double)logger_elapsed_micros() / G_USEC_PER_SEC;
 }
 
 static void _logger_sendRegisterCommandToHelper(ShadowLogger* logger,

--- a/src/support/logger/CMakeLists.txt
+++ b/src/support/logger/CMakeLists.txt
@@ -1,5 +1,6 @@
+add_cflags(-fPIC)
 add_library(logger STATIC
     logger.c
     log_level.c)
 target_include_directories(logger PRIVATE ${GLIB_INCLUDES})
-target_link_libraries(logger ${GLIB_LIBRARIES})
+target_link_libraries(logger ${GLIB_LIBRARIES} pthread)

--- a/src/support/logger/logger.c
+++ b/src/support/logger/logger.c
@@ -1,6 +1,7 @@
 #include "support/logger/logger.h"
 
 #include <pthread.h>
+#include <stdio.h>
 #include <sys/time.h>
 
 static Logger* defaultLogger = NULL;
@@ -13,19 +14,6 @@ void logger_setDefault(Logger* logger) {
 }
 
 Logger* logger_getDefault() { return defaultLogger; }
-
-static GLogLevelFlags _gloglevelflags(LogLevel level) {
-    switch (level) {
-        case LOGLEVEL_CRITICAL: return G_LOG_LEVEL_CRITICAL;
-        case LOGLEVEL_WARNING: return G_LOG_LEVEL_WARNING;
-        case LOGLEVEL_MESSAGE: return G_LOG_LEVEL_MESSAGE;
-        case LOGLEVEL_INFO: return G_LOG_LEVEL_INFO;
-        case LOGLEVEL_DEBUG: return G_LOG_LEVEL_DEBUG;
-        case LOGLEVEL_UNSET:
-        case LOGLEVEL_ERROR:
-        default: return G_LOG_LEVEL_ERROR;
-    }
-}
 
 // Process start time, initialized on first use.
 // TODO: Parse out of /proc/$$/stat instead to get the true process start time.
@@ -58,8 +46,8 @@ static void _logger_default_log(LogLevel level, const gchar* fileName,
     gmtime_r(&tv.tv_sec, &tm);
     gchar* timeString = g_strdup_printf("%02d:%02d:%02d.%06ld", tm.tm_hour,
                                         tm.tm_min, tm.tm_sec, tv.tv_usec);
-    g_log("shadow", _gloglevelflags(level), "%s [%s:%i] [%s] %s", timeString,
-          baseName, lineNumber, functionName, message);
+    g_print("%s %s [%s:%i] [%s] %s\n", timeString, loglevel_toStr(level),
+            baseName, lineNumber, functionName, message);
     g_free(message);
     g_free(timeString);
     g_free(baseName);

--- a/src/support/logger/logger.c
+++ b/src/support/logger/logger.c
@@ -19,35 +19,37 @@ Logger* logger_getDefault() { return defaultLogger; }
 // Process start time, initialized explicitly or on first use.
 static pthread_mutex_t _start_time_mutex = PTHREAD_MUTEX_INITIALIZER;
 static bool _start_time_initd = false;
-static struct timeval _start_time;
+static int64_t _monotonic_start_time_micros;
 
-struct timeval logger_get_global_start_time() {
+int64_t logger_now_micros() {
+    return g_get_monotonic_time();
+}
+
+int64_t logger_get_global_start_time_micros() {
     pthread_mutex_lock(&_start_time_mutex);
     if (!_start_time_initd) {
         // TODO: Parse out of /proc/$$/stat instead to get the true process
-        // start time.
-        gettimeofday(&_start_time, NULL);
+        // start time?
+        _monotonic_start_time_micros = logger_now_micros();
         _start_time_initd = true;
     }
-    struct timeval start_time = _start_time;
+    int64_t t = _monotonic_start_time_micros;
     pthread_mutex_unlock(&_start_time_mutex);
-    return start_time;
+    return t;
 }
 
-void logger_set_global_start_time(const struct timeval* t) {
+void logger_set_global_start_time_micros(int64_t t) {
     pthread_mutex_lock(&_start_time_mutex);
-    _start_time = *t;
+    _monotonic_start_time_micros = t;
     _start_time_initd = true;
     pthread_mutex_unlock(&_start_time_mutex);
 }
 
-struct timeval logger_get_global_elapsed_time() {
-    const struct timeval start_time = logger_get_global_start_time();
-    struct timeval now;
-    gettimeofday(&now, NULL);
-    struct timeval elapsed;
-    timersub(&now, &start_time, &elapsed);
-    return elapsed;
+int64_t logger_elapsed_micros() {
+    // We need to be careful here to get t0 first, since the first time this
+    // function is called it will cause the start time to be lazily initialized.
+    int64_t t0 = logger_get_global_start_time_micros();
+    return logger_now_micros() - t0;
 }
 
 static void _logger_default_log(LogLevel level, const gchar* fileName,
@@ -57,7 +59,12 @@ static void _logger_default_log(LogLevel level, const gchar* fileName,
     gchar* message = g_strdup_vprintf(format, vargs);
     gchar* baseName = g_path_get_basename(fileName);
 
-    struct timeval tv = logger_get_global_elapsed_time();
+    int64_t elapsed_micros =
+        logger_now_micros() - logger_get_global_start_time_micros();
+    struct timeval tv = {
+        .tv_sec = elapsed_micros / G_USEC_PER_SEC,
+        .tv_usec = elapsed_micros % G_USEC_PER_SEC,
+    };
     struct tm tm;
     gmtime_r(&tv.tv_sec, &tm);
     gchar* timeString = g_strdup_printf("%02d:%02d:%02d.%06ld", tm.tm_hour,

--- a/src/support/logger/logger.c
+++ b/src/support/logger/logger.c
@@ -1,5 +1,8 @@
 #include "support/logger/logger.h"
 
+#include <pthread.h>
+#include <sys/time.h>
+
 static Logger* defaultLogger = NULL;
 
 void logger_setDefault(Logger* logger) {
@@ -24,14 +27,42 @@ static GLogLevelFlags _gloglevelflags(LogLevel level) {
     }
 }
 
+// Process start time, initialized on first use.
+// TODO: Parse out of /proc/$$/stat instead to get the true process start time.
+static pthread_once_t _start_time_init_once = PTHREAD_ONCE_INIT;
+static struct timeval _start_time;
+static void _init_start_time() { gettimeofday(&_start_time, NULL); }
+static const struct timeval* _get_start_time() {
+    pthread_once(&_start_time_init_once, _init_start_time);
+    return &_start_time;
+}
+
+static struct timeval _elapsed() {
+    const struct timeval* start_time = _get_start_time();
+    struct timeval now;
+    gettimeofday(&now, NULL);
+    struct timeval elapsed;
+    timersub(&now, start_time, &elapsed);
+    return elapsed;
+}
+
 static void _logger_default_log(LogLevel level, const gchar* fileName,
                                 const gchar* functionName,
                                 const gint lineNumber, const gchar* format,
                                 va_list vargs) {
     gchar* message = g_strdup_vprintf(format, vargs);
-    g_log("shadow", _gloglevelflags(level), "[%s:%i] [%s] %s", fileName,
-          lineNumber, functionName, message);
+    gchar* baseName = g_path_get_basename(fileName);
+
+    struct timeval tv = _elapsed();
+    struct tm tm;
+    gmtime_r(&tv.tv_sec, &tm);
+    gchar* timeString = g_strdup_printf("%02d:%02d:%02d.%06ld", tm.tm_hour,
+                                        tm.tm_min, tm.tm_sec, tv.tv_usec);
+    g_log("shadow", _gloglevelflags(level), "%s [%s:%i] [%s] %s", timeString,
+          baseName, lineNumber, functionName, message);
     g_free(message);
+    g_free(timeString);
+    g_free(baseName);
 }
 
 void logger_log(Logger* logger, LogLevel level, const gchar* fileName,

--- a/src/support/logger/logger.c
+++ b/src/support/logger/logger.c
@@ -51,6 +51,11 @@ static void _logger_default_log(LogLevel level, const gchar* fileName,
     g_free(message);
     g_free(timeString);
     g_free(baseName);
+#ifdef DEBUG
+    if (level == LOGLEVEL_ERROR) {
+        abort();
+    }
+#endif
 }
 
 void logger_log(Logger* logger, LogLevel level, const gchar* fileName,

--- a/src/support/logger/logger.c
+++ b/src/support/logger/logger.c
@@ -59,8 +59,7 @@ static void _logger_default_log(LogLevel level, const gchar* fileName,
     gchar* message = g_strdup_vprintf(format, vargs);
     gchar* baseName = g_path_get_basename(fileName);
 
-    int64_t elapsed_micros =
-        logger_now_micros() - logger_get_global_start_time_micros();
+    int64_t elapsed_micros = logger_elapsed_micros();
     struct timeval tv = {
         .tv_sec = elapsed_micros / G_USEC_PER_SEC,
         .tv_usec = elapsed_micros % G_USEC_PER_SEC,

--- a/src/support/logger/logger.c
+++ b/src/support/logger/logger.c
@@ -20,7 +20,6 @@ Logger* logger_getDefault() { return defaultLogger; }
 static pthread_mutex_t _start_time_mutex = PTHREAD_MUTEX_INITIALIZER;
 static bool _start_time_initd = false;
 static struct timeval _start_time;
-static void _init_start_time() { gettimeofday(&_start_time, NULL); }
 
 struct timeval logger_get_global_start_time() {
     pthread_mutex_lock(&_start_time_mutex);
@@ -42,7 +41,7 @@ void logger_set_global_start_time(const struct timeval* t) {
     pthread_mutex_unlock(&_start_time_mutex);
 }
 
-static struct timeval _elapsed() {
+struct timeval logger_get_global_elapsed_time() {
     const struct timeval start_time = logger_get_global_start_time();
     struct timeval now;
     gettimeofday(&now, NULL);
@@ -58,7 +57,7 @@ static void _logger_default_log(LogLevel level, const gchar* fileName,
     gchar* message = g_strdup_vprintf(format, vargs);
     gchar* baseName = g_path_get_basename(fileName);
 
-    struct timeval tv = _elapsed();
+    struct timeval tv = logger_get_global_elapsed_time();
     struct tm tm;
     gmtime_r(&tv.tv_sec, &tm);
     gchar* timeString = g_strdup_printf("%02d:%02d:%02d.%06ld", tm.tm_hour,

--- a/src/support/logger/logger.h
+++ b/src/support/logger/logger.h
@@ -4,7 +4,7 @@
 /*
  * A simple logger API.
  *
- * By default this simply writes to stderr. However, it also supports
+ * By default this simply writes to stdout. However, it also supports
  * overriding with a custom Logger.  Unlike in glib, when a custom Logger is
  * supplied, it's that logger's job to do any necessary synchronization. This
  * allows us to use a custom Logger in Shadow that avoids a global lock.

--- a/src/support/logger/logger.h
+++ b/src/support/logger/logger.h
@@ -45,7 +45,7 @@ struct _Logger {
 // `logger` may be NULL.
 void logger_setDefault(Logger* logger);
 
-// Not thread safe. May return NULL.
+// May return NULL.
 Logger* logger_getDefault();
 
 // Thread safe. `logger` may be NULL, in which case glib's logging

--- a/src/support/logger/logger.h
+++ b/src/support/logger/logger.h
@@ -60,4 +60,13 @@ void logger_log(Logger* logger, LogLevel level, const gchar* fileName,
                 const gchar* functionName, const gint lineNumber,
                 const gchar* format, ...);
 
+// Logger implementations should use this to get the logging "start" time.
+// This ensures consistency when switching loggers, and enables us to
+// synchronize loggers across processes.
+struct timeval logger_get_global_start_time();
+
+// Set the global start time used in log messages. If this isn't called, the
+// start time will be set to the current time the first time it's accessed.
+void logger_set_global_start_time(const struct timeval* t);
+
 #endif

--- a/src/support/logger/logger.h
+++ b/src/support/logger/logger.h
@@ -74,7 +74,8 @@ int64_t logger_now_micros();
 // Returns elapsed micros since agreed-upon start time.
 int64_t logger_elapsed_micros();
 
-// Set the global start time used in log messages. If this isn't called, the
-// start time will be set to the current time the first time it's accessed.
+// Not thread safe.  Set the global start time used in log messages. If this
+// isn't called, the start time will be set to the current time the first time
+// it's accessed.
 void logger_set_global_start_time_micros(int64_t);
 #endif

--- a/src/support/logger/logger.h
+++ b/src/support/logger/logger.h
@@ -4,11 +4,10 @@
 /*
  * A simple logger API.
  *
- * By default this simply wraps glib's logging functionality. However, it also
- * supports overriding with a custom Logger.  Unlike in glib, when a custom
- * Logger is supplied, it's that logger's job to do any necessary
- * synchronization. This allows us to use a custom Logger in Shadow that avoids
- * a global lock.
+ * By default this simply writes to stderr. However, it also supports
+ * overriding with a custom Logger.  Unlike in glib, when a custom Logger is
+ * supplied, it's that logger's job to do any necessary synchronization. This
+ * allows us to use a custom Logger in Shadow that avoids a global lock.
  */
 
 #include <glib.h>

--- a/src/support/logger/logger.h
+++ b/src/support/logger/logger.h
@@ -60,19 +60,21 @@ void logger_log(Logger* logger, LogLevel level, const gchar* fileName,
                 const gchar* functionName, const gint lineNumber,
                 const gchar* format, ...);
 
-// Returns an agreed-upon start time for logging purposes, expressed as elapsed
-// time since the Unix epoch, as returned by gettimeofday(2).
+// Returns an agreed-upon start time for logging purposes, as returned by
+// logger_now_micros.
 //
 // Logger implementations should use this to get the logging "start" time.
 // This ensures consistency when switching loggers, and enables us to
 // synchronize loggers across processes.
-struct timeval logger_get_global_start_time();
+int64_t logger_get_global_start_time_micros();
+
+// Returns "now" according to a monotonic system clock.
+int64_t logger_now_micros();
+
+// Returns elapsed micros since agreed-upon start time.
+int64_t logger_elapsed_micros();
 
 // Set the global start time used in log messages. If this isn't called, the
 // start time will be set to the current time the first time it's accessed.
-void logger_set_global_start_time(const struct timeval* t);
-
-// Convenience function to get the current time as returned by `gettimeofday`
-// and subtract the global start time.
-struct timeval logger_get_global_elapsed_time();
+void logger_set_global_start_time_micros(int64_t);
 #endif

--- a/src/support/logger/logger.h
+++ b/src/support/logger/logger.h
@@ -60,6 +60,9 @@ void logger_log(Logger* logger, LogLevel level, const gchar* fileName,
                 const gchar* functionName, const gint lineNumber,
                 const gchar* format, ...);
 
+// Returns an agreed-upon start time for logging purposes, expressed as elapsed
+// time since the Unix epoch, as returned by gettimeofday(2).
+//
 // Logger implementations should use this to get the logging "start" time.
 // This ensures consistency when switching loggers, and enables us to
 // synchronize loggers across processes.
@@ -69,4 +72,7 @@ struct timeval logger_get_global_start_time();
 // start time will be set to the current time the first time it's accessed.
 void logger_set_global_start_time(const struct timeval* t);
 
+// Convenience function to get the current time as returned by `gettimeofday`
+// and subtract the global start time.
+struct timeval logger_get_global_elapsed_time();
 #endif

--- a/src/test/bind/CMakeLists.txt
+++ b/src/test/bind/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories(${GLIB_INCLUDES})
-link_libraries(${GLIB_LIBRARIES})
+link_libraries(${GLIB_LIBRARIES} logger)
 
 ## build the test as a dynamic executable that plugs into shadow
 add_library(shadow-plugin-test-bind SHARED test_bind.c)

--- a/src/test/bind/test_bind.c
+++ b/src/test/bind/test_bind.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <glib.h>
 
+#include "support/logger/logger.h"
 #include "test/test_glib_helpers.h"
 
 static int _do_bind(int fd, in_addr_t address, in_port_t port) {
@@ -42,10 +43,10 @@ static int _do_connect(int fd, struct sockaddr_in* serveraddr) {
             break;
         }
         if (count++ > 1000) {
-            g_message("waited for connect for 1 second, giving up");
+            message("waited for connect for 1 second, giving up");
             break;
         }
-        g_debug("connect() returned EINPROGRESS, retrying in 1 millisecond");
+        debug("connect() returned EINPROGRESS, retrying in 1 millisecond");
         usleep((useconds_t)1000);
     }
     errno = saved_errno;
@@ -60,15 +61,15 @@ static int _do_accept(int fd) {
     while (1) {
         result = accept(fd, NULL, NULL);
         saved_errno = errno;
-        g_debug("accept() returned %i %s", result, strerror(errno));
+        debug("accept() returned %i %s", result, strerror(errno));
         if (result >= 0 || errno != EINPROGRESS) {
             break;
         }
         if (count++ > 1000) {
-            g_message("waited for accept for 1 second, giving up");
+            message("waited for accept for 1 second, giving up");
             break;
         }
-        g_debug("accept() returned EINPROGRESS, retrying in 1 millisecond");
+        debug("accept() returned EINPROGRESS, retrying in 1 millisecond");
         usleep((useconds_t)1000);
     }
     errno = saved_errno;
@@ -79,35 +80,35 @@ static void _test_explicit_bind(gconstpointer gp) {
     int socket_type = GPOINTER_TO_INT(gp);
     int fd1 = 0, fd2 = 0;
 
-    g_debug("creating sockets");
+    debug("creating sockets");
 
     assert_true_errno((fd1 = socket(AF_INET, socket_type, 0)) >= 0);
     assert_true_errno((fd2 = socket(AF_INET, socket_type, 0)) >= 0);
 
-    g_debug("binding one socket to localhost:11111");
+    debug("binding one socket to localhost:11111");
     assert_true_errno(_do_bind(fd1, (in_addr_t)htonl(INADDR_LOOPBACK),
                                (in_port_t)htons(11111)) == 0);
 
-    g_debug("try to bind the same socket again, which this should fail since we already did bind");
+    debug("try to bind the same socket again, which this should fail since we already did bind");
     g_assert_true(_do_bind(fd1, (in_addr_t)htonl(INADDR_LOOPBACK),
                            (in_port_t)htons(11111)) == -1);
     assert_errno_is(EINVAL);
 
-    g_debug("binding a second socket to the same address as the first should fail");
+    debug("binding a second socket to the same address as the first should fail");
     g_assert_true(_do_bind(fd2, (in_addr_t)htonl(INADDR_LOOPBACK),
                            (in_port_t)htons(11111)) == -1);
     assert_errno_is(EADDRINUSE);
 
-    g_debug("binding a second socket to ANY with same port as the first should fail");
+    debug("binding a second socket to ANY with same port as the first should fail");
     g_assert_true(_do_bind(fd2, (in_addr_t)htonl(INADDR_ANY),
                            (in_port_t)htons(11111)) == -1);
     assert_errno_is(EADDRINUSE);
 
-    g_debug("binding to 0.0.0.0:0 should succeed");
+    debug("binding to 0.0.0.0:0 should succeed");
     assert_true_errno(
         _do_bind(fd2, (in_addr_t)htonl(INADDR_ANY), (in_port_t)htons(0)) == 0);
 
-    g_debug("re-binding a socket bound to 0.0.0.0:0 should fail");
+    debug("re-binding a socket bound to 0.0.0.0:0 should fail");
     g_assert_true(_do_bind(fd2, (in_addr_t)htonl(INADDR_ANY),
                            (in_port_t)htons(22222)) == -1);
     assert_errno_is(EINVAL);
@@ -131,20 +132,20 @@ static int _check_matching_addresses(int fd_server_listen, int fd_server_accept,
 
     assert_true_errno(getsockname(fd_server_listen, (struct sockaddr*) &server_listen_sockname, &addr_len) == 0);
 
-    g_debug("found sockname %s:%i for server listen fd %i",
+    debug("found sockname %s:%i for server listen fd %i",
             inet_ntoa(server_listen_sockname.sin_addr),
             (int)server_listen_sockname.sin_port, fd_server_listen);
 
     assert_true_errno(getsockname(fd_server_accept, (struct sockaddr*) &server_accept_sockname, &addr_len) == 0);
 
-    g_debug("found sockname %s:%i for server accept fd %i",
+    debug("found sockname %s:%i for server accept fd %i",
             inet_ntoa(server_accept_sockname.sin_addr),
             (int)server_accept_sockname.sin_port, fd_server_accept);
 
     assert_true_errno(getsockname(fd_client, (struct sockaddr*)&client_sockname,
                                   &addr_len) == 0);
 
-    g_debug("found sockname %s:%i for client fd %i",
+    debug("found sockname %s:%i for client fd %i",
             inet_ntoa(client_sockname.sin_addr), (int)client_sockname.sin_port,
             fd_client);
 
@@ -152,14 +153,14 @@ static int _check_matching_addresses(int fd_server_listen, int fd_server_accept,
                                   (struct sockaddr*)&server_accept_peername,
                                   &addr_len) == 0);
 
-    g_debug("found peername %s:%i for server accept fd %i",
+    debug("found peername %s:%i for server accept fd %i",
             inet_ntoa(server_accept_peername.sin_addr),
             (int)server_accept_peername.sin_port, fd_server_accept);
 
     assert_true_errno(getpeername(fd_client, (struct sockaddr*)&client_peername,
                                   &addr_len) == 0);
 
-    g_debug("found peername %s:%i for client fd %i",
+    debug("found peername %s:%i for client fd %i",
             inet_ntoa(client_peername.sin_addr), (int)client_peername.sin_port,
             fd_client);
 
@@ -189,11 +190,11 @@ static void _test_implicit_bind(gconstpointer gp) {
     socklen_t addr_len = sizeof(struct sockaddr_in);
     memset(&serveraddr, 0, sizeof(struct sockaddr_in));
 
-    g_debug("creating sockets");
+    debug("creating sockets");
     assert_true_errno((fd1 = socket(AF_INET, socket_type, 0)) >= 0);
     assert_true_errno((fd2 = socket(AF_INET, socket_type, 0)) >= 0);
 
-    g_debug("listening on server socket with implicit bind");
+    debug("listening on server socket with implicit bind");
     assert_true_errno(listen(fd1, 0) == 0);
 
     assert_true_errno(
@@ -208,21 +209,21 @@ static void _test_implicit_bind(gconstpointer gp) {
     return;
     // FIXME end
 
-    g_debug("connecting client socket to server at 0.0.0.0");
+    debug("connecting client socket to server at 0.0.0.0");
     assert_true_errno(_do_connect(fd2, &serveraddr) == 0);
 
     close(fd2);
     fd2 = 0;
     assert_true_errno((fd2 = socket(AF_INET, socket_type, 0)) >= 0);
 
-    g_debug("connecting client socket to server at 127.0.0.1");
+    debug("connecting client socket to server at 127.0.0.1");
     serveraddr.sin_addr.s_addr = (in_addr_t) htonl(INADDR_LOOPBACK);
     assert_true_errno(_do_connect(fd2, &serveraddr) == 0);
 
-    g_debug("accepting client connection");
+    debug("accepting client connection");
     assert_true_errno((fd3 = _do_accept(fd1)) >= 0);
 
-    g_debug("checking that server and client addresses match");
+    debug("checking that server and client addresses match");
     g_assert_true(_check_matching_addresses(fd1, fd3, fd2) == EXIT_SUCCESS);
 
     close(fd1);


### PR DESCRIPTION
In the default logger:
  * Log elapsed time
  * Log the source file basename instead of the whole path
  * Log using g_print (as shadow logger does) ~directly to stderr~ instead of to glib's logger
  * In debug builds, abort the program on errors.

As I was testing, dealing with glib's logger underneath was a bit of a headache. While it has some nice features, the defaults aren't want we want. Easier to just bypass it for now.

Ported bind test to use our logger macros instead of glib's to help test and to get the additional fields (code location, time, etc).