### PR TITLE
Call gettimeofday from within shadow logger

### DIFF
--- a/src/main/core/logger/shadow_logger.c
+++ b/src/main/core/logger/shadow_logger.c
@@ -8,6 +8,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/time.h>
 
 #include "main/core/logger/log_record.h"
 #include "main/core/logger/logger_helper.h"
@@ -185,6 +186,8 @@ void shadow_logger_logVA(ShadowLogger* logger, LogLevel level,
         logger->threadToDataMap, GUINT_TO_POINTER(pthread_self()));
     MAGIC_ASSERT(threadData);
 
+    struct timeval t;
+    gettimeofday(&t, NULL);
     gdouble timespan = g_timer_elapsed(threadData->runTimer, NULL);
 
     LogRecord* record =


### PR DESCRIPTION
Reproduce integration test breakage from #801 by simply calling `gettimeofday` from within the shadow logger (and not doing anything with the result)