### PR TITLE
Update issue template with new issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
-about: If you have trouble installing or using Shadow.
+about: An error or flaw producing unexpected results
 title: ''
-labels: support
+labels: Type: Bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for a new functionality or improved design
 title: ''
-labels: ''
+labels: 'Type: Enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,8 @@
 ---
 name: Question
-about: Learn more about how Shadow works.
+about: How or why Shadow works as it does
 title: ''
-labels: support
+labels: Type: Question
 assignees: ''
 
 ---


### PR DESCRIPTION
We recently added new issue labels, and now our issue creation templates assign labels that no longer exist. This fixes the label assignment to use the new labels and makes the issue type description consistent with the label types.