### PR TITLE
Fix unquoted string containing colon

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,8 +1,8 @@
 ---
-name: Bug report
-about: An error or flaw producing unexpected results
+name: 'Bug report'
+about: 'An error or flaw producing unexpected results'
 title: ''
-labels: Type: Bug
+labels: 'Type: Bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
-name: Feature request
-about: Suggest an idea for a new functionality or improved design
+name: 'Feature request'
+about: 'Suggest an idea for a new functionality or improved design'
 title: ''
 labels: 'Type: Enhancement'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,8 @@
 ---
-name: Question
-about: How or why Shadow works as it does
+name: 'Question'
+about: 'How or why Shadow works as it does'
 title: ''
-labels: Type: Question
+labels: 'Type: Question'
 assignees: ''
 
 ---


### PR DESCRIPTION
Whoops! shadow/shadow@57d1ae3f1752e2c25597bdbee78458fc3e87449b introduced an error that caused the bug and question issue templates to not be presented upon creating a new issue. I think it was an error with missing quotes for a string that contains a colon.