### PR TITLE
Re-enable some CI tests for other distros

### DIFF
--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -5,7 +5,7 @@ name: Tests
 
 on:
   push:
-    branches: [master, 'rebases/**']
+    branches: [dev]
     paths-ignore:
       - '**.md'
       - 'LICENSE'
@@ -22,24 +22,26 @@ jobs:
       options: '--shm-size="1g"'
     strategy:
       matrix:
-        container: ['ubuntu:18.04', 'centos:7'] #, 'ubuntu:16.04', 'ubuntu:20.04', 'debian:10-slim', 'fedora:32', 'centos:8']
-        cc: ['gcc'] #, 'clang']
+        # ubuntu:16.04 depends on the issue shadow/shadow#864
+        container: ['ubuntu:18.04', 'ubuntu:20.04', 'debian:10-slim', 'fedora:32', 'centos:7', 'centos:8'] # 'ubuntu:16.04'
+        # clang depends on the issue shadow/shadow#865
+        cc: ['gcc'] # 'clang'
         buildtype: ['debug', 'release']
         include:
 #          - container: 'ubuntu:16.04'
 #            package_manager: 'apt'
           - container: 'ubuntu:18.04'
             package_manager: 'apt'
-#          - container: 'ubuntu:20.04'
-#            package_manager: 'apt'
-#          - container: 'debian:10-slim'
-#            package_manager: 'apt'
-#          - container: 'fedora:32'
-#            package_manager: 'dnf-fedora'
+          - container: 'ubuntu:20.04'
+            package_manager: 'apt'
+          - container: 'debian:10-slim'
+            package_manager: 'apt'
+          - container: 'fedora:32'
+            package_manager: 'dnf-fedora'
           - container: 'centos:7'
             package_manager: 'yum-centos-7'
-#          - container: 'centos:8'
-#            package_manager: 'dnf-centos-8'
+          - container: 'centos:8'
+            package_manager: 'dnf-centos-8'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -51,17 +53,17 @@ jobs:
           DEBIAN_FRONTEND: 'noninteractive'
         run: |
           apt-get update
-          apt-get install -y ${{ matrix.cc }} g++ cmake make xz-utils python3 libglib2.0-0 libglib2.0-dev libigraph0v5 libigraph0-dev libc-dbg libprocps-dev curl
+          apt-get install -y ${{ matrix.cc }} g++ cmake make xz-utils python3 libglib2.0-0 libglib2.0-dev libigraph0v5 libigraph0-dev libc-dbg libprocps-dev curl findutils
 
       - name: Install Dependencies (dnf-fedora)
         if: ${{ matrix.package_manager == 'dnf-fedora' }}
-        run: dnf install --best -y ${{ matrix.cc }} cmake make gcc-c++ glib2 glib2-devel igraph igraph-devel python3 xz xz-devel yum-utils procps-devel curl
+        run: dnf install --best -y ${{ matrix.cc }} cmake make gcc-c++ glib2 glib2-devel igraph igraph-devel python3 xz xz-devel yum-utils procps-devel curl findutils
 
       - name: Install Dependencies (yum-centos-7)
         if: ${{ matrix.package_manager == 'yum-centos-7' }}
         run: |
           yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-          yum install -y ${{ matrix.cc }} cmake make gcc-c++ glib2 glib2-devel igraph igraph-devel python3 xz xz-devel yum-utils procps-devel curl
+          yum install -y ${{ matrix.cc }} cmake make gcc-c++ glib2 glib2-devel igraph igraph-devel python3 xz xz-devel yum-utils procps-devel curl findutils
 
       - name: Install Dependencies (dnf-centos-8)
         if: ${{ matrix.package_manager == 'dnf-centos-8' }}
@@ -73,7 +75,7 @@ jobs:
           dnf install -y http://vault.centos.org/centos/7.7.1908/os/x86_64/Packages/procps-ng-devel-3.3.10-26.el7.x86_64.rpm
           dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages/i/igraph-0.7.1-12.el7.x86_64.rpm
           dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages/i/igraph-devel-0.7.1-12.el7.x86_64.rpm
-          dnf install -y ${{ matrix.cc }} cmake make gcc-c++ glib2 glib2-devel python3 xz xz-devel yum-utils curl
+          dnf install -y ${{ matrix.cc }} cmake make gcc-c++ glib2 glib2-devel python3 xz xz-devel yum-utils curl findutils
 
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path

--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -6,9 +6,6 @@ name: Tests
 on:
   push:
     branches: [dev]
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.8]
+        python-version: [3.8]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@master

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -2,15 +2,13 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 
 name: PythonLint
+
 on:
   push:
-    paths:
-      - 'setup'
-      - '**.py'
+    branches: [dev]
   pull_request:
-    paths:
-      - 'setup'
-      - '**.py'
+    types: [opened, synchronize]
+
 jobs:
   lint_python:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Re-enables CI tests for ubuntu:20.04, debian:10-slim, fedora:32, and centos:8. The 'findutils' package is for our cmake rust unit tests which require the 'find' tool. This PR also stops running linting tests with Python 2.7.

The tests do not currently complete on ubuntu:16.04 (shadow/shadow#864) or when using clang (shadow/shadow#865).