### PR TITLE
Upgrade to CMake 3.2

### DIFF
--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -92,9 +92,15 @@ jobs:
       - name: Install Dependencies (yum-centos-7)
         if: ${{ matrix.package_manager == 'yum-centos-7' }}
         run: |
-          # clang on centos 7 requires gcc and gcc-c++ (libgcc is not sufficient)
+          # Clang on centos 7 requires gcc and gcc-c++ (libgcc is not sufficient).
+          # Must also link cmake to cmake3 as an alternative.
           yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-          yum install -y $CC_PACKAGE $CXX_PACKAGE gcc gcc-c++ cmake make glib2 glib2-devel igraph igraph-devel python3 xz xz-devel yum-utils procps-devel curl findutils
+          yum install -y $CC_PACKAGE $CXX_PACKAGE gcc gcc-c++ cmake3 make glib2 glib2-devel igraph igraph-devel python3 xz xz-devel yum-utils procps-devel curl findutils
+          alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 \
+            --slave /usr/local/bin/ctest ctest /usr/bin/ctest3 \
+            --slave /usr/local/bin/cpack cpack /usr/bin/cpack3 \
+            --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 \
+            --family cmake
 
       - name: Install Dependencies (dnf-centos-8)
         if: ${{ matrix.package_manager == 'dnf-centos-8' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ message(STATUS "System version: ${CMAKE_SYSTEM_VERSION}")
 message(STATUS "System processor: ${CMAKE_SYSTEM_PROCESSOR}")
 
 ## ensure cmake version
-cmake_minimum_required(VERSION 2.8.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 
 ## building with support for C11 on platforms that default to C99 or C89
 set (CMAKE_C_FLAGS "-std=gnu11 ${CMAKE_C_FLAGS}")

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -36,16 +36,11 @@ endif()
 
 include(ExternalProject)
 
-# since CMake 2.8 does not support 'BUILD_ALWAYS 1', we need to manually delete the timestamps
-file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/cmake-stamp)
-file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/cmake-tmp)
-
 ## build the rust library
 ExternalProject_Add(
     shadow-rust-project
     PREFIX ${CMAKE_CURRENT_SOURCE_DIR}
-    STAMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/cmake-stamp
-    TMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/cmake-tmp
+    BUILD_ALWAYS 1
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
@@ -54,8 +49,9 @@ ExternalProject_Add(
     LOG_BUILD OFF
 )
 
-# we can't predict exact executable names until this is fixed: https://github.com/rust-lang/cargo/issues/1924
-add_test(NAME rust-unit-tests COMMAND bash -c "exec \"$(find target/${RUST_BUILD_TYPE}/deps/ -type f -executable -name 'shadow_rs-*' -print | head -n 1)\" --color always")
+## we can't predict exact executable names until this is fixed: https://github.com/rust-lang/cargo/issues/1924
+add_test(NAME rust-unit-tests COMMAND bash -c "exec \"$(find target/${RUST_BUILD_TYPE}/deps/ \
+                                               -type f -executable -name 'shadow_rs-*' -print | head -n 1)\" --color always")
 set_property(TEST rust-unit-tests PROPERTY ENVIRONMENT "RUST_BACKTRACE=1")
 
 ## allow shadow to link to the static rust library

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -45,6 +45,7 @@ ExternalProject_Add(
     CONFIGURE_COMMAND ""
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
     BUILD_COMMAND cargo build ${RUST_BUILD_FLAG} --all-targets --target-dir ${CMAKE_CURRENT_BINARY_DIR}/target
+    BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/target/debug/libshadow_rs.a ${CMAKE_CURRENT_BINARY_DIR}/target/release/libshadow_rs.a
     INSTALL_COMMAND ""
     LOG_BUILD OFF
 )

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -10,16 +10,11 @@ add_definitions(-fPIC -g3 -DDEBUG -D_GNU_SOURCE)
 
 include(ExternalProject)
 
-# since CMake 2.8 does not support 'BUILD_ALWAYS 1', we need to manually delete the timestamps
-file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/cmake-stamp)
-file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/cmake-tmp)
-
 ## always build tests with the debug profile, even when shadow is built in release mode
 ExternalProject_Add(
    shadow-tests
    PREFIX ${CMAKE_CURRENT_SOURCE_DIR}
-   STAMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/cmake-stamp
-   TMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/cmake-tmp
+   BUILD_ALWAYS 1
    DOWNLOAD_COMMAND ""
    CONFIGURE_COMMAND ""
    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
CMake >= 3.2 is available by default on all supported platforms except for CentOS 7, which requires the `cmake3` package from EPEL and for `cmake` to be linked to `cmake` using a method such as https://stackoverflow.com/a/48842999.

> I'm a bit worried about requiring CMake v3.2 because it might not be available in all of our supported distros. I see that you have a way to make it work in CentOS 7, but I don't know if it's easy to get that working all older distros.

All of the other supported distros support CMake 3.2 (for example Ubuntu 16.04 is 3.5, Fedora 32 is 3.17, CentOS 8 is 3.11, and Debian 10 is 3.13). CentOS 7 is the oldest distro that we support, which uses CMake 2.8.

> It would require an extra step that we would need to ask users to perform during setup.

I agree this isn't ideal. If we wanted to not require this step, we could modify the setup script to search for cmake3 and ctest3, and use those instead if found.

> 3.2 is mainly required to get the build working with Ninja. Is it worth it?

I don't use Ninja, but I think the main advantage of ninja vs make is the speed. But Shadow doesn't take long to compile, so I'm not sure if the advantage is significant here. On the other hand, we get a lot of new CMake features by upgrading to 3.2, which might make things easier for us going forward.