### PR TITLE
Fix Rust coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set(CMAKE_C_FLAGS_DEBUG "")
 set(CMAKE_C_FLAGS_RELEASE "")
 add_compile_options(-ggdb)
 add_compile_options(-fno-omit-frame-pointer)
+
 if(SHADOW_DEBUG STREQUAL ON)
     message(STATUS "CMAKE_BUILD_TYPE Debug enabled.")
     set(CMAKE_BUILD_TYPE Debug)
@@ -146,12 +147,21 @@ else(SHADOW_DEBUG STREQUAL ON)
     add_definitions(-DNDEBUG)
     add_compile_options(-O3)
 endif(SHADOW_DEBUG STREQUAL ON)
+
 if(SHADOW_WERROR STREQUAL ON)
     add_compile_options(-Werror)
 endif(SHADOW_WERROR STREQUAL ON)
+
 if(SHADOW_COVERAGE STREQUAL ON)
     add_compile_options(--coverage)
     add_ldflags(--coverage)
+    ## from https://github.com/mozilla/grcov
+    set(CARGO_ENV_VARS "CARGO_INCREMENTAL=0 \
+                        RUSTFLAGS=\"-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code \
+                                    -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort\" \
+                        RUSTDOCFLAGS=\"-Cpanic=abort\"")
+else()
+    set(CARGO_ENV_VARS "")
 endif(SHADOW_COVERAGE STREQUAL ON)
 
 if($ENV{VERBOSE})

--- a/setup
+++ b/setup
@@ -200,12 +200,6 @@ def build(args, remaining):
             logging.warning("You usually want to enable --debug for coverage"
                     + " builds")
         cmake_cmd += " -DSHADOW_COVERAGE=ON"
-        # From https://github.com/mozilla/grcov
-        os.putenv("CARGO_INCREMENTAL", "0")
-        os.putenv("RUSTFLAGS", "-Zprofile -Ccodegen-units=1 -Copt-level=0"
-                + " -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests"
-                + " -Cpanic=abort")
-        os.putenv("RUSTDOCFLAGS", "-Cpanic=abort")
 
     # we will run from build directory
     calledDirectory = os.getcwd()

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -44,7 +44,7 @@ ExternalProject_Add(
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-    BUILD_COMMAND cargo build ${RUST_BUILD_FLAG} --all-targets --target-dir ${CMAKE_CURRENT_BINARY_DIR}/target
+    BUILD_COMMAND bash -c "${CARGO_ENV_VARS} cargo build ${RUST_BUILD_FLAG} --all-targets --target-dir ${CMAKE_CURRENT_BINARY_DIR}/target"
     BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/target/debug/libshadow_rs.a ${CMAKE_CURRENT_BINARY_DIR}/target/release/libshadow_rs.a
     INSTALL_COMMAND ""
     LOG_BUILD OFF

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -18,7 +18,7 @@ ExternalProject_Add(
    DOWNLOAD_COMMAND ""
    CONFIGURE_COMMAND ""
    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-   BUILD_COMMAND cargo build --target-dir ${CMAKE_CURRENT_BINARY_DIR}/target
+   BUILD_COMMAND bash -c "${CARGO_ENV_VARS} cargo build --target-dir ${CMAKE_CURRENT_BINARY_DIR}/target"
    INSTALL_COMMAND ""
    LOG_BUILD OFF
 )


### PR DESCRIPTION
Upgrading to CMake 3 broke the Rust code coverage reporting, so this PR corrects that.

Closes #879.