### PR TITLE
Don't fail CI tests on Codecov upload failure

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -64,7 +64,7 @@ jobs:
           name: coverage 
           file: grcov.lcov.txt
           flags: tests
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Upload shadow data directories
         uses: actions/upload-artifact@v2

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  branch: dev


### PR DESCRIPTION
~As our coverage was being run in `shadow/src`, codecov didn't know how to match the files in the repository with the files in the coverage report. This PR tells codecov how to link them.~

Set the Codecov upload action to not fail the CI test if the upload fails.

Also set the dev branch as the main branch, but I don't think this will activate until we add it to the master branch as well.