### PR TITLE
Update installing dependencies in doc

### DIFF
--- a/docs/1.1-Shadow.md
+++ b/docs/1.1-Shadow.md
@@ -56,8 +56,10 @@ sudo debuginfo-install glibc
 sudo yum install -y \
     python3-numpy \
     python3-lxml \
+    python3-matplotlib \
     python3-networkx \
-    python3-scipy
+    python3-scipy \
+    python3-yaml
 sudo yum install -y \
     dstat \
     git \
@@ -85,10 +87,10 @@ sudo apt-get install -y \
     cargo
 sudo apt-get install libc-dbg
 sudo apt-get install -y \
+    python3-numpy \
     python3-lxml \
     python3-matplotlib \
     python3-networkx \
-    python3-numpy \
     python3-scipy \
     python3-yaml
 sudo apt-get install -y \

--- a/docs/1.1-Shadow.md
+++ b/docs/1.1-Shadow.md
@@ -50,14 +50,14 @@ sudo yum install -y \
     xz \
     xz-devel \
     yum-utils \
-    procps-devel
+    procps-devel \
+    cargo
 sudo debuginfo-install glibc
 sudo yum install -y \
-    numpy \
-    python-lxml \
-    python-matplotlib \
-    python-networkx \
-    scipy
+    python3-numpy \
+    python3-lxml \
+    python3-networkx \
+    python3-scipy
 sudo yum install -y \
     dstat \
     git \
@@ -81,14 +81,16 @@ sudo apt-get install -y \
     make \
     python3 \
     xz-utils \
-    libprocps-dev
+    libprocps-dev \
+    cargo
 sudo apt-get install libc-dbg
 sudo apt-get install -y \
-    python-lxml \
-    python-matplotlib \
-    python-networkx \
-    python-numpy \
-    python-scipy
+    python3-lxml \
+    python3-matplotlib \
+    python3-networkx \
+    python3-numpy \
+    python3-scipy \
+    python3-yaml
 sudo apt-get install -y \
     dstat \
     git \


### PR DESCRIPTION
All cases are not covered, for example, `yum install cargo` is not handled on centos7 but works on centos8. I think it is sufficient to understand what the user has to install.
