### PR TITLE
Incremental Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
+# this file is also used with rsync --exclude-from
+# in 'ci/run.sh', so avoid globs
 .git
 build

--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -20,6 +20,11 @@ APT_PACKAGES="
   xz-utils
   "
 
+# packages that are only required for our CI environment
+APT_CI_PACKAGES="
+  rsync
+  "
+
 RPM_PACKAGES="
   cmake
   curl
@@ -38,6 +43,11 @@ RPM_PACKAGES="
   diffutils
   "
 
+# packages that are only required for our CI environment
+RPM_CI_PACKAGES="
+  rsync
+  "
+
 PYTHON_PACKAGES="
   PyYaml
   "
@@ -46,7 +56,7 @@ case "$CONTAINER" in
     ubuntu:*|debian:*)
         sed -i '/deb-src/s/^# //' /etc/apt/sources.list
         DEBIAN_FRONTEND=noninteractive apt-get update
-        DEBIAN_FRONTEND=noninteractive apt-get install -y $APT_PACKAGES
+        DEBIAN_FRONTEND=noninteractive apt-get install -y $APT_PACKAGES $APT_CI_PACKAGES
 
         # Handle dict ordering of src/tools/convert.py and allow diff on its tests
         # Before Python3.6, dict ordering was not predictable
@@ -60,12 +70,12 @@ case "$CONTAINER" in
         fi
         ;;
     fedora:*)
-        dnf install --best -y $RPM_PACKAGES
+        dnf install --best -y $RPM_PACKAGES $RPM_CI_PACKAGES
         ;;
     centos:7)
         yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
         RPM_PACKAGES=${RPM_PACKAGES/cmake/cmake3}
-        yum install -y $RPM_PACKAGES
+        yum install -y $RPM_PACKAGES $RPM_CI_PACKAGES
         alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 \
             --slave /usr/local/bin/ctest ctest /usr/bin/ctest3 \
             --slave /usr/local/bin/cpack cpack /usr/bin/cpack3 \
@@ -84,7 +94,7 @@ case "$CONTAINER" in
         RPM_PACKAGES=${RPM_PACKAGES/igraph-devel}
         RPM_PACKAGES=${RPM_PACKAGES/igraph}
 
-        dnf install -y ${RPM_PACKAGES}
+        dnf install -y ${RPM_PACKAGES} ${RPM_CI_PACKAGES}
         ;;
     *)
         echo "Unhandled container $CONTAINER"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -17,11 +17,22 @@ iterating on a test that's failing in GitHub's test runs.
 The [`run.sh`](../ci/run.sh) script builds a Docker images for all
 supported configurations, and runs our tests in them.
 
+On the first invocation you should tell the `run.sh` script to build the images
+using `-i`:
+
+
+```{.bash}
+sudo ci/run.sh -i
+```
+
+Future invocations can omit the `-i` option to use the existing image and
+build/test only the incremental changes:
+
 ```{.bash}
 sudo ci/run.sh
 ```
 
-Note that running all tests locally typically takes hours. More often,
+Note that building all images locally typically takes hours. More often,
 you'll want to only run some smaller set of configurations locally.
 To run only the configurations you specify, use the `-o` flag:
 


### PR DESCRIPTION
Use the '-i' option to `ci/run.sh` to build the images. You may only want to build the images on the first invocation, or if the Shadow code significantly changes.

@sporksmith Is this what you had in mind for incremental builds?