### PR TITLE
Fix default scheduler policy

### DIFF
--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -139,7 +139,7 @@ Scheduler* scheduler_new(SchedulerPolicyType policyType, guint nWorkers, gpointe
     if(nWorkers == 0) {
         scheduler->policyType = SP_SERIAL_GLOBAL;
     } else if(nWorkers > 0 && policyType == SP_SERIAL_GLOBAL) {
-        policyType = SP_PARALLEL_HOST_STEAL;
+        scheduler->policyType = SP_PARALLEL_HOST_STEAL;
     } else {
         scheduler->policyType = policyType;
     }


### PR DESCRIPTION
This seems like a bug to me, but the existing behaviour should be fine as the workers just won't be used.