### PR TITLE
If stoptime is reached, exit with an error code

### DIFF
--- a/src/main/core/main.c
+++ b/src/main/core/main.c
@@ -188,6 +188,11 @@ gint main_runShadow(gint argc, gchar* argv[]) {
         return EXIT_FAILURE;
     }
 
+    /* unblock all signals since cmake's ctest blocks SIGTERM (and maybe others) */
+    sigset_t new_sig_set;
+    sigemptyset(&new_sig_set);
+    sigprocmask(SIG_SETMASK, &new_sig_set, NULL);
+
     /* parse the options from the command line */
     gchar* cmds = g_strjoinv(" ", argv);
     gchar** cmdv = g_strsplit(cmds, " ", 0);

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -346,6 +346,10 @@ void process_stop(Process* proc) {
         proc->plugin.isExecuting = TRUE;
         thread_terminate(proc->mainThread);
         proc->plugin.isExecuting = FALSE;
+
+        /* if the return code was non-zero, increment the number of plugin errors */
+        _process_logReturnCode(proc, thread_getReturnCode(proc->mainThread));
+
         debug("unreffing main thread %p", proc->mainThread);
         thread_unref(proc->mainThread);
         proc->mainThread = NULL;

--- a/src/main/host/thread_ptrace.c
+++ b/src/main/host/thread_ptrace.c
@@ -499,9 +499,11 @@ void threadptrace_terminate(Thread* base) {
         return;
     }
 
-    if (ptrace(PTRACE_CONT, thread->base.nativePid, 0, SIGTERM) < 0) {
+    if (ptrace(PTRACE_DETACH, thread->base.nativePid, 0, SIGTERM) < 0) {
         warning("ptrace %d: %s", thread->base.nativePid, g_strerror(errno));
     }
+
+    _threadptrace_nextChildState(thread);
 }
 
 int threadptrace_getReturnCode(Thread* base) {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(shadow-test-launcher-fail test_launcher_fail.c test_launcher_comm
 # FIXME add_subdirectory(dynlink)
 # FIXME add_subdirectory(preload)
 
+add_subdirectory(stoptime)
 add_subdirectory(bind)
 add_subdirectory(config)
 add_subdirectory(cpp)

--- a/src/test/stoptime/CMakeLists.txt
+++ b/src/test/stoptime/CMakeLists.txt
@@ -1,0 +1,7 @@
+# tests to make sure that if we reach the stop time, shadow exits with an error message
+add_test(NAME stoptime COMMAND timeout 1 /bin/sleep 2)
+add_test(NAME stoptime-shadow-ptrace COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -l debug -d stoptime.shadow-ptrace.data ${CMAKE_CURRENT_SOURCE_DIR}/stoptime.shadow.config.xml)
+add_test(NAME stoptime-shadow-preload COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload -l debug -d stoptime.shadow-preload.data ${CMAKE_CURRENT_SOURCE_DIR}/stoptime.shadow.config.xml)
+
+# we expect the tests to have a non-zero exit code
+set_tests_properties(stoptime stoptime-shadow-ptrace stoptime-shadow-preload PROPERTIES WILL_FAIL true)

--- a/src/test/stoptime/stoptime.shadow.config.xml
+++ b/src/test/stoptime/stoptime.shadow.config.xml
@@ -1,0 +1,26 @@
+<shadow stoptime="5">
+  <topology><![CDATA[<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+  <key attr.name="packetloss" attr.type="double" for="edge" id="d4" />
+  <key attr.name="latency" attr.type="double" for="edge" id="d3" />
+  <key attr.name="bandwidthup" attr.type="int" for="node" id="d2" />
+  <key attr.name="bandwidthdown" attr.type="int" for="node" id="d1" />
+  <key attr.name="countrycode" attr.type="string" for="node" id="d0" />
+  <graph edgedefault="undirected">
+    <node id="poi-1">
+      <data key="d0">US</data>
+      <data key="d1">10240</data>
+      <data key="d2">10240</data>
+    </node>
+    <edge source="poi-1" target="poi-1">
+      <data key="d3">50.0</data>
+      <data key="d4">0.0</data>
+    </edge>
+  </graph>
+</graphml>
+]]></topology>
+  <plugin id="testexitcode" path="/bin/sleep"/>
+  <node id="testnode" quantity="1">
+    <application plugin="testexitcode" starttime="1" arguments="10"/>
+  </node>
+</shadow>
+


### PR DESCRIPTION
When running tests, if the test doesn't end before stoptime, shadow will exit with an exit code of 0, which ctest will think is a passing test. Instead, this PR will collect the exit code of the process and return that instead.

I'm not sure how this will affect experiments where the user doesn't care about the exit code at stoptime, where Shadow might now return an error code. Tor handles SIGTERM with libevent and returns an exit code of 0, so this shouldn't affect Tor experiments.

Closes shadow/shadow#902.