### PR TITLE
Proc maps parser updates

### DIFF
--- a/src/main/utility/proc_maps.rs
+++ b/src/main/utility/proc_maps.rs
@@ -74,17 +74,17 @@ impl FromStr for MappingPath {
 /// Represents a single line in /proc/[pid]/maps.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Mapping {
-    begin: usize,
-    end: usize,
-    read: bool,
-    write: bool,
-    execute: bool,
-    sharing: Sharing,
-    offset: usize,
-    device_major: i32,
-    device_minor: i32,
-    inode: i32,
-    path: Option<MappingPath>,
+    pub begin: usize,
+    pub end: usize,
+    pub read: bool,
+    pub write: bool,
+    pub execute: bool,
+    pub sharing: Sharing,
+    pub offset: usize,
+    pub device_major: i32,
+    pub device_minor: i32,
+    pub inode: i32,
+    pub path: Option<MappingPath>,
 }
 
 // Parses the given field with the given function, decorating errors with the field name and value.

--- a/src/main/utility/proc_maps.rs
+++ b/src/main/utility/proc_maps.rs
@@ -354,9 +354,10 @@ mod tests {
         // Undocumented '(deleted)' trailer, indicating that the mapped file has been removed from
         // the file system.
         {
-            let mapping = "00400000-00452000 r-xp 00000000 bb:cc 173521      /usr/bin/dbus-daemon (deleted)"
-                .parse::<Mapping>()
-                .unwrap();
+            let mapping =
+                "00400000-00452000 r-xp 00000000 bb:cc 173521      /usr/bin/dbus-daemon (deleted)"
+                    .parse::<Mapping>()
+                    .unwrap();
             assert!(mapping.deleted);
         }
     }
@@ -442,9 +443,11 @@ mod tests {
             .is_err());
 
         // Trailing garbage after (deleted)
-        assert!("7fffb2d48000-7fffb2d49000 ---p 00000000 00:00 0   [vdso] (deleted) z"
-            .parse::<Mapping>()
-            .is_err());
+        assert!(
+            "7fffb2d48000-7fffb2d49000 ---p 00000000 00:00 0   [vdso] (deleted) z"
+                .parse::<Mapping>()
+                .is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Some fixes made after starting to use the proc maps parser:

* Make the Mapping fields public
* Parse the undocumented '(deleted)' specifier