### PR TITLE
Split Rust Thread interface (trait) from implementation

### DIFF
--- a/src/main/host/syscall_types.rs
+++ b/src/main/host/syscall_types.rs
@@ -1,15 +1,27 @@
 use crate::cbindings as c;
 use std::convert::From;
 
+#[derive(Copy, Clone)]
+pub struct PluginPtr {
+    ptr: c::PluginPtr,
+}
+
 impl From<PluginPtr> for c::PluginPtr {
     fn from(v: PluginPtr) -> c::PluginPtr {
         v.ptr
     }
 }
 
-#[derive(Copy, Clone)]
-pub struct PluginPtr {
-    ptr: c::PluginPtr,
+impl From<c::PluginPtr> for PluginPtr {
+    fn from(v: c::PluginPtr) -> PluginPtr {
+        PluginPtr { ptr: v }
+    }
+}
+
+impl From<PluginPtr> for usize {
+    fn from(v: PluginPtr) -> usize {
+        v.ptr.val as usize
+    }
 }
 
 impl From<usize> for PluginPtr {
@@ -28,17 +40,9 @@ impl From<u64> for PluginPtr {
     }
 }
 
-impl From<c::PluginPtr> for PluginPtr {
-    fn from(v: c::PluginPtr) -> PluginPtr {
-        PluginPtr { ptr: v }
-    }
-}
-
-impl From<SysCallReg> for PluginPtr {
-    fn from(v: SysCallReg) -> PluginPtr {
-        PluginPtr {
-            ptr: unsafe { v.reg.as_ptr },
-        }
+impl From<PluginPtr> for u64 {
+    fn from(v: PluginPtr) -> u64 {
+        v.ptr.val
     }
 }
 
@@ -61,11 +65,23 @@ impl From<u64> for SysCallReg {
     }
 }
 
+impl From<SysCallReg> for u64 {
+    fn from(v: SysCallReg) -> u64 {
+        unsafe { v.reg.as_u64 }
+    }
+}
+
 impl From<usize> for SysCallReg {
     fn from(v: usize) -> SysCallReg {
         SysCallReg {
             reg: c::SysCallReg { as_u64: v as u64 },
         }
+    }
+}
+
+impl From<SysCallReg> for usize {
+    fn from(v: SysCallReg) -> usize {
+        unsafe { v.reg.as_u64 as usize }
     }
 }
 
@@ -77,6 +93,12 @@ impl From<i64> for SysCallReg {
     }
 }
 
+impl From<SysCallReg> for i64 {
+    fn from(v: SysCallReg) -> i64 {
+        unsafe { v.reg.as_i64 }
+    }
+}
+
 impl From<i32> for SysCallReg {
     fn from(v: i32) -> SysCallReg {
         SysCallReg {
@@ -85,10 +107,24 @@ impl From<i32> for SysCallReg {
     }
 }
 
+impl From<SysCallReg> for i32 {
+    fn from(v: SysCallReg) -> i32 {
+        unsafe { v.reg.as_i64 as i32 }
+    }
+}
+
 impl From<PluginPtr> for SysCallReg {
     fn from(v: PluginPtr) -> SysCallReg {
         SysCallReg {
             reg: c::SysCallReg { as_ptr: v.into() },
+        }
+    }
+}
+
+impl From<SysCallReg> for PluginPtr {
+    fn from(v: SysCallReg) -> PluginPtr {
+        PluginPtr {
+            ptr: unsafe { v.reg.as_ptr },
         }
     }
 }

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -3,59 +3,50 @@ use crate::cbindings as c;
 use crate::utility::syscall;
 use libc;
 
-/// Wraps the C Thread struct.
-pub struct Thread {
-    cthread: *mut c::Thread,
-}
+pub trait Thread {
+    /// Have the plugin thread natively execute the given syscall.
+    /// SAFETY
+    /// * `args` must not contain invalid PluginPtrs.
+    unsafe fn native_syscall(&self, n: i64, args: &[SysCallReg]) -> Result<SysCallReg, i32>;
 
-impl Thread {
-    pub fn new(cthread: *mut c::Thread) -> Thread {
-        unsafe {
-            c::thread_ref(cthread);
-        }
-        Thread { cthread }
+    /// Get a readable pointer to the plugin's memory.
+    /// SAFETY
+    /// * The specified memory region must be valid and readable.
+    /// * Returned pointer mustn't be accessed after Thread runs again or flush is called.
+    unsafe fn get_readable_ptr(
+        &self,
+        plugin_src: PluginPtr,
+        n: usize,
+    ) -> Result<*const ::std::os::raw::c_void, i32>;
+
+    /// Get a writeable pointer to the plugin's memory.
+    /// SAFETY
+    /// * The specified memory region must be valid and writeable.
+    /// * Returned pointer mustn't be accessed after Thread runs again or flush is called.
+    unsafe fn get_writeable_ptr(
+        &self,
+        plugin_src: PluginPtr,
+        n: usize,
+    ) -> Result<*mut ::std::os::raw::c_void, i32>;
+
+    fn get_process_id(&self) -> u32;
+    fn get_host_id(&self) -> u32;
+    fn get_system_pid(&self) -> libc::pid_t;
+
+    /// Flush (and invalidate) pointers previously returned by `get_readable_ptr` and
+    /// `get_writeable_ptr`.
+    fn flush(&mut self);
+
+    /// Natively execute munmap(2) on the given thread.
+    unsafe fn native_munmap(&self, ptr: PluginPtr, size: usize) -> Result<PluginPtr, i32> {
+        Ok(self
+            .native_syscall(libc::SYS_munmap, &[ptr.into(), size.into()])?
+            .into())
     }
 
-    fn native_syscall(&mut self, n: i64, args: &[SysCallReg]) -> Result<SysCallReg, i32> {
-        let raw_res;
-        // The `Into` here isn't strictly necessary since SysCallReg is an alias for c::SysCallReg,
-        // but that's an implementation detail of SysCallReg that could change later, and the
-        // compiler won't help us catch it when calling a variadic C function.
-        //
-        // We considered using an iterator here rather than having to pass an index everywhere
-        // below; we avoided it because argument evaluation order is currently a bit of a murky
-        // issue, even though it'll *probably* always be left-to-right.
-        // https://internals.rust-lang.org/t/rust-expression-order-of-evaluation/2605/16
-        let arg = |i| Into::<c::SysCallReg>::into(args[i]);
-        unsafe {
-            raw_res = match args.len() {
-                //
-                0 => c::thread_nativeSyscall(self.cthread, n),
-                1 => c::thread_nativeSyscall(self.cthread, n, arg(0)),
-                2 => c::thread_nativeSyscall(self.cthread, n, arg(0), arg(1)),
-                3 => c::thread_nativeSyscall(self.cthread, n, arg(0), arg(1), arg(2)),
-                4 => c::thread_nativeSyscall(self.cthread, n, arg(0), arg(1), arg(2), arg(3)),
-                5 => {
-                    c::thread_nativeSyscall(self.cthread, n, arg(0), arg(1), arg(2), arg(3), arg(4))
-                }
-                6 => c::thread_nativeSyscall(
-                    self.cthread,
-                    n,
-                    arg(0),
-                    arg(1),
-                    arg(2),
-                    arg(3),
-                    arg(4),
-                    arg(5),
-                ),
-                x => panic!("Bad number of syscall args {}", x),
-            }
-        }
-        syscall::raw_return_value_to_errno(raw_res)
-    }
-
-    pub fn native_mmap(
-        &mut self,
+    /// Natively execute mmap(2) on the given thread.
+    unsafe fn native_mmap(
+        &self,
         addr: PluginPtr,
         len: usize,
         prot: i32,
@@ -67,19 +58,172 @@ impl Thread {
             .native_syscall(
                 libc::SYS_mmap,
                 &[
-                    addr.into(),
-                    len.into(),
-                    prot.into(),
-                    flags.into(),
-                    fd.into(),
-                    offset.into(),
+                    SysCallReg::from(addr),
+                    SysCallReg::from(len),
+                    SysCallReg::from(prot),
+                    SysCallReg::from(flags),
+                    SysCallReg::from(fd),
+                    SysCallReg::from(offset),
                 ],
             )?
             .into())
     }
+
+    /// Natively execute mremap(2) on the given thread.
+    unsafe fn native_mremap(
+        &self,
+        old_addr: PluginPtr,
+        old_len: usize,
+        new_len: usize,
+        flags: i32,
+        new_addr: PluginPtr,
+    ) -> Result<PluginPtr, i32> {
+        Ok(self
+            .native_syscall(
+                libc::SYS_mremap,
+                &[
+                    SysCallReg::from(old_addr),
+                    SysCallReg::from(old_len),
+                    SysCallReg::from(new_len),
+                    SysCallReg::from(flags),
+                    SysCallReg::from(new_addr),
+                ],
+            )?
+            .into())
+    }
+
+    /// Natively execute open(2) on the given thread.
+    fn native_open(&self, pathname: PluginPtr, flags: i32, mode: i32) -> Result<i32, i32> {
+        let res = unsafe {
+            self.native_syscall(
+                libc::SYS_open,
+                &[
+                    SysCallReg::from(pathname),
+                    SysCallReg::from(flags),
+                    SysCallReg::from(mode),
+                ],
+            )
+        };
+        Ok(i32::from(res?))
+    }
+
+    /// Natively execute brk(2) on the given thread.
+    fn native_brk(&self, addr: PluginPtr) -> Result<PluginPtr, i32> {
+        let res = unsafe { self.native_syscall(libc::SYS_brk, &[SysCallReg::from(addr)]) };
+        Ok(PluginPtr::from(res?))
+    }
+
+    /// Allocates some space in the plugin's memory. Use `get_writeable_ptr` to write to it, and
+    /// `flush` to ensure that the write is flushed to the plugin's memory.
+    fn malloc_plugin_ptr(&self, size: usize) -> Result<PluginPtr, i32> {
+        // SAFETY: No pointer specified; can't pass a bad one.
+        unsafe {
+            self.native_mmap(
+                PluginPtr::from(0usize),
+                size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        }
+    }
+
+    /// SAFETY: ptr must have been returned from `malloc_plugin_ptr`
+    unsafe fn free_plugin_ptr(&self, ptr: PluginPtr, size: usize) -> Result<(), i32> {
+        self.native_munmap(ptr, size)?;
+        Ok(())
+    }
 }
 
-impl Drop for Thread {
+/// Wraps the C Thread struct.
+pub struct CThread {
+    cthread: *mut c::Thread,
+}
+
+impl CThread {
+    pub fn new(cthread: *mut c::Thread) -> CThread {
+        unsafe {
+            c::thread_ref(cthread);
+        }
+        CThread { cthread }
+    }
+}
+
+impl Thread for CThread {
+    unsafe fn native_syscall(&self, n: i64, args: &[SysCallReg]) -> Result<SysCallReg, i32> {
+        // We considered using an iterator here rather than having to pass an index everywhere
+        // below; we avoided it because argument evaluation order is currently a bit of a murky
+        // issue, even though it'll *probably* always be left-to-right.
+        // https://internals.rust-lang.org/t/rust-expression-order-of-evaluation/2605/16
+        let arg = |i| c::SysCallReg::from(args[i]);
+        let raw_res = match args.len() {
+            //
+            0 => c::thread_nativeSyscall(self.cthread, n),
+            1 => c::thread_nativeSyscall(self.cthread, n, arg(0)),
+            2 => c::thread_nativeSyscall(self.cthread, n, arg(0), arg(1)),
+            3 => c::thread_nativeSyscall(self.cthread, n, arg(0), arg(1), arg(2)),
+            4 => c::thread_nativeSyscall(self.cthread, n, arg(0), arg(1), arg(2), arg(3)),
+            5 => c::thread_nativeSyscall(self.cthread, n, arg(0), arg(1), arg(2), arg(3), arg(4)),
+            6 => c::thread_nativeSyscall(
+                self.cthread,
+                n,
+                arg(0),
+                arg(1),
+                arg(2),
+                arg(3),
+                arg(4),
+                arg(5),
+            ),
+            x => panic!("Bad number of syscall args {}", x),
+        };
+        syscall::raw_return_value_to_errno(raw_res)
+    }
+
+    unsafe fn get_readable_ptr(
+        &self,
+        plugin_src: PluginPtr,
+        n: usize,
+    ) -> Result<*const ::std::os::raw::c_void, i32> {
+        Ok(c::thread_getReadablePtr(
+            self.cthread,
+            plugin_src.into(),
+            n as u64,
+        ))
+    }
+
+    unsafe fn get_writeable_ptr(
+        &self,
+        plugin_src: PluginPtr,
+        n: usize,
+    ) -> Result<*mut ::std::os::raw::c_void, i32> {
+        Ok(c::thread_getWriteablePtr(
+            self.cthread,
+            plugin_src.into(),
+            n as u64,
+        ))
+    }
+
+    fn flush(&mut self) {
+        unsafe {
+            c::thread_flushPtrs(self.cthread);
+        }
+    }
+
+    fn get_process_id(&self) -> u32 {
+        unsafe { c::thread_getProcessId(self.cthread) }
+    }
+
+    fn get_host_id(&self) -> u32 {
+        unsafe { c::thread_getHostId(self.cthread) }
+    }
+
+    fn get_system_pid(&self) -> libc::pid_t {
+        unsafe { c::thread_getNativePid(self.cthread) }
+    }
+}
+
+impl Drop for CThread {
     fn drop(&mut self) {
         unsafe {
             c::thread_unref(self.cthread);


### PR DESCRIPTION
This will make it easier to later have Rust-native Thread implementations rather than wrapping the C interface.

Wraps some additional Thread functionality, and provides default-implementation in the Thread trait, e.g. to provide type-safe wrappers for specific syscalls.