### PR TITLE
When running from 'build/', don't use the installed shim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,10 @@ endif()
 foreach(library ${CMAKE_EXTRA_LIBRARIES})
     link_directories(${library})
 endforeach(library)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+## use the installed shim path only when shadow is installed
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
 ## get general includes
 include(CheckIncludeFile)

--- a/setup
+++ b/setup
@@ -44,13 +44,13 @@ def main():
         help="append PATH to the list of paths searched for headers. useful if dependencies are installed to non-standard locations, or when compiling custom libraries.",
         metavar="PATH",
         action="append", dest="extra_includes",
-        default=[INSTALL_PREFIX+ "/include"])
+        default=[])
 
     parser_build.add_argument('-l', '--library',
         help="append PATH to the list of paths searched for libraries. useful if dependencies are installed to non-standard locations, or when compiling custom libraries.",
         metavar="PATH",
         action="append", dest="extra_libraries",
-        default=[INSTALL_PREFIX+ "/lib"])
+        default=[])
 
     parser_build.add_argument('-c', '--clean',
         help="force a full rebuild of Shadow by removing build cache",

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -4,6 +4,9 @@
 
 include_directories(${RT_INCLUDES} ${DL_INCLUDES} ${M_INCLUDES} ${IGRAPH_INCLUDES} ${GLIB_INCLUDES})
 
+## link to the shim (rpath will not contain this path when shadow is installed)
+link_directories(${CMAKE_BINARY_DIR}/src/shim)
+
 ## compile defs and flags
 #add_definitions(-D_SVID_SOURCE -D_XOPEN_SOURCE=600 -D_ISOC11_SOURCE) #-D_GNU_SOURCE
 ## set the igraph version guesses
@@ -209,11 +212,7 @@ target_link_libraries(shadow shadow-c shadow-rs)
 install(TARGETS shadow DESTINATION bin)
 
 ## shadow needs to find libs after install
-set_target_properties(shadow PROPERTIES
-    INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib
-    INSTALL_RPATH_USE_LINK_PATH TRUE
-    LINK_FLAGS "-Wl,--no-as-needed,-rpath=${CMAKE_INSTALL_PREFIX}/lib"
-)
+set_target_properties(shadow PROPERTIES LINK_FLAGS "-Wl,--no-as-needed")
 
 add_subdirectory(cbindings)
 

--- a/src/shim/CMakeLists.txt
+++ b/src/shim/CMakeLists.txt
@@ -31,11 +31,7 @@ set(SHIM_FILES
   shim_shmem.c
 )
 add_library(${SHIM_LIB} SHARED ${SHIM_FILES})
-set_target_properties(${SHIM_LIB} PROPERTIES 
-    INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib
-    INSTALL_RPATH_USE_LINK_PATH TRUE 
-    LINK_FLAGS "-Wl,--no-as-needed,-rpath=${CMAKE_INSTALL_PREFIX}/lib"
-)
+set_target_properties(${SHIM_LIB} PROPERTIES LINK_FLAGS "-Wl,--no-as-needed")
 target_compile_options(${SHIM_LIB} PRIVATE -pthread -D_GNU_SOURCE)
 target_link_libraries(${SHIM_LIB} ${SHIM_HELPER_LIB} shadow-shmem logger
   ${RT_LIBRARIES} ${GLIB_LIBRARIES} -pthread -ldl)


### PR DESCRIPTION
Previously when running shadow from the 'build' directory (for example with './setup.py test'), shadow would use the installed shim rather than the most-recently built shim in 'build/src/shim'. This can lead to confusion if the shim was updated, but the tests are using the old installed shim. This also means that shadow must be installed before it can be tested.

This commit modifies how the rpath is generated and causes shadow to use a different rpath after it is installed.

Before:
```
$ ./setup build --clean --debug --test --library /tmp
$ ./setup install
$ readelf -d build/src/main/shadow | grep 'R.*PATH'
 <snip> (RUNPATH)            Library runpath: [/home/steve/.shadow/lib:/home/steve/.shadow/lib:/tmp:]
$ readelf -d ~/.shadow/bin/shadow | grep 'R.*PATH'
 <snip> (RUNPATH)            Library runpath: [/home/steve/.shadow/lib:/home/steve/.shadow/lib:/tmp]
$ readelf -d build/src/shim/libshadow-shim.so | grep 'R.*PATH'
 <snip> (RUNPATH)            Library runpath: [/home/steve/.shadow/lib:/home/steve/.shadow/lib:/tmp:]
$ readelf -d ~/.shadow/lib/libshadow-shim.so | grep 'R.*PATH'
 <snip> (RUNPATH)            Library runpath: [/home/steve/.shadow/lib:/home/steve/.shadow/lib:/tmp]
```

After:
```
$ ./setup build --clean --debug --test --library /tmp
$ ./setup install
$ readelf -d build/src/main/shadow | grep 'R.*PATH'
 <snip> (RUNPATH)            Library runpath: [/tmp:/shared/code/shadow-logging/build/src/shim:]
$ readelf -d ~/.shadow/bin/shadow | grep 'R.*PATH'
 <snip> (RUNPATH)            Library runpath: [/home/steve/.shadow/lib:/tmp]
$ readelf -d build/src/shim/libshadow-shim.so | grep 'R.*PATH'
 <snip> (RUNPATH)            Library runpath: [/tmp::::::::::::::::::::::::]
$ readelf -d ~/.shadow/lib/libshadow-shim.so | grep 'R.*PATH'
 <snip> (RUNPATH)            Library runpath: [/home/steve/.shadow/lib:/tmp]
```