### PR TITLE
Move libc-dbg to preceeding apt-get command

### DIFF
--- a/docs/1.1-Shadow.md
+++ b/docs/1.1-Shadow.md
@@ -62,6 +62,7 @@ sudo apt-get install -y \
     cmake \
     g++ \
     gcc \
+    libc-dbg \
     libglib2.0-0 \
     libglib2.0-dev \
     libigraph0-dev \
@@ -70,7 +71,6 @@ sudo apt-get install -y \
     python \
     python-pyelftools \
     xz-utils
-sudo apt-get install libc-dbg
 sudo apt-get install -y \
     python-lxml \
     python-matplotlib \


### PR DESCRIPTION
Note: I don't know if there is a reason that matters for having it be its own apt-get command. I suspect there isn't one.

I neglected to install libc-dbg because I didn't want the python stuff, but didn't see the libc-dbg line just before it.