### PR TITLE
Support multiple worker threads with work stealing

### DIFF
--- a/src/main/core/scheduler/scheduler_policy_host_steal.c
+++ b/src/main/core/scheduler/scheduler_policy_host_steal.c
@@ -191,6 +191,8 @@ static void _schedulerpolicyhoststeal_migrateHost(SchedulerPolicy* policy, Host*
         utility_assert(tdata->runningHost != tdataNew->runningHost);
         /* migrate the TLS of all objects associated with this host */
 //        host_migrate(host, &oldThread, &newThread);
+        debug("Migrating host %s from thread %u to thread %u", host_getName(host), tdata->tnumber,
+              tdataNew->tnumber);
     }
     _schedulerpolicyhoststeal_addHost(policy, host, newThread);
 }
@@ -308,6 +310,8 @@ static Event* _schedulerpolicyhoststeal_popFromThread(SchedulerPolicy* policy, H
         if(nextEvent == NULL) {
             /* no more events on the runningHost, mark it as NULL so we get a new one */
             g_queue_push_tail(tdata->processedHosts, host);
+            /* detach all ptrace attachments for this host so it can be stolen next round */
+            host_detachAllPlugins(host);
             tdata->runningHost = NULL;
         }
 

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -336,6 +336,11 @@ void host_boot(Host* host) {
     g_queue_foreach(host->processes, (GFunc)process_schedule, NULL);
 }
 
+void host_detachAllPlugins(Host* host) {
+    MAGIC_ASSERT(host);
+    g_queue_foreach(host->processes, process_detachPlugin, NULL);
+}
+
 guint host_getNewProcessID(Host* host) {
     MAGIC_ASSERT(host);
     return host->processIDCounter++;

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -79,6 +79,7 @@ void host_addApplication(Host* host, SimulationTime startTime,
                          SimulationTime stopTime, InterposeMethod interposeMethod,
                          const gchar* pluginName, const gchar* pluginPath,
                          const gchar* pluginSymbol, gchar** envv, gchar** argv);
+void host_detachAllPlugins(Host* host);
 void host_freeAllApplications(Host* host);
 
 gint host_compare(gconstpointer a, gconstpointer b, gpointer user_data);

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -400,6 +400,17 @@ void process_schedule(Process* proc, gpointer nothing) {
     }
 }
 
+void process_detachPlugin(gpointer procptr, gpointer nothing) {
+    Process* proc = procptr;
+    MAGIC_ASSERT(proc);
+    if (proc->interposeMethod == INTERPOSE_PTRACE) {
+        // Detach all ptrace attachements
+        if (proc->mainThread) {
+            threadptrace_detach(proc->mainThread);
+        }
+    }
+}
+
 gboolean process_isRunning(Process* proc) {
     MAGIC_ASSERT(proc);
     return (proc->mainThread != NULL && thread_isRunning(proc->mainThread)) ? TRUE : FALSE;

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -46,6 +46,7 @@ void process_unref(Process* proc);
 void process_schedule(Process* proc, gpointer nothing);
 void process_continue(Process* proc, Thread* thread);
 void process_stop(Process* proc);
+void process_detachPlugin(gpointer procptr, gpointer nothing);
 
 gboolean process_isRunning(Process* proc);
 

--- a/src/main/host/thread_ptrace.h
+++ b/src/main/host/thread_ptrace.h
@@ -6,5 +6,6 @@
 #include "main/host/thread.h"
 
 Thread* threadptrace_new(Host* host, Process* process, gint threadID);
+void threadptrace_detach(Thread* base);
 
 #endif


### PR DESCRIPTION
When using the work stealing scheduling policy, it is possible
that hosts are migrated between worker threads depending on the
plugin workloads. When migrating a host to a new worker thread,
the previous worker thread that was running it will need to detach
its ptrace attachments so that the new thread can attach and
continue tracing the plugin.

This commit adds a hook that detaches all ptrace attachments at
the end of each round of execution; in the following round, it
becomes possible again that the host could be stolen by another
worker. Also, before resuming a a ptrace session, the worker
checks and does a ptrace attach first if needed.

refs shadow/shadow#909