### PR TITLE
Support multiple worker threads with work stealing

### DIFF
--- a/src/main/cbindings/wrapper.rs
+++ b/src/main/cbindings/wrapper.rs
@@ -1732,3 +1732,6 @@ extern "C" {
 extern "C" {
     pub fn thread_getNativePid(thread: *mut Thread) -> pid_t;
 }
+extern "C" {
+    pub fn thread_getNativeTid(thread: *mut Thread) -> pid_t;
+}

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -336,6 +336,11 @@ void host_boot(Host* host) {
     g_queue_foreach(host->processes, (GFunc)process_schedule, NULL);
 }
 
+void host_detachAllPlugins(Host* host) {
+    MAGIC_ASSERT(host);
+    g_queue_foreach(host->processes, process_detachPlugin, NULL);
+}
+
 guint host_getNewProcessID(Host* host) {
     MAGIC_ASSERT(host);
     return host->processIDCounter++;

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -79,6 +79,7 @@ void host_addApplication(Host* host, SimulationTime startTime,
                          SimulationTime stopTime, InterposeMethod interposeMethod,
                          const gchar* pluginName, const gchar* pluginPath,
                          const gchar* pluginSymbol, gchar** envv, gchar** argv);
+void host_detachAllPlugins(Host* host);
 void host_freeAllApplications(Host* host);
 
 gint host_compare(gconstpointer a, gconstpointer b, gpointer user_data);

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -400,6 +400,19 @@ void process_schedule(Process* proc, gpointer nothing) {
     }
 }
 
+void process_detachPlugin(gpointer procptr, gpointer nothing) {
+    Process* proc = procptr;
+    MAGIC_ASSERT(proc);
+    if (proc->interposeMethod == INTERPOSE_PTRACE) {
+        // Detach all ptrace attachements
+        if (proc->mainThread) {
+            worker_setActiveProcess(proc);
+            threadptrace_detach(proc->mainThread);
+            worker_setActiveProcess(NULL);
+        }
+    }
+}
+
 gboolean process_isRunning(Process* proc) {
     MAGIC_ASSERT(proc);
     return (proc->mainThread != NULL && thread_isRunning(proc->mainThread)) ? TRUE : FALSE;

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -46,6 +46,7 @@ void process_unref(Process* proc);
 void process_schedule(Process* proc, gpointer nothing);
 void process_continue(Process* proc, Thread* thread);
 void process_stop(Process* proc);
+void process_detachPlugin(gpointer procptr, gpointer nothing);
 
 gboolean process_isRunning(Process* proc);
 

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -246,8 +246,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd,
         case DT_SOCKETPAIR:
         case DT_EPOLL:
         default:
-            warning("write() not yet implemented for descriptor type %i",
-                    (int)dType);
+            warning("write(%d) not yet implemented for descriptor type %i", fd, (int)dType);
             result = -ENOTSUP;
             break;
     }

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -58,6 +58,8 @@ void thread_run(Thread* thread, gchar** argv, gchar** envv) {
     MAGIC_ASSERT(thread);
     utility_assert(thread->methods.run);
     thread->nativePid = thread->methods.run(thread, argv, envv);
+    // In Linux, the PID is equal to the TID of its first thread.
+    thread->nativeTid = thread->nativePid;
 }
 
 SysCallCondition* thread_resume(Thread* thread) {
@@ -174,4 +176,9 @@ uint32_t thread_getHostId(Thread* thread) {
 pid_t thread_getNativePid(Thread* thread) {
     MAGIC_ASSERT(thread);
     return thread->nativePid;
+}
+
+pid_t thread_getNativeTid(Thread* thread) {
+    MAGIC_ASSERT(thread);
+    return thread->nativeTid;
 }

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -95,5 +95,6 @@ uint32_t thread_getProcessId(Thread* thread);
 uint32_t thread_getHostId(Thread* thread);
 
 pid_t thread_getNativePid(Thread* thread);
+pid_t thread_getNativeTid(Thread* thread);
 
 #endif /* SRC_MAIN_HOST_SHD_THREAD_H_ */

--- a/src/main/host/thread_protected.h
+++ b/src/main/host/thread_protected.h
@@ -39,6 +39,7 @@ struct _Thread {
     ThreadMethods methods;
     int threadID;
     pid_t nativePid;
+    pid_t nativeTid;
     Host* host;
     Process* process;
     int referenceCount;

--- a/src/main/host/thread_ptrace.h
+++ b/src/main/host/thread_ptrace.h
@@ -6,5 +6,6 @@
 #include "main/host/thread.h"
 
 Thread* threadptrace_new(Host* host, Process* process, gint threadID);
+void threadptrace_detach(Thread* base);
 
 #endif

--- a/src/shim/shim_logger.c
+++ b/src/shim/shim_logger.c
@@ -31,9 +31,8 @@ static size_t _simulation_nanos_string(char* dst, size_t size) {
         dst, size, "%02d:%02d:%02d.%09" PRIu64, tm.tm_hour, tm.tm_min, tm.tm_sec, nanos);
 }
 
-void shimlogger_log(Logger* base, LogLevel level, const char* fileName,
-                    const char* functionName, const int lineNumber,
-                    const char* format, va_list vargs) {
+void shimlogger_log(Logger* base, LogLevel level, const char* fileName, const char* functionName,
+                    const int lineNumber, const char* format, va_list vargs) {
     static __thread bool in_logger = false;
     // Stack-allocated to avoid dynamic allocation.
     char buf[200];

--- a/src/support/logger/logger.c
+++ b/src/support/logger/logger.c
@@ -76,8 +76,8 @@ size_t logger_elapsed_string(char* dst, size_t size) {
 const char* logger_base_name(const char* filename) {
     const char* rv = filename;
     for (const char* pos = filename; *pos != '\0'; ++pos) {
-        if (*pos == '/' && *(pos+1) != '\0') {
-            rv = pos+1;
+        if (*pos == '/' && *(pos + 1) != '\0') {
+            rv = pos + 1;
         }
     }
     return rv;

--- a/src/support/logger/logger.h
+++ b/src/support/logger/logger.h
@@ -58,10 +58,9 @@ Logger* logger_getDefault();
 // diagnostics that it does for `printf`.
 // https://clang.llvm.org/docs/AttributeReference.html#format
 // https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes
-__attribute__((__format__ (__printf__, 6, 7)))
-void logger_log(Logger* logger, LogLevel level, const char* fileName,
-                const char* functionName, const int lineNumber,
-                const char* format, ...);
+__attribute__((__format__(__printf__, 6, 7))) void
+logger_log(Logger* logger, LogLevel level, const char* fileName, const char* functionName,
+           const int lineNumber, const char* format, ...);
 
 // Returns an agreed-upon start time for logging purposes, as returned by
 // logger_now_micros.

--- a/src/test/phold/CMakeLists.txt
+++ b/src/test/phold/CMakeLists.txt
@@ -14,5 +14,5 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/weights.txt ${CMAKE_CURRENT_BINARY_DI
 add_test(NAME phold-shadow-ptrace COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -d phold.shadow-ptrace.data ${CMAKE_CURRENT_SOURCE_DIR}/phold.test.shadow.config.xml)
 # FIXME add_test(NAME phold-shadow-preload COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload -d phold.shadow-preload.data ${CMAKE_CURRENT_SOURCE_DIR}/phold.test.shadow.config.xml)
 
-# FIXME add_test(NAME phold-threaded-shadow-ptrace COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -d phold-threaded.shadow-ptrace.data -w 2 ${CMAKE_CURRENT_SOURCE_DIR}/phold.test.shadow.config.xml)
+add_test(NAME phold-threaded-shadow-ptrace COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -d phold-threaded.shadow-ptrace.data -w 2 ${CMAKE_CURRENT_SOURCE_DIR}/phold.test.shadow.config.xml)
 # FIXME add_test(NAME phold-threaded-shadow-preload COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload -d phold-threaded.shadow-preload.data -w 2 ${CMAKE_CURRENT_SOURCE_DIR}/phold.test.shadow.config.xml)


### PR DESCRIPTION
When using the work stealing scheduling policy, it is possible
that hosts are migrated between worker threads depending on the
plugin workloads. When migrating a host to a new worker thread,
the previous worker thread that was running it will need to detach
its ptrace attachments so that the new thread can attach and
continue tracing the plugin.

This commit adds a hook that detaches all ptrace attachments at
the end of each round of execution; in the following round, it
becomes possible again that the host could be stolen by another
worker. Also, before resuming a a ptrace session, the worker
checks and does a ptrace attach first if needed.

refs shadow/shadow#909