### PR TITLE
Fix getrandom-related issues

### DIFF
--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -134,7 +134,7 @@ static void _threadpreload_create_ipc_sockets(ThreadPreload* thread,
 static pid_t _threadpreload_fork_exec(ThreadPreload* thread, const char* file, char* const argv[],
                                       char* const envp[]) {
     pid_t shadow_pid = getpid();
-    pid_t pid = vfork();
+    pid_t pid = fork();
 
     switch (pid) {
         case -1:

--- a/src/shim/preload_syscalls.c
+++ b/src/shim/preload_syscalls.c
@@ -240,7 +240,7 @@ NOREMAP(int, getpeername, (int a, struct sockaddr* b, socklen_t* c), a, b, c);
 // TODO the following (getrandom) causes all shadow tests to fail with timeout in centos 8
 // I believe centos 8 contains a version of libc that contains a getrandom wrapper, whereas
 // it was previously only available through the syscall() function.
-//NOREMAP(ssize_t, getrandom, (void* a, size_t b, unsigned int c), a, b, c);
+NOREMAP(ssize_t, getrandom, (void* a, size_t b, unsigned int c), a, b, c);
 NOREMAP(int, getsockname, (int a, struct sockaddr* b, socklen_t* c), a, b, c);
 static REMAP(int, ioctl_explicit, ioctl, (int a, unsigned long b, char* c), a,b,c);
 NOREMAP(int, linkat, (int a, const char* b, int c, const char* d, int e), a, b, c, d, e);

--- a/src/shim/shim.c
+++ b/src/shim/shim.c
@@ -78,9 +78,8 @@ __attribute__((constructor(SHIM_CONSTRUCTOR_PRIORITY))) static void
 _shim_load() {
     shim_disableInterposition();
 
-    // We ultimately want to log to SHADOW_LOG_FILE, but we must temporarily
-    // override the default logger with one that has a recursion-guard before
-    // making any syscalls (e.g. to open the log file).
+    // We ultimately want to log to SHADOW_LOG_FILE, but first we redirect to
+    // stderr for any log messages that happen before we can open it.
     logger_setDefault(shimlogger_new(stderr));
 
     // If we're not running under Shadow, return. This can be useful

--- a/src/support/logger/logger.c
+++ b/src/support/logger/logger.c
@@ -85,6 +85,15 @@ const char* logger_base_name(const char* filename) {
 
 static void _logger_default_log(LogLevel level, const char* fileName, const char* functionName,
                                 const int lineNumber, const char* format, va_list vargs) {
+    static __thread bool in_logger = false;
+    if (in_logger) {
+        // Avoid recursing. We do this here rather than in logger_log so that
+        // specialized loggers could potentially do something better than just
+        // dropping the message.
+        return;
+    }
+    in_logger = true;
+
     // Stack-allocated to avoid dynamic allocation.
     char buf[200];
     size_t offset = 0;
@@ -108,6 +117,7 @@ static void _logger_default_log(LogLevel level, const char* fileName, const char
         abort();
     }
 #endif
+    in_logger = false;
 }
 
 void logger_log(Logger* logger, LogLevel level, const gchar* fileName,

--- a/src/test/bind/CMakeLists.txt
+++ b/src/test/bind/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(${GLIB_INCLUDES})
 link_libraries(${GLIB_LIBRARIES} logger)
 
-add_executable(test-bind test_bind.c)
+add_executable(test-bind test_bind.c ../test_common.c)
 
 ## register the tests
 add_test(NAME bind COMMAND test-bind)

--- a/src/test/bind/test_bind.c
+++ b/src/test/bind/test_bind.c
@@ -17,6 +17,7 @@
 
 #include "support/logger/logger.h"
 #include "test/test_glib_helpers.h"
+#include "test/test_common.h"
 
 static int _do_bind(int fd, in_addr_t address, in_port_t port) {
     struct sockaddr_in bindaddr;
@@ -206,8 +207,7 @@ static void _test_implicit_bind(gconstpointer gp) {
     // on ubuntu, the firewall 'ufw' blocks the remaining tests from succeeding
     // ufw auto-blocks 0.0.0.0 and 127.0.0.1, and can't seem to be made to allow it
     // so we bail out early until we have a fix
-    int running_in_shadow = getenv("SHADOW_SPAWNED") != NULL;
-    if (!running_in_shadow) {
+    if (!running_in_shadow()) {
         close(fd1);
         return;
     }

--- a/src/test/random/CMakeLists.txt
+++ b/src/test/random/CMakeLists.txt
@@ -1,5 +1,5 @@
 ## build the test as a dynamic executable that plugs into shadow
-add_executable(shadow-plugin-test-random test_random.c)
+add_executable(shadow-plugin-test-random test_random.c ../test_common.c)
 
 ## register the tests
 add_test(NAME random COMMAND shadow-plugin-test-random)

--- a/src/test/random/CMakeLists.txt
+++ b/src/test/random/CMakeLists.txt
@@ -5,4 +5,4 @@ add_executable(shadow-plugin-test-random test_random.c ../test_common.c)
 add_test(NAME random COMMAND shadow-plugin-test-random)
 
 add_test(NAME random-shadow-ptrace COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -l debug -d random.shadow-ptrace.data ${CMAKE_CURRENT_SOURCE_DIR}/random.test.shadow.config.xml)
-#add_test(NAME random-shadow-preload COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload -l debug -d random.shadow-preload.data ${CMAKE_CURRENT_SOURCE_DIR}/random.test.shadow.config.xml)
+add_test(NAME random-shadow-preload COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload -l debug -d random.shadow-preload.data ${CMAKE_CURRENT_SOURCE_DIR}/random.test.shadow.config.xml)

--- a/src/test/random/test_random.c
+++ b/src/test/random/test_random.c
@@ -13,6 +13,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "test/test_common.h"
+
 // The number of random values to generate with each method.
 #define RGENLEN 200
 // The number of buckets to use when checking random value distribution.
@@ -115,25 +117,31 @@ static int _test_getrandom() {
 int main(int argc, char* argv[]) {
     fprintf(stdout, "########## random test starting ##########\n");
 
-    fprintf(stdout, "########## starting _test_dev_random()\n");
-    if (_test_dev_random() == EXIT_FAILURE) {
-        fprintf(stdout, "########## _test_dev_random() failed\n");
-        return EXIT_FAILURE;
-    }
     fprintf(stdout, "########## starting _test_dev_urandom()\n");
     if (_test_dev_urandom() == EXIT_FAILURE) {
         fprintf(stdout, "########## _test_dev_urandom() failed\n");
         return EXIT_FAILURE;
     }
+
     fprintf(stdout, "########## starting _test_rand()\n");
     if (_test_rand() == EXIT_FAILURE) {
         fprintf(stdout, "########## _test_rand() failed\n");
         return EXIT_FAILURE;
     }
+
     fprintf(stdout, "########## starting _test_getrandom()\n");
     if (_test_getrandom() == EXIT_FAILURE) {
         fprintf(stdout, "########## _test_getrandom() failed\n");
         return EXIT_FAILURE;
+    }
+
+    // Outside of Shadow, this test could block indefinitely.
+    if (running_in_shadow()) {
+        fprintf(stdout, "########## starting _test_dev_random()\n");
+        if (_test_dev_random() == EXIT_FAILURE) {
+            fprintf(stdout, "########## _test_dev_random() failed\n");
+            return EXIT_FAILURE;
+        }
     }
 
     fprintf(stdout, "########## random test passed! ##########\n");

--- a/src/test/test_common.c
+++ b/src/test/test_common.c
@@ -2,6 +2,7 @@
  * The Shadow Simulator
  * See LICENSE for licensing information
  */
+#include "test/test_common.h"
 
 #include <errno.h>
 #include <netdb.h>
@@ -121,3 +122,5 @@ int common_get_connected_tcp_sockets(int* server_listener_fd_out, int* server_fd
 
     return EXIT_SUCCESS;
 }
+
+bool running_in_shadow() { return getenv("SHADOW_SPAWNED") != NULL; }

--- a/src/test/test_common.h
+++ b/src/test/test_common.h
@@ -7,11 +7,14 @@
 #define SRC_TEST_SHD_TEST_COMMON_H_
 
 #include <netdb.h>
+#include <stdbool.h>
 
 /* calls common_setup_tcp_sockets and common_connect_tcp_sockets in sequence */
 int common_get_connected_tcp_sockets(int* server_listener_fd_out, int* server_fd_out, int* client_fd_out);
 
 int common_setup_tcp_sockets(int* server_listener_fd_out, int* client_fd_out, in_port_t* server_listener_port_out);
 int common_connect_tcp_sockets(int server_listener_fd, int client_fd, int* server_fd_out, in_port_t server_listener_port);
+
+bool running_in_shadow();
 
 #endif /* SRC_TEST_SHD_TEST_COMMON_H_ */

--- a/src/test/unistd/CMakeLists.txt
+++ b/src/test/unistd/CMakeLists.txt
@@ -2,7 +2,7 @@ include_directories(${GLIB_INCLUDES})
 link_libraries(${GLIB_LIBRARIES})
 
 ## build the test as a dynamic executable that plugs into shadow
-add_executable(test-unistd test_unistd.c)
+add_executable(test-unistd test_unistd.c ../test_common.c)
 
 ## register the tests
 add_test(NAME unistd COMMAND bash -c "./test-unistd \"$(uname -s)\" \"$(uname -n)\" \"$(uname -r)\" \"$(uname -v)\" \"$(uname -m)\"")

--- a/src/test/unistd/test_unistd.c
+++ b/src/test/unistd/test_unistd.c
@@ -6,6 +6,7 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 
+#include "test/test_common.h"
 #include "test/test_glib_helpers.h"
 
 // Tests that the results are plausible, but can't really validate that it's our
@@ -82,7 +83,6 @@ static void _test_uname(gconstpointer gp_expected_name) {
 }
 
 int main(int argc, char* argv[]) {
-    bool running_in_shadow = getenv("SHADOW_SPAWNED") != NULL;
     g_test_init(&argc, &argv, NULL);
 
     if (argc < 6) {
@@ -100,7 +100,7 @@ int main(int argc, char* argv[]) {
     g_test_add_func("/unistd/getpid_nodeps", _test_getpid_nodeps);
     // TODO: Support `kill` in shadow (and/or find another way of validating
     // the pid)
-    if (!running_in_shadow) {
+    if (!running_in_shadow()) {
         g_test_add_func("/unistd/getpid_kill", _test_getpid_kill);
     }
 
@@ -108,7 +108,7 @@ int main(int argc, char* argv[]) {
                          _test_gethostname);
 
     // TODO: Implement uname in shadow
-    if (!running_in_shadow) {
+    if (!running_in_shadow()) {
         g_test_add_data_func("/unistd/uname", &expected_name, _test_uname);
     }
 


### PR DESCRIPTION
* Don't read from /dev/random in native tests
* Add recursion guard to default logger, fixing potential deadlock when global constructors call getrandom (or other wrapped functions) before the shim global constructor has run.
* Enable getrandom wrapper and threadpreload test.
* Change threadpreload to use fork instead of vfork now that it no longer uses execve right away.
* Add a test helper `running_in_shadow()`
