### PR TITLE
Ensure that shim is initialized before first wrapped syscall is made.

### DIFF
--- a/src/shim/shim.c
+++ b/src/shim/shim.c
@@ -153,7 +153,7 @@ static void _shim_load() {
 // This function should be called before any wrapped syscall. We also use the
 // constructor attribute to be completely sure that it's called before main.
 __attribute__((constructor)) void shim_ensure_init() {
-    static _Thread_local bool started_init = false;
+    static __thread bool started_init = false;
     if (started_init) {
         // Avoid deadlock when _shim_load's syscalls caused this function to be
         // called recursively.  In the uninitialized state,

--- a/src/shim/shim.h
+++ b/src/shim/shim.h
@@ -13,6 +13,10 @@
 
 ShMemBlock shim_thisThreadEventIPCBlk();
 
+// Should be called by all syscall wrappers to ensure the shim is initialized.
+void shim_ensure_init();
+
+
 // Disables syscall interposition for the current thread if it's enabled. (And
 // if not, increments a counter). Should be matched with a call to
 // _shim_enable_interposition.
@@ -26,8 +30,5 @@ void shim_enableInterposition();
 
 // Whether syscall interposition is currently enabled.
 bool shim_interpositionEnabled();
-
-// Used in the constructor attribute to initialize the shim.
-#define SHIM_CONSTRUCTOR_PRIORITY 200
 
 #endif // SHD_SHIM_SHIM_H_

--- a/src/test/clone/test_clone.c
+++ b/src/test/clone/test_clone.c
@@ -17,7 +17,7 @@
 
 #include <glib.h>
 
-#define CLONE_TEST_STACK_NBYTES 4096
+#define CLONE_TEST_STACK_NBYTES (4*4096)
 
 #define CLONE_FLAGS                                                                                \
     (CLONE_VM         /* Share process memory */                                                   \


### PR DESCRIPTION
Previously, we couldn't guarantee that some global constructor might not
call some of our wrapped syscalls before the shim was initialized by its
global constructor.

Our syscall wrapper now ensures that the shim is initialized, using a
pthread_once construct. We still use a global constructor to ensure that
the shim is initialized before calling main.