### PR TITLE
Using older Rust nightly version for coverage tests

### DIFF
--- a/ci/container_scripts/build_and_install.sh
+++ b/ci/container_scripts/build_and_install.sh
@@ -26,7 +26,8 @@ case "$BUILDTYPE" in
         ;;
     coverage)
         OPTIONS="--debug --coverage"
-        rustup default nightly
+        # using an older rust nightly until https://github.com/shadow/shadow/issues/941 is resolved
+        rustup default nightly-2020-08-20
         ;;
     *)
         echo "Unknown BUILDTYPE $BUILDTYPE"

--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -53,11 +53,12 @@ esac
 
 if [ "$BUILDTYPE" = coverage ]
 then
-    RUST_TOOLCHAIN=nightly
+    # using an older rust nightly until https://github.com/shadow/shadow/issues/941 is resolved
+    RUST_TOOLCHAIN=nightly-2020-08-20
 else
     RUST_TOOLCHAIN=stable
 fi
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain $RUST_TOOLCHAIN
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain "$RUST_TOOLCHAIN"
 PATH=$HOME/.cargo/bin:$PATH
 # Force cargo to download its package index
 cargo search foo


### PR DESCRIPTION
Until #941 is resolved, this PR uses `nightly-2020-08-20` for coverage tests.