### PR TITLE
Changed coverage CI tests to use clang 11

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,8 +27,8 @@ jobs:
         buildtype: ['debug', 'release']
         include:
           # Add a single coverage configuration
-          - container: 'ubuntu:18.04'
-            cc: 'clang'
+          - container: 'ubuntu:20.10'
+            cc: 'clang-11'
             buildtype: 'coverage'
     env:
       CC: ${{ matrix.cc }}

--- a/ci/container_scripts/build_and_install.sh
+++ b/ci/container_scripts/build_and_install.sh
@@ -4,10 +4,13 @@ set -euo pipefail
 
 case "$CC" in
 gcc)
-  export CXX=g++
+  export CXX="g++"
   ;;
 clang)
-  export CXX=clang++
+  export CXX="clang++"
+  ;;
+clang-11)
+  export CXX="clang++-11"
   ;;
 *)
   echo "Unknown cc $CC"
@@ -26,8 +29,7 @@ case "$BUILDTYPE" in
         ;;
     coverage)
         OPTIONS="--debug --coverage"
-        # using an older rust nightly until https://github.com/shadow/shadow/issues/941 is resolved
-        rustup default nightly-2020-08-20
+        rustup default nightly
         ;;
     *)
         echo "Unknown BUILDTYPE $BUILDTYPE"

--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -10,8 +10,7 @@ APT_PACKAGES="
   libc-dbg
   libglib2.0-0
   libglib2.0-dev
-  libigraph0-dev
-  libigraph0v5
+  libigraph-dev
   libprocps-dev
   make
   python3

--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -45,6 +45,9 @@ case "$CC" in
         fi
         install_packages clang
         ;;
+    clang-11)
+        install_packages clang-11
+        ;;
     *)
         echo "Unhandled cc $CC"
         exit 1
@@ -53,8 +56,7 @@ esac
 
 if [ "$BUILDTYPE" = coverage ]
 then
-    # using an older rust nightly until https://github.com/shadow/shadow/issues/941 is resolved
-    RUST_TOOLCHAIN=nightly-2020-08-20
+    RUST_TOOLCHAIN=nightly
 else
     RUST_TOOLCHAIN=stable
 fi


### PR DESCRIPTION
Ubuntu 20.10 is apparently planning on making LLVM 11 the default in September, just after the official LLVM 11 release date. So we should be able to simplify these changes when this happens.

https://discourse.ubuntu.com/t/groovy-gorilla-release-schedule/15531