### PR TITLE
Save process exit codes

### DIFF
--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -164,7 +164,7 @@ static void _threadpreload_cleanup(ThreadPreload* thread, int status) {
     } else if (WIFSIGNALED(status)) {
         int signum = WTERMSIG(status);
         debug("child %d terminated by signal %d", thread->base.nativePid, signum);
-        thread->returnCode = -1;
+        thread->returnCode = return_code_for_signal(signum);
     } else {
         debug("child %d quit unexpectedly", thread->base.nativePid);
         thread->returnCode = -1;
@@ -343,8 +343,8 @@ void threadpreload_terminate(Thread* base) {
     utility_assert(rc != -1);
 
     if (rc == 0) { // child is running, request a stop
-        debug("sending SIGTERM to %d", thread->base.nativePid);
-        kill(thread->base.nativePid, SIGTERM);
+        debug("sending SIGKILL to %d", thread->base.nativePid);
+        kill(thread->base.nativePid, SIGKILL);
         rc = waitpid(thread->base.nativePid, &status, 0);
         utility_assert(rc != -1 && rc > 0);
     }

--- a/src/main/utility/utility.c
+++ b/src/main/utility/utility.c
@@ -356,3 +356,9 @@ struct timespec utility_timespecFromMillis(int64_t millis) {
         .tv_nsec = (millis % 1000) * 1000000, // ms to ns
     };
 }
+
+int return_code_for_signal(int signal) {
+    // To calculate the return code if the process exited by a signal,
+    // follow the behaviour of bash and add 128 to to the signal.
+    return signal + 128;
+}

--- a/src/main/utility/utility.h
+++ b/src/main/utility/utility.h
@@ -105,4 +105,7 @@ void utility_handleError(const gchar* file, gint line, const gchar* funtcion, co
  * of seconds and nanoseconds. */
 struct timespec utility_timespecFromMillis(int64_t millis);
 
+/* If a process exited by a signal, use this return code. */
+int return_code_for_signal(int signal);
+
 #endif /* SHD_UTILITY_H_ */


### PR DESCRIPTION
Uses a SIGKILL rather than SIGTERM since we don't want shadow to block waiting for the process, and we do not yet allow the process to shutdown properly.

This PR creates a new file `*.exitcode`, which should contain the exit status of the process.