### PR TITLE
Move MemoryManager to Process

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -92,9 +92,6 @@ SysCallReg memorymanager_handleMunmap(MemoryManager *memory_manager,
 // * `thread` must point to a valid object.
 MemoryManager *memorymanager_new(Thread *thread);
 
-// Notifies memorymanager that plugin is about to call execve.
-void memorymanager_preExecHook(MemoryManager *memory_manager, Thread *thread);
-
 void rust_logging_init(void);
 
 #endif /* main_bindings_h */

--- a/src/main/host/memory_manager.rs
+++ b/src/main/host/memory_manager.rs
@@ -45,27 +45,10 @@ struct Region {
 
 /// Manages the address-space for a plugin process.
 pub struct MemoryManager {
-    // We unfortunately need to make heavy use of internal mutability here, so that methods
-    // returning immutable references (TODO: and later even mutable references) can take a `&self`
-    // rather than a `&mut self`, allowing there to be multiple outstanding references at once.
-    //
-    // Even the methods that return immutable references can require updating a fair bit of our
-    // bookkeeping. For example:
-    // * Our mapping of the program stack is extended lazily on first access to avoid wasting
-    //   memory (and because we can't get any explicit notification from the OS when it extends the
-    //   stack itself).
-    // * On the first access after an `execve` syscall, we reload the mapped regions from `proc`.
-    //   Perhaps we could require the caller to explicitly call another hook on the first syscall
-    //   after the `execve` is done (in addition to the hook it already calls before it's done),
-    //   but this is a bit awkward to do in the SysCallManager. Better to encapsulate that
-    //   complexity here.
     shm_file: ShmFile,
     regions: IntervalMap<Region>,
 
     misses_by_path: HashMap<String, u32>,
-
-    // We need to reinitialize some state after an exec, but need to wait until the next syscall.
-    need_post_exec_cleanup: bool,
 
     // The part of the stack that we've already remapped in the plugin.
     // We initially mmap enough *address space* in Shadow to accomodate a large stack, but we only
@@ -180,13 +163,6 @@ impl ShmFile {
             interval.start as i64,
         );
         assert!(res.is_ok());
-    }
-
-    fn truncate(&mut self) {
-        let res = unsafe { libc::ftruncate(self.shm_file.as_raw_fd(), 0) };
-        if res != 0 {
-            println!("Warning: ftruncate failed");
-        }
     }
 }
 
@@ -321,7 +297,19 @@ impl Drop for MemoryManager {
         drop(regions);
         */
 
-        self.reset_and_unmap_all();
+        // Mappings are no longer valid. Clear out our map, and unmap those regions.
+        let mutations = self.regions.clear(std::usize::MIN..std::usize::MAX);
+        for m in mutations {
+            if let Mutation::Removed(interval, region) = m {
+                if !region.shadow_base.is_null() {
+                    let res =
+                        unsafe { libc::munmap(region.shadow_base, interval.end - interval.start) };
+                    if res != 0 {
+                        println!("Warning: munmap failed");
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -356,9 +344,8 @@ impl MemoryManager {
             path_buf[..shm_path.len()].copy_from_slice(shm_path.as_bytes());
             path_buf[shm_path.len()] = b'\0';
             thread.flush();
-            let shm_plugin_fd = thread
-                .native_open(path_buf_plugin_ptr, libc::O_RDWR, 0)
-                .unwrap();
+            let shm_plugin_fd =
+                thread.native_open(path_buf_plugin_ptr, libc::O_RDWR | libc::O_CLOEXEC, 0).unwrap();
             thread
                 .free_plugin_ptr(path_buf_plugin_ptr, path_buf_len)
                 .unwrap();
@@ -378,29 +365,9 @@ impl MemoryManager {
             shm_file,
             regions,
             misses_by_path: HashMap::new(),
-            need_post_exec_cleanup: false,
             heap,
             stack_copied: stack_end..stack_end,
         }
-    }
-
-    // Clears all mappings, unmapping them from shadow's address space and recovering space from
-    // the memory file. e.g. called after execve and in Drop.
-    fn reset_and_unmap_all(&mut self) {
-        // Mappings are no longer valid. Clear out our map, and unmap those regions.
-        let mutations = self.regions.clear(std::usize::MIN..std::usize::MAX);
-        for m in mutations {
-            if let Mutation::Removed(interval, region) = m {
-                if !region.shadow_base.is_null() {
-                    let res =
-                        unsafe { libc::munmap(region.shadow_base, interval.end - interval.start) };
-                    if res != 0 {
-                        println!("Warning: munmap failed");
-                    }
-                }
-            }
-        }
-        self.shm_file.truncate();
     }
 
     // Processes the mutations returned by an IntervalMap::insert or IntervalMap::clear operation.
@@ -490,26 +457,6 @@ impl MemoryManager {
                 }
             }
         }
-    }
-
-    /// Should be called by shadow's SysCallHandler before allowing the plugin to execute the exec
-    /// syscall.
-    pub fn pre_exec_hook(&mut self, _thread: &impl Thread) {
-        self.need_post_exec_cleanup = true;
-    }
-
-    // Called internally on the next usage *after* execve syscall has executed. Re-initializes as
-    // needed.
-    fn post_exec_cleanup_if_needed(&mut self, thread: &mut impl Thread) {
-        if !self.need_post_exec_cleanup {
-            return;
-        }
-        self.reset_and_unmap_all();
-        self.regions = get_regions(thread.get_system_pid());
-        self.heap = get_heap(&self.shm_file, thread, &mut self.regions);
-        let stack_end = map_stack(&self.shm_file, &mut self.regions);
-        self.stack_copied = stack_end..stack_end;
-        self.need_post_exec_cleanup = false;
     }
 
     /// Gets a reference to an object in the plugin's memory.
@@ -795,7 +742,6 @@ impl MemoryManager {
         thread: &mut impl Thread,
         ptr: PluginPtr,
     ) -> Result<PluginPtr, i32> {
-        self.post_exec_cleanup_if_needed(thread);
         let requested_brk = usize::from(ptr);
 
         // On error, brk syscall returns current brk (end of heap). The only errors we specifically
@@ -934,7 +880,6 @@ impl MemoryManager {
         src: PluginPtr,
         n: usize,
     ) -> Option<*mut c_void> {
-        self.post_exec_cleanup_if_needed(thread);
         if n == 0 {
             // Length zero pointer should never be deref'd. Just return null.
             println!("Warning: returning NULL for zero-length pointer");
@@ -1121,17 +1066,6 @@ mod export {
         memory_manager
             .get_mutable_ptr(&mut thread, plugin_src, n)
             .unwrap()
-    }
-
-    /// Notifies memorymanager that plugin is about to call execve.
-    #[no_mangle]
-    pub unsafe extern "C" fn memorymanager_preExecHook(
-        memory_manager: *mut MemoryManager,
-        thread: *mut c::Thread,
-    ) {
-        let memory_manager = &mut *memory_manager;
-        let thread = CThread::new(thread);
-        memory_manager.pre_exec_hook(&thread);
     }
 
     /// Fully handles the `brk` syscall, keeping the "heap" mapped in our shared mem file.

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -493,7 +493,7 @@ static void _process_free(Process* proc) {
     if(proc->processName) {
         g_string_free(proc->processName, TRUE);
     }
-    if(proc->memoryManager) {
+    if (proc->memoryManager) {
         memorymanager_free(proc->memoryManager);
     }
 
@@ -555,7 +555,7 @@ MemoryManager* process_getMemoryManager(Process* proc) {
 
 void process_setMemoryManager(Process* proc, MemoryManager* memoryManager) {
     MAGIC_ASSERT(proc);
-    if(proc->memoryManager) {
+    if (proc->memoryManager) {
         memorymanager_free(proc->memoryManager);
     }
     proc->memoryManager = memoryManager;

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -563,11 +563,8 @@ void process_setMemoryManager(Process* proc, MemoryManager* memoryManager) {
 
 const void* process_getReadablePtr(Process* proc, Thread* thread, PluginPtr plugin_src, size_t n) {
     MAGIC_ASSERT(proc);
-    if (proc->memoryManager) {
-        return memorymanager_getReadablePtr(proc->memoryManager, thread, plugin_src, n);
-    } else {
-        return thread_getReadablePtr(thread, plugin_src, n);
-    }
+    utility_assert(proc->memoryManager);
+    return memorymanager_getReadablePtr(proc->memoryManager, thread, plugin_src, n);
 }
 
 // Returns a writable pointer corresponding to the named region. The initial
@@ -576,11 +573,8 @@ const void* process_getReadablePtr(Process* proc, Thread* thread, PluginPtr plug
 // The returned pointer is automatically invalidated when the plugin runs again.
 void* process_getWriteablePtr(Process* proc, Thread* thread, PluginPtr plugin_src, size_t n) {
     MAGIC_ASSERT(proc);
-    if (proc->memoryManager) {
-        return memorymanager_getWriteablePtr(proc->memoryManager, thread, plugin_src, n);
-    } else {
-        return thread_getWriteablePtr(thread, plugin_src, n);
-    }
+    utility_assert(proc->memoryManager);
+    return memorymanager_getWriteablePtr(proc->memoryManager, thread, plugin_src, n);
 }
 
 // Returns a writeable pointer corresponding to the specified src. Use when
@@ -589,11 +583,8 @@ void* process_getWriteablePtr(Process* proc, Thread* thread, PluginPtr plugin_sr
 // The returned pointer is automatically invalidated when the plugin runs again.
 void* process_getMutablePtr(Process* proc, Thread* thread, PluginPtr plugin_src, size_t n) {
     MAGIC_ASSERT(proc);
-    if (proc->memoryManager) {
-        return memorymanager_getMutablePtr(proc->memoryManager, thread, plugin_src, n);
-    } else {
-        return thread_getMutablePtr(thread, plugin_src, n);
-    }
+    utility_assert(proc->memoryManager);
+    return memorymanager_getMutablePtr(proc->memoryManager, thread, plugin_src, n);
 }
 
 // Flushes and invalidates all previously returned readable/writeable plugin

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <wchar.h>
 
+#include "main/bindings/c/bindings.h"
 #include "main/core/support/definitions.h"
 #include "main/host/descriptor/descriptor_types.h"
 #include "main/host/descriptor/timer.h"
@@ -68,5 +69,31 @@ guint process_getProcessID(Process* proc);
 int process_registerDescriptor(Process* proc, Descriptor* desc);
 void process_deregisterDescriptor(Process* proc, Descriptor* desc);
 Descriptor* process_getRegisteredDescriptor(Process* proc, int handle);
+
+// Make the data at plugin_src available in shadow's address space.
+//
+// The returned pointer is read-only, and is automatically invalidated when the
+// plugin runs again.
+const void* process_getReadablePtr(Process* proc, Thread* thread, PluginPtr plugin_src, size_t n);
+
+// Returns a writable pointer corresponding to the named region. The initial
+// contents of the returned memory are unspecified.
+//
+// The returned pointer is automatically invalidated when the plugin runs again.
+void* process_getWriteablePtr(Process* proc, Thread* thread, PluginPtr plugin_src, size_t n);
+
+// Returns a writeable pointer corresponding to the specified src. Use when
+// the data at the given address needs to be both read and written.
+//
+// The returned pointer is automatically invalidated when the plugin runs again.
+void* process_getMutablePtr(Process* proc, Thread* thread, PluginPtr plugin_src, size_t n);
+
+// Flushes and invalidates all previously returned readable/writeable plugin
+// pointers, as if returning control to the plugin. This can be useful in
+// conjunction with `thread_nativeSyscall` operations that touch memory.
+void process_flushPtrs(Process* proc, Thread* thread);
+
+MemoryManager* process_getMemoryManager(Process* proc);
+void process_setMemoryManager(Process* proc, MemoryManager* memoryManager);
 
 #endif /* SHD_PROCESS_H_ */

--- a/src/main/host/syscall/epoll.c
+++ b/src/main/host/syscall/epoll.c
@@ -105,7 +105,7 @@ SysCallReturn syscallhandler_epoll_ctl(SysCallHandler* sys,
     }
 
     const struct epoll_event* event =
-        process_getReadablePtr(sys->process,sys->thread, eventPtr, sizeof(*event));
+        process_getReadablePtr(sys->process, sys->thread, eventPtr, sizeof(*event));
 
     debug("Calling epoll_control on epoll %i with child %i", epfd, fd);
     errorCode = epoll_control(epoll, op, descriptor, event);
@@ -186,7 +186,7 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
     guint numEventsNeeded = MIN((guint)maxevents, numReadyEvents);
     size_t sizeNeeded = sizeof(struct epoll_event) * numEventsNeeded;
     struct epoll_event* events =
-        process_getWriteablePtr(sys->process,sys->thread, eventsPtr, sizeNeeded);
+        process_getWriteablePtr(sys->process, sys->thread, eventsPtr, sizeNeeded);
 
     /* Retrieve the events. */
     gint nEvents = 0;

--- a/src/main/host/syscall/epoll.c
+++ b/src/main/host/syscall/epoll.c
@@ -105,7 +105,7 @@ SysCallReturn syscallhandler_epoll_ctl(SysCallHandler* sys,
     }
 
     const struct epoll_event* event =
-        memorymanager_getReadablePtr(sys->memoryManager,sys->thread, eventPtr, sizeof(*event));
+        process_getReadablePtr(sys->process,sys->thread, eventPtr, sizeof(*event));
 
     debug("Calling epoll_control on epoll %i with child %i", epfd, fd);
     errorCode = epoll_control(epoll, op, descriptor, event);
@@ -186,7 +186,7 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
     guint numEventsNeeded = MIN((guint)maxevents, numReadyEvents);
     size_t sizeNeeded = sizeof(struct epoll_event) * numEventsNeeded;
     struct epoll_event* events =
-        memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, eventsPtr, sizeNeeded);
+        process_getWriteablePtr(sys->process,sys->thread, eventsPtr, sizeNeeded);
 
     /* Retrieve the events. */
     gint nEvents = 0;

--- a/src/main/host/syscall/fcntl.c
+++ b/src/main/host/syscall/fcntl.c
@@ -62,8 +62,8 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, File* file, int fd,
         case F_OFD_GETLK:
 #endif
         {
-            struct flock* flk = memorymanager_getMutablePtr(
-                sys->memoryManager, sys->thread, argReg.as_ptr, sizeof(*flk));
+            struct flock* flk = process_getMutablePtr(
+                sys->process, sys->thread, argReg.as_ptr, sizeof(*flk));
             result = file_fcntl(file, command, (void*)flk);
             break;
         }
@@ -78,13 +78,13 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, File* file, int fd,
 #endif
         {
             const struct flock* flk =
-                memorymanager_getReadablePtr(sys->memoryManager,sys->thread, argReg.as_ptr, sizeof(*flk));
+                process_getReadablePtr(sys->process,sys->thread, argReg.as_ptr, sizeof(*flk));
             result = file_fcntl(file, command, (void*)flk);
             break;
         }
 
         case F_GETOWN_EX: {
-            struct f_owner_ex* foe = memorymanager_getWriteablePtr(sys->memoryManager,
+            struct f_owner_ex* foe = process_getWriteablePtr(sys->process,
                 sys->thread, argReg.as_ptr, sizeof(*foe));
             result = file_fcntl(file, command, foe);
             break;
@@ -92,7 +92,7 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, File* file, int fd,
 
         case F_SETOWN_EX: {
             const struct f_owner_ex* foe =
-                memorymanager_getReadablePtr(sys->memoryManager,sys->thread, argReg.as_ptr, sizeof(*foe));
+                process_getReadablePtr(sys->process,sys->thread, argReg.as_ptr, sizeof(*foe));
             result = file_fcntl(file, command, (void*)foe);
             break;
         }
@@ -104,7 +104,7 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, File* file, int fd,
         case F_GET_FILE_RW_HINT:
 #endif
         {
-            uint64_t* hint = memorymanager_getWriteablePtr(sys->memoryManager,
+            uint64_t* hint = process_getWriteablePtr(sys->process,
                 sys->thread, argReg.as_ptr, sizeof(*hint));
             result = file_fcntl(file, command, hint);
             break;
@@ -117,7 +117,7 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, File* file, int fd,
         case F_SET_FILE_RW_HINT:
 #endif
         {
-            const uint64_t* hint = memorymanager_getReadablePtr(sys->memoryManager,
+            const uint64_t* hint = process_getReadablePtr(sys->process,
                 sys->thread, argReg.as_ptr, sizeof(*hint));
             result = file_fcntl(file, command, (void*)hint);
             break;

--- a/src/main/host/syscall/fcntl.c
+++ b/src/main/host/syscall/fcntl.c
@@ -62,8 +62,8 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, File* file, int fd,
         case F_OFD_GETLK:
 #endif
         {
-            struct flock* flk = process_getMutablePtr(
-                sys->process, sys->thread, argReg.as_ptr, sizeof(*flk));
+            struct flock* flk =
+                process_getMutablePtr(sys->process, sys->thread, argReg.as_ptr, sizeof(*flk));
             result = file_fcntl(file, command, (void*)flk);
             break;
         }
@@ -78,21 +78,21 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, File* file, int fd,
 #endif
         {
             const struct flock* flk =
-                process_getReadablePtr(sys->process,sys->thread, argReg.as_ptr, sizeof(*flk));
+                process_getReadablePtr(sys->process, sys->thread, argReg.as_ptr, sizeof(*flk));
             result = file_fcntl(file, command, (void*)flk);
             break;
         }
 
         case F_GETOWN_EX: {
-            struct f_owner_ex* foe = process_getWriteablePtr(sys->process,
-                sys->thread, argReg.as_ptr, sizeof(*foe));
+            struct f_owner_ex* foe =
+                process_getWriteablePtr(sys->process, sys->thread, argReg.as_ptr, sizeof(*foe));
             result = file_fcntl(file, command, foe);
             break;
         }
 
         case F_SETOWN_EX: {
             const struct f_owner_ex* foe =
-                process_getReadablePtr(sys->process,sys->thread, argReg.as_ptr, sizeof(*foe));
+                process_getReadablePtr(sys->process, sys->thread, argReg.as_ptr, sizeof(*foe));
             result = file_fcntl(file, command, (void*)foe);
             break;
         }
@@ -104,8 +104,8 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, File* file, int fd,
         case F_GET_FILE_RW_HINT:
 #endif
         {
-            uint64_t* hint = process_getWriteablePtr(sys->process,
-                sys->thread, argReg.as_ptr, sizeof(*hint));
+            uint64_t* hint =
+                process_getWriteablePtr(sys->process, sys->thread, argReg.as_ptr, sizeof(*hint));
             result = file_fcntl(file, command, hint);
             break;
         }
@@ -117,8 +117,8 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, File* file, int fd,
         case F_SET_FILE_RW_HINT:
 #endif
         {
-            const uint64_t* hint = process_getReadablePtr(sys->process,
-                sys->thread, argReg.as_ptr, sizeof(*hint));
+            const uint64_t* hint =
+                process_getReadablePtr(sys->process, sys->thread, argReg.as_ptr, sizeof(*hint));
             result = file_fcntl(file, command, (void*)hint);
             break;
         }

--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -127,8 +127,7 @@ SysCallReturn syscallhandler_fstat(SysCallHandler* sys,
     }
 
     /* Get some memory in which to return the result. */
-    struct stat* buf =
-        process_getWriteablePtr(sys->process,sys->thread, bufPtr, sizeof(*buf));
+    struct stat* buf = process_getWriteablePtr(sys->process, sys->thread, bufPtr, sizeof(*buf));
 
     return (SysCallReturn){
         .state = SYSCALL_DONE, .retval.as_i64 = file_fstat(file_desc, buf)};
@@ -152,8 +151,7 @@ SysCallReturn syscallhandler_fstatfs(SysCallHandler* sys,
     }
 
     /* Get some memory in which to return the result. */
-    struct statfs* buf =
-        process_getWriteablePtr(sys->process,sys->thread, bufPtr, sizeof(*buf));
+    struct statfs* buf = process_getWriteablePtr(sys->process, sys->thread, bufPtr, sizeof(*buf));
 
     return (SysCallReturn){
         .state = SYSCALL_DONE, .retval.as_i64 = file_fstatfs(file_desc, buf)};
@@ -316,7 +314,7 @@ SysCallReturn syscallhandler_fsetxattr(SysCallHandler* sys,
     }
 
     const void* value = (valuePtr.val && size > 0)
-                            ? process_getReadablePtr(sys->process,sys->thread, valuePtr, size)
+                            ? process_getReadablePtr(sys->process, sys->thread, valuePtr, size)
                             : NULL;
 
     return (SysCallReturn){
@@ -351,7 +349,7 @@ SysCallReturn syscallhandler_fgetxattr(SysCallHandler* sys,
     }
 
     void* value = (valuePtr.val && size > 0)
-                      ? process_getWriteablePtr(sys->process,sys->thread, valuePtr, size)
+                      ? process_getWriteablePtr(sys->process, sys->thread, valuePtr, size)
                       : NULL;
 
     return (SysCallReturn){
@@ -373,7 +371,7 @@ SysCallReturn syscallhandler_flistxattr(SysCallHandler* sys,
     }
 
     void* list = (listPtr.val && size > 0)
-                     ? process_getWriteablePtr(sys->process,sys->thread, listPtr, size)
+                     ? process_getWriteablePtr(sys->process, sys->thread, listPtr, size)
                      : NULL;
 
     return (SysCallReturn){
@@ -484,7 +482,7 @@ SysCallReturn syscallhandler_getdents(SysCallHandler* sys,
 
     /* Get the path string from the plugin. */
     struct linux_dirent* dirp =
-        process_getWriteablePtr(sys->process,sys->thread, dirpPtr, sizeof(*dirp));
+        process_getWriteablePtr(sys->process, sys->thread, dirpPtr, sizeof(*dirp));
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
@@ -514,7 +512,7 @@ SysCallReturn syscallhandler_getdents64(SysCallHandler* sys,
 
     /* Get the path string from the plugin. */
     struct linux_dirent64* dirp =
-        process_getWriteablePtr(sys->process,sys->thread, dirpPtr, sizeof(*dirp));
+        process_getWriteablePtr(sys->process, sys->thread, dirpPtr, sizeof(*dirp));
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }

--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -128,7 +128,7 @@ SysCallReturn syscallhandler_fstat(SysCallHandler* sys,
 
     /* Get some memory in which to return the result. */
     struct stat* buf =
-        memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, bufPtr, sizeof(*buf));
+        process_getWriteablePtr(sys->process,sys->thread, bufPtr, sizeof(*buf));
 
     return (SysCallReturn){
         .state = SYSCALL_DONE, .retval.as_i64 = file_fstat(file_desc, buf)};
@@ -153,7 +153,7 @@ SysCallReturn syscallhandler_fstatfs(SysCallHandler* sys,
 
     /* Get some memory in which to return the result. */
     struct statfs* buf =
-        memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, bufPtr, sizeof(*buf));
+        process_getWriteablePtr(sys->process,sys->thread, bufPtr, sizeof(*buf));
 
     return (SysCallReturn){
         .state = SYSCALL_DONE, .retval.as_i64 = file_fstatfs(file_desc, buf)};
@@ -316,7 +316,7 @@ SysCallReturn syscallhandler_fsetxattr(SysCallHandler* sys,
     }
 
     const void* value = (valuePtr.val && size > 0)
-                            ? memorymanager_getReadablePtr(sys->memoryManager,sys->thread, valuePtr, size)
+                            ? process_getReadablePtr(sys->process,sys->thread, valuePtr, size)
                             : NULL;
 
     return (SysCallReturn){
@@ -351,7 +351,7 @@ SysCallReturn syscallhandler_fgetxattr(SysCallHandler* sys,
     }
 
     void* value = (valuePtr.val && size > 0)
-                      ? memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, valuePtr, size)
+                      ? process_getWriteablePtr(sys->process,sys->thread, valuePtr, size)
                       : NULL;
 
     return (SysCallReturn){
@@ -373,7 +373,7 @@ SysCallReturn syscallhandler_flistxattr(SysCallHandler* sys,
     }
 
     void* list = (listPtr.val && size > 0)
-                     ? memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, listPtr, size)
+                     ? process_getWriteablePtr(sys->process,sys->thread, listPtr, size)
                      : NULL;
 
     return (SysCallReturn){
@@ -484,7 +484,7 @@ SysCallReturn syscallhandler_getdents(SysCallHandler* sys,
 
     /* Get the path string from the plugin. */
     struct linux_dirent* dirp =
-        memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, dirpPtr, sizeof(*dirp));
+        process_getWriteablePtr(sys->process,sys->thread, dirpPtr, sizeof(*dirp));
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
@@ -514,7 +514,7 @@ SysCallReturn syscallhandler_getdents64(SysCallHandler* sys,
 
     /* Get the path string from the plugin. */
     struct linux_dirent64* dirp =
-        memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, dirpPtr, sizeof(*dirp));
+        process_getWriteablePtr(sys->process,sys->thread, dirpPtr, sizeof(*dirp));
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }

--- a/src/main/host/syscall/fileat.c
+++ b/src/main/host/syscall/fileat.c
@@ -168,8 +168,7 @@ SysCallReturn syscallhandler_newfstatat(SysCallHandler* sys,
     }
 
     /* Get some memory in which to return the result. */
-    struct stat* buf =
-        process_getWriteablePtr(sys->process,sys->thread, bufPtr, sizeof(*buf));
+    struct stat* buf = process_getWriteablePtr(sys->process, sys->thread, bufPtr, sizeof(*buf));
 
     return (SysCallReturn){
         .state = SYSCALL_DONE,
@@ -243,7 +242,7 @@ SysCallReturn syscallhandler_futimesat(SysCallHandler* sys,
     }
 
     const struct timeval* times =
-        process_getReadablePtr(sys->process,sys->thread, timesPtr, 2 * sizeof(*times));
+        process_getReadablePtr(sys->process, sys->thread, timesPtr, 2 * sizeof(*times));
 
     return (SysCallReturn){
         .state = SYSCALL_DONE,
@@ -273,7 +272,7 @@ SysCallReturn syscallhandler_utimensat(SysCallHandler* sys,
     }
 
     const struct timespec* times =
-        process_getReadablePtr(sys->process,sys->thread, timesPtr, 2 * sizeof(*times));
+        process_getReadablePtr(sys->process, sys->thread, timesPtr, 2 * sizeof(*times));
 
     return (SysCallReturn){
         .state = SYSCALL_DONE,
@@ -460,7 +459,7 @@ SysCallReturn syscallhandler_readlinkat(SysCallHandler* sys,
     }
 
     /* Get the path string from the plugin. */
-    char* buf = process_getWriteablePtr(sys->process,sys->thread, bufPtr, bufSize);
+    char* buf = process_getWriteablePtr(sys->process, sys->thread, bufPtr, bufSize);
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
@@ -510,7 +509,7 @@ SysCallReturn syscallhandler_statx(SysCallHandler* sys,
 
     /* Get the path string from the plugin. */
     struct statx* statxbuf =
-        process_getWriteablePtr(sys->process,sys->thread, statxbufPtr, sizeof(*statxbuf));
+        process_getWriteablePtr(sys->process, sys->thread, statxbufPtr, sizeof(*statxbuf));
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }

--- a/src/main/host/syscall/fileat.c
+++ b/src/main/host/syscall/fileat.c
@@ -169,7 +169,7 @@ SysCallReturn syscallhandler_newfstatat(SysCallHandler* sys,
 
     /* Get some memory in which to return the result. */
     struct stat* buf =
-        memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, bufPtr, sizeof(*buf));
+        process_getWriteablePtr(sys->process,sys->thread, bufPtr, sizeof(*buf));
 
     return (SysCallReturn){
         .state = SYSCALL_DONE,
@@ -243,7 +243,7 @@ SysCallReturn syscallhandler_futimesat(SysCallHandler* sys,
     }
 
     const struct timeval* times =
-        memorymanager_getReadablePtr(sys->memoryManager,sys->thread, timesPtr, 2 * sizeof(*times));
+        process_getReadablePtr(sys->process,sys->thread, timesPtr, 2 * sizeof(*times));
 
     return (SysCallReturn){
         .state = SYSCALL_DONE,
@@ -273,7 +273,7 @@ SysCallReturn syscallhandler_utimensat(SysCallHandler* sys,
     }
 
     const struct timespec* times =
-        memorymanager_getReadablePtr(sys->memoryManager,sys->thread, timesPtr, 2 * sizeof(*times));
+        process_getReadablePtr(sys->process,sys->thread, timesPtr, 2 * sizeof(*times));
 
     return (SysCallReturn){
         .state = SYSCALL_DONE,
@@ -460,7 +460,7 @@ SysCallReturn syscallhandler_readlinkat(SysCallHandler* sys,
     }
 
     /* Get the path string from the plugin. */
-    char* buf = memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, bufPtr, bufSize);
+    char* buf = process_getWriteablePtr(sys->process,sys->thread, bufPtr, bufSize);
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
@@ -510,7 +510,7 @@ SysCallReturn syscallhandler_statx(SysCallHandler* sys,
 
     /* Get the path string from the plugin. */
     struct statx* statxbuf =
-        memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, statxbufPtr, sizeof(*statxbuf));
+        process_getWriteablePtr(sys->process,sys->thread, statxbufPtr, sizeof(*statxbuf));
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }

--- a/src/main/host/syscall/ioctl.c
+++ b/src/main/host/syscall/ioctl.c
@@ -84,7 +84,7 @@ SysCallReturn syscallhandler_ioctl(SysCallHandler* sys,
             }
         }
 
-        int* lenout = memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, argPtr, sizeof(int));
+        int* lenout = process_getWriteablePtr(sys->process,sys->thread, argPtr, sizeof(int));
         *lenout = (int)buflen;
     } else {
         warning("We do not support ioctl request %lu on descriptor %i", request,

--- a/src/main/host/syscall/ioctl.c
+++ b/src/main/host/syscall/ioctl.c
@@ -84,7 +84,7 @@ SysCallReturn syscallhandler_ioctl(SysCallHandler* sys,
             }
         }
 
-        int* lenout = process_getWriteablePtr(sys->process,sys->thread, argPtr, sizeof(int));
+        int* lenout = process_getWriteablePtr(sys->process, sys->thread, argPtr, sizeof(int));
         *lenout = (int)buflen;
     } else {
         warning("We do not support ioctl request %lu on descriptor %i", request,

--- a/src/main/host/syscall/mman.c
+++ b/src/main/host/syscall/mman.c
@@ -194,12 +194,9 @@ SysCallReturn syscallhandler_brk(SysCallHandler* sys, const SysCallArgs* args) {
 
     // Delegate to the memoryManager.
     MemoryManager* mm = process_getMemoryManager(sys->process);
-    if (mm) {
-        SysCallReg result = memorymanager_handleBrk(mm, sys->thread, newBrk);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval = result};
-    } else {
-        return (SysCallReturn){.state = SYSCALL_NATIVE};
-    }
+    utility_assert(mm);
+    SysCallReg result = memorymanager_handleBrk(mm, sys->thread, newBrk);
+    return (SysCallReturn){.state = SYSCALL_DONE, .retval = result};
 }
 
 SysCallReturn syscallhandler_mmap(SysCallHandler* sys, const SysCallArgs* args) {
@@ -234,13 +231,10 @@ SysCallReturn syscallhandler_mremap(SysCallHandler* sys, const SysCallArgs* args
 
     // Delegate to the memoryManager.
     MemoryManager* mm = process_getMemoryManager(sys->process);
-    if (mm) {
-        SysCallReg result =
-            memorymanager_handleMremap(mm, sys->thread, old_addr, old_size, new_size, flags, new_addr);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval = result};
-    } else {
-        return (SysCallReturn){.state = SYSCALL_NATIVE};
-    }
+    utility_assert(mm);
+    SysCallReg result =
+        memorymanager_handleMremap(mm, sys->thread, old_addr, old_size, new_size, flags, new_addr);
+    return (SysCallReturn){.state = SYSCALL_DONE, .retval = result};
 }
 
 SysCallReturn syscallhandler_munmap(SysCallHandler* sys, const SysCallArgs* args) {
@@ -249,10 +243,7 @@ SysCallReturn syscallhandler_munmap(SysCallHandler* sys, const SysCallArgs* args
 
     // Delegate to the memoryManager.
     MemoryManager* mm = process_getMemoryManager(sys->process);
-    if (mm) {
-        SysCallReg result = memorymanager_handleMunmap(mm, sys->thread, addr, len);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval = result};
-    } else {
-        return (SysCallReturn){.state = SYSCALL_NATIVE};
-    }
+    utility_assert(mm);
+    SysCallReg result = memorymanager_handleMunmap(mm, sys->thread, addr, len);
+    return (SysCallReturn){.state = SYSCALL_DONE, .retval = result};
 }

--- a/src/main/host/syscall/process.c
+++ b/src/main/host/syscall/process.c
@@ -9,7 +9,10 @@
 
 SysCallReturn syscallhandler_execve(SysCallHandler* sys, const SysCallArgs* args) {
     // Notify the memorymanager that exec is about to be called.
-    memorymanager_preExecHook(sys->memoryManager, sys->thread);
+    MemoryManager* mm = process_getMemoryManager(sys->process);
+    if (mm)  {
+        memorymanager_preExecHook(mm, sys->thread);
+    }
 
     // Have the plugin execute it natively.
     return (SysCallReturn){.state = SYSCALL_NATIVE};

--- a/src/main/host/syscall/process.c
+++ b/src/main/host/syscall/process.c
@@ -8,11 +8,9 @@
 #include "main/host/syscall/protected.h"
 
 SysCallReturn syscallhandler_execve(SysCallHandler* sys, const SysCallArgs* args) {
-    // Notify the memorymanager that exec is about to be called.
-    MemoryManager* mm = process_getMemoryManager(sys->process);
-    if (mm)  {
-        memorymanager_preExecHook(mm, sys->thread);
-    }
+    // The MemoryManager's state is no longer valid after an exec.
+    // Destroy it, to be recreated on the next syscall.
+    process_setMemoryManager(sys->process, NULL);
 
     // Have the plugin execute it natively.
     return (SysCallReturn){.state = SYSCALL_NATIVE};

--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -13,7 +13,6 @@
  * handlers.
  */
 
-#include "main/bindings/c/bindings.h"
 #include "main/host/descriptor/timer.h"
 #include "main/host/host.h"
 #include "main/host/process.h"
@@ -29,9 +28,6 @@ struct _SysCallHandler {
     Host* host;
     Process* process;
     Thread* thread;
-
-    /* Owned exclusively by the SysCallHandler. */
-    MemoryManager* memoryManager;
 
     /* Timers are used to support the timerfd syscalls (man timerfd_create);
      * they are types of descriptors on which we can listen for events.

--- a/src/main/host/syscall/random.c
+++ b/src/main/host/syscall/random.c
@@ -31,7 +31,7 @@ SysCallReturn syscallhandler_getrandom(SysCallHandler* sys, const SysCallArgs* a
     }
 
     // Get the buffer where we can copy the random bytes
-    char* buf = memorymanager_getWriteablePtr(sys->memoryManager, sys->thread, bufPtr, count);
+    char* buf = process_getWriteablePtr(sys->process, sys->thread, bufPtr, count);
 
     // Get the source from the host to maintain determinism.
     Random* rng = host_getRandom(sys->host);

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -107,7 +107,7 @@ _syscallhandler_getnameHelper(SysCallHandler* sys,
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
     }
 
-    socklen_t* addrlen = memorymanager_getMutablePtr(sys->memoryManager, sys->thread, addrlenPtr, sizeof(*addrlen));
+    socklen_t* addrlen = process_getMutablePtr(sys->process, sys->thread, addrlenPtr, sizeof(*addrlen));
 
     /* The result is truncated if they didn't give us enough space. */
     size_t retSize = MIN(*addrlen, sizeof(*inet_addr));
@@ -116,7 +116,7 @@ _syscallhandler_getnameHelper(SysCallHandler* sys,
     if (retSize > 0) {
         /* Return the results */
         struct sockaddr* addr =
-            memorymanager_getWriteablePtr(sys->memoryManager, sys->thread, addrPtr, retSize);
+            process_getWriteablePtr(sys->process, sys->thread, addrPtr, retSize);
         memcpy(addr, inet_addr, retSize);
     }
 
@@ -259,7 +259,7 @@ static int _syscallhandler_getTCPOptHelper(SysCallHandler* sys, TCP* tcp,
     switch (optname) {
         case TCP_INFO: {
             /* Get the len via clone, so we can write to optlenPtr too. */
-            socklen_t* optlen = memorymanager_getMutablePtr(sys->memoryManager, sys->thread, optlenPtr, sizeof(*optlen));
+            socklen_t* optlen = process_getMutablePtr(sys->process, sys->thread, optlenPtr, sizeof(*optlen));
             size_t sizeNeeded = sizeof(struct tcp_info);
 
             if (*optlen < sizeNeeded) {
@@ -270,7 +270,7 @@ static int _syscallhandler_getTCPOptHelper(SysCallHandler* sys, TCP* tcp,
             /* Write the tcp info and its size. */
             *optlen = sizeNeeded;
             struct tcp_info* info =
-                memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, optvalPtr, sizeNeeded);
+                process_getWriteablePtr(sys->process,sys->thread, optvalPtr, sizeNeeded);
             tcp_getInfo(tcp, info);
 
             return 0;
@@ -289,7 +289,7 @@ static int _syscallhandler_getSocketOptHelper(SysCallHandler* sys, Socket* sock,
                                               PluginPtr optlenPtr) {
     /* Get the len via clone, so we can write to optlenPtr too. */
     const socklen_t* optlen =
-        memorymanager_getReadablePtr(sys->memoryManager, sys->thread, optlenPtr, sizeof(*optlen));
+        process_getReadablePtr(sys->process, sys->thread, optlenPtr, sizeof(*optlen));
 
     /* All options we currently support are integers. When adding support for
      * more options, make sure to check length requirements. */
@@ -298,7 +298,7 @@ static int _syscallhandler_getSocketOptHelper(SysCallHandler* sys, Socket* sock,
         return -EINVAL;
     }
 
-    int* optval = memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, optvalPtr, sizeof(int));
+    int* optval = process_getWriteablePtr(sys->process,sys->thread, optvalPtr, sizeof(int));
 
     switch (optname) {
         case SO_SNDBUF: {
@@ -339,7 +339,7 @@ static int _syscallhandler_setSocketOptHelper(SysCallHandler* sys, Socket* sock,
     switch (optname) {
         case SO_SNDBUF: {
             const unsigned int* val =
-                memorymanager_getReadablePtr(sys->memoryManager,sys->thread, optvalPtr, sizeof(int));
+                process_getReadablePtr(sys->process,sys->thread, optvalPtr, sizeof(int));
             size_t newsize =
                 (*val) * 2; // Linux kernel doubles this value upon setting
             socket_setOutputBufferSize(sock, newsize);
@@ -350,7 +350,7 @@ static int _syscallhandler_setSocketOptHelper(SysCallHandler* sys, Socket* sock,
         }
         case SO_RCVBUF: {
             const unsigned int* val =
-                memorymanager_getReadablePtr(sys->memoryManager,sys->thread, optvalPtr, sizeof(int));
+                process_getReadablePtr(sys->process,sys->thread, optvalPtr, sizeof(int));
             size_t newsize =
                 (*val) * 2; // Linux kernel doubles this value upon setting
             socket_setInputBufferSize(sock, newsize);
@@ -431,7 +431,7 @@ SysCallReturn _syscallhandler_recvfromHelper(SysCallHandler* sys, int sockfd,
     /* TODO: Dynamically compute size based on how much data is actually
      * available in the descriptor. */
     size_t sizeNeeded = MIN(bufSize, SYSCALL_IO_BUFSIZE);
-    void* buf = memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, bufPtr, sizeNeeded);
+    void* buf = process_getWriteablePtr(sys->process,sys->thread, bufPtr, sizeNeeded);
     struct sockaddr_in inet_addr = {.sin_family = AF_INET};
 
     ssize_t retval = transport_receiveUserData(
@@ -497,7 +497,7 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
 
     if (destAddrPtr.val) {
         const struct sockaddr* dest_addr =
-            memorymanager_getReadablePtr(sys->memoryManager, sys->thread, destAddrPtr, addrlen);
+            process_getReadablePtr(sys->process, sys->thread, destAddrPtr, addrlen);
         utility_assert(dest_addr);
 
         /* TODO: we assume AF_INET here, change this when we support AF_UNIX */
@@ -579,7 +579,7 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
          * available in the descriptor. */
         size_t sizeNeeded = MIN(bufSize, SYSCALL_IO_BUFSIZE);
         const void* buf =
-            memorymanager_getReadablePtr(sys->memoryManager, sys->thread, bufPtr, sizeNeeded);
+            process_getReadablePtr(sys->process, sys->thread, bufPtr, sizeNeeded);
 
         retval = transport_sendUserData(
             (Transport*)socket_desc, buf, sizeNeeded, dest_ip, dest_port);
@@ -654,7 +654,7 @@ SysCallReturn syscallhandler_bind(SysCallHandler* sys,
     }
 
     const struct sockaddr* addr =
-        memorymanager_getReadablePtr(sys->memoryManager, sys->thread, addrPtr, addrlen);
+        process_getReadablePtr(sys->process, sys->thread, addrPtr, addrlen);
     utility_assert(addr);
 
     /* TODO: we assume AF_INET here, change this when we support AF_UNIX */
@@ -705,7 +705,7 @@ SysCallReturn syscallhandler_connect(SysCallHandler* sys,
     }
 
     const struct sockaddr* addr =
-        memorymanager_getReadablePtr(sys->memoryManager, sys->thread, addrPtr, addrlen);
+        process_getReadablePtr(sys->process, sys->thread, addrPtr, addrlen);
     utility_assert(addr);
 
     /* TODO: we assume AF_INET here, change this when we support AF_UNIX */

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -107,7 +107,8 @@ _syscallhandler_getnameHelper(SysCallHandler* sys,
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
     }
 
-    socklen_t* addrlen = process_getMutablePtr(sys->process, sys->thread, addrlenPtr, sizeof(*addrlen));
+    socklen_t* addrlen =
+        process_getMutablePtr(sys->process, sys->thread, addrlenPtr, sizeof(*addrlen));
 
     /* The result is truncated if they didn't give us enough space. */
     size_t retSize = MIN(*addrlen, sizeof(*inet_addr));
@@ -259,7 +260,8 @@ static int _syscallhandler_getTCPOptHelper(SysCallHandler* sys, TCP* tcp,
     switch (optname) {
         case TCP_INFO: {
             /* Get the len via clone, so we can write to optlenPtr too. */
-            socklen_t* optlen = process_getMutablePtr(sys->process, sys->thread, optlenPtr, sizeof(*optlen));
+            socklen_t* optlen =
+                process_getMutablePtr(sys->process, sys->thread, optlenPtr, sizeof(*optlen));
             size_t sizeNeeded = sizeof(struct tcp_info);
 
             if (*optlen < sizeNeeded) {
@@ -270,7 +272,7 @@ static int _syscallhandler_getTCPOptHelper(SysCallHandler* sys, TCP* tcp,
             /* Write the tcp info and its size. */
             *optlen = sizeNeeded;
             struct tcp_info* info =
-                process_getWriteablePtr(sys->process,sys->thread, optvalPtr, sizeNeeded);
+                process_getWriteablePtr(sys->process, sys->thread, optvalPtr, sizeNeeded);
             tcp_getInfo(tcp, info);
 
             return 0;
@@ -298,7 +300,7 @@ static int _syscallhandler_getSocketOptHelper(SysCallHandler* sys, Socket* sock,
         return -EINVAL;
     }
 
-    int* optval = process_getWriteablePtr(sys->process,sys->thread, optvalPtr, sizeof(int));
+    int* optval = process_getWriteablePtr(sys->process, sys->thread, optvalPtr, sizeof(int));
 
     switch (optname) {
         case SO_SNDBUF: {
@@ -339,7 +341,7 @@ static int _syscallhandler_setSocketOptHelper(SysCallHandler* sys, Socket* sock,
     switch (optname) {
         case SO_SNDBUF: {
             const unsigned int* val =
-                process_getReadablePtr(sys->process,sys->thread, optvalPtr, sizeof(int));
+                process_getReadablePtr(sys->process, sys->thread, optvalPtr, sizeof(int));
             size_t newsize =
                 (*val) * 2; // Linux kernel doubles this value upon setting
             socket_setOutputBufferSize(sock, newsize);
@@ -350,7 +352,7 @@ static int _syscallhandler_setSocketOptHelper(SysCallHandler* sys, Socket* sock,
         }
         case SO_RCVBUF: {
             const unsigned int* val =
-                process_getReadablePtr(sys->process,sys->thread, optvalPtr, sizeof(int));
+                process_getReadablePtr(sys->process, sys->thread, optvalPtr, sizeof(int));
             size_t newsize =
                 (*val) * 2; // Linux kernel doubles this value upon setting
             socket_setInputBufferSize(sock, newsize);
@@ -431,7 +433,7 @@ SysCallReturn _syscallhandler_recvfromHelper(SysCallHandler* sys, int sockfd,
     /* TODO: Dynamically compute size based on how much data is actually
      * available in the descriptor. */
     size_t sizeNeeded = MIN(bufSize, SYSCALL_IO_BUFSIZE);
-    void* buf = process_getWriteablePtr(sys->process,sys->thread, bufPtr, sizeNeeded);
+    void* buf = process_getWriteablePtr(sys->process, sys->thread, bufPtr, sizeNeeded);
     struct sockaddr_in inet_addr = {.sin_family = AF_INET};
 
     ssize_t retval = transport_receiveUserData(
@@ -578,8 +580,7 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
         /* TODO: Dynamically compute size based on how much data is actually
          * available in the descriptor. */
         size_t sizeNeeded = MIN(bufSize, SYSCALL_IO_BUFSIZE);
-        const void* buf =
-            process_getReadablePtr(sys->process, sys->thread, bufPtr, sizeNeeded);
+        const void* buf = process_getReadablePtr(sys->process, sys->thread, bufPtr, sizeNeeded);
 
         retval = transport_sendUserData(
             (Transport*)socket_desc, buf, sizeNeeded, dest_ip, dest_port);

--- a/src/main/host/syscall/time.c
+++ b/src/main/host/syscall/time.c
@@ -38,7 +38,7 @@ SysCallReturn syscallhandler_nanosleep(SysCallHandler* sys,
 
     /* Grab the arg from the syscall register. */
     const struct timespec* req =
-        memorymanager_getReadablePtr(sys->memoryManager,sys->thread, args->args[0].as_ptr, sizeof(*req));
+        process_getReadablePtr(sys->process,sys->thread, args->args[0].as_ptr, sizeof(*req));
 
     /* Bounds checking. */
     if (!(req->tv_nsec >= 0 && req->tv_nsec <= 999999999)) {
@@ -89,7 +89,7 @@ SysCallReturn syscallhandler_clock_gettime(SysCallHandler* sys,
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
     }
 
-    struct timespec* res_timespec = memorymanager_getWriteablePtr(sys->memoryManager,
+    struct timespec* res_timespec = process_getWriteablePtr(sys->process,
         sys->thread, args->args[1].as_ptr, sizeof(*res_timespec));
 
     EmulatedTime now = _syscallhandler_getEmulatedTime();
@@ -105,7 +105,7 @@ SysCallReturn syscallhandler_time(SysCallHandler* sys, const SysCallArgs* args) 
     time_t seconds = _syscallhandler_getEmulatedTime() / SIMTIME_ONE_SECOND;
 
     if (tlocPtr.val) {
-        time_t* tloc = memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, tlocPtr, sizeof(*tloc));
+        time_t* tloc = process_getWriteablePtr(sys->process,sys->thread, tlocPtr, sizeof(*tloc));
         *tloc = seconds;
     }
 
@@ -117,7 +117,7 @@ SysCallReturn syscallhandler_gettimeofday(SysCallHandler* sys, const SysCallArgs
 
     if (tvPtr.val) {
         EmulatedTime now = _syscallhandler_getEmulatedTime();
-        struct timeval* tv = memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, tvPtr, sizeof(*tv));
+        struct timeval* tv = process_getWriteablePtr(sys->process,sys->thread, tvPtr, sizeof(*tv));
         tv->tv_sec = now / SIMTIME_ONE_SECOND;
         tv->tv_usec = (now % SIMTIME_ONE_SECOND) / SIMTIME_ONE_MICROSECOND;
     }

--- a/src/main/host/syscall/time.c
+++ b/src/main/host/syscall/time.c
@@ -38,7 +38,7 @@ SysCallReturn syscallhandler_nanosleep(SysCallHandler* sys,
 
     /* Grab the arg from the syscall register. */
     const struct timespec* req =
-        process_getReadablePtr(sys->process,sys->thread, args->args[0].as_ptr, sizeof(*req));
+        process_getReadablePtr(sys->process, sys->thread, args->args[0].as_ptr, sizeof(*req));
 
     /* Bounds checking. */
     if (!(req->tv_nsec >= 0 && req->tv_nsec <= 999999999)) {
@@ -89,8 +89,8 @@ SysCallReturn syscallhandler_clock_gettime(SysCallHandler* sys,
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
     }
 
-    struct timespec* res_timespec = process_getWriteablePtr(sys->process,
-        sys->thread, args->args[1].as_ptr, sizeof(*res_timespec));
+    struct timespec* res_timespec = process_getWriteablePtr(
+        sys->process, sys->thread, args->args[1].as_ptr, sizeof(*res_timespec));
 
     EmulatedTime now = _syscallhandler_getEmulatedTime();
     res_timespec->tv_sec = now / SIMTIME_ONE_SECOND;
@@ -105,7 +105,7 @@ SysCallReturn syscallhandler_time(SysCallHandler* sys, const SysCallArgs* args) 
     time_t seconds = _syscallhandler_getEmulatedTime() / SIMTIME_ONE_SECOND;
 
     if (tlocPtr.val) {
-        time_t* tloc = process_getWriteablePtr(sys->process,sys->thread, tlocPtr, sizeof(*tloc));
+        time_t* tloc = process_getWriteablePtr(sys->process, sys->thread, tlocPtr, sizeof(*tloc));
         *tloc = seconds;
     }
 
@@ -117,7 +117,7 @@ SysCallReturn syscallhandler_gettimeofday(SysCallHandler* sys, const SysCallArgs
 
     if (tvPtr.val) {
         EmulatedTime now = _syscallhandler_getEmulatedTime();
-        struct timeval* tv = process_getWriteablePtr(sys->process,sys->thread, tvPtr, sizeof(*tv));
+        struct timeval* tv = process_getWriteablePtr(sys->process, sys->thread, tvPtr, sizeof(*tv));
         tv->tv_sec = now / SIMTIME_ONE_SECOND;
         tv->tv_usec = (now % SIMTIME_ONE_SECOND) / SIMTIME_ONE_MICROSECOND;
     }

--- a/src/main/host/syscall/timerfd.c
+++ b/src/main/host/syscall/timerfd.c
@@ -119,13 +119,13 @@ SysCallReturn syscallhandler_timerfd_settime(SysCallHandler* sys,
     }
 
     const struct itimerspec* newValue =
-        process_getReadablePtr(sys->process,sys->thread, newValuePtr, sizeof(*newValue));
+        process_getReadablePtr(sys->process, sys->thread, newValuePtr, sizeof(*newValue));
 
     /* Old value is allowed to be null. */
     struct itimerspec* oldValue = NULL;
     if (oldValuePtr.val) {
         oldValue =
-            process_getWriteablePtr(sys->process,sys->thread, oldValuePtr, sizeof(*oldValue));
+            process_getWriteablePtr(sys->process, sys->thread, oldValuePtr, sizeof(*oldValue));
     }
 
     /* Service the call in the timer module. */
@@ -155,7 +155,7 @@ SysCallReturn syscallhandler_timerfd_gettime(SysCallHandler* sys,
     }
 
     struct itimerspec* currValue =
-        process_getWriteablePtr(sys->process,sys->thread, currValuePtr, sizeof(*currValue));
+        process_getWriteablePtr(sys->process, sys->thread, currValuePtr, sizeof(*currValue));
 
     /* Service the call in the timer module. */
     errcode = timer_getTime(timer, currValue);

--- a/src/main/host/syscall/timerfd.c
+++ b/src/main/host/syscall/timerfd.c
@@ -119,13 +119,13 @@ SysCallReturn syscallhandler_timerfd_settime(SysCallHandler* sys,
     }
 
     const struct itimerspec* newValue =
-        memorymanager_getReadablePtr(sys->memoryManager,sys->thread, newValuePtr, sizeof(*newValue));
+        process_getReadablePtr(sys->process,sys->thread, newValuePtr, sizeof(*newValue));
 
     /* Old value is allowed to be null. */
     struct itimerspec* oldValue = NULL;
     if (oldValuePtr.val) {
         oldValue =
-            memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, oldValuePtr, sizeof(*oldValue));
+            process_getWriteablePtr(sys->process,sys->thread, oldValuePtr, sizeof(*oldValue));
     }
 
     /* Service the call in the timer module. */
@@ -155,7 +155,7 @@ SysCallReturn syscallhandler_timerfd_gettime(SysCallHandler* sys,
     }
 
     struct itimerspec* currValue =
-        memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, currValuePtr, sizeof(*currValue));
+        process_getWriteablePtr(sys->process,sys->thread, currValuePtr, sizeof(*currValue));
 
     /* Service the call in the timer module. */
     errcode = timer_getTime(timer, currValue);

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -52,7 +52,7 @@ static int _syscallhandler_validateVecParams(SysCallHandler* sys, int fd,
 
     /* Get the vector of pointers. */
     const struct iovec* iov =
-        process_getReadablePtr(sys->process,sys->thread, iovPtr, iovlen * sizeof(*iov));
+        process_getReadablePtr(sys->process, sys->thread, iovPtr, iovlen * sizeof(*iov));
 
     /* Check that all of the buf pointers are valid. */
     for (unsigned long i = 0; i < iovlen; i++) {
@@ -114,7 +114,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
             size_t bufSize = iov[i].iov_len;
 
             buffersv[i].iov_base =
-                process_getWriteablePtr(sys->process,sys->thread, bufPtr, bufSize);
+                process_getWriteablePtr(sys->process, sys->thread, bufPtr, bufSize);
             buffersv[i].iov_len = bufSize;
         }
 
@@ -144,8 +144,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                     break;
                 }
                 case DT_PIPE: {
-                    void* buf =
-                        process_getWriteablePtr(sys->process,sys->thread, bufPtr, bufSize);
+                    void* buf = process_getWriteablePtr(sys->process, sys->thread, bufPtr, bufSize);
                     result = transport_receiveUserData(
                         (Transport*)desc, buf, bufSize, NULL, NULL);
                     break;
@@ -234,7 +233,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
             size_t bufSize = iov[i].iov_len;
 
             buffersv[i].iov_base =
-                (void*)process_getReadablePtr(sys->process,sys->thread, bufPtr, bufSize);
+                (void*)process_getReadablePtr(sys->process, sys->thread, bufPtr, bufSize);
             buffersv[i].iov_len = bufSize;
         }
 
@@ -265,7 +264,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                 }
                 case DT_PIPE: {
                     const void* buf =
-                        process_getReadablePtr(sys->process,sys->thread, bufPtr, bufSize);
+                        process_getReadablePtr(sys->process, sys->thread, bufPtr, bufSize);
                     result = transport_sendUserData(
                         (Transport*)desc, buf, bufSize, 0, 0);
                     break;

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -52,7 +52,7 @@ static int _syscallhandler_validateVecParams(SysCallHandler* sys, int fd,
 
     /* Get the vector of pointers. */
     const struct iovec* iov =
-        memorymanager_getReadablePtr(sys->memoryManager,sys->thread, iovPtr, iovlen * sizeof(*iov));
+        process_getReadablePtr(sys->process,sys->thread, iovPtr, iovlen * sizeof(*iov));
 
     /* Check that all of the buf pointers are valid. */
     for (unsigned long i = 0; i < iovlen; i++) {
@@ -114,7 +114,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
             size_t bufSize = iov[i].iov_len;
 
             buffersv[i].iov_base =
-                memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, bufPtr, bufSize);
+                process_getWriteablePtr(sys->process,sys->thread, bufPtr, bufSize);
             buffersv[i].iov_len = bufSize;
         }
 
@@ -145,7 +145,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                 }
                 case DT_PIPE: {
                     void* buf =
-                        memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, bufPtr, bufSize);
+                        process_getWriteablePtr(sys->process,sys->thread, bufPtr, bufSize);
                     result = transport_receiveUserData(
                         (Transport*)desc, buf, bufSize, NULL, NULL);
                     break;
@@ -234,7 +234,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
             size_t bufSize = iov[i].iov_len;
 
             buffersv[i].iov_base =
-                (void*)memorymanager_getReadablePtr(sys->memoryManager,sys->thread, bufPtr, bufSize);
+                (void*)process_getReadablePtr(sys->process,sys->thread, bufPtr, bufSize);
             buffersv[i].iov_len = bufSize;
         }
 
@@ -265,7 +265,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                 }
                 case DT_PIPE: {
                     const void* buf =
-                        memorymanager_getReadablePtr(sys->memoryManager,sys->thread, bufPtr, bufSize);
+                        process_getReadablePtr(sys->process,sys->thread, bufPtr, bufSize);
                     result = transport_sendUserData(
                         (Transport*)desc, buf, bufSize, 0, 0);
                     break;

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -63,7 +63,7 @@ static SysCallReturn _syscallhandler_pipeHelper(SysCallHandler* sys,
 
     /* Return the pipe fds to the caller. */
     size_t sizeNeeded = sizeof(int) * 2;
-    gint* pipefd = memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, pipefdPtr, sizeNeeded);
+    gint* pipefd = process_getWriteablePtr(sys->process,sys->thread, pipefdPtr, sizeNeeded);
 
     pipefd[0] =
         process_registerDescriptor(sys->process, (Descriptor*)pipeReader);
@@ -123,7 +123,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd,
     /* TODO: Dynamically compute size based on how much data is actually
      * available in the descriptor. */
     size_t sizeNeeded = MIN(bufSize, SYSCALL_IO_BUFSIZE);
-    void* buf = memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, bufPtr, sizeNeeded);
+    void* buf = process_getWriteablePtr(sys->process,sys->thread, bufPtr, sizeNeeded);
 
     ssize_t result = 0;
     switch (dType) {
@@ -222,7 +222,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd,
     /* TODO: Dynamically compute size based on how much data is actually
      * available in the descriptor. */
     size_t sizeNeeded = MIN(bufSize, SYSCALL_IO_BUFSIZE);
-    const void* buf = memorymanager_getReadablePtr(sys->memoryManager,sys->thread, bufPtr, sizeNeeded);
+    const void* buf = process_getReadablePtr(sys->process,sys->thread, bufPtr, sizeNeeded);
 
     ssize_t result = 0;
     switch (dType) {
@@ -356,7 +356,7 @@ SysCallReturn syscallhandler_uname(SysCallHandler* sys,
     }
 
     buf =
-        memorymanager_getWriteablePtr(sys->memoryManager,sys->thread, args->args[0].as_ptr, sizeof(*buf));
+        process_getWriteablePtr(sys->process,sys->thread, args->args[0].as_ptr, sizeof(*buf));
 
     const gchar* hostname = host_getName(sys->host);
 

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -63,7 +63,7 @@ static SysCallReturn _syscallhandler_pipeHelper(SysCallHandler* sys,
 
     /* Return the pipe fds to the caller. */
     size_t sizeNeeded = sizeof(int) * 2;
-    gint* pipefd = process_getWriteablePtr(sys->process,sys->thread, pipefdPtr, sizeNeeded);
+    gint* pipefd = process_getWriteablePtr(sys->process, sys->thread, pipefdPtr, sizeNeeded);
 
     pipefd[0] =
         process_registerDescriptor(sys->process, (Descriptor*)pipeReader);
@@ -123,7 +123,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd,
     /* TODO: Dynamically compute size based on how much data is actually
      * available in the descriptor. */
     size_t sizeNeeded = MIN(bufSize, SYSCALL_IO_BUFSIZE);
-    void* buf = process_getWriteablePtr(sys->process,sys->thread, bufPtr, sizeNeeded);
+    void* buf = process_getWriteablePtr(sys->process, sys->thread, bufPtr, sizeNeeded);
 
     ssize_t result = 0;
     switch (dType) {
@@ -222,7 +222,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd,
     /* TODO: Dynamically compute size based on how much data is actually
      * available in the descriptor. */
     size_t sizeNeeded = MIN(bufSize, SYSCALL_IO_BUFSIZE);
-    const void* buf = process_getReadablePtr(sys->process,sys->thread, bufPtr, sizeNeeded);
+    const void* buf = process_getReadablePtr(sys->process, sys->thread, bufPtr, sizeNeeded);
 
     ssize_t result = 0;
     switch (dType) {
@@ -355,8 +355,7 @@ SysCallReturn syscallhandler_uname(SysCallHandler* sys,
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
     }
 
-    buf =
-        process_getWriteablePtr(sys->process,sys->thread, args->args[0].as_ptr, sizeof(*buf));
+    buf = process_getWriteablePtr(sys->process, sys->thread, args->args[0].as_ptr, sizeof(*buf));
 
     const gchar* hostname = host_getName(sys->host);
 

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -171,8 +171,11 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
                                           const SysCallArgs* args) {
     MAGIC_ASSERT(sys);
 
-    // Lazily initialize memoryManager on the first syscall. It needs a thread
-    // in the syscall state for its initialization.
+    // Initialize the process's MemoryManager if it doesn't exist. In practice
+    // this happens the first time a process makes a syscall, and on the first
+    // syscall after an `exec` (which destroys the MemoryManager). It's done
+    // here because the MemoryManager needs a plugin thread that's ready to
+    // make syscalls in order to perform its initialization.
     if (!process_getMemoryManager(sys->process)) {
         process_setMemoryManager(sys->process, memorymanager_new(sys->thread));
     }


### PR DESCRIPTION
Progress on #826 

Move MemoryManager from SyscallHandler to Process so that it can be shared amongst threads.

Also:
* Instead of setting a flag in MemoryManager to re-initialize itself after an exec, just destroy the whole thing. The SysCallHandler will re-create it lazily on the next syscall.
* Unlink shared memory file as soon as we're done opening it, reducing the risk of leaving stale files around after a crash.