### PR TITLE
Invert spinlock loop condition

### DIFF
--- a/src/shim/binary_spinning_sem.cc
+++ b/src/shim/binary_spinning_sem.cc
@@ -27,7 +27,7 @@ void BinarySpinningSem::wait() {
     bool expected = true;
 
     while (_spin_ctr++ < _thresh &&
-           _x.compare_exchange_weak(expected, false, std::memory_order_acquire)) {
+           !_x.compare_exchange_weak(expected, false, std::memory_order_acquire)) {
         expected = true;
         __asm__("pause"); // (rwails) Not sure if this op is helpful.
     }


### PR DESCRIPTION
IIUC the loop was exiting immediately when it *didn't* hold the lock,
and then ending up blocking the `sem_wait`, and looping unnecessarily
when it *did* hold the lock.

It looks like the condition was inadvertently inverted in https://github.com/shadow/shadow/commit/91367d13955381d8b5e2c5e0f1e2c074ec9969a2

Notably, phold-shadow-preload performance got substantially worse @
91367d13955381d8b5e2c5e0f1e2c074ec9969a2, and this change seems to
recover that performance loss. (With phold-shadow-preload enabled
locally, and run on centos-7 using a recompiled libc).