### PR TITLE
Clear the signal mask at startup

### DIFF
--- a/src/main/core/main.c
+++ b/src/main/core/main.c
@@ -189,6 +189,12 @@ gint main_runShadow(gint argc, gchar* argv[]) {
         return EXIT_FAILURE;
     }
 
+    /* unblock all signals in shadow and child processes since cmake's ctest blocks SIGTERM (and
+     * maybe others) */
+    sigset_t new_sig_set;
+    sigemptyset(&new_sig_set);
+    sigprocmask(SIG_SETMASK, &new_sig_set, NULL);
+
     /* parse the options from the command line */
     gchar* cmds = g_strjoinv(" ", argv);
     gchar** cmdv = g_strsplit(cmds, " ", 0);


### PR DESCRIPTION
We don't technically need this at the moment now that we've switched to SIGKILL for child processes, but since the current behaviour might be unexpected in the future, probably best to add this now before I forget about it.