### PR TITLE
Use valid sockaddr when testing invalid file descriptors

### DIFF
--- a/src/test/socket/bind/test_bind.rs
+++ b/src/test/socket/bind/test_bind.rs
@@ -137,10 +137,19 @@ fn get_tests() -> Vec<test_utils::ShadowTest<String>> {
 
 // test binding using an argument that cannot be a fd
 fn test_invalid_fd() -> Result<(), String> {
+    let addr = libc::sockaddr_in {
+        sin_family: libc::AF_INET as u16,
+        sin_port: 11111u16.to_be(),
+        sin_addr: libc::in_addr {
+            s_addr: libc::INADDR_LOOPBACK.to_be(),
+        },
+        sin_zero: [0; 8],
+    };
+
     let args = BindArguments {
         fd: -1,
-        addr: None,
-        addr_len: 5,
+        addr: Some(LibcSockAddr::In(addr)),
+        addr_len: std::mem::size_of_val(&addr) as u32,
     };
 
     check_bind_call(&args, Some(libc::EBADF))
@@ -148,10 +157,19 @@ fn test_invalid_fd() -> Result<(), String> {
 
 // test binding using an argument that could be a fd, but is not
 fn test_non_existent_fd() -> Result<(), String> {
+    let addr = libc::sockaddr_in {
+        sin_family: libc::AF_INET as u16,
+        sin_port: 11111u16.to_be(),
+        sin_addr: libc::in_addr {
+            s_addr: libc::INADDR_LOOPBACK.to_be(),
+        },
+        sin_zero: [0; 8],
+    };
+
     let args = BindArguments {
         fd: 8934,
-        addr: None,
-        addr_len: 5,
+        addr: Some(LibcSockAddr::In(addr)),
+        addr_len: std::mem::size_of_val(&addr) as u32,
     };
 
     check_bind_call(&args, Some(libc::EBADF))
@@ -159,10 +177,19 @@ fn test_non_existent_fd() -> Result<(), String> {
 
 // test binding a valid fd that is not a socket
 fn test_non_socket_fd() -> Result<(), String> {
+    let addr = libc::sockaddr_in {
+        sin_family: libc::AF_INET as u16,
+        sin_port: 11111u16.to_be(),
+        sin_addr: libc::in_addr {
+            s_addr: libc::INADDR_LOOPBACK.to_be(),
+        },
+        sin_zero: [0; 8],
+    };
+
     let args = BindArguments {
         fd: 0, // assume the fd 0 is already open and is not a socket
-        addr: None,
-        addr_len: 5,
+        addr: Some(LibcSockAddr::In(addr)),
+        addr_len: std::mem::size_of_val(&addr) as u32,
     };
 
     check_bind_call(&args, Some(libc::ENOTSOCK))

--- a/src/test/socket/connect/test_connect.rs
+++ b/src/test/socket/connect/test_connect.rs
@@ -137,10 +137,19 @@ fn get_tests() -> Vec<test_utils::ShadowTest<String>> {
 
 /// Test connect() using an argument that cannot be a fd.
 fn test_invalid_fd() -> Result<(), String> {
+    let addr = libc::sockaddr_in {
+        sin_family: libc::AF_INET as u16,
+        sin_port: 11111u16.to_be(),
+        sin_addr: libc::in_addr {
+            s_addr: libc::INADDR_LOOPBACK.to_be(),
+        },
+        sin_zero: [0; 8],
+    };
+
     let args = ConnectArguments {
         fd: -1,
-        addr: None,
-        addr_len: 5,
+        addr: Some(addr),
+        addr_len: std::mem::size_of_val(&addr) as u32,
     };
 
     check_connect_call(&args, Some(libc::EBADF))
@@ -148,10 +157,19 @@ fn test_invalid_fd() -> Result<(), String> {
 
 /// Test connect() using an argument that could be a fd, but is not.
 fn test_non_existent_fd() -> Result<(), String> {
+    let addr = libc::sockaddr_in {
+        sin_family: libc::AF_INET as u16,
+        sin_port: 11111u16.to_be(),
+        sin_addr: libc::in_addr {
+            s_addr: libc::INADDR_LOOPBACK.to_be(),
+        },
+        sin_zero: [0; 8],
+    };
+
     let args = ConnectArguments {
         fd: 8934,
-        addr: None,
-        addr_len: 5,
+        addr: Some(addr),
+        addr_len: std::mem::size_of_val(&addr) as u32,
     };
 
     check_connect_call(&args, Some(libc::EBADF))
@@ -159,10 +177,19 @@ fn test_non_existent_fd() -> Result<(), String> {
 
 /// Test connect() using a valid fd that is not a socket.
 fn test_non_socket_fd() -> Result<(), String> {
+    let addr = libc::sockaddr_in {
+        sin_family: libc::AF_INET as u16,
+        sin_port: 11111u16.to_be(),
+        sin_addr: libc::in_addr {
+            s_addr: libc::INADDR_LOOPBACK.to_be(),
+        },
+        sin_zero: [0; 8],
+    };
+
     let args = ConnectArguments {
         fd: 0, // assume the fd 0 is already open and is not a socket
-        addr: None,
-        addr_len: 5,
+        addr: Some(addr),
+        addr_len: std::mem::size_of_val(&addr) as u32,
     };
 
     check_connect_call(&args, Some(libc::ENOTSOCK))

--- a/src/test/socket/getsockname/test_getsockname.rs
+++ b/src/test/socket/getsockname/test_getsockname.rs
@@ -105,11 +105,21 @@ fn get_tests() -> Vec<test_utils::ShadowTest<String>> {
 
 /// Test getsockname using an argument that cannot be a fd.
 fn test_invalid_fd() -> Result<(), String> {
+    // fill the sockaddr with dummy data
+    let addr = libc::sockaddr_in {
+        sin_family: 123u16,
+        sin_port: 456u16.to_be(),
+        sin_addr: libc::in_addr {
+            s_addr: 789u32.to_be(),
+        },
+        sin_zero: [1; 8],
+    };
+
     // getsockname() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
         fd: -1,
-        addr: None,
-        addr_len: Some(5),
+        addr: Some(addr),
+        addr_len: Some(std::mem::size_of_val(&addr) as u32),
     };
 
     check_getsockname_call(&mut args, Some(libc::EBADF))
@@ -117,11 +127,21 @@ fn test_invalid_fd() -> Result<(), String> {
 
 /// Test getsockname using an argument that could be a fd, but is not.
 fn test_non_existent_fd() -> Result<(), String> {
+    // fill the sockaddr with dummy data
+    let addr = libc::sockaddr_in {
+        sin_family: 123u16,
+        sin_port: 456u16.to_be(),
+        sin_addr: libc::in_addr {
+            s_addr: 789u32.to_be(),
+        },
+        sin_zero: [1; 8],
+    };
+
     // getsockname() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
         fd: 8934,
-        addr: None,
-        addr_len: Some(5),
+        addr: Some(addr),
+        addr_len: Some(std::mem::size_of_val(&addr) as u32),
     };
 
     check_getsockname_call(&mut args, Some(libc::EBADF))
@@ -129,11 +149,21 @@ fn test_non_existent_fd() -> Result<(), String> {
 
 /// Test getsockname using a valid fd that is not a socket.
 fn test_non_socket_fd() -> Result<(), String> {
+    // fill the sockaddr with dummy data
+    let addr = libc::sockaddr_in {
+        sin_family: 123u16,
+        sin_port: 456u16.to_be(),
+        sin_addr: libc::in_addr {
+            s_addr: 789u32.to_be(),
+        },
+        sin_zero: [1; 8],
+    };
+
     // getsockname() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
         fd: 0, // assume the fd 0 is already open and is not a socket
-        addr: None,
-        addr_len: Some(5),
+        addr: Some(addr),
+        addr_len: Some(std::mem::size_of_val(&addr) as u32),
     };
 
     check_getsockname_call(&mut args, Some(libc::ENOTSOCK))


### PR DESCRIPTION
Should improve the reliability of socket API integration tests on different kernels.