### PR TITLE
Disabled socketpair() tests in shadow

### DIFF
--- a/src/test/socket/socketpair/CMakeLists.txt
+++ b/src/test/socket/socketpair/CMakeLists.txt
@@ -1,12 +1,14 @@
 add_test(NAME socketpair COMMAND ../../target/debug/test_socketpair)
 list(APPEND TestNames socketpair)
 
-foreach(Method ptrace preload)
-    # runs the shadow tests with only the passing tests, not all tests
-    add_test(NAME socketpair-shadow-${Method} COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=${Method}
-        -l debug -d socketpair.shadow-${Method}.data ${CMAKE_CURRENT_SOURCE_DIR}/socketpair.shadow.config.xml)
-    list(APPEND TestNames socketpair-shadow-${Method})
-endforeach()
+# TODO: once socketpair() is supported, re-enable these tests
+
+#foreach(Method ptrace preload)
+#    # runs the shadow tests with only the passing tests, not all tests
+#    add_test(NAME socketpair-shadow-${Method} COMMAND ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=${Method}
+#        -l debug -d socketpair.shadow-${Method}.data ${CMAKE_CURRENT_SOURCE_DIR}/socketpair.shadow.config.xml)
+#    list(APPEND TestNames socketpair-shadow-${Method})
+#endforeach()
 
 set_property(TEST ${TestNames} PROPERTY ENVIRONMENT "RUST_BACKTRACE=1")
 # need to check the test's return code, not just shadow's (see shadow/shadow#902)

--- a/src/test/socket/socketpair/test_socketpair.rs
+++ b/src/test/socket/socketpair/test_socketpair.rs
@@ -69,12 +69,10 @@ fn get_tests() -> Vec<test_utils::ShadowTest<Option<[libc::c_int; 2]>, String>> 
                             move || test_arguments(domain, sock_type, flag, protocol),
                             test_utils::ShadowPassing::Yes,
                         ),
-                        // socketpair() is the only part of shadow's socket API that uses UNIX
-                        // sockets, so getsockname won't work with these sockets
                         test_utils::ShadowTest::new(
                             &append_args("test_sockname_peername"),
                             move || test_sockname_peername(domain, sock_type, flag, protocol),
-                            test_utils::ShadowPassing::No,
+                            test_utils::ShadowPassing::Yes,
                         ),
                     ];
 


### PR DESCRIPTION
When I enabled the shadow tests for `socketpair()`, I forgot to check that Shadow actually supported remapping the `socketpair()` system call rather than just calling the native system call. This PR disables the tests in shadow.