### PR TITLE
Fix ThreadPtrace migration

### DIFF
--- a/src/main/host/thread_ptrace.c
+++ b/src/main/host/thread_ptrace.c
@@ -504,6 +504,10 @@ static void _threadptrace_doAttach(ThreadPtrace* thread) {
 
 static void _threadptrace_doDetach(ThreadPtrace* thread) {
     utility_assert(thread->childState == THREAD_PTRACE_CHILD_STATE_SYSCALL);
+    if (thread->needAttachment) {
+        // We're already detached.
+        return;
+    }
 
     // First rewind the instruction pointer so that the current syscall will be
     // retried when we resume. This isn't *strictly* necessary, but it's not

--- a/src/test/phold/test_phold.c
+++ b/src/test/phold/test_phold.c
@@ -454,6 +454,10 @@ static int _phold_parseWeightsFile(PHold* phold) {
         return FALSE;
     }
 
+    // Remove any trailing whitespace (such as newline at EOF inserted
+    // transparently by some editors).
+    g_strchomp(contents);
+
     gchar** lines = g_strsplit(contents, (const gchar*) "\n", -1);
 
     phold->num_peers = 0;


### PR DESCRIPTION
When running phold-threaded-shadow-ptrace with more hosts (e.g. 20
instead of the default 10), we'd get errors in threadptrace_doDetach. It
turns out that a host can end up calling detach on a plugin that's
already detached.

Since threadptrace_doDetach was assuming it was starting from an
attached state, things didn't go well.

We now simply silently return if already detached.