### PR TITLE
In ThreadPtrace, avoid blocking while waiting for traced thread

### DIFF
--- a/src/main/host/thread_ptrace.c
+++ b/src/main/host/thread_ptrace.c
@@ -35,6 +35,9 @@
 
 static char SYSCALL_INSTRUCTION[] = {0x0f, 0x05};
 
+// Number of times to do a non-blocking wait while waiting for traced thread.
+#define THREADPTRACE_MAX_SPIN 8096
+
 typedef enum {
     // Doesn't exist yet.
     THREAD_PTRACE_CHILD_STATE_NONE = 0,
@@ -367,11 +370,27 @@ static void _threadptrace_updateChildState(ThreadPtrace* thread, StopReason reas
     }
 }
 
+static pid_t _waitpid_spin(pid_t pid, int *wstatus, int options) {
+    int count = 0;
+    pid_t rv = 0;
+    // First do non-blocking waits.
+    do {
+        rv = waitpid(pid, wstatus, options|WNOHANG);
+    } while (rv == 0 && count++ < THREADPTRACE_MAX_SPIN);
+
+    // If we haven't gotten an answer yet, make a blocking call.
+    if (rv == 0) {
+        rv = waitpid(pid, wstatus, options);
+    }
+
+    return rv;
+}
+
 static void _threadptrace_nextChildState(ThreadPtrace* thread) {
     // Wait for child to stop.
 
     int wstatus;
-    if (waitpid(thread->base.nativeTid, &wstatus, 0) < 0) {
+    if (_waitpid_spin(thread->base.nativeTid, &wstatus, 0) < 0) {
         error("waitpid: %s", g_strerror(errno));
         return;
     }
@@ -447,7 +466,7 @@ static void _threadptrace_doAttach(ThreadPtrace* thread) {
         abort();
     }
     int wstatus;
-    if (waitpid(thread->base.nativeTid, &wstatus, 0) < 0) {
+    if (_waitpid_spin(thread->base.nativeTid, &wstatus, 0) < 0) {
         error("waitpid: %s", g_strerror(errno));
         abort();
     }
@@ -475,7 +494,7 @@ static void _threadptrace_doAttach(ThreadPtrace* thread) {
             error("ptrace: %s", g_strerror(errno));
             abort();
         }
-        if (waitpid(thread->base.nativeTid, &wstatus, 0) < 0) {
+        if (_waitpid_spin(thread->base.nativeTid, &wstatus, 0) < 0) {
             error("waitpid: %s", g_strerror(errno));
             abort();
         }
@@ -544,7 +563,7 @@ static void _threadptrace_doDetach(ThreadPtrace* thread) {
         abort();
     }
     int wstatus;
-    if (waitpid(thread->base.nativeTid, &wstatus, 0) < 0) {
+    if (_waitpid_spin(thread->base.nativeTid, &wstatus, 0) < 0) {
         error("waitpid: %s", g_strerror(errno));
         abort();
     }
@@ -668,7 +687,7 @@ void threadptrace_terminate(Thread* base) {
     }
 
     int wstatus;
-    if (waitpid(thread->base.nativePid, &wstatus, 0) < 0) {
+    if (_waitpid_spin(thread->base.nativePid, &wstatus, 0) < 0) {
         error("waitpid: %s", g_strerror(errno));
         return;
     }
@@ -849,7 +868,7 @@ long threadptrace_nativeSyscall(Thread* base, long n, va_list args) {
             abort();
         }
         int wstatus;
-        if (waitpid(thread->base.nativeTid, &wstatus, 0) < 0) {
+        if (_waitpid_spin(thread->base.nativeTid, &wstatus, 0) < 0) {
             error("waitpid: %s", g_strerror(errno));
             abort();
         }
@@ -915,7 +934,7 @@ int threadptrace_clone(Thread* base, unsigned long flags, PluginPtr child_stack,
     // for that stop, which puts the child into the
     // THREAD_PTRACE_CHILD_STATE_TRACE_ME state.
     int wstatus;
-    if (waitpid(childNativeTid, &wstatus, 0) < 0) {
+    if (_waitpid_spin(childNativeTid, &wstatus, 0) < 0) {
         error("waitpid: %s", g_strerror(errno));
         abort();
     }


### PR DESCRIPTION
With 30s of simulation time:

@ dev:
```
./setup build --werror --test && ./setup install && ./setup test -j1 phold
...
Test project /home/jnewsome/projects/shadow/build
    Start 27: phold-shadow-ptrace
1/2 Test #27: phold-shadow-ptrace ..............   Passed   11.67 sec
    Start 28: phold-threaded-shadow-ptrace
2/2 Test #28: phold-threaded-shadow-ptrace .....   Passed    6.98 sec
```

@ this PR:
```
./setup build --werror --test && ./setup install && ./setup test -j1 phold
...
Test project /home/jnewsome/projects/shadow/build
    Start 27: phold-shadow-ptrace
1/2 Test #27: phold-shadow-ptrace ..............   Passed    9.05 sec
    Start 28: phold-threaded-shadow-ptrace
2/2 Test #28: phold-threaded-shadow-ptrace .....   Passed    5.53 sec
```