### PR TITLE
Added a dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# documentation at: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+
+updates:
+  - package-ecosystem: 'cargo'
+    directory: '/src/main'
+    schedule:
+      interval: 'daily'
+    target-branch: 'dev'
+    labels:
+      - 'Component: Dependencies'
+
+  - package-ecosystem: 'cargo'
+    directory: '/src/test'
+    schedule:
+      interval: 'daily'
+    target-branch: 'dev'
+    labels:
+      - 'Component: Dependencies'


### PR DESCRIPTION
Attempting to add a Dependabot config file for keeping our Rust dependencies up to date.

https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates