### PR TITLE
[main branch] Added a dependabot config for the dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# documentation at: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+
+updates:
+  - package-ecosystem: 'cargo'
+    directory: '/src/main'
+    schedule:
+      interval: 'daily'
+    target-branch: 'dev'
+    labels:
+      - 'Component: Dependencies'
+
+  - package-ecosystem: 'cargo'
+    directory: '/src/test'
+    schedule:
+      interval: 'daily'
+    target-branch: 'dev'
+    labels:
+      - 'Component: Dependencies'


### PR DESCRIPTION
I did some testing in another repository, and the dependabot config must be in the main branch.

See also: shadow/shadow#988