### PR TITLE
Support TCP tests in preload mode

### DIFF
--- a/src/shim/preload_syscalls.c
+++ b/src/shim/preload_syscalls.c
@@ -222,6 +222,7 @@ NOREMAP(int, clock_gettime, (clockid_t a, struct timespec* b), a,b);
 NOREMAP(int, close, (int a), a);
 NOREMAP(int, connect, (int a, const struct sockaddr* b, socklen_t c), a,b,c);
 NOREMAP(int, creat, (const char *a, mode_t b), a,b);
+REMAP(int, creat64, creat, (const char *a, mode_t b), a,b);
 NOREMAP(int, epoll_create, (int a), a);
 NOREMAP(int, epoll_create1, (int a), a);
 NOREMAP(int, epoll_ctl, (int a, int b, int c, struct epoll_event* d), a,b,c,d);
@@ -230,6 +231,7 @@ NOREMAP(int, epoll_wait, (int a, struct epoll_event* b, int c, int d), a,b,c,d);
 NOREMAP(int, faccessat, (int a, const char *b, int c, int d), a, b, c, d);
 NOREMAP(int, fadvise64, (int a, off_t b, off_t c, int d), a, b, c, d);
 NOREMAP(int, fallocate, (int a, int b, off_t c, off_t d), a, b, c, d);
+REMAP(int, fallocate64, fallocate, (int a, int b, off_t c, off_t d), a, b, c, d);
 NOREMAP(int, fchdir, (int a), a);
 NOREMAP(int, fchmod, (int a, mode_t b), a, b);
 NOREMAP(int, fchown, (int a, uid_t b, gid_t c), a, b, c);
@@ -262,6 +264,7 @@ NOREMAP(off_t, lseek, (int a, off_t b, int c), a, b, c);
 NOREMAP(int, mkdirat, (int a, const char* b, mode_t c), a, b, c);
 NOREMAP(int, mknodat, (int a, const char* b, mode_t c, dev_t d), a, b, c, d);
 NOREMAP(void*, mmap, (void* a, size_t b, int c, int d, int e, off_t f), a, b, c, d, e, f);
+REMAP(void*, mmap64, mmap, (void* a, size_t b, int c, int d, int e, off_t f), a, b, c, d, e, f);
 #ifdef SYS_mmap2
 NOREMAP(void*, mmap2, (void* a, size_t b, int c, int d, int e, off_t f), a, b, c, d, e, f);
 #endif
@@ -327,6 +330,14 @@ int open(const char* pathname, int flags, ...) {
     return open_explicit(pathname, flags, mode);
 }
 
+int open64(const char* pathname, int flags, ...) {
+    va_list args;
+    va_start(args, flags);
+    mode_t mode = va_arg(args, mode_t);
+    va_end(args);
+    return open_explicit(pathname, flags, mode);
+}
+
 int openat(int dirfd, const char* pathname, int flags, ...) {
     va_list args;
     va_start(args, flags);
@@ -344,6 +355,22 @@ int ioctl(int fd, unsigned long request, ...) {
 }
 
 int fcntl(int fd, int command, ...) {
+    va_list args;
+    va_start(args, command);
+    char* argp = va_arg(args, char*);
+    va_end(args);
+    return fcntl_explicit(fd, command, argp);
+}
+
+int __fcntl(int fd, int command, ...) {
+    va_list args;
+    va_start(args, command);
+    char* argp = va_arg(args, char*);
+    va_end(args);
+    return fcntl_explicit(fd, command, argp);
+}
+
+int fcntl64(int fd, int command, ...) {
     va_list args;
     va_start(args, command);
     char* argp = va_arg(args, char*);

--- a/src/test/tcp/CMakeLists.txt
+++ b/src/test/tcp/CMakeLists.txt
@@ -14,7 +14,7 @@ foreach(BlockingMode blocking nonblocking-epoll) # nonblocking-poll nonblocking-
 
     foreach(Network loopback lossless lossy)
         # FIXME: enable preload
-        foreach(InterposeMethod ptrace) # preload)
+        foreach(InterposeMethod ptrace preload)
             add_test(
                 NAME tcp-${BlockingMode}-${Network}-shadow-${InterposeMethod}
                 COMMAND sh -c "\


### PR DESCRIPTION
These changes are enough to make the tcp-shadow-preload tests work.