### PR TITLE
Changed script shebangs and CI workflows to use python3

### DIFF
--- a/.github/workflows/build_shadow.yml
+++ b/.github/workflows/build_shadow.yml
@@ -27,24 +27,24 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: sudo apt-get install -y ${{ matrix.cc }} g++ cmake make xz-utils python libglib2.0-0 libglib2.0-dev libigraph0v5 libigraph0-dev libc-dbg python-pyelftools
+        run: sudo apt-get install -y ${{ matrix.cc }} g++ cmake make xz-utils python3 libglib2.0-0 libglib2.0-dev libigraph0v5 libigraph0-dev libc-dbg python3-pyelftools
 
       - name: Build Debug
         if: ${{ matrix.buildtype == 'debug' }}
-        run: CC=${{ matrix.cc }} python setup build --clean --test --werror --debug
+        run: CC=${{ matrix.cc }} ./setup build --clean --test --werror --debug
 
       - name: Build Release
         if: ${{ matrix.buildtype == 'release' }}
-        run: CC=${{ matrix.cc }} python setup build --clean --test --werror
+        run: CC=${{ matrix.cc }} ./setup build --clean --test --werror
 
       - name: Install
-        run: python setup install
+        run: ./setup install
 
       - name: Test
         # For now, if the first batch of tests fails, rerun the failing tests
         # and continue on if they then pass. This is to work around sporadic
         # and difficult to debug errors such as #798
-        run: python setup test || python setup test --rerun-failed
+        run: ./setup test || ./setup test --rerun-failed
 
       - name: Upload shadow logs
         uses: actions/upload-artifact@v2
@@ -67,6 +67,10 @@ jobs:
     steps:
       - name: Update packages
         run: sudo apt-get update
+
+      - name: Update packages
+        # shadow-plugin-tor v0.0.1's CI test script installs Python 2, but Shadow requires Python 3
+        run: sudo apt-get install -y python3 python3-pyelftools
 
       - name: Checkout shadow
         uses: actions/checkout@v2

--- a/setup
+++ b/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 /*

--- a/src/external/elf-loader/extract-system-config.py
+++ b/src/external/elf-loader/extract-system-config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/src/external/elf-loader/get-valgrind-cflags.py
+++ b/src/external/elf-loader/get-valgrind-cflags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import os

--- a/src/external/elf-loader/test/junit_xml_output/__init__.py
+++ b/src/external/elf-loader/test/junit_xml_output/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import xml.etree.ElementTree as ET
 import xml.dom.minidom
 

--- a/src/external/elf-loader/test/run-valgrind.py
+++ b/src/external/elf-loader/test/run-valgrind.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import subprocess

--- a/src/external/elf-loader/test/testjunit.py
+++ b/src/external/elf-loader/test/testjunit.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 ## -*- Mode: python; py-indent-offset: 4; indent-tabs-mode: nil; coding: utf-8; -*-
 
 from __future__ import print_function


### PR DESCRIPTION
Part of shadow/shadow#422 for the main branch.

When installing Shadow on Ubuntu 18.04 following the [guide](https://github.com/shadow/shadow/tree/master/docs/1.1-Shadow.md) which recommends Python 3, the Python scripts fail due to the `#!/usr/bin/env python` shebang if Python 2 is not installed. This PR forces the scripts to run under Python 3.