### PR TITLE
Update cbindgen to 0.15.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Rust packages
         run: |
           rustup component add rustfmt
-          cargo install --force --version 0.14.6 cbindgen
+          cargo install --force --version 0.15.0 cbindgen
           cargo install --force --version 0.55.1 bindgen
       - name: Check bindings
         run: |


### PR DESCRIPTION
This fixes the bindings check in our CI. The previous version we'd pinned to has been [yanked](https://crates.io/crates/cbindgen/0.14.6) from crates.io. (Not sure why, but presumably because of some serious bug)