### PR TITLE
Move --output-on-failure from setup to ci

### DIFF
--- a/ci/container_scripts/test.sh
+++ b/ci/container_scripts/test.sh
@@ -24,4 +24,4 @@ fi
 # Try rerunning failed tests once.
 # TODO: We should only do this for an allowed-list of known-flaky tests,
 # and there should be issues filed for each such test.
-./setup test -j4 -- -E "$EXCLUDE" -C "$CONFIG" || ./setup test -j4 -- -E "$EXCLUDE" -C "$CONFIG" --rerun-failed
+./setup test -j4 -- -E "$EXCLUDE" -C "$CONFIG" --output-on-failure || ./setup test -j4 -- -E "$EXCLUDE" -C "$CONFIG" --output-on-failure --rerun-failed

--- a/setup
+++ b/setup
@@ -260,7 +260,7 @@ def test(args, remaining):
     os.chdir(testdir)
 
     # test, wait for it to finish
-    testcmd = "ctest --output-on-failure -j{0} --timeout {1}".format(args.njobs, args.timeout)
+    testcmd = "ctest -j{0} --timeout {1}".format(args.njobs, args.timeout)
     if args.do_verbose:
         testcmd += " --verbose"
 


### PR DESCRIPTION
When debugging locally it's generally easier to look at build/Testing/Temporary/LastTest.log,
instead of trying to scroll through direct terminal output.

--output-on-failure is more useful in the ci, where it would otherwise
be an extra step to download LastTest.log from a GitHub artifact or copy
out of a local Docker container.