### PR TITLE
Expand futex tests

### DIFF
--- a/src/test/futex/CMakeLists.txt
+++ b/src/test/futex/CMakeLists.txt
@@ -1,5 +1,7 @@
+include_directories(${GLIB_INCLUDES})
+
 add_executable(test-futex test_futex.c)
-target_link_libraries(test-futex ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(test-futex ${CMAKE_THREAD_LIBS_INIT} ${GLIB_LIBRARIES} logger)
 
 ## register the tests
 add_test(NAME futex COMMAND test-futex)

--- a/src/test/futex/CMakeLists.txt
+++ b/src/test/futex/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(${GLIB_INCLUDES})
 
-add_executable(test-futex test_futex.c)
+add_executable(test-futex test_futex.c ../test_common.c)
 target_link_libraries(test-futex ${CMAKE_THREAD_LIBS_INIT} ${GLIB_LIBRARIES} logger)
 
 ## register the tests

--- a/src/test/futex/test_futex.c
+++ b/src/test/futex/test_futex.c
@@ -4,6 +4,7 @@
  */
 
 #include <errno.h>
+#include <glib.h>
 #include <linux/futex.h>
 #include <pthread.h>
 #include <stdbool.h>
@@ -14,7 +15,6 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <glib.h>
 
 #include "support/logger/logger.h"
 #include "test/test_common.h"
@@ -34,13 +34,13 @@ static void _wait_for_condition(bool* c) {
 }
 
 // Set `c` to true.
-static void _set_condition(bool *c) {
+static void _set_condition(bool* c) {
     *c = true;
     __sync_synchronize();
 }
 
 // Get `c`'s value.
-static bool _get_condition(bool *c) {
+static bool _get_condition(bool* c) {
     __sync_synchronize();
     return *c;
 }
@@ -51,7 +51,7 @@ typedef struct {
     bool child_finished;
 } FutexWaitTestChildArg;
 
-static void* _futex_wait_test_child(void *void_arg) {
+static void* _futex_wait_test_child(void* void_arg) {
     FutexWaitTestChildArg* arg = void_arg;
     _set_condition(&arg->child_started);
     debug("Child about to wait");
@@ -110,7 +110,7 @@ typedef struct {
     int* futex;
 } FutexWaitBitsetTestChildArg;
 
-static void* _futex_wait_bitset_test_child(void *void_arg) {
+static void* _futex_wait_bitset_test_child(void* void_arg) {
     FutexWaitBitsetTestChildArg* arg = void_arg;
     _set_condition(&arg->child_started);
     debug("Child %d about to wait", arg->id);
@@ -129,12 +129,12 @@ static void _futex_wait_bitset_test() {
     int futex = UNAVAILABLE;
 
     // Get all 5 children waiting.
-    for(int i=0; i<5; ++i) {
-        arg[i] = (FutexWaitBitsetTestChildArg) {
-            .child_started=false,
-                .child_finished=false,
-                .id=i,
-                .futex = &futex,
+    for (int i = 0; i < 5; ++i) {
+        arg[i] = (FutexWaitBitsetTestChildArg){
+            .child_started = false,
+            .child_finished = false,
+            .id = i,
+            .futex = &futex,
         };
 
         pthread_t child = {0};
@@ -298,7 +298,7 @@ static void _futex_stress_test() {
     g_assert_cmpint(PTR_TO_INT(aux_result), ==, 0);
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
     g_test_init(&argc, &argv, NULL);
     g_test_set_nonfatal_assertions();
 


### PR DESCRIPTION
Added some more granular tests for ease of debugging.

Also added tests for FUTEX_WAIT_BITSET and FUTEX_WAKE_BITSET. These aren't implemented in Shadow yet, but it looks like these are used in `sem_wait` and `sem_post`. I'd started to work on these to support handling the resulting futex syscalls in ptrace/preload "hybrid mode", but for now ended up handling it a different way for now (by setting a flag to let Shadow know that the plugin is executing in the shim).