### PR TITLE
Enable epoll preload tests on all platforms

### DIFF
--- a/src/test/epoll/CMakeLists.txt
+++ b/src/test/epoll/CMakeLists.txt
@@ -17,14 +17,12 @@ add_test(
     | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -l debug -d epoll-ptrace.shadow.data - \
     "
 )
-# FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
 add_test(
     NAME epoll-shadow-preload
     COMMAND sh -c "\
     ${yaml2xml} ${CMAKE_CURRENT_SOURCE_DIR}/epoll.test.shadow.config.yaml --output - \
     | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload -l debug -d epoll-preload.shadow.data - \
     "
-    CONFIGURATIONS ilibc
 )
 
 
@@ -35,13 +33,11 @@ add_test(
     | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -l debug -d epoll-writeable-ptrace.shadow.data - \
     "
 )
-# FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
 add_test(
     NAME epoll-writeable-shadow-preload
     COMMAND sh -c "\
     ${yaml2xml} ${CMAKE_CURRENT_SOURCE_DIR}/epoll-writeable.test.shadow.config.yaml --output - \
     | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload -l debug -d epoll-writeable-preload.shadow.data - \
     "
-    CONFIGURATIONS ilibc
 )
 


### PR DESCRIPTION
The epoll preload tests were set to only run under the "ilibc" configuration, but the patched libc wasn't actually being used (`LD_LIBRARY_PATH` wasn't set in the shadow config file). The epoll preload tests seem to work on all CI platforms without the patched libc, so the "ilibc" requirement has been removed.