### PR TITLE
Minor documentation improvements (main branch)

### DIFF
--- a/docs/1.1-Shadow.md
+++ b/docs/1.1-Shadow.md
@@ -1,5 +1,7 @@
 This page describes how to setup and install Shadow from a bare-bones Linux installation and is the recommended setup and installation method.
 
+*Note:* It is recommended to install on Ubuntu 18.04 as it is currently the only platform tested in our CI environment.
+
 ## Dependencies
 
 ### Requirements
@@ -46,7 +48,7 @@ sudo yum install -y \
     xz \
     xz-devel \
     yum-utils
-sudo yum debuginfo-install glibc
+sudo yum debuginfo-install -y glibc
 sudo yum install -y \
     python3-numpy \
     python3-lxml \

--- a/docs/1.1-Shadow.md
+++ b/docs/1.1-Shadow.md
@@ -33,6 +33,8 @@ Most of the libraries/tools used by Shadow are available through the system pack
 In more recent versions of Fedora (and maybe at some point CentOS), `yum` can be exchanged for `dnf` in these commands.
 Before running these commands, please check any platform-specific requirements below.
 
+**Warning:** YUM and DNF often install 32-bit (`i686`) versions of libraries. You may want to use the `--best` option to make sure you're installing the 64-bit (`x86_64`) versions, which are required by Shadow.
+
 ```bash
 sudo yum install -y \
     cmake \

--- a/docs/1.2-Shadow-with-Docker.md
+++ b/docs/1.2-Shadow-with-Docker.md
@@ -1,5 +1,7 @@
 This page describes how to set up Shadow using Docker; this installation method is optional.
 
+**Warning:** This documentation is for an older version of Shadow. Please use only as a reference, and follow the instructions in the [installation document](1.1-Shadow.md).
+
 ## Building your own docker image
 
 There are many ways to do this.  Below, we base our install off of Fedora 22.

--- a/docs/1.2-Shadow-with-Docker.md
+++ b/docs/1.2-Shadow-with-Docker.md
@@ -1,23 +1,5 @@
 This page describes how to set up Shadow using Docker; this installation method is optional.
 
-## Pre-built images
-A docker image that includes just Shadow (release v1.10.2) is available at [https://security.cs.georgetown.edu/shadow-docker-images/shadow-standalone.tar.gz](https://security.cs.georgetown.edu/shadow-docker-images/shadow-standalone.tar.gz).  
-
-An image that includes Shadow along with the Tor plugin is available at [https://security.cs.georgetown.edu/shadow-docker-images/shadow-tor.tar.gz](https://security.cs.georgetown.edu/shadow-docker-images/shadow-tor.tar.gz).
-
-To use these images:
-
-1. Download the desired image (see above URLs).
-2. Load it via: ```gunzip -c shadow-standalone.tar.gz | docker load```
-3. Run it via: ```docker run -t -i -u shadow shadow-standalone /bin/bash```
-
-(Replace *shadow-standalone* with *shadow-tor* if you are using the image with the Tor plugin.)
-
-The **shadow** user has sudo access.  Its password is ***shadow***.
-
-Remember to save your modifications!  See the fine [Docker documentation](https://docs.docker.com/engine/getstarted/) for more information about how to use containers and images.
-
-
 ## Building your own docker image
 
 There are many ways to do this.  Below, we base our install off of Fedora 22.


### PR DESCRIPTION
Removed the "pre-built" images section from the Docker instructions since it has a very old version of Shadow. Also added a warning that the "build your own" Docker instructions don't work.

Added a recommendation to use Ubuntu 18.04 since Shadow doesn't build in Fedora 32 or Ubuntu 20.04.

And a couple other small changes.