### PR TITLE
Syscall handler for fcntl64

### DIFF
--- a/src/main/host/syscall/fcntl.c
+++ b/src/main/host/syscall/fcntl.c
@@ -184,3 +184,7 @@ SysCallReturn syscallhandler_fcntl(SysCallHandler* sys,
 
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
 }
+
+SysCallReturn syscallhandler_fcntl64(SysCallHandler* sys, const SysCallArgs* args) {
+    return syscallhandler_fcntl(sys, args);
+}

--- a/src/main/host/syscall/fcntl.c
+++ b/src/main/host/syscall/fcntl.c
@@ -68,6 +68,15 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, File* file, int fd,
             break;
         }
 
+#if defined(F_GETLK64) && F_GETLK64 != F_GETLK
+        case F_GETLK64: {
+            struct flock64* flk =
+                process_getMutablePtr(sys->process, sys->thread, argReg.as_ptr, sizeof(*flk));
+            result = file_fcntl(file, command, (void*)flk);
+            break;
+        }
+#endif
+
         case F_SETLK:
 #ifdef F_OFD_SETLK
         case F_OFD_SETLK:
@@ -82,6 +91,21 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, File* file, int fd,
             result = file_fcntl(file, command, (void*)flk);
             break;
         }
+
+#if defined(F_SETLK64) && F_SETLK64 != F_SETLK
+        case F_SETLK64:
+#endif
+#if defined(F_SETLKW64) && F_SETLKW64 != F_SETLKW
+        case F_SETLKW64:
+#endif
+#if (defined(F_SETLK64) && F_SETLK64 != F_SETLK) || (defined(F_SETLKW64) && F_SETLKW64 != F_SETLKW)
+        {
+            const struct flock64* flk =
+                process_getReadablePtr(sys->process, sys->thread, argReg.as_ptr, sizeof(*flk));
+            result = file_fcntl(file, command, (void*)flk);
+            break;
+        }
+#endif
 
         case F_GETOWN_EX: {
             struct f_owner_ex* foe =
@@ -186,5 +210,8 @@ SysCallReturn syscallhandler_fcntl(SysCallHandler* sys,
 }
 
 SysCallReturn syscallhandler_fcntl64(SysCallHandler* sys, const SysCallArgs* args) {
+    // Our fcntl supports the flock64 struct when any of the F_GETLK64, F_SETLK64, and F_SETLKW64
+    // commands are specified, so we can just use our fcntl handler directly.
+    debug("fcntl64 called, forwarding to fcntl handler");
     return syscallhandler_fcntl(sys, args);
 }

--- a/src/main/host/syscall/fcntl.h
+++ b/src/main/host/syscall/fcntl.h
@@ -9,5 +9,6 @@
 #include "main/host/syscall/protected.h"
 
 SYSCALL_HANDLER(fcntl);
+SYSCALL_HANDLER(fcntl64);
 
 #endif /* SRC_MAIN_HOST_SYSCALL_FCNTL_H_ */

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -216,6 +216,9 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         HANDLE(fchown);
         HANDLE(fchownat);
         HANDLE(fcntl);
+#ifdef SYS_fcntl64
+        HANDLE(fcntl64);
+#endif
         HANDLE(fdatasync);
         HANDLE(fgetxattr);
         HANDLE(flistxattr);
@@ -320,9 +323,6 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         NATIVE(dup);
         NATIVE(dup2);
         NATIVE(dup3);
-#ifdef SYS_fcntl64
-        NATIVE(fcntl64);
-#endif
         NATIVE(poll);
         NATIVE(ppoll);
         NATIVE(select);


### PR DESCRIPTION
Redirect `fcntl64` to the `fcntl` handler.