### PR TITLE
Fix bug in UDP socket stats

### DIFF
--- a/src/main/host/descriptor/udp.c
+++ b/src/main/host/descriptor/udp.c
@@ -160,14 +160,6 @@ static gssize _udp_sendUserData(Transport* transport, gconstpointer buffer,
         warning("unable to send UDP packet");
     }
 
-    /* update the tracker output buffer stats */
-    Tracker* tracker = host_getTracker(worker_getActiveHost());
-    Socket* socket = (Socket* )udp;
-    gsize outLength = socket_getOutputBufferLength(socket);
-    gsize outSize = socket_getOutputBufferSize(socket);
-    tracker_updateSocketOutputBuffer(
-        tracker, descriptor_getHandle((Descriptor*)udp), outLength, outSize);
-
     debug("buffered %"G_GSIZE_FORMAT" outbound UDP bytes from user", bytes_sent);
 
     // return EWOULDBLOCK only if no bytes were sent, and we were requested to send >0 bytes
@@ -215,14 +207,6 @@ static gssize _udp_receiveUserData(Transport* transport, gpointer buffer,
 
     /* destroy packet, throwing away any bytes not claimed by the app */
     packet_unref(packet);
-
-    /* update the tracker input buffer stats */
-    Tracker* tracker = host_getTracker(worker_getActiveHost());
-    Socket* socket = (Socket* )udp;
-    gsize inLength = socket_getInputBufferLength(socket);
-    gsize inSize = socket_getInputBufferSize(socket);
-    tracker_updateSocketInputBuffer(
-        tracker, descriptor_getHandle((Descriptor*)udp), inLength, inSize);
 
     debug("user read %u inbound UDP bytes", bytesCopied);
 

--- a/src/main/host/descriptor/udp.c
+++ b/src/main/host/descriptor/udp.c
@@ -216,13 +216,13 @@ static gssize _udp_receiveUserData(Transport* transport, gpointer buffer,
     /* destroy packet, throwing away any bytes not claimed by the app */
     packet_unref(packet);
 
-    /* update the tracker output buffer stats */
+    /* update the tracker input buffer stats */
     Tracker* tracker = host_getTracker(worker_getActiveHost());
     Socket* socket = (Socket* )udp;
-    gsize outLength = socket_getOutputBufferLength(socket);
-    gsize outSize = socket_getOutputBufferSize(socket);
-    tracker_updateSocketOutputBuffer(
-        tracker, descriptor_getHandle((Descriptor*)udp), outLength, outSize);
+    gsize inLength = socket_getInputBufferLength(socket);
+    gsize inSize = socket_getInputBufferSize(socket);
+    tracker_updateSocketInputBuffer(
+        tracker, descriptor_getHandle((Descriptor*)udp), inLength, inSize);
 
     debug("user read %u inbound UDP bytes", bytesCopied);
 


### PR DESCRIPTION
The UDP socket stats were not being set correctly when receiving packets, so fixed that in one commit. Also, the stats were being set twice, once in the socket code (`socket_addToOutputBuffer()` and `socket_removeFromOutputBuffer()`), and then in the UDP code. There's no reason to set it twice, so the UDP socket stat updating was removed in another commit.