### PR TITLE
Pthread join

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -32,6 +32,7 @@ fn bindgen_test_layout__PluginPtr() {
         )
     );
 }
+pub type PluginVirtualPtr = _PluginPtr;
 pub type PluginPtr = _PluginPtr;
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -292,7 +293,10 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn thread_setTidAddress(thread: *mut Thread, addr: PluginPtr);
+    pub fn thread_setTidAddress(thread: *mut Thread, addr: PluginVirtualPtr);
+}
+extern "C" {
+    pub fn thread_getTidAddress(thread: *mut Thread) -> PluginVirtualPtr;
 }
 extern "C" {
     pub fn thread_isLeader(thread: *mut Thread) -> bool;

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -212,6 +212,11 @@ SysCallCondition* thread_getSysCallCondition(Thread* thread) {
     return thread->cond;
 }
 
+PluginVirtualPtr thread_getTidAddress(Thread* thread) {
+    MAGIC_ASSERT(thread);
+    return thread->tidAddress;
+}
+
 void thread_setTidAddress(Thread* thread, PluginPtr addr) {
     MAGIC_ASSERT(thread);
     thread->tidAddress = addr;

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -107,7 +107,10 @@ int thread_clone(Thread* thread, unsigned long flags, PluginPtr child_stack, Plu
 
 // Sets the `clear_child_tid` attribute as for `set_tid_address(2)`. The thread
 // will perform a futex-wake operation on the given address on termination.
-void thread_setTidAddress(Thread* thread, PluginPtr addr);
+void thread_setTidAddress(Thread* thread, PluginVirtualPtr addr);
+
+// Gets the `clear_child_tid` attribute, as set by `thread_setTidAddress`.
+PluginVirtualPtr thread_getTidAddress(Thread* thread);
 
 // Returns whether the given thread is its thread group (aka process) leader.
 // Typically this is true for the first thread created in a process.

--- a/src/test/clone/CMakeLists.txt
+++ b/src/test/clone/CMakeLists.txt
@@ -19,3 +19,5 @@ add_test(
     | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -l debug -d clone.shadow_ptrace.data - \
     "
 )
+# need to check the test's return code, not just shadow's (see shadow/shadow#902)
+set_property(TEST clone-shadow-ptrace PROPERTY FAIL_REGULAR_EXPRESSION "main error code '.*' for process")

--- a/src/test/pthreads/CMakeLists.txt
+++ b/src/test/pthreads/CMakeLists.txt
@@ -15,3 +15,5 @@ add_test(
     | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -l debug -d pthreads.shadow-ptrace.data - \
     "
 )
+# need to check the test's return code, not just shadow's (see shadow/shadow#902)
+set_property(TEST pthreads-shadow-ptrace PROPERTY FAIL_REGULAR_EXPRESSION "main error code '.*' for process")

--- a/src/test/pthreads/test_pthreads.c
+++ b/src/test/pthreads/test_pthreads.c
@@ -321,9 +321,6 @@ int main(int argc, char* argv[]) {
         return -1;
     }
 
-    // FIXME: re-enable these.
-    // https://github.com/shadow/shadow/issues/826
-#if 0
     pthread_t threads[NUM_THREADS];
 
     /* actually 3 tests */
@@ -344,5 +341,4 @@ int main(int argc, char* argv[]) {
 
     fprintf(stdout, "########## pthreads test passed! ##########\n");
     return 0;
-#endif
 }


### PR DESCRIPTION
Implements clear-and-wake on `set_child_tid`, per set_tid_address(2)

This also appears to be sufficient for `pthread_join` to work, so re-enabled corresponding tests.

This does *not* yet implement robust lists as per `get_robust_list(2)`. One could imagine alternatively implementing `pthread_join` using that mechanism, but it appears that our supported platforms do not.

Progress on #826 