### PR TITLE
Replace all references to python 2 in the documentation with python 3 

### DIFF
--- a/docs/2-Getting-Started-Tutorial.md
+++ b/docs/2-Getting-Started-Tutorial.md
@@ -142,11 +142,11 @@ Shadow includes some python scripts that can parse some important statistics fro
 # start in the base shadow/ directory
 cd ../..
 # parse the shadow output file
-python src/tools/parse-shadow.py --help
-python src/tools/parse-shadow.py --prefix results resource/examples/shadow.log
+python3 src/tools/parse-shadow.py --help
+python3 src/tools/parse-shadow.py --prefix results resource/examples/shadow.log
 # plot the results!
-python src/tools/plot-shadow.py --help
-python src/tools/plot-shadow.py --data results "example-plots"
+python3 src/tools/plot-shadow.py --help
+python3 src/tools/plot-shadow.py --data results "example-plots"
 ```
 
 The `parse-*.py` scripts generate `stats.*.json.xz` files. The (heavily trimmed) contents of `stats.shadow.json` look a little like this.
@@ -194,14 +194,14 @@ mv shadow.data window1000.data
 To parse these log files, we use the following scripts:
 
 ```bash
-python ../../src/tools/parse-shadow.py --prefix=window1.results window1.log
-python ../../src/tools/parse-shadow.py --prefix=window1000.results window1000.log
+python3 ../../src/tools/parse-shadow.py --prefix=window1.results window1.log
+python3 ../../src/tools/parse-shadow.py --prefix=window1000.results window1000.log
 ```
 
 Each of the directories `window1.results/` and `window1000.results/` now contain data statistics files extracted from the log files. We can now combine and visualize these results with the `plot-shadow.py` script:
 
 ```bash
-python ../../src/tools/plot-shadow.py --prefix "window" --data window1.results/ "1 packet" --data window1000.results/ "1000 packets"
+python3 ../../src/tools/plot-shadow.py --prefix "window" --data window1.results/ "1 packet" --data window1000.results/ "1000 packets"
 ```
 
 Then open the PDF file that was created to compare results from the experiments.

--- a/docs/5-Developer-Guide.md
+++ b/docs/5-Developer-Guide.md
@@ -19,7 +19,7 @@ cargo install --force cbindgen bindgen
 
 When debugging, it will be helpful to use the Shadow option `--cpu-threshold=-1`. It disables the automatic virtual CPU delay measurement feature. This feature may introduce non-deterministic behaviors, even when running the exact same experiment twice, by the re-ordering of events that occurs due to how the kernel schedules the physical CPU of the experiment machine. Disabling the feature with the above option will ensure a deterministic experiment, making debugging easier.
 
-Build Shadow with debugging symbols by using the `-g` flag. See the help menu with `python setup.py build --help`.
+Build Shadow with debugging symbols by using the `-g` flag. See the help menu with `./setup build --help`.
 
 These days, shadow can typically be run directly from gdb:
 ```

--- a/src/tools/convert.py
+++ b/src/tools/convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 from collections import defaultdict

--- a/src/tools/convert_multi_app.py
+++ b/src/tools/convert_multi_app.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import os,sys

--- a/src/tools/generate_example_config.py
+++ b/src/tools/generate_example_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys, networkx as nx
 from lxml import etree

--- a/src/tools/parse-shadow.py
+++ b/src/tools/parse-shadow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import sys, os, argparse, re, json, itertools

--- a/src/tools/plot-shadow.py
+++ b/src/tools/plot-shadow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # make sure print works in python2.7 (this statement must be at beginning of file)
 from __future__ import print_function
@@ -10,7 +10,7 @@ from itertools import cycle
 from re import search
 
 """
-python parse-shadow.py --help
+python3 parse-shadow.py --help
 """
 
 pylab.rcParams.update({

--- a/src/tools/strip_log_for_compare.py
+++ b/src/tools/strip_log_for_compare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 '''
 Make cleaner diffs of shadow logfiles by stripping the parts of the logs that


### PR DESCRIPTION
Update last shadow part of the https://github.com/shadow/shadow/issues/422

There are still some python2 references in the Docker and Vagrant doc. What should I do with there old docs ?

https://github.com/shadow/shadow/blob/master/docs/1.2-Shadow-with-Docker.md
https://github.com/shadow/shadow/blob/master/docs/1.3-Shadow-with-Vagrant.md

