### PR TITLE
Prevent idle workers in the work stealing policy

### DIFF
--- a/src/main/core/scheduler/scheduler_policy_host_steal.c
+++ b/src/main/core/scheduler/scheduler_policy_host_steal.c
@@ -43,7 +43,7 @@ struct _HostStealThreadData {
     /* which worker thread this is */
     guint tnumber;
     GMutex lock;
-    volatile bool isStealable;
+    bool isStealable;
 };
 
 typedef struct _HostStealPolicyData HostStealPolicyData;
@@ -358,8 +358,8 @@ static Event* _schedulerpolicyhoststeal_pop(SchedulerPolicy* policy, SimulationT
             }
         }
 
-	/* we are now ready for other threads to steal our workload */
-	__atomic_store_n(&tdata->isStealable, true, __ATOMIC_RELEASE);
+        /* we are now ready for other threads to steal our workload */
+        __atomic_store_n(&tdata->isStealable, true, __ATOMIC_RELEASE);
     }
     /* attempt to get an event from this thread's queue */
     Event* nextEvent = _schedulerpolicyhoststeal_popFromThread(policy, tdata, tdata->unprocessedHosts, barrier);
@@ -380,8 +380,12 @@ static Event* _schedulerpolicyhoststeal_pop(SchedulerPolicy* policy, SimulationT
         HostStealThreadData* stolenTdata = g_array_index(data->threadList, HostStealThreadData*, stolenTnumber);
         g_rw_lock_reader_unlock(&data->lock);
 
-        /* make sure the workload has been updated for this round */
-        while(!__atomic_load_n(&stolenTdata->isStealable, __ATOMIC_ACQUIRE)) {};
+        /* Make sure the workload has been updated for this round.
+         * This boolean is preventing race conditions upon the start of each round,
+         * and since we don't expect it to take long for the other threads to run
+         * through the unprocessedHosts reset above, spinning is OK. */
+        while (!__atomic_load_n(&stolenTdata->isStealable, __ATOMIC_ACQUIRE)) {
+        };
 
         /* We don't need a lock here, because we're only reading, and a misread just means either
          * we read as empty when it's not, in which case the assigned thread (or one of the others)
@@ -459,7 +463,7 @@ static SimulationTime _schedulerpolicyhoststeal_getNextTime(SchedulerPolicy* pol
         g_queue_foreach(tdata->unprocessedHosts, (GFunc)_schedulerpolicyhoststeal_findMinTime, &searchState);
         g_queue_foreach(tdata->processedHosts, (GFunc)_schedulerpolicyhoststeal_findMinTime, &searchState);
 
-	/* since we are in-between rounds, reset our stealable flag */
+        /* since we are in-between rounds, reset our stealable flag */
         __atomic_store_n(&tdata->isStealable, false, __ATOMIC_RELEASE);
     }
 

--- a/src/main/core/scheduler/scheduler_policy_host_steal.c
+++ b/src/main/core/scheduler/scheduler_policy_host_steal.c
@@ -5,6 +5,7 @@
 
 #include <glib.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "main/core/scheduler/scheduler_policy.h"
@@ -42,6 +43,7 @@ struct _HostStealThreadData {
     /* which worker thread this is */
     guint tnumber;
     GMutex lock;
+    volatile bool isStealable;
 };
 
 typedef struct _HostStealPolicyData HostStealPolicyData;
@@ -355,6 +357,9 @@ static Event* _schedulerpolicyhoststeal_pop(SchedulerPolicy* policy, SimulationT
                 g_queue_push_tail(tdata->unprocessedHosts, g_queue_pop_head(tdata->processedHosts));
             }
         }
+
+	/* we are now ready for other threads to steal our workload */
+	__atomic_store_n(&tdata->isStealable, true, __ATOMIC_RELEASE);
     }
     /* attempt to get an event from this thread's queue */
     Event* nextEvent = _schedulerpolicyhoststeal_popFromThread(policy, tdata, tdata->unprocessedHosts, barrier);
@@ -374,6 +379,10 @@ static Event* _schedulerpolicyhoststeal_pop(SchedulerPolicy* policy, SimulationT
         g_rw_lock_reader_lock(&data->lock);
         HostStealThreadData* stolenTdata = g_array_index(data->threadList, HostStealThreadData*, stolenTnumber);
         g_rw_lock_reader_unlock(&data->lock);
+
+        /* make sure the workload has been updated for this round */
+        while(!__atomic_load_n(&stolenTdata->isStealable, __ATOMIC_ACQUIRE)) {};
+
         /* We don't need a lock here, because we're only reading, and a misread just means either
          * we read as empty when it's not, in which case the assigned thread (or one of the others)
          * will pick it up anyway, or it reads as non-empty when it is empty, in which case we'll
@@ -449,7 +458,11 @@ static SimulationTime _schedulerpolicyhoststeal_getNextTime(SchedulerPolicy* pol
         /* make sure we get all hosts, which are probably held in the processedHosts queue between rounds */
         g_queue_foreach(tdata->unprocessedHosts, (GFunc)_schedulerpolicyhoststeal_findMinTime, &searchState);
         g_queue_foreach(tdata->processedHosts, (GFunc)_schedulerpolicyhoststeal_findMinTime, &searchState);
+
+	/* since we are in-between rounds, reset our stealable flag */
+        __atomic_store_n(&tdata->isStealable, false, __ATOMIC_RELEASE);
     }
+
     info("next event at time %"G_GUINT64_FORMAT, searchState.nextEventTime);
 
     return searchState.nextEventTime;


### PR DESCRIPTION
This fixes two main issues:
- Ensures that the very first round is synchronized properly, by waiting until the workers finish setting up all of the host objects before advancing the master clock to scheduling round 1
- Ensures that during every round, no thread can steal from another thread until the other thread has reset its "unprocessed" hosts queue

Closes #1046 