### PR TITLE
Prefer vfork to fork

### DIFF
--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -52,9 +52,7 @@ static ThreadPreload* _threadToThreadPreload(Thread* thread) {
     return (ThreadPreload*)thread;
 }
 
-static Thread* _threadPreloadToThread(ThreadPreload* thread) {
-    return (Thread*)thread;
-}
+static Thread* _threadPreloadToThread(ThreadPreload* thread) { return (Thread*)thread; }
 
 static void _threadpreload_auxFree(void* p, void* _) {
     ShMemBlock* blk = (ShMemBlock*)p;
@@ -80,8 +78,7 @@ static void _threadpreload_auxWrite(void* p, void* t) {
 
     ShimEvent resp = {0};
 
-    req.event_data.shmem_blk.serial =
-        shmemallocator_globalBlockSerialize(&write_blk->blk);
+    req.event_data.shmem_blk.serial = shmemallocator_globalBlockSerialize(&write_blk->blk);
     req.event_data.shmem_blk.plugin_ptr = write_blk->plugin_ptr;
     req.event_data.shmem_blk.n = write_blk->n;
 
@@ -113,7 +110,7 @@ void threadpreload_free(Thread* base) {
     worker_countObject(OBJECT_TYPE_THREAD_PRELOAD, COUNTER_TYPE_FREE);
 }
 
-static gchar** _add_shadow_pid_to_env(gchar **envp) {
+static gchar** _add_shadow_pid_to_env(gchar** envp) {
 
     enum { BUF_NBYTES = 256 };
     char strbuf[BUF_NBYTES] = {0};
@@ -129,8 +126,14 @@ static gchar** _add_shadow_pid_to_env(gchar **envp) {
 
 static pid_t _threadpreload_fork_exec(ThreadPreload* thread, const char* file, char* const argv[],
                                       char* const envp[]) {
-    pid_t shadow_pid = getpid();
+
+    // vfork has superior performance to fork with large workloads.
     pid_t pid = vfork();
+
+    // Beware! Unless you really know what you're doing, don't add any code
+    // between here and the execvpe below. The forked child process is sharing
+    // memory and control structures with the parent at this point. See
+    // `man 2 vfork`.
 
     switch (pid) {
         case -1:
@@ -183,8 +186,7 @@ pid_t threadpreload_run(Thread* base, gchar** argv, gchar** envv) {
     utility_assert(thread->ipc_blk.p);
     ipcData_init(thread->ipc_blk.p, shimipc_spinMax());
 
-    ShMemBlockSerialized ipc_blk_serial =
-        shmemallocator_globalBlockSerialize(&thread->ipc_blk);
+    ShMemBlockSerialized ipc_blk_serial = shmemallocator_globalBlockSerialize(&thread->ipc_blk);
 
     char ipc_blk_buf[SHD_SHMEM_BLOCK_SERIALIZED_MAX_STRLEN] = {0};
     shmemblockserialized_toString(&ipc_blk_serial, ipc_blk_buf);
@@ -197,8 +199,7 @@ pid_t threadpreload_run(Thread* base, gchar** argv, gchar** envv) {
 
     gchar* envStr = utility_strvToNewStr(myenvv);
     gchar* argStr = utility_strvToNewStr(argv);
-    message("forking new thread with environment '%s' and arguments '%s'",
-            envStr, argStr);
+    message("forking new thread with environment '%s' and arguments '%s'", envStr, argStr);
     g_free(envStr);
     g_free(argStr);
 
@@ -248,8 +249,7 @@ SysCallCondition* threadpreload_resume(Thread* base) {
                 debug("sending start event code to %d on %p", thread->base.nativePid,
                       thread->ipc_blk.p);
 
-                thread->currentEvent.event_data.start.simulation_nanos =
-                    worker_getEmulatedTime();
+                thread->currentEvent.event_data.start.simulation_nanos = worker_getEmulatedTime();
                 shimevent_sendEventToPlugin(thread->ipc_blk.p, &thread->currentEvent);
                 break;
             }
@@ -265,8 +265,7 @@ SysCallCondition* threadpreload_resume(Thread* base) {
             }
             case SHD_SHIM_EVENT_SYSCALL: {
                 SysCallReturn result = syscallhandler_make_syscall(
-                    thread->sys,
-                    &thread->currentEvent.event_data.syscall.syscall_args);
+                    thread->sys, &thread->currentEvent.event_data.syscall.syscall_args);
 
                 if (result.state == SYSCALL_BLOCK) {
                     if (shimipc_sendExplicitBlockMessageEnabled()) {
@@ -304,8 +303,7 @@ SysCallCondition* threadpreload_resume(Thread* base) {
                         .event_id = SHD_SHIM_EVENT_SYSCALL_COMPLETE,
                         .event_data = {
                             .syscall_complete = {.retval = result.retval,
-                                                 .simulation_nanos =
-                                                     worker_getEmulatedTime()},
+                                                 .simulation_nanos = worker_getEmulatedTime()},
 
                         }};
                 } else if (result.state == SYSCALL_NATIVE) {
@@ -406,8 +404,7 @@ static ShMemBlock _threadpreload_readPtrImpl(ThreadPreload* thread, PluginPtr pl
     return blk;
 }
 
-const void* threadpreload_getReadablePtr(Thread* base, PluginPtr plugin_src,
-                                         size_t n) {
+const void* threadpreload_getReadablePtr(Thread* base, PluginPtr plugin_src, size_t n) {
     ThreadPreload* thread = _threadToThreadPreload(base);
 
     ShMemBlock* blk = calloc(1, sizeof(ShMemBlock));
@@ -423,7 +420,7 @@ const void* threadpreload_getReadablePtr(Thread* base, PluginPtr plugin_src,
 }
 
 int threadpreload_getReadableString(Thread* base, PluginPtr plugin_src, size_t n,
-                             const char** str_out, size_t* strlen_out) {
+                                    const char** str_out, size_t* strlen_out) {
     ThreadPreload* thread = _threadToThreadPreload(base);
 
     ShMemBlock* blk = calloc(1, sizeof(ShMemBlock));
@@ -450,8 +447,7 @@ int threadpreload_getReadableString(Thread* base, PluginPtr plugin_src, size_t n
     return 0;
 }
 
-void* threadpreload_getWriteablePtr(Thread* base, PluginPtr plugin_src,
-                                    size_t n) {
+void* threadpreload_getWriteablePtr(Thread* base, PluginPtr plugin_src, size_t n) {
     ThreadPreload* thread = _threadToThreadPreload(base);
 
     // Allocate a block for the clone
@@ -504,7 +500,7 @@ long threadpreload_nativeSyscall(Thread* base, long n, va_list args) {
     // ABI supports at most 6 arguments, and processing more arguments here than
     // were actually passed doesn't hurt anything. e.g. this is what libc's
     // syscall(2) function does as well.
-    for (int i=0; i<6; ++i) {
+    for (int i = 0; i < 6; ++i) {
         req.event_data.syscall.syscall_args.args[i].as_i64 = va_arg(args, int64_t);
     }
     shimevent_sendEventToPlugin(thread->ipc_blk.p, &req);
@@ -540,8 +536,7 @@ Thread* threadpreload_new(Host* host, Process* process, gint threadID) {
     };
     thread->sys = syscallhandler_new(host, process, _threadPreloadToThread(thread));
 
-    _Static_assert(
-        sizeof(void*) == 8, "thread-preload impl assumes 8 byte pointers");
+    _Static_assert(sizeof(void*) == 8, "thread-preload impl assumes 8 byte pointers");
 
     // thread has access to a global, thread safe shared memory manager
 

--- a/src/shim/shim.c
+++ b/src/shim/shim.c
@@ -151,11 +151,16 @@ static void _shim_load() {
 
     const char* shadow_pid_str = getenv("SHADOW_PID");
     if (shadow_pid_str) {
+        unsigned long long tmp_pid = 0;
         pid_t shadow_pid = 0;
-        int rc = sscanf(shadow_pid_str, "%llu", &shadow_pid);
+        int rc = sscanf(shadow_pid_str, "%llu", &tmp_pid);
         if (rc != 1) {
             error("SHADOW_PID does not contain an unsigned: %s", shadow_pid_str);
         } else {
+
+            assert((pid_t)tmp_pid == tmp_pid);
+            shadow_pid = (pid_t)tmp_pid;
+
             if (getppid() != shadow_pid) { // Validate that Shadow is still alive.
                 error("Shadow exited.");
                 exit(-1); // If Shadow's dead, we can just get out(?)


### PR DESCRIPTION
Changes thread_preload.c to use `vfork()` instead of `fork()` during
process creation. This change has a significant impact on experiment
performance with many (> 1000) processes to manage.
Initialization runtime is reduced by a large factor.

`prctl(PR_SET_PDEATHSIG, SIGKILL)` and `getppid()` have been moved to
the shim in `_shim_load()`.

n.b. I believe this change does not affect ptrace mode. The `prctl` call
may be duplicated, but shouldn't hurt for now.