### PR TITLE
CPU Pinning

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -98,6 +98,7 @@ set(shadow_srcs
     host/descriptor/timer.c
     host/descriptor/transport.c
     host/descriptor/udp.c
+    host/affinity.c
     host/process.c
     host/cpu.c
     host/futex.c

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -35,6 +35,7 @@ struct _WorkerRunData {
 
 typedef struct _Worker Worker;
 
+int worker_getAffinity();
 DNS* worker_getDNS();
 Topology* worker_getTopology();
 Options* worker_getOptions();

--- a/src/main/host/affinity.c
+++ b/src/main/host/affinity.c
@@ -5,65 +5,70 @@
 #endif              // _GNU_SOURCE
 
 #include <assert.h>
+#include <glib.h>
 #include <sched.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <sys/sysinfo.h>
 
+#include "main/core/support/options.h"
 #include "support/logger/logger.h"
 
 // Compute once and cache this value. Apparently fetching is expensive and
 // requires parsing procfs.
-static int _NCPUS = -1; // Starts uninitialized.
+static int _ncpus = -1; // Starts uninitialized.
 
-__attribute__((constructor)) static void _init_ncpus() { _NCPUS = get_nprocs(); }
+static gint _affinity_enabled = 0;
+
+OPTION_EXPERIMENTAL_ENTRY(
+    "cpu-pin", 0, 0, G_OPTION_ARG_INT, &_affinity_enabled,
+    "Pin workers to fixed CPU cores, pin plugins to the worker's core", "[0|1]")
+
+__attribute__((constructor)) static void _init_ncpus() { _ncpus = get_nprocs(); }
 
 int affinity_getGoodWorkerAffinity(guint worker_thread_id) {
-    assert(_NCPUS > 0);                    // Our host better have at least one CPU.
-    return (int)worker_thread_id % _NCPUS; // Uniform distribution of workers over CPUs
+    assert(_ncpus > 0);                    // Our host better have at least one CPU.
+    return (int)worker_thread_id % _ncpus; // Uniform distribution of workers over CPUs
 }
 
 int affinity_setProcessAffinity(pid_t pid, int old_cpu_num, int new_cpu_num) {
+    assert(_ncpus > 0 && pid >= 0);
 
-    return old_cpu_num;
-
-    if (new_cpu_num == AFFINITY_UNINIT) {
-      return old_cpu_num;
+    // We can short-circuit if there's no work to do.
+    if (!_affinity_enabled || new_cpu_num == AFFINITY_UNINIT || new_cpu_num == old_cpu_num) {
+        return old_cpu_num;
     }
 
     cpu_set_t* cpu_set = NULL;
+    bool set_affinity_suceeded = false;
+    int retval = new_cpu_num;
 
-    if (new_cpu_num >= _NCPUS) {
-        goto FAIL;
+    if (new_cpu_num < _ncpus) { // Good, we are trying to set to a valid CPU
+        cpu_set = CPU_ALLOC(_ncpus);
+
+        if (cpu_set) { // Good, the CPU set allocation succeeded
+
+            size_t cpu_set_size = CPU_ALLOC_SIZE(_ncpus);
+
+            // Clear the CPU set
+            CPU_ZERO_S(cpu_set_size, cpu_set);
+            // And then add the new_cpu_num as the only element of the set
+            CPU_SET_S(new_cpu_num, cpu_set_size, cpu_set);
+
+            int rc = sched_setaffinity(pid, cpu_set_size, cpu_set);
+
+            set_affinity_suceeded = (rc == 0);
+        }
     }
 
-    cpu_set = CPU_ALLOC(_NCPUS);
-
-    if (!cpu_set) {
-        goto FAIL;
-    }
-
-    size_t cpu_set_size = CPU_ALLOC_SIZE(_NCPUS);
-
-    // Clear the CPU set
-    CPU_ZERO_S(cpu_set_size, cpu_set);
-    // And then add the new_cpu_num as the only element of the set.
-    CPU_SET_S(new_cpu_num, cpu_set_size, cpu_set);
-
-    int rc = sched_setaffinity(pid, cpu_set_size, cpu_set);
-    if (rc == -1) {
-        goto FAIL;
+    if (!set_affinity_suceeded) {
+        warning("Could not set CPU affinity for PID %d to %d", (int)pid, new_cpu_num);
+        retval = old_cpu_num;
     }
 
     if (cpu_set) {
         CPU_FREE(cpu_set);
     }
 
-    return new_cpu_num;
-
-FAIL: // So sue me.
-    warning("Could not set CPU affinity for PID %d to %d", (int)pid, new_cpu_num);
-    if (cpu_set) {
-        CPU_FREE(cpu_set);
-    }
-    return old_cpu_num;
+    return retval;
 }

--- a/src/main/host/affinity.c
+++ b/src/main/host/affinity.c
@@ -1,0 +1,69 @@
+#include "affinity.h"
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE // Make sure this is defined for CPU_* macros
+#endif              // _GNU_SOURCE
+
+#include <assert.h>
+#include <sched.h>
+#include <stddef.h>
+#include <sys/sysinfo.h>
+
+#include "support/logger/logger.h"
+
+// Compute once and cache this value. Apparently fetching is expensive and
+// requires parsing procfs.
+static int _NCPUS = -1; // Starts uninitialized.
+
+__attribute__((constructor)) static void _init_ncpus() { _NCPUS = get_nprocs(); }
+
+int affinity_getGoodWorkerAffinity(guint worker_thread_id) {
+    assert(_NCPUS > 0);                    // Our host better have at least one CPU.
+    return (int)worker_thread_id % _NCPUS; // Uniform distribution of workers over CPUs
+}
+
+int affinity_setProcessAffinity(pid_t pid, int old_cpu_num, int new_cpu_num) {
+
+    return old_cpu_num;
+
+    if (new_cpu_num == AFFINITY_UNINIT) {
+      return old_cpu_num;
+    }
+
+    cpu_set_t* cpu_set = NULL;
+
+    if (new_cpu_num >= _NCPUS) {
+        goto FAIL;
+    }
+
+    cpu_set = CPU_ALLOC(_NCPUS);
+
+    if (!cpu_set) {
+        goto FAIL;
+    }
+
+    size_t cpu_set_size = CPU_ALLOC_SIZE(_NCPUS);
+
+    // Clear the CPU set
+    CPU_ZERO_S(cpu_set_size, cpu_set);
+    // And then add the new_cpu_num as the only element of the set.
+    CPU_SET_S(new_cpu_num, cpu_set_size, cpu_set);
+
+    int rc = sched_setaffinity(pid, cpu_set_size, cpu_set);
+    if (rc == -1) {
+        goto FAIL;
+    }
+
+    if (cpu_set) {
+        CPU_FREE(cpu_set);
+    }
+
+    return new_cpu_num;
+
+FAIL: // So sue me.
+    warning("Could not set CPU affinity for PID %d to %d", (int)pid, new_cpu_num);
+    if (cpu_set) {
+        CPU_FREE(cpu_set);
+    }
+    return old_cpu_num;
+}

--- a/src/main/host/affinity.c
+++ b/src/main/host/affinity.c
@@ -31,7 +31,7 @@ int affinity_getGoodWorkerAffinity(guint worker_thread_id) {
     return (int)worker_thread_id % _ncpus; // Uniform distribution of workers over CPUs
 }
 
-int affinity_setProcessAffinity(pid_t pid, int old_cpu_num, int new_cpu_num) {
+int affinity_setProcessAffinity(pid_t pid, int new_cpu_num, int old_cpu_num) {
     assert(_ncpus > 0 && pid >= 0);
 
     // We can short-circuit if there's no work to do.

--- a/src/main/host/affinity.c
+++ b/src/main/host/affinity.c
@@ -20,9 +20,9 @@ static int _ncpus = -1; // Starts uninitialized.
 
 static gint _affinity_enabled = 0;
 
-OPTION_EXPERIMENTAL_ENTRY(
-    "cpu-pin", 0, 0, G_OPTION_ARG_INT, &_affinity_enabled,
-    "Pin workers to fixed CPU cores, pin plugins to the worker's core", "[0|1]")
+OPTION_EXPERIMENTAL_ENTRY("cpu-pin", 0, 0, G_OPTION_ARG_INT, &_affinity_enabled,
+                          "Pin workers to fixed CPU cores, pin plugins to the worker's core",
+                          "[0|1]")
 
 __attribute__((constructor)) static void _init_ncpus() { _ncpus = get_nprocs(); }
 
@@ -62,7 +62,8 @@ int affinity_setProcessAffinity(pid_t pid, int new_cpu_num, int old_cpu_num) {
     }
 
     if (!set_affinity_suceeded) {
-        warning("Could not set CPU affinity for PID %d to %d", (int)pid, new_cpu_num);
+        critical("cpu-pin was set, but the CPU affinity for PID %d could not be set to %d",
+                 (int)pid, new_cpu_num);
         retval = old_cpu_num;
     }
 

--- a/src/main/host/affinity.h
+++ b/src/main/host/affinity.h
@@ -5,6 +5,12 @@
 #include <sched.h>
 #include <sys/types.h>
 
+/*
+ * Use AFFINITY_UNINIT as a value specifying that the CPU affinity of the
+ * process is not known or not initialized. AFFINITY_UNINIT is a good value to
+ * initalize affinity variables with before the affinity has been set with
+ * affinity_setProcessAffinity().
+ */
 enum { AFFINITY_UNINIT = -1 };
 
 /*

--- a/src/main/host/affinity.h
+++ b/src/main/host/affinity.h
@@ -1,0 +1,42 @@
+#ifndef AFFINITY_H_
+#define AFFINITY_H_
+
+#include <glib.h>
+#include <sched.h>
+#include <sys/types.h>
+
+enum { AFFINITY_UNINIT = -1 };
+
+/*
+ * Returns a good CPU number affinity for a worker thread with the given thread id.
+ *
+ * THREAD SAFETY: thread-safe.
+ */
+int affinity_getGoodWorkerAffinity(guint worker_thread_id);
+
+/*
+ * Try to set the affinity of the process with the given pid to new_cpu_num. Logs a
+ * warning if the attempt was not sucessful.
+ *
+ * Providing the old_cpu_num allows this function to short-circuit in the event
+ * that a CPU migration is not required. Set this parameter to AFFINITY_UNINIT
+ * if the process affinity has not yet been set or the current affinity is
+ * unknown.
+ *
+ * Returns the CPU number of the pid after assignment. In other words, if the
+ * call was successful, this function returns new_cpu_num. Otherwise, it
+ * returns old_cpu_num.
+ *
+ * THREAD SAFETY: thread-safe.
+ */
+int affinity_setProcessAffinity(pid_t pid, int new_cpu_num, int old_cpu_num);
+
+/*
+ * Helper function. Same semantics as affinity_setProcessAffinity but sets the
+ * affinity of the calling thread/process.
+ */
+static inline int affinity_setThisProcessAffinity(int new_cpu_num, int old_cpu_num) {
+  return affinity_setProcessAffinity(0, new_cpu_num, old_cpu_num);
+}
+
+#endif // AFFINITY_H_

--- a/src/main/host/thread_protected.h
+++ b/src/main/host/thread_protected.h
@@ -10,6 +10,7 @@
 
 #include <stdarg.h>
 
+#include "main/host/affinity.h"
 #include "main/host/syscall_types.h"
 #include "main/host/thread.h"
 #include "main/utility/utility.h"
@@ -42,6 +43,7 @@ struct _Thread {
     ThreadMethods methods;
     pid_t nativePid;
     pid_t nativeTid;
+    int affinity;
     Host* host;
     Process* process;
     // If non-null, this address should be cleared and futex-awoken on thread exit.


### PR DESCRIPTION
This PR adds an optional flag that enables CPU pinning for Shadow workers and plugins. Workers are pinned uniformly among logical CPUs available on the machine. Plugin threads are pinned to the same logical CPU that the worker is pinned to. This behavior is enabled with the `--cpu-pin=1` flag.

Pinning can yield a significant performance improvement. On syscall dense workloads, I am measuring a 20-50% improvement in performance (using `--cpu-pin=1 and --preload-spin-max=0`).