### PR TITLE
Add support for the dup() syscall

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -135,6 +135,8 @@ SysCallReg memorymanager_handleMprotect(MemoryManager *memory_manager,
 
 SysCallReturn rustsyscallhandler_close(SysCallHandler *sys, const SysCallArgs *args);
 
+SysCallReturn rustsyscallhandler_dup(SysCallHandler *sys, const SysCallArgs *args);
+
 SysCallReturn rustsyscallhandler_read(SysCallHandler *sys, const SysCallArgs *args);
 
 SysCallReturn rustsyscallhandler_write(SysCallHandler *sys, const SysCallArgs *args);

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -679,6 +679,9 @@ extern "C" {
     ) -> SysCallReturn;
 }
 extern "C" {
+    pub fn syscallhandler_dup(sys: *mut SysCallHandler, args: *const SysCallArgs) -> SysCallReturn;
+}
+extern "C" {
     pub fn syscallhandler_getpid(
         sys: *mut SysCallHandler,
         args: *const SysCallArgs,

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -296,6 +296,12 @@ SysCallReturn syscallhandler_close(SysCallHandler* sys,
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errorCode};
 }
 
+SysCallReturn syscallhandler_dup(SysCallHandler* sys,
+                                   const SysCallArgs* args) {
+    warning("Cannot dup legacy descriptors");
+    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EOPNOTSUPP};
+}
+
 SysCallReturn syscallhandler_pipe2(SysCallHandler* sys,
                                    const SysCallArgs* args) {
     return _syscallhandler_pipeHelper(

--- a/src/main/host/syscall/unistd.h
+++ b/src/main/host/syscall/unistd.h
@@ -9,6 +9,7 @@
 #include "main/host/syscall/protected.h"
 
 SYSCALL_HANDLER(close);
+SYSCALL_HANDLER(dup);
 SYSCALL_HANDLER(getpid);
 SYSCALL_HANDLER(pipe);
 SYSCALL_HANDLER(pipe2);

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -215,6 +215,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         HANDLE_RUST(close);
         HANDLE(connect);
         HANDLE(creat);
+        HANDLE_RUST(dup);
         HANDLE(epoll_create);
         HANDLE(epoll_create1);
         HANDLE(epoll_ctl);
@@ -335,7 +336,6 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         NATIVE(sched_setaffinity);
 
         // operations on file descriptors
-        NATIVE(dup);
         NATIVE(dup2);
         NATIVE(dup3);
         NATIVE(poll);

--- a/src/shim/preload_syscalls.c
+++ b/src/shim/preload_syscalls.c
@@ -223,6 +223,7 @@ NOREMAP(int, close, (int a), a);
 NOREMAP(int, connect, (int a, const struct sockaddr* b, socklen_t c), a,b,c);
 NOREMAP(int, creat, (const char *a, mode_t b), a,b);
 REMAP(int, creat64, creat, (const char *a, mode_t b), a,b);
+NOREMAP(int, dup, (int a), a);
 NOREMAP(int, epoll_create, (int a), a);
 NOREMAP(int, epoll_create1, (int a), a);
 NOREMAP(int, epoll_ctl, (int a, int b, int c, struct epoll_event* d), a,b,c,d);

--- a/src/test/pipe/test_pipe.rs
+++ b/src/test/pipe/test_pipe.rs
@@ -41,8 +41,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
             test_read_write,
             set![TestEnv::Libc, TestEnv::Shadow],
         ),
-        // TODO: support dup() in Shadow
-        test_utils::ShadowTest::new("test_dup", test_dup, set![TestEnv::Libc]),
+        test_utils::ShadowTest::new("test_dup", test_dup, set![TestEnv::Libc, TestEnv::Shadow]),
         test_utils::ShadowTest::new(
             "test_write_to_read_end",
             test_write_to_read_end,


### PR DESCRIPTION
Only works for the Rust descriptors, not the C descriptors.