### PR TITLE
Set the plugin's stdin as /dev/null

### DIFF
--- a/src/test/socket/accept/test_accept.rs
+++ b/src/test/socket/accept/test_accept.rs
@@ -66,7 +66,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
             test_utils::ShadowTest::new(
                 &append_args("test_non_socket_fd"),
                 move || test_non_socket_fd(accept_fn),
-                set![TestEnv::Libc],
+                set![TestEnv::Libc, TestEnv::Shadow],
             ),
             test_utils::ShadowTest::new(
                 &append_args("test_invalid_sock_type"),

--- a/src/test/socket/bind/test_bind.rs
+++ b/src/test/socket/bind/test_bind.rs
@@ -61,7 +61,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
         test_utils::ShadowTest::new(
             "test_non_socket_fd",
             test_non_socket_fd,
-            set![TestEnv::Libc],
+            set![TestEnv::Libc, TestEnv::Shadow],
         ),
         test_utils::ShadowTest::new("test_null_addr", test_null_addr, set![TestEnv::Libc]),
         test_utils::ShadowTest::new(

--- a/src/test/socket/connect/test_connect.rs
+++ b/src/test/socket/connect/test_connect.rs
@@ -54,7 +54,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
         test_utils::ShadowTest::new(
             "test_non_socket_fd",
             test_non_socket_fd,
-            set![TestEnv::Libc],
+            set![TestEnv::Libc, TestEnv::Shadow],
         ),
         test_utils::ShadowTest::new(
             "test_null_addr",

--- a/src/test/socket/getpeername/test_getpeername.rs
+++ b/src/test/socket/getpeername/test_getpeername.rs
@@ -54,7 +54,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
         test_utils::ShadowTest::new(
             "test_non_socket_fd",
             test_non_socket_fd,
-            set![TestEnv::Libc],
+            set![TestEnv::Libc, TestEnv::Shadow],
         ),
         test_utils::ShadowTest::new(
             "test_non_connected_fd",

--- a/src/test/socket/getsockname/test_getsockname.rs
+++ b/src/test/socket/getsockname/test_getsockname.rs
@@ -54,7 +54,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
         test_utils::ShadowTest::new(
             "test_non_socket_fd",
             test_non_socket_fd,
-            set![TestEnv::Libc],
+            set![TestEnv::Libc, TestEnv::Shadow],
         ),
         test_utils::ShadowTest::new(
             "test_null_addr",

--- a/src/test/socket/listen/test_listen.rs
+++ b/src/test/socket/listen/test_listen.rs
@@ -59,7 +59,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
         test_utils::ShadowTest::new(
             "test_non_socket_fd",
             test_non_socket_fd,
-            set![TestEnv::Libc],
+            set![TestEnv::Libc, TestEnv::Shadow],
         ),
         test_utils::ShadowTest::new(
             "test_invalid_sock_type",

--- a/src/test/socket/sendto_recvfrom/test_sendto_recvfrom.rs
+++ b/src/test/socket/sendto_recvfrom/test_sendto_recvfrom.rs
@@ -92,7 +92,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
         test_utils::ShadowTest::new(
             "test_non_socket_fd",
             test_non_socket_fd,
-            set![TestEnv::Libc],
+            set![TestEnv::Libc, TestEnv::Shadow],
         ),
         test_utils::ShadowTest::new(
             "test_not_connected_tcp",

--- a/src/test/socket/shutdown/test_shutdown.rs
+++ b/src/test/socket/shutdown/test_shutdown.rs
@@ -53,7 +53,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
         test_utils::ShadowTest::new(
             "test_non_socket_fd",
             test_non_socket_fd,
-            set![TestEnv::Libc],
+            set![TestEnv::Libc, TestEnv::Shadow],
         ),
         test_utils::ShadowTest::new(
             "test_invalid_how",


### PR DESCRIPTION
Previously Shadow did not have an active fd 0 (stdin), but would never assign fd 0 to new descriptors since the descriptor table's indexCounter is initialized as 2.