### PR TITLE
Adds CPU pinning to the development branch.

### DIFF
--- a/src/main/core/main.c
+++ b/src/main/core/main.c
@@ -246,7 +246,7 @@ gint main_runShadow(gint argc, gchar* argv[]) {
     if (options_getCPUPinning(options)) {
         int rc = affinity_initPlatformInfo();
         if (rc) {
-            abort();
+          return EXIT_FAILURE;
         }
     }
 

--- a/src/main/host/thread_protected.h
+++ b/src/main/host/thread_protected.h
@@ -52,6 +52,8 @@ struct _Thread {
     // Non-null if blocked by a syscall.
     SysCallCondition* cond;
 
+    int affinity;
+
     MAGIC_DECLARE;
 };
 

--- a/src/main/host/thread_protected.h
+++ b/src/main/host/thread_protected.h
@@ -52,6 +52,10 @@ struct _Thread {
     // Non-null if blocked by a syscall.
     SysCallCondition* cond;
 
+    // Value storing the current CPU affinity of the thread (more preceisely,
+    // of the native thread backing this thread object). This value will be set
+    // to AFFINITY_UNINIT if CPU pinning is not enabled or if the thread has
+    // not yet been pinned to a CPU.
     int affinity;
 
     MAGIC_DECLARE;


### PR DESCRIPTION
Adds CPU pinning to the development branch.
On calls to `thread_run` and`thread_resume`, the plugin's CPU affinity is set to the worker's
current affinity when affinity mode is enabled.