### PR TITLE
Minor fix for Rust compiler warning

### DIFF
--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -361,7 +361,6 @@ mod export {
     use super::*;
 
     /// An opaque type used when passing `*const AtomicRefCell<File>` to C.
-    #[no_mangle]
     pub enum PosixFileArc {}
 
     /// The new compat descriptor takes ownership of the reference to the legacy descriptor and


### PR DESCRIPTION
Small change to fix a warning that occurs in new Rust versions.