### PR TITLE
Pin CPUs in phold test for efficiency

### DIFF
--- a/src/test/phold/CMakeLists.txt
+++ b/src/test/phold/CMakeLists.txt
@@ -15,7 +15,7 @@ add_test(
     NAME phold-shadow-ptrace
     COMMAND sh -c "\
     ${yaml2xml} ${CMAKE_CURRENT_SOURCE_DIR}/phold.test.shadow.config.yaml --output - \
-    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -d phold.shadow-ptrace.data - \
+    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace --pin-cpus -d phold.shadow-ptrace.data - \
     "
 )
 
@@ -24,7 +24,7 @@ add_test(
     NAME phold-shadow-ptrace-only
     COMMAND sh -c "\
     ${yaml2xml} ${CMAKE_CURRENT_SOURCE_DIR}/phold.test.shadow.config.yaml --output - \
-    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace-only -d phold.shadow-ptrace-only.data - \
+    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace-only --pin-cpus -d phold.shadow-ptrace-only.data - \
     "
 )
 
@@ -33,7 +33,7 @@ add_test(
     NAME phold-shadow-preload
     COMMAND sh -c "\
     ${yaml2xml} ${CMAKE_CURRENT_SOURCE_DIR}/phold.test.shadow.config.yaml --output - \
-    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload -d phold.shadow-preload.data -
+    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload --pin-cpus -d phold.shadow-preload.data -
     "
     CONFIGURATIONS ilibc
 )
@@ -42,7 +42,7 @@ add_test(
     NAME phold-threaded-shadow-ptrace
     COMMAND sh -c "\
     ${yaml2xml} ${CMAKE_CURRENT_SOURCE_DIR}/phold.test.shadow.config.yaml --output - \
-    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -d phold-threaded.shadow-ptrace.data -w 2 - \
+    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace --pin-cpus -d phold-threaded.shadow-ptrace.data -w 2 - \
     "
 )
 
@@ -50,7 +50,7 @@ add_test(
     NAME phold-threaded-shadow-ptrace-only
     COMMAND sh -c "\
     ${yaml2xml} ${CMAKE_CURRENT_SOURCE_DIR}/phold.test.shadow.config.yaml --output - \
-    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace-only -d phold-threaded.shadow-ptrace-only.data -w 2 - \
+    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace-only --pin-cpus -d phold-threaded.shadow-ptrace-only.data -w 2 - \
     "
 )
 
@@ -59,11 +59,18 @@ add_test(
     NAME phold-threaded-shadow-preload
     COMMAND sh -c "\
     ${yaml2xml} ${CMAKE_CURRENT_SOURCE_DIR}/phold.test.shadow.config.yaml --output - \
-    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload -d phold-threaded.shadow-preload.data -w 2 - \
+    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload --pin-cpus -d phold-threaded.shadow-preload.data -w 2 - \
     "
     CONFIGURATIONS ilibc
 )
 
 # These tests currently run very slowly in the GitHub CI, which only gives them 2 CPUs.
 # Hopefully will be fixed by https://github.com/shadow/shadow/issues/965.
-set_tests_properties(phold-shadow-ptrace phold-shadow-preload phold-threaded-shadow-ptrace phold-threaded-shadow-ptrace-only phold-threaded-shadow-preload phold-threaded-shadow-ptrace-only PROPERTIES TIMEOUT 90)
+set_tests_properties(
+    phold-shadow-ptrace
+    phold-shadow-ptrace-only
+    phold-shadow-preload
+    phold-threaded-shadow-ptrace
+    phold-threaded-shadow-ptrace-only
+    phold-threaded-shadow-preload
+        PROPERTIES TIMEOUT 60)


### PR DESCRIPTION
This PR reduces *worst case* runtime of the phold tests.

Here is some unscientific results:

## Before this PR

Debug mode, CPU pinning off:

![image](https://user-images.githubusercontent.com/788144/108262608-243a3f80-7133-11eb-84b5-ee4382f08758.png)

Release mode, CPU pinning off:

![image](https://user-images.githubusercontent.com/788144/108262917-901ca800-7133-11eb-8de9-7396917e0a9e.png)

## After this PR

Debug mode, CPU pinning on:

![image](https://user-images.githubusercontent.com/788144/108263030-b5a9b180-7133-11eb-9e5d-08c22cb64cc6.png)

Release mode, CPU pinning on:

![image](https://user-images.githubusercontent.com/788144/108263072-c35f3700-7133-11eb-95ae-77a9c0f205b8.png)

## Commentary (off-channel):

- pinning off is beneficial when you are not running with multiple workers. without pinning, a plugin can “steal” an extra CPU that’s available on the machine
- when debugging is on, there is a lot more work being done on my machine and it’s probably overloaded running all 4 tests in parallel, so in that case pinning helps
- it seems like overall we will win when testing by enabling pinning, because the major decrease in debug mode runtime is worth the minor increase in release mode runtime