### PR TITLE
Define macros for consistent & concise test defs

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -31,6 +31,42 @@ add_executable(shadow-test-launcher-fail test_launcher_fail.c test_launcher_comm
 ## Wrapper around the yaml2xml tool
 set (yaml2xml "python3 ${CMAKE_SOURCE_DIR}/src/tools/convert.py yaml2xml")
 
+## Track all shadow test names to create our leakcheck dependency
+set(AllShadowTestNames "")
+
+## === Helper macros for consistently defining tests. ===
+
+## Tests that need more features should use add_test directly.
+macro(add_linux_tests testname)
+   add_test(NAME ${testname}-linux COMMAND ${ARGN})
+   set_property(TEST ${testname}-linux PROPERTY ENVIRONMENT "RUST_BACKTRACE=1")
+endmacro()
+
+## Call with the name of the test, and then the three optional interpose methods.
+## add_shadow_tests(mmap hybrid ptrace) will add the mmap test for those modes.
+macro(add_shadow_tests testname)
+   set(AllShadowTestNames ${AllShadowTestNames} PARENT_SCOPE)
+   foreach(Method ${ARGN}) # ARGN are the args given after the expected 'name' arg
+      add_test(
+         NAME ${testname}-shadow-${Method}
+         COMMAND sh -c "\
+         ${yaml2xml} ${CMAKE_CURRENT_SOURCE_DIR}/${testname}-shadow.yaml --output - \
+         | ${CMAKE_BINARY_DIR}/src/main/shadow \
+            --interpose-method=${Method} \
+            --log-level=debug \
+            --data-directory=${testname}-shadow-${Method}.data \
+            - \
+         "
+      )
+      list(APPEND TestNames ${testname}-shadow-${Method})
+      list(APPEND AllShadowTestNames ${testname}-shadow-${Method})
+   endforeach()
+   set_property(TEST ${TestNames} PROPERTY ENVIRONMENT "RUST_BACKTRACE=1")
+   # need to check the test's return code, not just shadow's (see shadow/shadow#902)
+   set_property(TEST ${TestNames} PROPERTY FAIL_REGULAR_EXPRESSION "main error code '.*' for process")
+endmacro()
+## === end test helper macros ===
+
 ## add the test directories
 # FIXME uncomment these as we get them working in Phantom.
 # FIXME add_subdirectory(dynlink)
@@ -62,23 +98,24 @@ add_subdirectory(timerfd)
 add_subdirectory(udp)
 add_subdirectory(unistd)
 
+message(STATUS "AllShadowTestNames = ${AllShadowTestNames}")
+
 ## grep the LastTest.log.tmp file for the counter diff lines, and make sure
 ## that each such line matches the line in src/test/leakcheck.log
 add_test(
-	NAME shadow-leakcheck-grep
+	NAME leakcheck-shadow-grep
 	COMMAND /usr/bin/env bash ${CMAKE_SOURCE_DIR}/src/test/leakcheck-grep.sh
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
-## FIXME - eventually need all Shadow tests in the DEPENDS list
-# All shadow test targets should be listed as dependencies, so that the leakcheck can grep their output for leaks.
-# Generate with: `(cd build ; ctest -R shadow -E leakcheck -N | head --lines=-2 | tail --lines=+2 | awk '{printf $3 ";"}')`
-set_tests_properties(shadow-leakcheck-grep PROPERTIES DEPENDS "bind-shadow-ptrace;bind-shadow-preload;clone-shadow-ptrace;config-convert-shadow;cpp-shadow-ptrace;cpp-shadow-preload;epoll-shadow-ptrace;epoll-writeable-shadow-ptrace;eventfd-shadow-ptrace;eventfd-shadow-preload;file-shadow-ptrace;mmap-shadow-ptrace;phold-shadow-ptrace;phold-threaded-shadow-ptrace;random-shadow-ptrace;random-shadow-preload;shutdown-shadow-ptrace;shutdown-shadow-preload;sleep-shadow-ptrace;sleep-shadow-preload;sockbuf-shadow-ptrace;socket-shadow-ptrace;socket-shadow-preload;bind-shadow-ptrace;bind-shadow-preload;listen-shadow-ptrace;listen-shadow-preload;getsockname-shadow-ptrace;getsockname-shadow-preload;accept-shadow-ptrace;accept-shadow-preload;timerfd-shadow-ptrace;udp-uniprocess-shadow-ptrace;udp-uniprocess-shadow-preload;udp-shadow-ptrace;unistd-shadow-ptrace;unistd-shadow-preload")
+# List all shadow tests as dependencies, so that the leakcheck can grep their output for leaks.
+## TODO swap the following lines when all tests have been converted to the macros
+#set_tests_properties(leakcheck-shadow-grep PROPERTIES DEPENDS "${AllShadowTestNames}")
+set_tests_properties(leakcheck-shadow-grep PROPERTIES DEPENDS "bind-shadow-ptrace;bind-shadow-preload;clone-shadow-ptrace;config-convert-shadow;cpp-shadow-ptrace;cpp-shadow-preload;epoll-shadow-ptrace;epoll-writeable-shadow-ptrace;eventfd-shadow-ptrace;eventfd-shadow-preload;file-shadow-ptrace;mmap-shadow-ptrace;phold-shadow-ptrace;phold-threaded-shadow-ptrace;random-shadow-ptrace;random-shadow-preload;shutdown-shadow-ptrace;shutdown-shadow-preload;sleep-shadow-ptrace;sleep-shadow-preload;sockbuf-shadow-ptrace;socket-shadow-ptrace;socket-shadow-preload;bind-shadow-ptrace;bind-shadow-preload;listen-shadow-ptrace;listen-shadow-preload;getsockname-shadow-ptrace;getsockname-shadow-preload;accept-shadow-ptrace;accept-shadow-preload;timerfd-shadow-ptrace;udp-uniprocess-shadow-ptrace;udp-uniprocess-shadow-preload;udp-shadow-ptrace;unistd-shadow-ptrace;unistd-shadow-preload")
 
 add_test(
-	NAME shadow-leakcheck-compare
+	NAME leakcheck-shadow-compare
 	COMMAND /usr/bin/env bash ${CMAKE_SOURCE_DIR}/src/test/leakcheck-compare.sh
         ${CMAKE_CURRENT_BINARY_DIR}/leakcheck.log
 		${CMAKE_SOURCE_DIR}/src/test/leakcheck.log
 )
-set_tests_properties(shadow-leakcheck-compare PROPERTIES DEPENDS "shadow-leakcheck-grep")
-
+set_tests_properties(leakcheck-shadow-compare PROPERTIES DEPENDS "leakcheck-shadow-grep")

--- a/src/test/bind/CMakeLists.txt
+++ b/src/test/bind/CMakeLists.txt
@@ -1,21 +1,5 @@
 include_directories(${GLIB_INCLUDES})
 link_libraries(${GLIB_LIBRARIES} logger)
-
 add_executable(test-bind test_bind.c ../test_common.c)
-
-## register the tests
-add_test(NAME bind COMMAND test-bind)
-add_test(
-    NAME bind-shadow-ptrace
-    COMMAND sh -c "\
-    ${yaml2xml} ${CMAKE_CURRENT_SOURCE_DIR}/bind.test.shadow.config.yaml --output - \
-    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=ptrace -l debug -d bind.shadow-ptrace.data - \
-    "
-)
-add_test(
-    NAME bind-shadow-preload
-    COMMAND sh -c "\
-    ${yaml2xml} ${CMAKE_CURRENT_SOURCE_DIR}/bind.test.shadow.config.yaml --output -\
-    | ${CMAKE_BINARY_DIR}/src/main/shadow --interpose-method=preload -l debug -d bind.shadow-preload.data -\
-    "
-)
+add_linux_tests(bind test-bind)
+add_shadow_tests(bind ptrace ptrace-only preload)

--- a/src/test/bind/bind-shadow.yaml
+++ b/src/test/bind/bind-shadow.yaml
@@ -1,3 +1,5 @@
+options:
+  stoptime: 5
 topology:
 - graphml: |
     <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
@@ -18,8 +20,6 @@ topology:
         </edge>
       </graph>
     </graphml>
-kill:
-- time: 5
 plugins:
 - id: testbind
   path: test-bind


### PR DESCRIPTION
This will (i) make it easier to define new tests concisely, (ii) make all of the test cases actually fail when they should, and (iii) make the tests more consistent.