### PR TITLE
Increased phold timeout and set PROCESSORS to 2

### DIFF
--- a/src/test/phold/CMakeLists.txt
+++ b/src/test/phold/CMakeLists.txt
@@ -73,4 +73,10 @@ set_tests_properties(
     phold-threaded-shadow-hybrid
     phold-threaded-shadow-ptrace
     phold-threaded-shadow-preload
-        PROPERTIES TIMEOUT 60)
+        PROPERTIES TIMEOUT 120)
+
+set_tests_properties(
+    phold-threaded-shadow-hybrid
+    phold-threaded-shadow-ptrace
+    phold-threaded-shadow-preload
+        PROPERTIES PROCESSORS 2)


### PR DESCRIPTION
The `phold-shadow-hybrid` test was failing for me since the timeout was too low, and setting the `PROCESSORS` property to 2 seems to make the test time more reliable.