### PR TITLE
Rust logger performance improvements

### DIFF
--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -13,7 +13,8 @@ atomic_refcell = "0.1"
 bitflags = "1.2"
 lazy_static = "1.4.0"
 libc = "0.2"
-log = "0.4"
+# don't log debug or trace levels in release mode
+log = { version = "0.4", features = ["release_max_level_info"] }
 log-bindings = { path = "../support/logger/rust_bindings" }
 nix = "0.20.0"
 rand = "0.8.0"

--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -25,6 +25,8 @@ add_custom_command(OUTPUT wrapper.rs
         --whitelist-function "descriptor_setHandle"
         --whitelist-function "process_.*CompatDescriptor"
         --whitelist-function "process_get.*Ptr"
+        --whitelist-function "shadow_logger_getDefault"
+        --whitelist-function "shadow_logger_shouldFilter"
         --whitelist-function "statuslistener_ref"
         --whitelist-function "statuslistener_unref"
         --whitelist-function "statuslistener_onStatusChanged"

--- a/src/main/bindings/rust/wrapper.h
+++ b/src/main/bindings/rust/wrapper.h
@@ -5,6 +5,7 @@
 
 // Don't forget to whitelist functions/types/vars in CMakeLists.txt
 
+#include "main/core/logger/shadow_logger.h"
 #include "main/host/descriptor/descriptor.h"
 #include "main/host/status.h"
 #include "main/host/status_listener.h"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -18,6 +18,28 @@ pub struct _GTimer {
     _unused: [u8; 0],
 }
 pub type GTimer = _GTimer;
+pub use self::_LogLevel as LogLevel;
+pub const _LogLevel_LOGLEVEL_UNSET: _LogLevel = 0;
+pub const _LogLevel_LOGLEVEL_ERROR: _LogLevel = 1;
+pub const _LogLevel_LOGLEVEL_CRITICAL: _LogLevel = 2;
+pub const _LogLevel_LOGLEVEL_WARNING: _LogLevel = 3;
+pub const _LogLevel_LOGLEVEL_MESSAGE: _LogLevel = 4;
+pub const _LogLevel_LOGLEVEL_INFO: _LogLevel = 5;
+pub const _LogLevel_LOGLEVEL_DEBUG: _LogLevel = 6;
+pub const _LogLevel_LOGLEVEL_TRACE: _LogLevel = 7;
+pub type _LogLevel = i32;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _ShadowLogger {
+    _unused: [u8; 0],
+}
+pub type ShadowLogger = _ShadowLogger;
+extern "C" {
+    pub fn shadow_logger_getDefault() -> *mut ShadowLogger;
+}
+extern "C" {
+    pub fn shadow_logger_shouldFilter(logger: *mut ShadowLogger, level: LogLevel) -> bool;
+}
 pub use self::_Status as Status;
 pub const _Status_STATUS_NONE: _Status = 0;
 pub const _Status_STATUS_DESCRIPTOR_ACTIVE: _Status = 1;

--- a/src/main/core/logger/log_wrapper.rs
+++ b/src/main/core/logger/log_wrapper.rs
@@ -1,5 +1,7 @@
-use log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
+use crate::cshadow as c;
 use log_bindings as c_log;
+
+use log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 use std::{ffi, fmt};
 
 static LOGGER: ShadowLogger = ShadowLogger {};
@@ -20,6 +22,10 @@ impl Log for ShadowLogger {
             Level::Debug => c_log::_LogLevel_LOGLEVEL_DEBUG,
             Level::Trace => c_log::_LogLevel_LOGLEVEL_TRACE,
         };
+
+        if unsafe { c::shadow_logger_shouldFilter(c::shadow_logger_getDefault(), log_level) } {
+            return;
+        }
 
         // allocate null-terminated strings
         let file = ffi::CString::new(record.file().unwrap_or("<none>")).unwrap();

--- a/src/main/core/logger/shadow_logger.c
+++ b/src/main/core/logger/shadow_logger.c
@@ -99,7 +99,7 @@ void shadow_logger_setFilterLevel(ShadowLogger* logger, LogLevel level) {
     logger->filterLevel = level;
 }
 
-gboolean shadow_logger_shouldFilter(ShadowLogger* logger, LogLevel level) {
+bool shadow_logger_shouldFilter(ShadowLogger* logger, LogLevel level) {
     MAGIC_ASSERT(logger);
 
     /* check if the message should be filtered */

--- a/src/main/core/logger/shadow_logger.h
+++ b/src/main/core/logger/shadow_logger.h
@@ -8,6 +8,7 @@
 
 #include <glib.h>
 #include <pthread.h>
+#include <stdbool.h>
 
 #include "support/logger/log_level.h"
 
@@ -28,7 +29,7 @@ void shadow_logger_setDefault(ShadowLogger* logger);
 ShadowLogger* shadow_logger_getDefault();
 
 void shadow_logger_setFilterLevel(ShadowLogger* logger, LogLevel level);
-gboolean shadow_logger_shouldFilter(ShadowLogger* logger, LogLevel level);
+bool shadow_logger_shouldFilter(ShadowLogger* logger, LogLevel level);
 
 void shadow_logger_setEnableBuffering(ShadowLogger* logger, gboolean enabled);
 


### PR DESCRIPTION
1. When building Shadow in release mode, filter the Rust debug
   logging at compile time.

2. Before formatting the message string, add a runtime check to
   see if we should filter the current log message.