### PR TITLE
Support multiple socket types in the network interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,8 @@ set(CMAKE_C_FLAGS_DEBUG "")
 set(CMAKE_C_FLAGS_RELEASE "")
 add_compile_options(-ggdb)
 add_compile_options(-fno-omit-frame-pointer)
+add_compile_options(-Wreturn-type)
+add_compile_options(-Wswitch)
 
 message(STATUS "Found CMAKE_BUILD_TYPE='$ENV{CMAKE_BUILD_TYPE}'")
 if("$ENV{CMAKE_BUILD_TYPE}" STREQUAL "Debug")

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -88,6 +88,7 @@ set(shadow_srcs
     host/descriptor/channel.c
     host/descriptor/descriptor.c
     host/status_listener.c
+    host/descriptor/compat_socket.c
     host/descriptor/descriptor_table.c
     host/descriptor/eventd.c
     host/descriptor/epoll.c
@@ -132,6 +133,7 @@ set(shadow_srcs
     host/thread_preload.c
     host/thread_ptrace.c
     host/network_interface.c
+    host/network_queuing_disciplines.c
     host/tracker.c
 
     routing/payload.c
@@ -151,6 +153,7 @@ set(shadow_srcs
     utility/pcap_writer.c
     utility/priority_queue.c
     utility/random.c
+    utility/tagged_ptr.c
     utility/utility.c
 )
 add_library(shadow-c STATIC ${shadow_srcs})

--- a/src/main/host/descriptor/compat_socket.c
+++ b/src/main/host/descriptor/compat_socket.c
@@ -12,6 +12,14 @@
 #include "main/utility/tagged_ptr.h"
 #include "support/logger/logger.h"
 
+static void compatsockettypes_assertValid(CompatSocketTypes type) {
+    switch (type) {
+        case CST_LEGACY_SOCKET:
+        case CST_NONE: return;
+    }
+    error("Invalid CompatSocket type");
+}
+
 CompatSocket compatsocket_fromLegacySocket(Socket* socket) {
     CompatSocket new_socket = {
         .type = CST_LEGACY_SOCKET,
@@ -26,21 +34,23 @@ CompatSocket compatsocket_refAs(const CompatSocket* socket) {
         .object = socket->object,
     };
 
-    if (new_socket.type == CST_LEGACY_SOCKET) {
-        descriptor_ref(new_socket.object.as_legacy_socket);
-    } else {
-        error("Unexpected CompatSocket type");
+    switch (new_socket.type) {
+        case CST_LEGACY_SOCKET: descriptor_ref(new_socket.object.as_legacy_socket); break;
+        case CST_NONE: error("Unexpected CompatSocket type");
     }
+
+    compatsockettypes_assertValid(new_socket.type);
 
     return new_socket;
 }
 
 void compatsocket_unref(const CompatSocket* socket) {
-    if (socket->type == CST_LEGACY_SOCKET) {
-        descriptor_unref(socket->object.as_legacy_socket);
-    } else {
-        error("Unexpected CompatSocket type");
+    switch (socket->type) {
+        case CST_LEGACY_SOCKET: descriptor_unref(socket->object.as_legacy_socket); break;
+        case CST_NONE: error("Unexpected CompatSocket type");
     }
+
+    compatsockettypes_assertValid(socket->type);
 }
 
 uintptr_t compatsocket_toTagged(const CompatSocket* socket) {
@@ -49,11 +59,12 @@ uintptr_t compatsocket_toTagged(const CompatSocket* socket) {
 
     const void* object_ptr;
 
-    if (socket->type == CST_LEGACY_SOCKET) {
-        object_ptr = object.as_legacy_socket;
-    } else {
-        error("Unexpected CompatSocket type");
+    switch (socket->type) {
+        case CST_LEGACY_SOCKET: object_ptr = object.as_legacy_socket; break;
+        case CST_NONE: error("Unexpected CompatSocket type");
     }
+
+    compatsockettypes_assertValid(socket->type);
 
     return tagPtr(object_ptr, type);
 }
@@ -65,12 +76,12 @@ CompatSocket compatsocket_fromTagged(uintptr_t ptr) {
     uintptr_t tag = 0;
     void* object_ptr = untagPtr(ptr, &tag);
 
-    if (tag == CST_LEGACY_SOCKET) {
-        object.as_legacy_socket = object_ptr;
-    } else {
-        error("Unexpected socket pointer tag");
-        abort();
+    switch (tag) {
+        case CST_LEGACY_SOCKET: object.as_legacy_socket = object_ptr; break;
+        case CST_NONE: error("Unexpected socket pointer tag");
     }
+
+    compatsockettypes_assertValid(tag);
 
     type = tag;
 
@@ -83,55 +94,57 @@ CompatSocket compatsocket_fromTagged(uintptr_t ptr) {
 }
 
 ProtocolType compatsocket_getProtocol(const CompatSocket* socket) {
-    if (socket->type == CST_LEGACY_SOCKET) {
-        return socket_getProtocol(socket->object.as_legacy_socket);
-    } else {
-        error("Unexpected CompatSocket type");
-        abort();
+    switch (socket->type) {
+        case CST_LEGACY_SOCKET: return socket_getProtocol(socket->object.as_legacy_socket);
+        case CST_NONE: error("Unexpected CompatSocket type");
     }
+
+    error("Invalid CompatSocket type");
 }
 
 bool compatsocket_getPeerName(const CompatSocket* socket, in_addr_t* ip, in_port_t* port) {
-    if (socket->type == CST_LEGACY_SOCKET) {
-        return socket_getPeerName(socket->object.as_legacy_socket, ip, port);
-    } else {
-        error("Unexpected CompatSocket type");
-        abort();
+    switch (socket->type) {
+        case CST_LEGACY_SOCKET:
+            return socket_getPeerName(socket->object.as_legacy_socket, ip, port);
+        case CST_NONE: error("Unexpected CompatSocket type");
     }
+
+    error("Invalid CompatSocket type");
 }
 
 bool compatsocket_getSocketName(const CompatSocket* socket, in_addr_t* ip, in_port_t* port) {
-    if (socket->type == CST_LEGACY_SOCKET) {
-        return socket_getSocketName(socket->object.as_legacy_socket, ip, port);
-    } else {
-        error("Unexpected CompatSocket type");
-        abort();
+    switch (socket->type) {
+        case CST_LEGACY_SOCKET:
+            return socket_getSocketName(socket->object.as_legacy_socket, ip, port);
+        case CST_NONE: error("Unexpected CompatSocket type");
     }
+
+    error("Invalid CompatSocket type");
 }
 
 const Packet* compatsocket_peekNextOutPacket(const CompatSocket* socket) {
-    if (socket->type == CST_LEGACY_SOCKET) {
-        return socket_peekNextOutPacket(socket->object.as_legacy_socket);
-    } else {
-        error("Unexpected CompatSocket type");
-        abort();
+    switch (socket->type) {
+        case CST_LEGACY_SOCKET: return socket_peekNextOutPacket(socket->object.as_legacy_socket);
+        case CST_NONE: error("Unexpected CompatSocket type");
     }
+
+    error("Invalid CompatSocket type");
 }
 
 void compatsocket_pushInPacket(const CompatSocket* socket, Packet* packet) {
-    if (socket->type == CST_LEGACY_SOCKET) {
-        socket_pushInPacket(socket->object.as_legacy_socket, packet);
-    } else {
-        error("Unexpected CompatSocket type");
-        abort();
+    switch (socket->type) {
+        case CST_LEGACY_SOCKET: return socket_pushInPacket(socket->object.as_legacy_socket, packet);
+        case CST_NONE: error("Unexpected CompatSocket type");
     }
+
+    error("Invalid CompatSocket type");
 }
 
 Packet* compatsocket_pullOutPacket(const CompatSocket* socket) {
-    if (socket->type == CST_LEGACY_SOCKET) {
-        return socket_pullOutPacket(socket->object.as_legacy_socket);
-    } else {
-        error("Unexpected CompatSocket type");
-        abort();
+    switch (socket->type) {
+        case CST_LEGACY_SOCKET: return socket_pullOutPacket(socket->object.as_legacy_socket);
+        case CST_NONE: error("Unexpected CompatSocket type");
     }
+
+    error("Invalid CompatSocket type");
 }

--- a/src/main/host/descriptor/compat_socket.c
+++ b/src/main/host/descriptor/compat_socket.c
@@ -20,7 +20,7 @@ CompatSocket compatsocket_fromLegacySocket(Socket* socket) {
     return new_socket;
 }
 
-CompatSocket compatsocket_cloneRef(const CompatSocket* socket) {
+CompatSocket compatsocket_refAs(const CompatSocket* socket) {
     CompatSocket new_socket = {
         .type = socket->type,
         .object = socket->object,
@@ -35,7 +35,7 @@ CompatSocket compatsocket_cloneRef(const CompatSocket* socket) {
     return new_socket;
 }
 
-void compatsocket_drop(const CompatSocket* socket) {
+void compatsocket_unref(const CompatSocket* socket) {
     if (socket->type == CST_LEGACY_SOCKET) {
         descriptor_unref(socket->object.as_legacy_socket);
     } else {

--- a/src/main/host/descriptor/compat_socket.c
+++ b/src/main/host/descriptor/compat_socket.c
@@ -1,0 +1,137 @@
+/*
+ * The Shadow Simulator
+ * See LICENSE for licensing information
+ */
+
+#include "main/host/descriptor/compat_socket.h"
+
+#include <stdlib.h>
+
+#include "main/bindings/c/bindings-opaque.h"
+#include "main/host/descriptor/socket.h"
+#include "main/utility/tagged_ptr.h"
+#include "support/logger/logger.h"
+
+CompatSocket compatsocket_fromLegacySocket(Socket* socket) {
+    CompatSocket new_socket = {
+        .type = CST_LEGACY_SOCKET,
+        .object.as_legacy_socket = socket,
+    };
+    return new_socket;
+}
+
+CompatSocket compatsocket_cloneRef(const CompatSocket* socket) {
+    CompatSocket new_socket = {
+        .type = socket->type,
+        .object = socket->object,
+    };
+
+    if (new_socket.type == CST_LEGACY_SOCKET) {
+        descriptor_ref(new_socket.object.as_legacy_socket);
+    } else {
+        error("Unexpected CompatSocket type");
+    }
+
+    return new_socket;
+}
+
+void compatsocket_drop(const CompatSocket* socket) {
+    if (socket->type == CST_LEGACY_SOCKET) {
+        descriptor_unref(socket->object.as_legacy_socket);
+    } else {
+        error("Unexpected CompatSocket type");
+    }
+}
+
+uintptr_t compatsocket_toTagged(const CompatSocket* socket) {
+    CompatSocketTypes type = socket->type;
+    CompatSocketObject object = socket->object;
+
+    const void* object_ptr;
+
+    if (socket->type == CST_LEGACY_SOCKET) {
+        object_ptr = object.as_legacy_socket;
+    } else {
+        error("Unexpected CompatSocket type");
+    }
+
+    return tagPtr(object_ptr, type);
+}
+
+CompatSocket compatsocket_fromTagged(uintptr_t ptr) {
+    CompatSocketTypes type;
+    CompatSocketObject object;
+
+    uintptr_t tag = 0;
+    void* object_ptr = untagPtr(ptr, &tag);
+
+    if (tag == CST_LEGACY_SOCKET) {
+        object.as_legacy_socket = object_ptr;
+    } else {
+        error("Unexpected socket pointer tag");
+        abort();
+    }
+
+    type = tag;
+
+    CompatSocket socket = {
+        .type = type,
+        .object = object,
+    };
+
+    return socket;
+}
+
+ProtocolType compatsocket_getProtocol(const CompatSocket* socket) {
+    if (socket->type == CST_LEGACY_SOCKET) {
+        return socket_getProtocol(socket->object.as_legacy_socket);
+    } else {
+        error("Unexpected CompatSocket type");
+        abort();
+    }
+}
+
+bool compatsocket_getPeerName(const CompatSocket* socket, in_addr_t* ip, in_port_t* port) {
+    if (socket->type == CST_LEGACY_SOCKET) {
+        return socket_getPeerName(socket->object.as_legacy_socket, ip, port);
+    } else {
+        error("Unexpected CompatSocket type");
+        abort();
+    }
+}
+
+bool compatsocket_getSocketName(const CompatSocket* socket, in_addr_t* ip, in_port_t* port) {
+    if (socket->type == CST_LEGACY_SOCKET) {
+        return socket_getSocketName(socket->object.as_legacy_socket, ip, port);
+    } else {
+        error("Unexpected CompatSocket type");
+        abort();
+    }
+}
+
+const Packet* compatsocket_peekNextOutPacket(const CompatSocket* socket) {
+    if (socket->type == CST_LEGACY_SOCKET) {
+        return socket_peekNextOutPacket(socket->object.as_legacy_socket);
+    } else {
+        error("Unexpected CompatSocket type");
+        abort();
+    }
+}
+
+void compatsocket_pushInPacket(const CompatSocket* socket, Packet* packet) {
+    if (socket->type == CST_LEGACY_SOCKET) {
+        socket_pushInPacket(socket->object.as_legacy_socket, packet);
+    } else {
+        error("Unexpected CompatSocket type");
+        abort();
+    }
+}
+
+Packet* compatsocket_pullOutPacket(const CompatSocket* socket) {
+    if (socket->type == CST_LEGACY_SOCKET) {
+        return socket_pullOutPacket(socket->object.as_legacy_socket);
+    } else {
+        error("Unexpected CompatSocket type");
+        abort();
+    }
+}

--- a/src/main/host/descriptor/compat_socket.h
+++ b/src/main/host/descriptor/compat_socket.h
@@ -31,8 +31,8 @@ struct _CompatSocket {
 CompatSocket compatsocket_fromLegacySocket(Socket* socket);
 
 /* reference counting */
-CompatSocket compatsocket_cloneRef(const CompatSocket* socket);
-void compatsocket_drop(const CompatSocket* socket);
+CompatSocket compatsocket_refAs(const CompatSocket* socket);
+void compatsocket_unref(const CompatSocket* socket);
 
 /* converting between a CompatSocket and a tagged pointer */
 uintptr_t compatsocket_toTagged(const CompatSocket* socket);

--- a/src/main/host/descriptor/compat_socket.h
+++ b/src/main/host/descriptor/compat_socket.h
@@ -15,6 +15,7 @@ typedef struct _CompatSocket CompatSocket;
 #include "main/utility/tagged_ptr.h"
 
 enum _CompatSocketTypes {
+    CST_NONE,
     CST_LEGACY_SOCKET,
 };
 

--- a/src/main/host/descriptor/compat_socket.h
+++ b/src/main/host/descriptor/compat_socket.h
@@ -1,0 +1,48 @@
+/*
+ * The Shadow Simulator
+ * See LICENSE for licensing information
+ */
+
+#ifndef SRC_MAIN_HOST_DESCRIPTOR_COMPAT_SOCKET_H_
+#define SRC_MAIN_HOST_DESCRIPTOR_COMPAT_SOCKET_H_
+
+typedef enum _CompatSocketTypes CompatSocketTypes;
+typedef union _CompatSocketObject CompatSocketObject;
+typedef struct _CompatSocket CompatSocket;
+
+#include "main/bindings/c/bindings-opaque.h"
+#include "main/host/descriptor/socket.h"
+#include "main/utility/tagged_ptr.h"
+
+enum _CompatSocketTypes {
+    CST_LEGACY_SOCKET,
+};
+
+union _CompatSocketObject {
+    Socket* as_legacy_socket;
+};
+
+struct _CompatSocket {
+    CompatSocketTypes type;
+    CompatSocketObject object;
+};
+
+CompatSocket compatsocket_fromLegacySocket(Socket* socket);
+
+/* reference counting */
+CompatSocket compatsocket_cloneRef(const CompatSocket* socket);
+void compatsocket_drop(const CompatSocket* socket);
+
+/* converting between a CompatSocket and a tagged pointer */
+uintptr_t compatsocket_toTagged(const CompatSocket* socket);
+CompatSocket compatsocket_fromTagged(uintptr_t ptr);
+
+/* compatability wrappers */
+ProtocolType compatsocket_getProtocol(const CompatSocket* socket);
+bool compatsocket_getPeerName(const CompatSocket* socket, in_addr_t* ip, in_port_t* port);
+bool compatsocket_getSocketName(const CompatSocket* socket, in_addr_t* ip, in_port_t* port);
+const Packet* compatsocket_peekNextOutPacket(const CompatSocket* socket);
+void compatsocket_pushInPacket(const CompatSocket* socket, Packet* packet);
+Packet* compatsocket_pullOutPacket(const CompatSocket* socket);
+
+#endif /* SRC_MAIN_HOST_DESCRIPTOR_COMPAT_SOCKET_H_ */

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -10,6 +10,7 @@
 
 #include "main/core/support/definitions.h"
 #include "main/core/worker.h"
+#include "main/host/descriptor/compat_socket.h"
 #include "main/host/descriptor/descriptor.h"
 #include "main/host/descriptor/socket.h"
 #include "main/host/descriptor/tcp.h"
@@ -431,7 +432,8 @@ gboolean socket_addToOutputBuffer(Socket* socket, Packet* packet) {
     /* tell the interface to include us when sending out to the network */
     in_addr_t ip = packet_getSourceIP(packet);
     NetworkInterface* interface = host_lookupInterface(worker_getActiveHost(), ip);
-    networkinterface_wantsSend(interface, socket);
+    CompatSocket compat_socket = compatsocket_fromLegacySocket(socket);
+    networkinterface_wantsSend(interface, &compat_socket);
 
     return TRUE;
 }

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -471,16 +471,10 @@ Router* host_getUpstreamRouter(Host* host, in_addr_t handle) {
     return networkinterface_getRouter(interface);
 }
 
-void host_associateInterface(Host* host, Socket* socket, in_addr_t bindAddress,
-                             in_port_t bindPort, in_addr_t peerAddress,
-                             in_port_t peerPort) {
+void host_associateInterface(Host* host, Socket* socket, in_addr_t bindAddress) {
     MAGIC_ASSERT(host);
 
-    /* connect up socket layer */
-    socket_setPeerName(socket, peerAddress, peerPort);
-    socket_setSocketName(socket, bindAddress, bindPort);
-
-    /* now associate the interfaces corresponding to bindAddress with socket */
+    /* associate the interfaces corresponding to bindAddress with socket */
     if(bindAddress == htonl(INADDR_ANY)) {
         /* need to associate all interfaces */
         GHashTableIter iter;

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -498,13 +498,8 @@ void host_disassociateInterface(Host* host, const CompatSocket* socket) {
     }
 
     in_addr_t bindAddress;
-    if (socket->type == CST_LEGACY_SOCKET) {
-        if (!socket_isBound(socket->object.as_legacy_socket)) {
-            return;
-        }
-        socket_getSocketName(socket->object.as_legacy_socket, &bindAddress, NULL);
-    } else {
-        error("Unexpected CompatSocket type");
+    if (!compatsocket_getSocketName(socket, &bindAddress, NULL)) {
+        return;
     }
 
     if (bindAddress == htonl(INADDR_ANY)) {

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -19,6 +19,7 @@
 #include "main/core/support/options.h"
 #include "main/host/cpu.h"
 #include "main/host/descriptor/descriptor.h"
+#include "main/host/descriptor/compat_socket.h"
 #include "main/host/futex_table.h"
 #include "main/host/network_interface.h"
 #include "main/host/tracker.h"
@@ -117,8 +118,8 @@ gboolean host_doesInterfaceExist(Host* host, in_addr_t interfaceIP);
 gboolean host_isInterfaceAvailable(Host* host, ProtocolType type,
                                    in_addr_t interfaceIP, in_port_t port,
                                    in_addr_t peerIP, in_port_t peerPort);
-void host_associateInterface(Host* host, Socket* socket, in_addr_t bindAddress);
-void host_disassociateInterface(Host* host, Socket* socket);
+void host_associateInterface(Host* host, const CompatSocket* socket, in_addr_t bindAddress);
+void host_disassociateInterface(Host* host, const CompatSocket* socket);
 in_port_t host_getRandomFreePort(Host* host, ProtocolType type,
                                  in_addr_t interfaceIP, in_addr_t peerIP,
                                  in_port_t peerPort);

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -117,9 +117,7 @@ gboolean host_doesInterfaceExist(Host* host, in_addr_t interfaceIP);
 gboolean host_isInterfaceAvailable(Host* host, ProtocolType type,
                                    in_addr_t interfaceIP, in_port_t port,
                                    in_addr_t peerIP, in_port_t peerPort);
-void host_associateInterface(Host* host, Socket* socket, in_addr_t bindAddress,
-                             in_port_t bindPort, in_addr_t peerAddress,
-                             in_port_t peerPort);
+void host_associateInterface(Host* host, Socket* socket, in_addr_t bindAddress);
 void host_disassociateInterface(Host* host, Socket* socket);
 in_port_t host_getRandomFreePort(Host* host, ProtocolType type,
                                  in_addr_t interfaceIP, in_addr_t peerIP,

--- a/src/main/host/network_interface.h
+++ b/src/main/host/network_interface.h
@@ -11,6 +11,7 @@
 #include <netinet/in.h>
 
 #include "main/core/support/options.h"
+#include "main/host/descriptor/compat_socket.h"
 #include "main/host/descriptor/socket.h"
 #include "main/host/protocol.h"
 #include "main/routing/address.h"
@@ -28,10 +29,11 @@ guint32 networkinterface_getSpeedDownKiBps(NetworkInterface* interface);
 
 gboolean networkinterface_isAssociated(NetworkInterface* interface, ProtocolType type,
         in_port_t port, in_addr_t peerAddr, in_port_t peerPort);
-void networkinterface_associate(NetworkInterface* interface, Socket* transport);
-void networkinterface_disassociate(NetworkInterface* interface, Socket* transport);
 
-void networkinterface_wantsSend(NetworkInterface* interface, Socket* transport);
+void networkinterface_associate(NetworkInterface* interface, const CompatSocket* socket);
+void networkinterface_disassociate(NetworkInterface* interface, const CompatSocket* socket);
+
+void networkinterface_wantsSend(NetworkInterface* interface, const CompatSocket* socket);
 void networkinterface_sent(NetworkInterface* interface);
 
 void networkinterface_startRefillingTokenBuckets(NetworkInterface* interface);

--- a/src/main/host/network_queuing_disciplines.c
+++ b/src/main/host/network_queuing_disciplines.c
@@ -25,7 +25,7 @@ void rrsocketqueue_destroy(RrSocketQueue* self, void (*fn_processItem)(const Com
 
     if (fn_processItem != NULL) {
         while (!rrsocketqueue_isEmpty(self)) {
-            CompatSocket socket;
+            CompatSocket socket = {0};
             bool found = rrsocketqueue_pop(self, &socket);
 
             utility_assert(found);
@@ -63,6 +63,7 @@ bool rrsocketqueue_pop(RrSocketQueue* self, CompatSocket* socket) {
 void rrsocketqueue_push(RrSocketQueue* self, const CompatSocket* socket) {
     utility_assert(self != NULL);
     utility_assert(self->queue != NULL);
+    utility_assert(socket->type != CST_NONE);
     g_queue_push_tail(self->queue, (void*)compatsocket_toTagged(socket));
 }
 
@@ -109,7 +110,7 @@ void fifosocketqueue_destroy(FifoSocketQueue* self, void (*fn_processItem)(const
 
     if (fn_processItem != NULL) {
         while (!fifosocketqueue_isEmpty(self)) {
-            CompatSocket socket;
+            CompatSocket socket = {0};
             bool found = fifosocketqueue_pop(self, &socket);
 
             utility_assert(found);
@@ -147,6 +148,7 @@ bool fifosocketqueue_pop(FifoSocketQueue* self, CompatSocket* socket) {
 void fifosocketqueue_push(FifoSocketQueue* self, const CompatSocket* socket) {
     utility_assert(self != NULL);
     utility_assert(self->queue != NULL);
+    utility_assert(socket->type != CST_NONE);
     priorityqueue_push(self->queue, (void*)compatsocket_toTagged(socket));
 }
 

--- a/src/main/host/network_queuing_disciplines.c
+++ b/src/main/host/network_queuing_disciplines.c
@@ -1,0 +1,157 @@
+/*
+ * The Shadow Simulator
+ * See LICENSE for licensing information
+ */
+
+#include "main/host/network_queuing_disciplines.h"
+
+#include <glib.h>
+#include <stdbool.h>
+
+#include "main/host/descriptor/compat_socket.h"
+#include "main/routing/packet.h"
+#include "main/utility/priority_queue.h"
+#include "main/utility/utility.h"
+
+void rrsocketqueue_init(RrSocketQueue* self) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue == NULL);
+    self->queue = g_queue_new();
+}
+
+void rrsocketqueue_destroy(RrSocketQueue* self, void (*fn_processItem)(const CompatSocket*)) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue != NULL);
+
+    if (fn_processItem != NULL) {
+        while (!rrsocketqueue_isEmpty(self)) {
+            CompatSocket socket;
+            bool found = rrsocketqueue_pop(self, &socket);
+
+            utility_assert(found);
+            if (!found) {
+                continue;
+            }
+
+            fn_processItem(&socket);
+        }
+    }
+
+    g_queue_free(self->queue);
+    self->queue = NULL;
+}
+
+bool rrsocketqueue_isEmpty(RrSocketQueue* self) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue != NULL);
+    return g_queue_is_empty(self->queue);
+}
+
+bool rrsocketqueue_pop(RrSocketQueue* self, CompatSocket* socket) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue != NULL);
+
+    uintptr_t taggedSocket = (uintptr_t)g_queue_pop_head(self->queue);
+    if (taggedSocket == 0) {
+        return false;
+    }
+
+    *socket = compatsocket_fromTagged(taggedSocket);
+    return true;
+}
+
+void rrsocketqueue_push(RrSocketQueue* self, const CompatSocket* socket) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue != NULL);
+    g_queue_push_tail(self->queue, (void*)compatsocket_toTagged(socket));
+}
+
+bool rrsocketqueue_find(RrSocketQueue* self, const CompatSocket* socket) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue != NULL);
+    return g_queue_find(self->queue, (void*)compatsocket_toTagged(socket));
+}
+
+static gint _compareSocket(const CompatSocket* sa, const CompatSocket* sb) {
+    const Packet* pa = compatsocket_peekNextOutPacket(sa);
+    const Packet* pb = compatsocket_peekNextOutPacket(sb);
+
+    utility_assert(pa != NULL);
+    utility_assert(pb != NULL);
+
+    if (pa == NULL) {
+        return -1;
+    }
+
+    if (pb == NULL) {
+        return +1;
+    }
+
+    return packet_getPriority(pa) > packet_getPriority(pb) ? +1 : -1;
+}
+
+static gint _compareSocketTagged(uintptr_t sa_tagged, uintptr_t sb_tagged, gpointer userData) {
+    CompatSocket sa = compatsocket_fromTagged(sa_tagged);
+    CompatSocket sb = compatsocket_fromTagged(sb_tagged);
+
+    return _compareSocket(&sa, &sb);
+}
+
+void fifosocketqueue_init(FifoSocketQueue* self) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue == NULL);
+    self->queue = priorityqueue_new((GCompareDataFunc)_compareSocketTagged, NULL, NULL);
+}
+
+void fifosocketqueue_destroy(FifoSocketQueue* self, void (*fn_processItem)(const CompatSocket*)) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue != NULL);
+
+    if (fn_processItem != NULL) {
+        while (!fifosocketqueue_isEmpty(self)) {
+            CompatSocket socket;
+            bool found = fifosocketqueue_pop(self, &socket);
+
+            utility_assert(found);
+            if (!found) {
+                continue;
+            }
+
+            fn_processItem(&socket);
+        }
+    }
+
+    priorityqueue_free(self->queue);
+    self->queue = NULL;
+}
+
+bool fifosocketqueue_isEmpty(FifoSocketQueue* self) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue != NULL);
+    return priorityqueue_isEmpty(self->queue);
+}
+
+bool fifosocketqueue_pop(FifoSocketQueue* self, CompatSocket* socket) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue != NULL);
+
+    uintptr_t taggedSocket = (uintptr_t)priorityqueue_pop(self->queue);
+    if (taggedSocket == 0) {
+        return false;
+    }
+
+    *socket = compatsocket_fromTagged(taggedSocket);
+    return true;
+}
+
+void fifosocketqueue_push(FifoSocketQueue* self, const CompatSocket* socket) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue != NULL);
+    priorityqueue_push(self->queue, (void*)compatsocket_toTagged(socket));
+}
+
+bool fifosocketqueue_find(FifoSocketQueue* self, const CompatSocket* socket) {
+    utility_assert(self != NULL);
+    utility_assert(self->queue != NULL);
+    return priorityqueue_find(self->queue, (void*)compatsocket_toTagged(socket));
+}

--- a/src/main/host/network_queuing_disciplines.h
+++ b/src/main/host/network_queuing_disciplines.h
@@ -1,0 +1,43 @@
+/*
+ * The Shadow Simulator
+ * See LICENSE for licensing information
+ */
+
+#ifndef SRC_MAIN_HOST_NETWORK_QUEUING_DISCIPLINES_H_
+#define SRC_MAIN_HOST_NETWORK_QUEUING_DISCIPLINES_H_
+
+#include <glib.h>
+#include <stdbool.h>
+
+#include "main/host/descriptor/compat_socket.h"
+#include "main/utility/priority_queue.h"
+
+/* A round-robin socket queue. */
+typedef struct _RrSocketQueue RrSocketQueue;
+struct _RrSocketQueue {
+    GQueue* queue;
+};
+
+/* A first-in-first-out socket queue. */
+typedef struct _FifoSocketQueue FifoSocketQueue;
+struct _FifoSocketQueue {
+    PriorityQueue* queue;
+};
+
+void rrsocketqueue_init(RrSocketQueue* self);
+void rrsocketqueue_destroy(RrSocketQueue* self, void (*fn_processItem)(const CompatSocket*));
+
+bool rrsocketqueue_isEmpty(RrSocketQueue* self);
+bool rrsocketqueue_pop(RrSocketQueue* self, CompatSocket* socket);
+void rrsocketqueue_push(RrSocketQueue* self, const CompatSocket* socket);
+bool rrsocketqueue_find(RrSocketQueue* self, const CompatSocket* socket);
+
+void fifosocketqueue_init(FifoSocketQueue* self);
+void fifosocketqueue_destroy(FifoSocketQueue* self, void (*fn_processItem)(const CompatSocket*));
+
+bool fifosocketqueue_isEmpty(FifoSocketQueue* self);
+bool fifosocketqueue_pop(FifoSocketQueue* self, CompatSocket* socket);
+void fifosocketqueue_push(FifoSocketQueue* self, const CompatSocket* socket);
+bool fifosocketqueue_find(FifoSocketQueue* self, const CompatSocket* socket);
+
+#endif /* SRC_MAIN_HOST_NETWORK_QUEUING_DISCIPLINES_H_ */

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -37,6 +37,7 @@
 #include "main/core/worker.h"
 #include "main/host/cpu.h"
 #include "main/host/descriptor/channel.h"
+#include "main/host/descriptor/compat_socket.h"
 #include "main/host/descriptor/descriptor.h"
 #include "main/host/descriptor/descriptor_table.h"
 #include "main/host/descriptor/descriptor_types.h"
@@ -821,7 +822,8 @@ void process_deregisterLegacyDescriptor(Process* proc, LegacyDescriptor* desc) {
     if (desc) {
         LegacyDescriptorType dType = descriptor_getType(desc);
         if (dType == DT_TCPSOCKET || dType == DT_UDPSOCKET) {
-            host_disassociateInterface(proc->host, (Socket*)desc);
+            CompatSocket compat_socket = compatsocket_fromLegacySocket((Socket*)desc);
+            host_disassociateInterface(proc->host, &compat_socket);
         }
         descriptor_setOwnerProcess(desc, NULL);
         descriptortable_remove(proc->descTable, descriptor_getHandle(desc));

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -14,6 +14,7 @@
 
 #include "main/core/worker.h"
 #include "main/host/descriptor/channel.h"
+#include "main/host/descriptor/compat_socket.h"
 #include "main/host/descriptor/descriptor.h"
 #include "main/host/descriptor/socket.h"
 #include "main/host/descriptor/tcp.h"
@@ -277,8 +278,8 @@ static int _syscallhandler_bindHelper(SysCallHandler* sys, Socket* socket_desc,
     socket_setSocketName(socket_desc, addr, port);
 
     /* set associations */
-    host_associateInterface(
-        sys->host, socket_desc, addr, port, peerAddr, peerPort);
+    CompatSocket compat_socket = compatsocket_fromLegacySocket(socket_desc);
+    host_associateInterface(sys->host, &compat_socket, addr);
     return 0;
 }
 
@@ -607,8 +608,8 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
             socket_setSocketName(socket_desc, bindAddr, bindPort);
 
             /* set netiface->socket associations */
-            host_associateInterface(
-                sys->host, socket_desc, bindAddr, bindPort, 0, 0);
+            CompatSocket compat_socket = compatsocket_fromLegacySocket(socket_desc);
+            host_associateInterface(sys->host, &compat_socket, bindAddr);
         }
     } else { // DT_TCPSOCKET
         errcode = tcp_getConnectionError((TCP*)socket_desc);

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -272,7 +272,11 @@ static int _syscallhandler_bindHelper(SysCallHandler* sys, Socket* socket_desc,
         return -EADDRINUSE;
     }
 
-    /* bind port and set associations */
+    /* connect up socket layer */
+    socket_setPeerName(socket_desc, peerAddr, peerPort);
+    socket_setSocketName(socket_desc, addr, port);
+
+    /* set associations */
     host_associateInterface(
         sys->host, socket_desc, addr, port, peerAddr, peerPort);
     return 0;
@@ -598,7 +602,11 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
                     .state = SYSCALL_DONE, .retval.as_i64 = -EADDRNOTAVAIL};
             }
 
-            /* bind port and set netiface->socket associations */
+            /* connect up socket layer */
+            socket_setPeerName(socket_desc, 0, 0);
+            socket_setSocketName(socket_desc, bindAddr, bindPort);
+
+            /* set netiface->socket associations */
             host_associateInterface(
                 sys->host, socket_desc, bindAddr, bindPort, 0, 0);
         }

--- a/src/main/routing/packet.c
+++ b/src/main/routing/packet.c
@@ -310,7 +310,7 @@ guint packet_getPayloadLength(Packet* packet) {
     }
 }
 
-gdouble packet_getPriority(Packet* packet) {
+gdouble packet_getPriority(const Packet* packet) {
     MAGIC_ASSERT(packet);
     return packet->priority;
 }

--- a/src/main/routing/packet.h
+++ b/src/main/routing/packet.h
@@ -78,7 +78,7 @@ void packet_updateTCP(Packet* packet, guint acknowledgement, GList* selectiveACK
         guint window, SimulationTime timestampValue, SimulationTime timestampEcho);
 
 guint packet_getPayloadLength(Packet* packet);
-gdouble packet_getPriority(Packet* packet);
+gdouble packet_getPriority(const Packet* packet);
 guint packet_getHeaderSize(Packet* packet);
 
 in_addr_t packet_getDestinationIP(Packet* packet);

--- a/src/main/utility/tagged_ptr.c
+++ b/src/main/utility/tagged_ptr.c
@@ -5,17 +5,21 @@
  */
 
 #include "main/utility/tagged_ptr.h"
-#include "main/utility/utility.h"
+#include "support/logger/logger.h"
 
-// two low-order bits
-const uintptr_t TAG_MASK = (1 << 2) - 1;
+// three low-order bits
+const uintptr_t TAG_MASK = (1 << 3) - 1;
 
 // store a tag in the unused low-order bits of a pointer
 uintptr_t tagPtr(const void* ptr, uintptr_t tag) {
     uintptr_t ptrInt = (uintptr_t)ptr;
 
-    utility_assert((ptrInt & TAG_MASK) == 0);
-    utility_assert((tag & ~TAG_MASK) == 0);
+    if ((ptrInt & TAG_MASK) != 0) {
+        error("Low-order bits of pointer are in use");
+    }
+    if ((tag & ~TAG_MASK) != 0) {
+        error("Tag has high-order bits set");
+    }
 
     return ptrInt | tag;
 }

--- a/src/main/utility/tagged_ptr.c
+++ b/src/main/utility/tagged_ptr.c
@@ -1,0 +1,30 @@
+/*
+ * The Shadow Simulator
+ * Copyright (c) 2010-2011, Rob Jansen
+ * See LICENSE for licensing information
+ */
+
+#include "main/utility/tagged_ptr.h"
+#include "main/utility/utility.h"
+
+// two low-order bits
+const uintptr_t TAG_MASK = (1 << 2) - 1;
+
+// store a tag in the unused low-order bits of a pointer
+uintptr_t tagPtr(const void* ptr, uintptr_t tag) {
+    uintptr_t ptrInt = (uintptr_t)ptr;
+
+    utility_assert((ptrInt & TAG_MASK) == 0);
+    utility_assert((tag & ~TAG_MASK) == 0);
+
+    return ptrInt | tag;
+}
+
+// remove the tag from a tagged pointer
+void* untagPtr(uintptr_t taggedPtr, uintptr_t* tag) {
+    if (tag != NULL) {
+        *tag = taggedPtr & TAG_MASK;
+    }
+
+    return (void*)(taggedPtr & ~TAG_MASK);
+}

--- a/src/main/utility/tagged_ptr.h
+++ b/src/main/utility/tagged_ptr.h
@@ -1,0 +1,16 @@
+/*
+ * The Shadow Simulator
+ * See LICENSE for licensing information
+ */
+
+#ifndef SRC_MAIN_UTILITY_TAGGED_PTR_H_
+#define SRC_MAIN_UTILITY_TAGGED_PTR_H_
+
+#include <stdint.h>
+
+extern const uintptr_t TAG_MASK;
+
+uintptr_t tagPtr(const void* ptr, uintptr_t tag);
+void* untagPtr(uintptr_t taggedPtr, uintptr_t* tag);
+
+#endif /* SRC_MAIN_UTILITY_TAGGED_PTR_H_ */

--- a/src/support/logger/logger.h
+++ b/src/support/logger/logger.h
@@ -13,12 +13,16 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include "support/logger/log_level.h"
 
 /* convenience macros for logging messages at various levels */
 // clang-format off
-#define error(...)      logger_log(logger_getDefault(), LOGLEVEL_ERROR, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+
+// logger_log() should already exit/abort at error level, but we include it here explicitly
+// so that the compiler knows it will not return
+#define error(...)    { logger_log(logger_getDefault(), LOGLEVEL_ERROR, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__); abort(); }
 #define critical(...)   logger_log(logger_getDefault(), LOGLEVEL_CRITICAL, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 #define warning(...)    logger_log(logger_getDefault(), LOGLEVEL_WARNING, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 #define message(...)    logger_log(logger_getDefault(), LOGLEVEL_MESSAGE, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
@@ -28,6 +32,7 @@
 #else
 #define debug(...)
 #endif
+
 // clang-format on
 
 typedef struct _Logger Logger;

--- a/src/test/phold/CMakeLists.txt
+++ b/src/test/phold/CMakeLists.txt
@@ -36,3 +36,21 @@ add_shadow_tests(
     ARGS --pin-cpus --workers 2
     PROPERTIES RUN_SERIAL TRUE
     CONFIGURATIONS ilibc)
+
+# Run tests with the round-robin queueing discipline (the current default is fifo).
+# Ideally we'd want to test the different queueing displinces on a test that has a lot of
+# congestion and hosts sending data on mulitple sockets at once, but phold is currently the closest
+# test that we have to that configuration.
+add_shadow_tests(
+    BASENAME phold-rr-qdisc
+    METHODS hybrid ptrace
+    LOGLEVEL info
+    ARGS --pin-cpus --interface-qdisc=RR
+    PROPERTIES RUN_SERIAL TRUE)
+add_shadow_tests(
+    BASENAME phold-rr-qdisc
+    METHODS preload
+    LOGLEVEL info
+    ARGS --pin-cpus --interface-qdisc=RR
+    PROPERTIES RUN_SERIAL TRUE
+    CONFIGURATIONS ilibc)

--- a/src/test/phold/phold-rr-qdisc.yaml
+++ b/src/test/phold/phold-rr-qdisc.yaml
@@ -1,0 +1,1 @@
+phold.yaml


### PR DESCRIPTION
This adds a `CompatSocket` struct containing a union of socket pointers and a type. The network interface code now works with these `CompatSocket` objects instead of just `Socket` objects so that we can support more socket types in the future. To prevent us from having to dynamically allocate memory for these`CompatSocket` whenever we store them (which occurs whenever a plugin binds a socket or writes to a socket), we store a tagged pointer instead that replaces the low-order bits of the socket object pointer with a tag containing the type of socket object.