### PR TITLE
Improve rust syscalls/descriptors

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -139,7 +139,11 @@ SysCallReturn rustsyscallhandler_dup(SysCallHandler *sys, const SysCallArgs *arg
 
 SysCallReturn rustsyscallhandler_read(SysCallHandler *sys, const SysCallArgs *args);
 
+SysCallReturn rustsyscallhandler_pread64(SysCallHandler *sys, const SysCallArgs *args);
+
 SysCallReturn rustsyscallhandler_write(SysCallHandler *sys, const SysCallArgs *args);
+
+SysCallReturn rustsyscallhandler_pwrite64(SysCallHandler *sys, const SysCallArgs *args);
 
 SysCallReturn rustsyscallhandler_pipe(SysCallHandler *sys, const SysCallArgs *args);
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -155,6 +155,8 @@ void bytequeue_free(ByteQueue *bq_ptr);
 
 size_t bytequeue_len(ByteQueue *bq);
 
+bool bytequeue_isEmpty(ByteQueue *bq);
+
 void bytequeue_push(ByteQueue *bq, const unsigned char *src, size_t len);
 
 size_t bytequeue_pop(ByteQueue *bq, unsigned char *dst, size_t len);

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -114,7 +114,7 @@ impl From<FileStatus> for c::Status {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum NewStatusListenerFilter {
     Never,
     OffToOn,
@@ -303,6 +303,20 @@ impl PosixFile {
     }
 }
 
+impl std::fmt::Debug for PosixFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pipe(_) => write!(f, "Pipe")?,
+        }
+        write!(
+            f,
+            "(status: {:?}, flags: {:?})",
+            self.status(),
+            self.get_flags()
+        )
+    }
+}
+
 bitflags::bitflags! {
     // Linux only supports a single descriptor flag:
     // https://www.gnu.org/software/libc/manual/html_node/Descriptor-Flags.html
@@ -311,7 +325,7 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Descriptor {
     file: Arc<AtomicRefCell<PosixFile>>,
     flags: DescriptorFlags,

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -343,8 +343,13 @@ bitflags::bitflags! {
 
 #[derive(Clone, Debug)]
 pub struct Descriptor {
+    /// The PosixFile that this descriptor points to.
     file: Arc<AtomicRefCell<PosixFile>>,
+    /// Descriptor flags.
     flags: DescriptorFlags,
+    /// A count of how many open descriptors there are with reference to this file. Since a
+    /// reference to the file can be held by other objects like an epoll file, it should
+    /// be true that `Arc::strong_count(&self.count)` <= `Arc::strong_count(&self.file)`.
     count: Arc<()>,
 }
 

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -350,7 +350,7 @@ pub struct Descriptor {
     /// A count of how many open descriptors there are with reference to this file. Since a
     /// reference to the file can be held by other objects like an epoll file, it should
     /// be true that `Arc::strong_count(&self.count)` <= `Arc::strong_count(&self.file)`.
-    count: Arc<()>,
+    open_count: Arc<()>,
 }
 
 impl Descriptor {
@@ -358,7 +358,7 @@ impl Descriptor {
         Self {
             file,
             flags: DescriptorFlags::empty(),
-            count: Arc::new(()),
+            open_count: Arc::new(()),
         }
     }
 
@@ -374,8 +374,8 @@ impl Descriptor {
         self.flags = flags;
     }
 
-    pub fn get_fd_count(&self) -> usize {
-        Arc::<()>::strong_count(&self.count)
+    pub fn get_open_count(&self) -> usize {
+        Arc::<()>::strong_count(&self.open_count)
     }
 }
 

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -266,15 +266,25 @@ impl PosixFile {
         }
     }
 
-    pub fn read(&mut self, bytes: &mut [u8], event_queue: &mut EventQueue) -> SyscallReturn {
+    pub fn read(
+        &mut self,
+        bytes: &mut [u8],
+        offset: libc::off_t,
+        event_queue: &mut EventQueue,
+    ) -> SyscallReturn {
         match self {
-            Self::Pipe(f) => f.read(bytes, event_queue),
+            Self::Pipe(f) => f.read(bytes, offset, event_queue),
         }
     }
 
-    pub fn write(&mut self, bytes: &[u8], event_queue: &mut EventQueue) -> SyscallReturn {
+    pub fn write(
+        &mut self,
+        bytes: &[u8],
+        offset: libc::off_t,
+        event_queue: &mut EventQueue,
+    ) -> SyscallReturn {
         match self {
-            Self::Pipe(f) => f.write(bytes, event_queue),
+            Self::Pipe(f) => f.write(bytes, offset, event_queue),
         }
     }
 

--- a/src/main/host/descriptor/pipe.rs
+++ b/src/main/host/descriptor/pipe.rs
@@ -73,7 +73,7 @@ impl PipeFile {
         let num_written = self.buffer.borrow_mut().write(bytes, event_queue);
 
         // the write would block if we could not write any bytes, but were asked to
-        if num_written == 0 && bytes.len() > 0 {
+        if num_written == 0 && !bytes.is_empty() {
             SyscallReturn::Error(nix::errno::EWOULDBLOCK)
         } else {
             SyscallReturn::Success(num_written as i32)

--- a/src/main/host/descriptor/pipe.rs
+++ b/src/main/host/descriptor/pipe.rs
@@ -43,6 +43,16 @@ impl PipeFile {
         self.flags = flags;
     }
 
+    pub fn close(&mut self, event_queue: &mut EventQueue) -> SyscallReturn {
+        // set the closed flag and remove the active flag
+        self.copy_status(
+            FileStatus::CLOSED | FileStatus::ACTIVE,
+            FileStatus::CLOSED,
+            event_queue,
+        );
+        SyscallReturn::Success(0)
+    }
+
     pub fn read(&mut self, bytes: &mut [u8], event_queue: &mut EventQueue) -> SyscallReturn {
         // if the file is not open for reading, return EBADF
         if !self.mode.contains(FileMode::READ) {
@@ -72,7 +82,7 @@ impl PipeFile {
 
     pub fn enable_notifications(arc: &Arc<AtomicRefCell<PosixFile>>) {
         // we remove some of these later in this function
-        let monitoring = FileStatus::CLOSED | FileStatus::READABLE | FileStatus::WRITABLE;
+        let monitoring = FileStatus::READABLE | FileStatus::WRITABLE;
 
         let weak = Arc::downgrade(arc);
         match *arc.borrow_mut() {

--- a/src/main/host/descriptor/pipe.rs
+++ b/src/main/host/descriptor/pipe.rs
@@ -53,7 +53,17 @@ impl PipeFile {
         SyscallReturn::Success(0)
     }
 
-    pub fn read(&mut self, bytes: &mut [u8], event_queue: &mut EventQueue) -> SyscallReturn {
+    pub fn read(
+        &mut self,
+        bytes: &mut [u8],
+        offset: libc::off_t,
+        event_queue: &mut EventQueue,
+    ) -> SyscallReturn {
+        // pipes don't support seeking
+        if offset != 0 {
+            return SyscallReturn::Error(nix::errno::Errno::ESPIPE);
+        }
+
         // if the file is not open for reading, return EBADF
         if !self.mode.contains(FileMode::READ) {
             return SyscallReturn::Error(nix::errno::Errno::EBADF);
@@ -64,7 +74,17 @@ impl PipeFile {
         SyscallReturn::Success(num_read as i32)
     }
 
-    pub fn write(&mut self, bytes: &[u8], event_queue: &mut EventQueue) -> SyscallReturn {
+    pub fn write(
+        &mut self,
+        bytes: &[u8],
+        offset: libc::off_t,
+        event_queue: &mut EventQueue,
+    ) -> SyscallReturn {
+        // pipes don't support seeking
+        if offset != 0 {
+            return SyscallReturn::Error(nix::errno::Errno::ESPIPE);
+        }
+
         // if the file is not open for writing, return EBADF
         if !self.mode.contains(FileMode::WRITE) {
             return SyscallReturn::Error(nix::errno::Errno::EBADF);

--- a/src/main/host/syscall/unistd.rs
+++ b/src/main/host/syscall/unistd.rs
@@ -70,6 +70,8 @@ pub fn dup_helper(
     fd: libc::c_int,
     desc: &Descriptor,
 ) -> c::SysCallReturn {
+    debug!("Duping fd {} ({:?})", fd, desc);
+
     // clone the descriptor and register it
     let new_desc = CompatDescriptor::New(desc.clone());
     let new_fd = unsafe {

--- a/src/main/host/syscall/unistd.rs
+++ b/src/main/host/syscall/unistd.rs
@@ -106,7 +106,7 @@ pub fn read(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCallRet
     let fd = unsafe { args.args[0].as_i64 } as libc::c_int;
     let buf_ptr = unsafe { args.args[1].as_ptr };
     let buf_size = unsafe { args.args[2].as_u64 } as libc::size_t;
-    let offset = 0 as libc::off_t;
+    let offset = 0;
 
     // get the descriptor, or return early if it doesn't exist
     let desc = match syscall::get_descriptor(fd, sys.process) {
@@ -213,7 +213,7 @@ pub fn write(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCallRe
     let fd = unsafe { args.args[0].as_i64 } as libc::c_int;
     let buf_ptr = unsafe { args.args[1].as_ptr };
     let buf_size = unsafe { args.args[2].as_u64 } as libc::size_t;
-    let offset = 0 as libc::off_t;
+    let offset = 0;
 
     // get the descriptor, or return early if it doesn't exist
     let desc = match syscall::get_descriptor(fd, sys.process) {

--- a/src/main/host/syscall/unistd.rs
+++ b/src/main/host/syscall/unistd.rs
@@ -71,18 +71,13 @@ pub fn dup(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCallRetu
         Err(errno) => return SyscallReturn::Error(errno).into(),
     };
 
-    // if it's a legacy descriptor, use the C syscall handler instead
-    let desc = match desc {
-        CompatDescriptor::New(d) => d,
+    match desc {
+        CompatDescriptor::New(desc) => dup_helper(sys, fd, desc),
+        // if it's a legacy descriptor, use the C syscall handler instead
         CompatDescriptor::Legacy(_) => unsafe {
-            return c::syscallhandler_dup(
-                sys as *mut c::SysCallHandler,
-                args as *const c::SysCallArgs,
-            );
+            c::syscallhandler_dup(sys as *mut c::SysCallHandler, args as *const c::SysCallArgs)
         },
-    };
-
-    dup_helper(sys, fd, desc)
+    }
 }
 
 pub fn dup_helper(
@@ -114,18 +109,13 @@ pub fn read(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCallRet
         Err(errno) => return SyscallReturn::Error(errno).into(),
     };
 
-    // if it's a legacy descriptor, use the C syscall handler instead
-    let desc = match desc {
-        CompatDescriptor::New(d) => d,
+    match desc {
+        CompatDescriptor::New(desc) => read_helper(sys, fd, desc, buf_ptr, buf_size, offset),
+        // if it's a legacy descriptor, use the C syscall handler instead
         CompatDescriptor::Legacy(_) => unsafe {
-            return c::syscallhandler_read(
-                sys as *mut c::SysCallHandler,
-                args as *const c::SysCallArgs,
-            );
+            c::syscallhandler_read(sys as *mut c::SysCallHandler, args as *const c::SysCallArgs)
         },
-    };
-
-    read_helper(sys, fd, desc, buf_ptr, buf_size, offset)
+    }
 }
 
 pub fn pread64(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCallReturn {
@@ -140,18 +130,13 @@ pub fn pread64(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCall
         Err(errno) => return SyscallReturn::Error(errno).into(),
     };
 
-    // if it's a legacy descriptor, use the C syscall handler instead
-    let desc = match desc {
-        CompatDescriptor::New(d) => d,
+    match desc {
+        CompatDescriptor::New(desc) => read_helper(sys, fd, desc, buf_ptr, buf_size, offset),
+        // if it's a legacy descriptor, use the C syscall handler instead
         CompatDescriptor::Legacy(_) => unsafe {
-            return c::syscallhandler_pread64(
-                sys as *mut c::SysCallHandler,
-                args as *const c::SysCallArgs,
-            );
+            c::syscallhandler_pread64(sys as *mut c::SysCallHandler, args as *const c::SysCallArgs)
         },
-    };
-
-    read_helper(sys, fd, desc, buf_ptr, buf_size, offset)
+    }
 }
 
 fn read_helper(
@@ -221,18 +206,13 @@ pub fn write(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCallRe
         Err(errno) => return SyscallReturn::Error(errno).into(),
     };
 
-    // if it's a legacy descriptor, use the C syscall handler instead
-    let desc = match desc {
-        CompatDescriptor::New(d) => d,
+    match desc {
+        CompatDescriptor::New(desc) => write_helper(sys, fd, desc, buf_ptr, buf_size, offset),
+        // if it's a legacy descriptor, use the C syscall handler instead
         CompatDescriptor::Legacy(_) => unsafe {
-            return c::syscallhandler_write(
-                sys as *mut c::SysCallHandler,
-                args as *const c::SysCallArgs,
-            );
+            c::syscallhandler_write(sys as *mut c::SysCallHandler, args as *const c::SysCallArgs)
         },
-    };
-
-    write_helper(sys, fd, desc, buf_ptr, buf_size, offset)
+    }
 }
 
 pub fn pwrite64(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCallReturn {
@@ -247,18 +227,13 @@ pub fn pwrite64(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCal
         Err(errno) => return SyscallReturn::Error(errno).into(),
     };
 
-    // if it's a legacy descriptor, use the C syscall handler instead
-    let desc = match desc {
-        CompatDescriptor::New(d) => d,
+    match desc {
+        CompatDescriptor::New(desc) => write_helper(sys, fd, desc, buf_ptr, buf_size, offset),
+        // if it's a legacy descriptor, use the C syscall handler instead
         CompatDescriptor::Legacy(_) => unsafe {
-            return c::syscallhandler_pwrite64(
-                sys as *mut c::SysCallHandler,
-                args as *const c::SysCallArgs,
-            );
+            c::syscallhandler_pwrite64(sys as *mut c::SysCallHandler, args as *const c::SysCallArgs)
         },
-    };
-
-    write_helper(sys, fd, desc, buf_ptr, buf_size, offset)
+    }
 }
 
 fn write_helper(

--- a/src/main/host/syscall/unistd.rs
+++ b/src/main/host/syscall/unistd.rs
@@ -40,7 +40,7 @@ pub fn close(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCallRe
         };
 
         // if this is the last remaining descriptor
-        if desc.get_fd_count() == 1 {
+        if desc.get_open_count() == 1 {
             let posix_file = desc.get_file();
 
             result = Some(EventQueue::queue_and_run(|event_queue| {

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -315,7 +315,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         HANDLE(poll);
         HANDLE(ppoll);
         HANDLE(prctl);
-        HANDLE(pread64);
+        HANDLE_RUST(pread64);
         HANDLE(preadv);
 #ifdef SYS_preadv2
         HANDLE(preadv2);
@@ -326,7 +326,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
 #ifdef SYS_prlimit64
         HANDLE(prlimit64);
 #endif
-        HANDLE(pwrite64);
+        HANDLE_RUST(pwrite64);
         HANDLE(pwritev);
 #ifdef SYS_pwritev2
         HANDLE(pwritev2);

--- a/src/main/utility/byte_queue.rs
+++ b/src/main/utility/byte_queue.rs
@@ -50,6 +50,10 @@ impl ByteQueue {
         self.length
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Push bytes to the head of the queue.
     pub fn push(&mut self, src: &[u8]) {
         // create new buffer head lazily as opposed to proactively
@@ -197,6 +201,13 @@ mod export {
         assert!(!bq.is_null());
         let bq = unsafe { &mut *bq };
         bq.len()
+    }
+
+    #[no_mangle]
+    pub extern "C" fn bytequeue_isEmpty(bq: *mut ByteQueue) -> bool {
+        assert!(!bq.is_null());
+        let bq = unsafe { &mut *bq };
+        bq.is_empty()
     }
 
     #[no_mangle]


### PR DESCRIPTION
Rearranged the Rust syscall helper code, added Rust wrappers for the `pread64` and `pwrite64` syscalls, added the `Debug` trait to some Rust types, and set the `CLOSED` (and remove the `ACTIVE`) flag when the pipe is closed.