### PR TITLE
Set a specific Rust nightly version for coverage tests

### DIFF
--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -56,7 +56,8 @@ esac
 
 if [ "$BUILDTYPE" = coverage ]
 then
-    RUST_TOOLCHAIN=nightly
+    # using an older rust nightly until we update coverage tests to use clang-12
+    RUST_TOOLCHAIN=nightly-2021-03-01
 else
     RUST_TOOLCHAIN=stable
 fi


### PR DESCRIPTION
The latest Rust nightly version breaks our coverage tests as Rust is now using Clang/LLVM 12, but our CI environment has Clang 11 installed. Setting an older Rust nightly version for now.