### PR TITLE
Disabled coverage tests in CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,10 +29,12 @@ jobs:
         cc: ['gcc', 'clang']
         buildtype: ['debug', 'release']
         include:
+          # TODO: re-enable coverage tests once we figure out why they're failing
+          #       (https://github.com/shadow/shadow/issues/1152)
           # Add a single coverage configuration
-          - container: 'ubuntu:20.10'
-            cc: 'clang-11'
-            buildtype: 'coverage'
+          #- container: 'ubuntu:20.10'
+          #  cc: 'clang-11'
+          #  buildtype: 'coverage'
           # Add a single configuration for testing the C syscall handlers
           - container: 'ubuntu:20.04'
             cc: 'clang'


### PR DESCRIPTION
Coverage tests are currently [failing in the CI](https://github.com/shadow/shadow/issues/1152), so this PR disables them until we figure out how to fix them.