### PR TITLE
Re-enable the coverage tests

### DIFF
--- a/.github/workflows/ci_maintenance.yaml
+++ b/.github/workflows/ci_maintenance.yaml
@@ -1,0 +1,32 @@
+name: CI Maintenance
+
+on:
+  schedule:
+    # once every 4 months (Feb, June, Oct)
+    - cron: '0 0 1 2,6,10 *'
+  # run manually from the GitHub Actions webpage
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: 'Update versions of tools used in CI',
+            labels: ['Component: Testing', 'Priority: Low', 'Type: Maintenance'],
+            body:
+          `The Shadow CI environment has hard-coded versions of some tools. These versions should be periodically updated, and any compatibility issues fixed.
+
+          - rust nightly version for coverage builds (\`ci/container_scripts/install_extra_deps.sh\` — \`RUST_TOOLCHAIN\`)
+          - bindgen and cbindgen versions for the bindings lint (\`.github/workflows/lint.yml\`)
+          - python version for the python lint (\`.github/workflows/lint.yml\`)
+
+          *This issue is automatically generated every 4 months by the workflow "${{ github.workflow }}".*
+          `
+          })

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,12 +29,10 @@ jobs:
         cc: ['gcc', 'clang']
         buildtype: ['debug', 'release']
         include:
-          # TODO: re-enable coverage tests once we figure out why they're failing
-          #       (https://github.com/shadow/shadow/issues/1152)
           # Add a single coverage configuration
-          #- container: 'ubuntu:20.10'
-          #  cc: 'clang-11'
-          #  buildtype: 'coverage'
+          - container: 'ubuntu:20.10'
+            cc: 'clang-11'
+            buildtype: 'coverage'
           # Add a single configuration for testing the C syscall handlers
           - container: 'ubuntu:20.04'
             cc: 'clang'

--- a/ci/container_scripts/build_and_install.sh
+++ b/ci/container_scripts/build_and_install.sh
@@ -21,19 +21,15 @@ esac
 case "$BUILDTYPE" in
     "release")
         OPTIONS=""
-        rustup default stable
         ;;
     "debug")
         OPTIONS="--debug"
-        rustup default stable
         ;;
     "use-c-syscalls")
         OPTIONS="--debug --use-c-syscalls"
-        rustup default stable
         ;;
     "coverage")
         OPTIONS="--debug --coverage"
-        rustup default nightly
         ;;
     *)
         echo "Unknown BUILDTYPE $BUILDTYPE"

--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -56,7 +56,7 @@ esac
 
 if [ "$BUILDTYPE" = coverage ]
 then
-    RUST_TOOLCHAIN=nightly
+    RUST_TOOLCHAIN=nightly-2021-03-01
 else
     RUST_TOOLCHAIN=stable
 fi
@@ -67,6 +67,8 @@ then
 fi
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain "$RUST_TOOLCHAIN" ${RUSTPROFILE:+"$RUSTPROFILE"}
-PATH=$HOME/.cargo/bin:$PATH
+PATH="$HOME/.cargo/bin:$PATH"
+rustup default "${RUST_TOOLCHAIN}"
+
 # Force cargo to download its package index
 cargo search foo


### PR DESCRIPTION
This PR sets a hard-coded Rust nightly version for building the coverage data, re-enables the coverage tests, and adds a CI workflow to create a new issue every 4 months reminding us to update the versions of tools that we use in the CI (currently Rust nightly, bindgen, and cbindgen).