### PR TITLE
Do not use subroutine execution timers by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ option(SHADOW_EXPORT "export service libraries and headers (default: OFF)" OFF)
 option(SHADOW_WERROR "turn compiler warnings into errors. (default: OFF)" OFF)
 option(SHADOW_COVERAGE "enable code-coverage instrumentation. (default: OFF)" OFF)
 option(SHADOW_USE_C_SYSCALLS "use only the C syscall handlers. (default: OFF)" OFF)
+option(SHADOW_USE_PERF_TIMERS "compile in timers for tracking the run time of various internal operations. (default: OFF)" OFF)
 
 ## display selected user options
 MESSAGE(STATUS)
@@ -128,6 +129,7 @@ MESSAGE(STATUS "SHADOW_EXPORT=${SHADOW_EXPORT}")
 MESSAGE(STATUS "SHADOW_WERROR=${SHADOW_WERROR}")
 MESSAGE(STATUS "SHADOW_COVERAGE=${SHADOW_COVERAGE}")
 MESSAGE(STATUS "SHADOW_USE_C_SYSCALLS=${SHADOW_USE_C_SYSCALLS}")
+MESSAGE(STATUS "SHADOW_USE_PERF_TIMERS=${SHADOW_USE_PERF_TIMERS}")
 MESSAGE(STATUS "-------------------------------------------------------------------------------")
 MESSAGE(STATUS)
 
@@ -170,7 +172,13 @@ else()
 endif(SHADOW_COVERAGE STREQUAL ON)
 
 if(SHADOW_USE_C_SYSCALLS STREQUAL ON)
+    message(STATUS "C syscalls enabled")
     add_definitions(-DUSE_C_SYSCALLS)
+endif()
+
+if(SHADOW_USE_PERF_TIMERS STREQUAL ON)
+    message(STATUS "Perf timers enabled")
+    add_definitions(-DUSE_PERF_TIMERS)
 endif()
 
 if($ENV{VERBOSE})

--- a/setup
+++ b/setup
@@ -72,6 +72,11 @@ def main():
         action="store_true", dest="do_use_c_syscalls",
         default=False)
 
+    parser_build.add_argument('--use-perf-timers',
+        help="compile in timers for tracking the run time of various internal operations",
+        action="store_true", dest="do_use_perf_timers",
+        default=False)
+
     parser_build.add_argument('-v', '--verbose',
         help="print verbose output from the compiler",
         action="store_true", dest="do_verbose",
@@ -201,6 +206,7 @@ def build(args, remaining):
     if args.do_valgrind: cmake_cmd += " -DLOADER_VALGRIND=ON"
     if args.do_werror: cmake_cmd += " -DSHADOW_WERROR=ON"
     if args.do_use_c_syscalls: cmake_cmd += " -DSHADOW_USE_C_SYSCALLS=ON"
+    if args.do_use_perf_timers: cmake_cmd += " -DSHADOW_USE_PERF_TIMERS=ON"
 
     if args.do_coverage:
         if not args.do_debug:

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -65,9 +65,14 @@ void host_unref(Host* host);
 void host_lock(Host* host);
 void host_unlock(Host* host);
 
+#ifdef USE_PERF_TIMERS
 void host_continueExecutionTimer(Host* host);
 void host_stopExecutionTimer(Host* host);
-gdouble host_getElapsedExecutionTime(Host* host);
+#else
+// define macros that do nothing
+#define host_continueExecutionTimer(host)
+#define host_stopExecutionTimer(host)
+#endif
 
 void host_setup(Host* host, DNS* dns, Topology* topology, guint rawCPUFreq, const gchar* hostRootPath);
 void host_boot(Host* host);

--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -45,6 +45,10 @@ struct _SysCallHandler {
      * to negative to indicate that no syscalls are currently blocked. */
     long blockedSyscallNR;
 
+    // TODO: if we build bindings on the fly, uncomment the ifdef and endif so that this timer
+    // object is not included in the struct unless necessary.
+    // https://github.com/shadow/shadow/issues/1158
+    //#ifdef USE_PERF_TIMERS
     /* Used to track the time elapsed while handling a syscall. */
     GTimer* perfTimer;
     /* The cumulative time consumed while handling the current syscall.
@@ -52,6 +56,7 @@ struct _SysCallHandler {
     gdouble perfSecondsCurrent;
     /* The total time elapsed while handling all syscalls. */
     gdouble perfSecondsTotal;
+    //#endif
     /* The total number of syscalls that we have handled. */
     long numSyscalls;
 


### PR DESCRIPTION
Shadow includes internal performance timers to help us track execution
time of various subroutines. The timer-related functions have shown
up on performance profiles as causing significant overhead. These timers
are now disabled by default.

We add a new --use-perf-timers option to the setup script, and a new
USE_PERF_TIMERS option to cmake that allows us to toggle the performance
timers back on if desired.

Closes #1141