### PR TITLE
Use number of system CPU cores for number of test jobs

### DIFF
--- a/setup
+++ b/setup
@@ -126,7 +126,8 @@ def main():
         help="number of tests to run simultaneously during testing",
         metavar="N", type=int,
         action="store", dest="njobs",
-        default=4)#multiprocessing.cpu_count())
+        # use a minimum of 4 jobs by default
+        default=max(4, multiprocessing.cpu_count()))
 
     parser_test.add_argument('-r', '--rerun-failed',
         help="Run only the tests that failed previously",


### PR DESCRIPTION
Still use a minimum of 4 jobs, but use more if we have more CPU cores.

This could potentially make race conditions in the tests more common since some non-Shadow tests still bind to the same ports, but those are bugs in the tests that we can fix.