### PR TITLE
Use a unique file name in poll tests

### DIFF
--- a/src/test/file/CMakeLists.txt
+++ b/src/test/file/CMakeLists.txt
@@ -2,6 +2,9 @@ include_directories(${GLIB_INCLUDES})
 link_libraries(${GLIB_LIBRARIES})
 add_executable(test-file test_file.c)
 add_linux_tests(BASENAME file COMMAND test-file)
-add_shadow_tests(BASENAME file METHODS hybrid ptrace)
+
+# run using different rng seeds since we use mkstemp()
+add_shadow_tests(BASENAME file METHODS hybrid ARGS "--seed 0")
+add_shadow_tests(BASENAME file METHODS ptrace ARGS "--seed 1")
 # FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
-add_shadow_tests(BASENAME file METHODS preload CONFIGURATIONS ilibc)
+add_shadow_tests(BASENAME file METHODS preload CONFIGURATIONS ilibc ARGS "--seed 2")

--- a/src/test/memory/CMakeLists.txt
+++ b/src/test/memory/CMakeLists.txt
@@ -1,4 +1,7 @@
 add_linux_tests(BASENAME mmap COMMAND sh -c "../target/debug/test_mmap --libc-passing")
-add_shadow_tests(BASENAME mmap METHODS hybrid ptrace)
+
+# run using different rng seeds since we use mkstemp()
+add_shadow_tests(BASENAME mmap METHODS hybrid ARGS "--seed 0")
+add_shadow_tests(BASENAME mmap METHODS ptrace ARGS "--seed 1")
 # FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
-add_shadow_tests(BASENAME mmap METHODS preload CONFIGURATIONS ilibc)
+add_shadow_tests(BASENAME mmap METHODS preload CONFIGURATIONS ilibc ARGS "--seed 2")

--- a/src/test/poll/CMakeLists.txt
+++ b/src/test/poll/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_linux_tests(BASENAME poll COMMAND sh -c "../target/debug/test_poll --libc-passing")
-add_shadow_tests(BASENAME poll METHODS hybrid ptrace preload)
+
+# run using different rng seeds since we use mkstemp()
+add_shadow_tests(BASENAME poll METHODS hybrid ARGS "--seed 0")
+add_shadow_tests(BASENAME poll METHODS ptrace ARGS "--seed 1")
+# FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
+add_shadow_tests(BASENAME poll METHODS preload CONFIGURATIONS ilibc ARGS "--seed 2")

--- a/src/test/poll/poll.yaml
+++ b/src/test/poll/poll.yaml
@@ -1,5 +1,9 @@
+# The LD_LIBRARY_PATH here points to where we put the patched libc binaries in
+# our CI, to work around https://github.com/shadow/shadow/issues/892.  It should
+# have no effect in environments where that directory doesn't exist.
 options:
   stoptime: 5
+  environment: LD_LIBRARY_PATH=/opt/libc-interpose-centos7
 topology:
 - graphml: |
     <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">


### PR DESCRIPTION
Hopefully this fixes the test errors we've had in the CI.

This PR also sets different seeds for the 'file' and 'memory' tests since they use `mkstemp`.