### PR TITLE
Disable the codecov status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,6 @@
 codecov:
   branch: dev
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
Disabling the codecov status checks, which often show as failing tests whenever the code coverage decreases.

In the future we may want to re-enable these, but with a threshold of 0 so that it still shows as passing and we get the [coverage annotations](https://about.codecov.io/blog/announcing-line-by-line-coverage-via-github-checks/). We may also want to update the Shadow code to use `GCOV_EXCL_LINE` and similar flags to prevent gcov from complaining about unused error conditions.