### PR TITLE
Add option to disable the MemoryManager

### DIFF
--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -482,7 +482,7 @@ SysCallReturn syscallhandler_getdents(SysCallHandler* sys,
 
     /* Get the path string from the plugin. */
     struct linux_dirent* dirp =
-        process_getWriteablePtr(sys->process, sys->thread, dirpPtr, sizeof(*dirp));
+        process_getWriteablePtr(sys->process, sys->thread, dirpPtr, count);
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
@@ -512,7 +512,7 @@ SysCallReturn syscallhandler_getdents64(SysCallHandler* sys,
 
     /* Get the path string from the plugin. */
     struct linux_dirent64* dirp =
-        process_getWriteablePtr(sys->process, sys->thread, dirpPtr, sizeof(*dirp));
+        process_getWriteablePtr(sys->process, sys->thread, dirpPtr, count);
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }

--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -481,8 +481,7 @@ SysCallReturn syscallhandler_getdents(SysCallHandler* sys,
     }
 
     /* Get the path string from the plugin. */
-    struct linux_dirent* dirp =
-        process_getWriteablePtr(sys->process, sys->thread, dirpPtr, count);
+    struct linux_dirent* dirp = process_getWriteablePtr(sys->process, sys->thread, dirpPtr, count);
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }

--- a/src/main/host/syscall/mman.c
+++ b/src/main/host/syscall/mman.c
@@ -236,9 +236,9 @@ SysCallReturn syscallhandler_brk(SysCallHandler* sys, const SysCallArgs* args) {
 
     // Delegate to the memoryManager.
     MemoryManager* mm = process_getMemoryManager(sys->process);
-    utility_assert(mm);
-    SysCallReg result = memorymanager_handleBrk(mm, sys->thread, newBrk);
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval = result};
+    return mm ? (SysCallReturn){.state = SYSCALL_DONE,
+                                .retval = memorymanager_handleBrk(mm, sys->thread, newBrk)}
+              : (SysCallReturn){.state = SYSCALL_NATIVE};
 }
 
 SysCallReturn syscallhandler_mmap(SysCallHandler* sys, const SysCallArgs* args) {
@@ -273,10 +273,10 @@ SysCallReturn syscallhandler_mremap(SysCallHandler* sys, const SysCallArgs* args
 
     // Delegate to the memoryManager.
     MemoryManager* mm = process_getMemoryManager(sys->process);
-    utility_assert(mm);
-    SysCallReg result =
-        memorymanager_handleMremap(mm, sys->thread, old_addr, old_size, new_size, flags, new_addr);
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval = result};
+    return mm ? (SysCallReturn){.state = SYSCALL_DONE,
+                                .retval = memorymanager_handleMremap(
+                                    mm, sys->thread, old_addr, old_size, new_size, flags, new_addr)}
+              : (SysCallReturn){.state = SYSCALL_NATIVE};
 }
 
 SysCallReturn syscallhandler_munmap(SysCallHandler* sys, const SysCallArgs* args) {
@@ -285,9 +285,9 @@ SysCallReturn syscallhandler_munmap(SysCallHandler* sys, const SysCallArgs* args
 
     // Delegate to the memoryManager.
     MemoryManager* mm = process_getMemoryManager(sys->process);
-    utility_assert(mm);
-    SysCallReg result = memorymanager_handleMunmap(mm, sys->thread, addr, len);
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval = result};
+    return mm ? (SysCallReturn){.state = SYSCALL_DONE,
+                                .retval = memorymanager_handleMunmap(mm, sys->thread, addr, len)}
+              : (SysCallReturn){.state = SYSCALL_NATIVE};
 }
 
 SysCallReturn syscallhandler_mprotect(SysCallHandler* sys, const SysCallArgs* args) {
@@ -297,7 +297,8 @@ SysCallReturn syscallhandler_mprotect(SysCallHandler* sys, const SysCallArgs* ar
 
     // Delegate to the memoryManager.
     MemoryManager* mm = process_getMemoryManager(sys->process);
-    utility_assert(mm);
-    SysCallReg result = memorymanager_handleMprotect(mm, sys->thread, addr, len, prot);
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval = result};
+    return mm ? (SysCallReturn){.state = SYSCALL_DONE,
+                                .retval =
+                                    memorymanager_handleMprotect(mm, sys->thread, addr, len, prot)}
+              : (SysCallReturn){.state = SYSCALL_NATIVE};
 }

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -50,6 +50,13 @@
 #define SYS_copy_file_range 326
 #endif
 
+static bool _useMM = true;
+OPTION_EXPERIMENTAL_ENTRY("disable-memory-manager", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE,
+                          &_useMM,
+                          "Disable the MemoryManager. This can be useful for debugging, but will "
+                          "hurt performance in most cases.",
+                          NULL)
+
 SysCallHandler* syscallhandler_new(Host* host, Process* process,
                                    Thread* thread) {
     utility_assert(host);
@@ -218,7 +225,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
     // syscall after an `exec` (which destroys the MemoryManager). It's done
     // here because the MemoryManager needs a plugin thread that's ready to
     // make syscalls in order to perform its initialization.
-    if (!process_getMemoryManager(sys->process)) {
+    if (_useMM && !process_getMemoryManager(sys->process)) {
         process_setMemoryManager(sys->process, memorymanager_new(sys->thread));
     }
     SysCallReturn scr;


### PR DESCRIPTION
Add option to disable the MemoryManager, and fix some bugs in the fallback memory-access paths.

* Fix buffer size requested in getdents and getdents64
* Add missing memory-flush after writing the `clear_child_tid` pointer