### PR TITLE
Small ioctl and sendto bug fixes, and implement FIONBIO for Nginx

### DIFF
--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -237,3 +237,8 @@ void descriptor_addFlags(LegacyDescriptor* descriptor, gint flags) {
     MAGIC_ASSERT(descriptor);
     descriptor->flags |= flags;
 }
+
+void descriptor_removeFlags(LegacyDescriptor* descriptor, gint flags) {
+    MAGIC_ASSERT(descriptor);
+    descriptor->flags &= ~flags;
+}

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -36,6 +36,7 @@ gint* descriptor_getHandleReference(LegacyDescriptor* descriptor);
 gint descriptor_getFlags(LegacyDescriptor* descriptor);
 void descriptor_setFlags(LegacyDescriptor* descriptor, gint flags);
 void descriptor_addFlags(LegacyDescriptor* descriptor, gint flags);
+void descriptor_removeFlags(LegacyDescriptor* descriptor, gint flags);
 
 /*
  * One of the main functions of the descriptor is to track its poll status,

--- a/src/main/host/syscall/ioctl.c
+++ b/src/main/host/syscall/ioctl.c
@@ -44,23 +44,36 @@ static int _syscallhandler_ioctlFileHelper(SysCallHandler* sys, File* file, int 
 static int _syscallhandler_ioctlTCPHelper(SysCallHandler* sys, TCP* tcp, int fd,
                                           unsigned long request, PluginPtr argPtr) {
     int result = -EINVAL;
-    size_t buflen = 0;
 
     switch (request) {
         case SIOCINQ: { // equivalent to FIONREAD
-            buflen = tcp_getInputBufferLength(tcp);
+            int* lenout = process_getWriteablePtr(sys->process, sys->thread, argPtr, sizeof(int));
+            *lenout = (int)tcp_getInputBufferLength(tcp);
             result = 0;
             break;
         }
 
         case SIOCOUTQ: { // equivalent to TIOCOUTQ
-            buflen = tcp_getOutputBufferLength(tcp);
+            int* lenout = process_getWriteablePtr(sys->process, sys->thread, argPtr, sizeof(int));
+            *lenout = (int)tcp_getOutputBufferLength(tcp);
             result = 0;
             break;
         }
 
         case SIOCOUTQNSD: {
-            buflen = tcp_getNotSentBytes(tcp);
+            int* lenout = process_getWriteablePtr(sys->process, sys->thread, argPtr, sizeof(int));
+            *lenout = (int)tcp_getNotSentBytes(tcp);
+            result = 0;
+            break;
+        }
+
+        case FIONBIO: {
+            const int* val = process_getReadablePtr(sys->process, sys->thread, argPtr, sizeof(int));
+            if (*val == 0) {
+                descriptor_removeFlags((LegacyDescriptor*)tcp, O_NONBLOCK);
+            } else {
+                descriptor_addFlags((LegacyDescriptor*)tcp, O_NONBLOCK);
+            }
             result = 0;
             break;
         }
@@ -72,28 +85,35 @@ static int _syscallhandler_ioctlTCPHelper(SysCallHandler* sys, TCP* tcp, int fd,
         }
     }
 
-    if (result == 0) {
-        int* lenout = process_getWriteablePtr(sys->process, sys->thread, argPtr, sizeof(int));
-        *lenout = (int)buflen;
-    }
-
     return result;
 }
 
 static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
                                           unsigned long request, PluginPtr argPtr) {
     int result = -EINVAL;
-    size_t buflen = 0;
 
     switch (request) {
         case SIOCINQ: { // equivalent to FIONREAD
-            buflen = socket_getInputBufferLength((Socket*)udp);
+            int* lenout = process_getWriteablePtr(sys->process, sys->thread, argPtr, sizeof(int));
+            *lenout = (int)socket_getInputBufferLength((Socket*)udp);
             result = 0;
             break;
         }
 
         case SIOCOUTQ: { // equivalent to TIOCOUTQ
-            buflen = socket_getOutputBufferLength((Socket*)udp);
+            int* lenout = process_getWriteablePtr(sys->process, sys->thread, argPtr, sizeof(int));
+            *lenout = socket_getOutputBufferLength((Socket*)udp);
+            result = 0;
+            break;
+        }
+
+        case FIONBIO: {
+            const int* val = process_getReadablePtr(sys->process, sys->thread, argPtr, sizeof(int));
+            if (*val == 0) {
+                descriptor_removeFlags((LegacyDescriptor*)udp, O_NONBLOCK);
+            } else {
+                descriptor_addFlags((LegacyDescriptor*)udp, O_NONBLOCK);
+            }
             result = 0;
             break;
         }
@@ -103,11 +123,6 @@ static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
             warning("We do not yet handle ioctl request %lu on udp socket %i", request, fd);
             break;
         }
-    }
-
-    if (result == 0) {
-        int* lenout = process_getWriteablePtr(sys->process, sys->thread, argPtr, sizeof(int));
-        *lenout = (int)buflen;
     }
 
     return result;
@@ -141,7 +156,8 @@ SysCallReturn syscallhandler_ioctl(SysCallHandler* sys,
     } else if (dtype == DT_UDPSOCKET) {
         result = _syscallhandler_ioctlUDPHelper(sys, (UDP*)desc, fd, request, argPtr);
     } else {
-        warning("We do not support ioctl request %lu on descriptor %i", request, fd);
+        warning(
+            "We do not support ioctl request %lu on descriptor %i of type %i", request, fd, dtype);
         result = -ENOTTY;
     }
 

--- a/src/main/host/syscall/ioctl.c
+++ b/src/main/host/syscall/ioctl.c
@@ -93,7 +93,7 @@ static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
         }
 
         case SIOCOUTQ: { // equivalent to TIOCOUTQ
-            buflen = socket_getInputBufferLength((Socket*)udp);
+            buflen = socket_getOutputBufferLength((Socket*)udp);
             result = 0;
             break;
         }

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -611,7 +611,7 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
             CompatSocket compat_socket = compatsocket_fromLegacySocket(socket_desc);
             host_associateInterface(sys->host, &compat_socket, bindAddr);
         }
-    } else { // DT_TCPSOCKET
+    } else if (descriptor_getType(desc) == DT_TCPSOCKET) {
         errcode = tcp_getConnectionError((TCP*)socket_desc);
 
         debug("connection error state is currently %i", errcode);


### PR DESCRIPTION
Fixes two socket bugs and implements `FIONBIO` for `ioctl()` to set a socket as non-blocking, which is required for Nginx.

Closes shadow/shadow#344.

Nginx can be used with the following (still missing some syscalls and socket options, but it works):

```
$ shadow --disable-memory-manager shadow-nginx.yaml
```

nginx.conf:
```
error_log stderr;

# shadow wants to run nginx in the foreground
daemon off;

# shadow doesn't support fork()
master_process off;
worker_processes 0;

# don't use the system pid file
pid nginx.pid;

events {
  # we're not using any workers, so this is the maximum number
  # of simultaneous connections we can support
  worker_connections 1024;
}

http {
  include             /etc/nginx/mime.types;
  default_type        application/octet-stream;

  # shadow does not support sendfile() nor TCP_NODELAY
  sendfile off;
  tcp_nodelay off;

  access_log off;

  server {
    listen 80;

    location / {
      root /var/www/html;
      index index.nginx-debian.html;
    }
  }
}
```

shadow-nginx.yaml:
```
options:
  stoptime: 10
topology:
- graphml: |
    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
      <key attr.name="packetloss" attr.type="double" for="edge" id="d4" />
      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
      <key attr.name="bandwidthup" attr.type="int" for="node" id="d2" />
      <key attr.name="bandwidthdown" attr.type="int" for="node" id="d1" />
      <key attr.name="countrycode" attr.type="string" for="node" id="d0" />
      <graph edgedefault="undirected">
        <node id="poi-1">
          <data key="d0">US</data>
          <data key="d1">10240</data>
          <data key="d2">10240</data>
        </node>
        <edge source="poi-1" target="poi-1">
          <data key="d3">50.0</data>
          <data key="d4">0.0</data>
        </edge>
      </graph>
    </graphml>
plugins:
- id: nginx
  path: /usr/sbin/nginx
- id: curl
  path: /usr/bin/curl
hosts:
- id: server
  quantity: 1
  processes:
  - plugin: nginx
    starttime: 1
    arguments: -c /path/to/working-dir/nginx.conf -p /path/to/working-dir/shadow.data/hosts/server
- id: client
  quantity: 20
  processes:
  - plugin: curl
    starttime: 3
    arguments: server --verbose
```