### PR TITLE
Improvements to the CompatDescriptor

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -400,7 +400,10 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn process_deregisterCompatDescriptor(proc_: *mut Process, handle: ::std::os::raw::c_int);
+    pub fn process_deregisterCompatDescriptor(
+        proc_: *mut Process,
+        handle: ::std::os::raw::c_int,
+    ) -> *mut CompatDescriptor;
 }
 extern "C" {
     pub fn process_getRegisteredCompatDescriptor(

--- a/src/main/host/descriptor/descriptor_table.c
+++ b/src/main/host/descriptor/descriptor_table.c
@@ -125,7 +125,7 @@ static void _descriptortable_trimIndicesTail(DescriptorTable* table) {
     }
 }
 
-bool descriptortable_remove(DescriptorTable* table, int index) {
+CompatDescriptor* descriptortable_remove(DescriptorTable* table, int index) {
     MAGIC_ASSERT(table);
 
     if (g_hash_table_contains(table->descriptors, GINT_TO_POINTER(index))) {
@@ -134,13 +134,14 @@ bool descriptortable_remove(DescriptorTable* table, int index) {
         /* Make sure we do not operate on the descriptor after we remove it,
          * because that could cause it to be freed and invalidate it. */
         compatdescriptor_setHandle(descriptor, 0);
-        g_hash_table_remove(table->descriptors, GINT_TO_POINTER(index));
+        g_hash_table_steal(table->descriptors, GINT_TO_POINTER(index));
+
         g_queue_insert_sorted(table->availableIndices, GINT_TO_POINTER(index),
                               _descriptortable_compareInts, NULL);
         _descriptortable_trimIndicesTail(table);
-        return true;
+        return descriptor;
     } else {
-        return false;
+        return NULL;
     }
 }
 

--- a/src/main/host/descriptor/descriptor_table.h
+++ b/src/main/host/descriptor/descriptor_table.h
@@ -37,12 +37,11 @@ int descriptortable_add(DescriptorTable* table, CompatDescriptor* descriptor);
 /* Stop storing the descriptor so that it can no longer be referenced. The table
  * index that was used to store the descriptor is cleared from the descriptor
  * and may be assigned to new descriptors that are later added to the table.
- * Returns true if the descriptor was found in the table and removed, and false
- * otherwise.
+ * Returns an owned pointer to the CompatDescriptor if the descriptor was found
+ * in the table and removed, and NULL otherwise.
  *
- * NOTE: this will unref the descriptor which may cause it to be freed. If you
- * still need access to it, you should ref it before calling this function. */
-bool descriptortable_remove(DescriptorTable* table, int index);
+ * NOTE: this will not unref the descriptor and you should do so manually. */
+CompatDescriptor* descriptortable_remove(DescriptorTable* table, int index);
 
 /* Returns the descriptor at the given table index, or NULL if we are not
  * storing a descriptor at the given index. */

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -795,9 +795,9 @@ int process_registerCompatDescriptor(Process* proc, CompatDescriptor* compatDesc
     return descriptortable_add(proc->descTable, compatDesc);
 }
 
-void process_deregisterCompatDescriptor(Process* proc, int handle) {
+CompatDescriptor* process_deregisterCompatDescriptor(Process* proc, int handle) {
     MAGIC_ASSERT(proc);
-    descriptortable_remove(proc->descTable, handle);
+    return descriptortable_remove(proc->descTable, handle);
 }
 
 CompatDescriptor* process_getRegisteredCompatDescriptor(Process* proc, int handle) {
@@ -826,7 +826,9 @@ void process_deregisterLegacyDescriptor(Process* proc, LegacyDescriptor* desc) {
             host_disassociateInterface(proc->host, &compat_socket);
         }
         descriptor_setOwnerProcess(desc, NULL);
-        descriptortable_remove(proc->descTable, descriptor_getHandle(desc));
+        CompatDescriptor* compatDesc =
+            descriptortable_remove(proc->descTable, descriptor_getHandle(desc));
+        compatdescriptor_free(compatDesc);
     }
 }
 

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -79,12 +79,15 @@ guint process_getProcessID(Process* proc);
  * - If we don't find a matching thread, return 0. */
 pid_t process_findNativeTID(Process* proc, pid_t virtualPID, pid_t virtualTID);
 
-/* Handle all of the descriptors owned by this process. */
+/* Handle all of the descriptors owned by this process. Deregistering a CompatDescriptor returns
+ * an owned reference to that CompatDescriptor, and you must drop it manually when finished. */
 int process_registerCompatDescriptor(Process* proc, CompatDescriptor* compatDesc);
-void process_deregisterCompatDescriptor(Process* proc, int handle);
+CompatDescriptor* process_deregisterCompatDescriptor(Process* proc, int handle);
 CompatDescriptor* process_getRegisteredCompatDescriptor(Process* proc, int handle);
 
-/* Handle only the legacy descriptors owned by this process. */
+/* Handle only the legacy descriptors owned by this process. Unlike the deregister method for the
+ * CompatDescriptor, you do not need to manually unref the LegacyDescriptor as it's done
+ * automatically. */
 int process_registerLegacyDescriptor(Process* proc, LegacyDescriptor* desc);
 void process_deregisterLegacyDescriptor(Process* proc, LegacyDescriptor* desc);
 LegacyDescriptor* process_getRegisteredLegacyDescriptor(Process* proc, int handle);

--- a/src/main/host/syscall/unistd.rs
+++ b/src/main/host/syscall/unistd.rs
@@ -90,7 +90,10 @@ pub fn dup_helper(
     // clone the descriptor and register it
     let new_desc = CompatDescriptor::New(desc.clone());
     let new_fd = unsafe {
-        c::process_registerCompatDescriptor(sys.process, Box::into_raw(Box::new(new_desc)))
+        c::process_registerCompatDescriptor(
+            sys.process,
+            CompatDescriptor::into_raw(Box::new(new_desc)),
+        )
     };
 
     // return the new fd
@@ -354,13 +357,13 @@ fn pipe_helper(sys: &mut c::SysCallHandler, fd_ptr: c::PluginPtr, flags: i32) ->
     fds[0] = unsafe {
         c::process_registerCompatDescriptor(
             sys.process,
-            Box::into_raw(Box::new(CompatDescriptor::New(reader_desc))),
+            CompatDescriptor::into_raw(Box::new(CompatDescriptor::New(reader_desc))),
         )
     };
     fds[1] = unsafe {
         c::process_registerCompatDescriptor(
             sys.process,
-            Box::into_raw(Box::new(CompatDescriptor::New(writer_desc))),
+            CompatDescriptor::into_raw(Box::new(CompatDescriptor::New(writer_desc))),
         )
     };
 

--- a/src/main/host/syscall/unistd.rs
+++ b/src/main/host/syscall/unistd.rs
@@ -18,8 +18,6 @@ pub fn close(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCallRe
 
     debug!("Trying to close fd {}", fd);
 
-    let result;
-
     // scope used to make sure that desc cannot be used after deregistering it
     {
         // get the descriptor, or return early if it doesn't exist
@@ -29,31 +27,26 @@ pub fn close(sys: &mut c::SysCallHandler, args: &c::SysCallArgs) -> c::SysCallRe
         };
 
         // if it's a legacy descriptor, use the C syscall handler instead
-        let desc = match desc {
-            CompatDescriptor::New(d) => d,
-            CompatDescriptor::Legacy(_) => unsafe {
-                return c::syscallhandler_close(
+        if let CompatDescriptor::Legacy(_) = desc {
+            return unsafe {
+                c::syscallhandler_close(
                     sys as *mut c::SysCallHandler,
                     args as *const c::SysCallArgs,
-                );
-            },
-        };
-
-        // if this is the last remaining descriptor
-        if desc.get_open_count() == 1 {
-            let posix_file = desc.get_file();
-
-            result = Some(EventQueue::queue_and_run(|event_queue| {
-                posix_file.borrow_mut().close(event_queue)
-            }));
-        } else {
-            result = None;
+                )
+            };
         }
     }
 
     // according to "man 2 close", in Linux any errors that may occur will happen after the fd is
     // released, so we should always deregister the descriptor
-    unsafe { c::process_deregisterCompatDescriptor(sys.process, fd) };
+    let desc = unsafe { c::process_deregisterCompatDescriptor(sys.process, fd) };
+    let desc = CompatDescriptor::from_raw(desc).unwrap();
+    let desc = match *desc {
+        CompatDescriptor::New(d) => d,
+        _ => unreachable!(),
+    };
+
+    let result = EventQueue::queue_and_run(|event_queue| desc.close(event_queue));
 
     if let Some(result) = result {
         result.into()


### PR DESCRIPTION
Instead of dropping the CompatDescriptor internally when the descriptor is deregistered, the descriptor table now returns an owned reference to the CompatDescriptor so that we can drop it ourselves. This lets us add a nicer `close()` method to the CompatDescriptor.