### PR TITLE
Added Rust wrappers around process_get*Ptr() functions

### DIFF
--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -268,7 +268,7 @@ impl PosixFile {
 
     pub fn read(
         &mut self,
-        bytes: &mut [u8],
+        bytes: Option<&mut [u8]>,
         offset: libc::off_t,
         event_queue: &mut EventQueue,
     ) -> SyscallReturn {
@@ -279,7 +279,7 @@ impl PosixFile {
 
     pub fn write(
         &mut self,
-        bytes: &[u8],
+        bytes: Option<&[u8]>,
         offset: libc::off_t,
         event_queue: &mut EventQueue,
     ) -> SyscallReturn {

--- a/src/main/host/descriptor/pipe.rs
+++ b/src/main/host/descriptor/pipe.rs
@@ -55,7 +55,7 @@ impl PipeFile {
 
     pub fn read(
         &mut self,
-        bytes: &mut [u8],
+        bytes: Option<&mut [u8]>,
         offset: libc::off_t,
         event_queue: &mut EventQueue,
     ) -> SyscallReturn {
@@ -69,6 +69,11 @@ impl PipeFile {
             return SyscallReturn::Error(nix::errno::Errno::EBADF);
         }
 
+        let bytes = match bytes {
+            Some(b) => b,
+            None => return SyscallReturn::Error(nix::errno::Errno::EFAULT),
+        };
+
         let num_read = self.buffer.borrow_mut().read(bytes, event_queue);
 
         SyscallReturn::Success(num_read as i32)
@@ -76,7 +81,7 @@ impl PipeFile {
 
     pub fn write(
         &mut self,
-        bytes: &[u8],
+        bytes: Option<&[u8]>,
         offset: libc::off_t,
         event_queue: &mut EventQueue,
     ) -> SyscallReturn {
@@ -89,6 +94,11 @@ impl PipeFile {
         if !self.mode.contains(FileMode::WRITE) {
             return SyscallReturn::Error(nix::errno::Errno::EBADF);
         }
+
+        let bytes = match bytes {
+            Some(b) => b,
+            None => return SyscallReturn::Error(nix::errno::Errno::EFAULT),
+        };
 
         let num_written = self.buffer.borrow_mut().write(bytes, event_queue);
 

--- a/src/main/host/syscall/mod.rs
+++ b/src/main/host/syscall/mod.rs
@@ -1,5 +1,7 @@
-use atomic_refcell::AtomicRefCell;
+use std::convert::TryInto;
 use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
 
 use crate::cshadow as c;
 use crate::host::descriptor::{CompatDescriptor, FileStatus, PosixFile};
@@ -71,4 +73,103 @@ pub fn get_descriptor(
     }
 
     Ok(desc)
+}
+
+pub enum PluginPtrError {
+    /// Was `NULL` inside the plugin.
+    Null,
+    /// Length was 0.
+    ZeroLen,
+    /// Length was too small to represent the generic type `T`.
+    LenTooSmall,
+}
+
+pub fn get_readable_ptr<T>(
+    process: *mut c::Process,
+    thread: *mut c::Thread,
+    plugin_ptr: c::PluginPtr,
+    num_bytes: usize,
+) -> Result<*const T, PluginPtrError> {
+    if plugin_ptr.val == 0 {
+        return Err(PluginPtrError::Null);
+    }
+
+    if num_bytes == 0 {
+        return Err(PluginPtrError::ZeroLen);
+    }
+
+    if num_bytes < std::mem::size_of::<T>() {
+        return Err(PluginPtrError::LenTooSmall);
+    }
+
+    let num_bytes = num_bytes.try_into().unwrap();
+
+    let ptr = unsafe { c::process_getReadablePtr(process, thread, plugin_ptr, num_bytes) };
+    let ptr = ptr as *const T;
+    assert!(!ptr.is_null());
+
+    // check pointer alignment
+    assert_eq!((ptr as usize) % std::mem::align_of::<T>(), 0);
+
+    Ok(ptr)
+}
+
+pub fn get_writable_ptr<T>(
+    process: *mut c::Process,
+    thread: *mut c::Thread,
+    plugin_ptr: c::PluginPtr,
+    num_bytes: usize,
+) -> Result<*mut T, PluginPtrError> {
+    if plugin_ptr.val == 0 {
+        return Err(PluginPtrError::Null);
+    }
+
+    if num_bytes == 0 {
+        return Err(PluginPtrError::ZeroLen);
+    }
+
+    if num_bytes < std::mem::size_of::<T>() {
+        return Err(PluginPtrError::LenTooSmall);
+    }
+
+    let num_bytes = num_bytes.try_into().unwrap();
+
+    let ptr = unsafe { c::process_getWriteablePtr(process, thread, plugin_ptr, num_bytes) };
+    let ptr = ptr as *mut T;
+    assert!(!ptr.is_null());
+
+    // check pointer alignment
+    assert_eq!((ptr as usize) % std::mem::align_of::<T>(), 0);
+
+    Ok(ptr)
+}
+
+pub fn get_mutable_ptr<T>(
+    process: *mut c::Process,
+    thread: *mut c::Thread,
+    plugin_ptr: c::PluginPtr,
+    num_bytes: usize,
+) -> Result<*mut T, PluginPtrError> {
+    if plugin_ptr.val == 0 {
+        return Err(PluginPtrError::Null);
+    }
+
+    if num_bytes == 0 {
+        return Err(PluginPtrError::ZeroLen);
+    }
+
+    if num_bytes < std::mem::size_of::<T>() {
+        return Err(PluginPtrError::LenTooSmall);
+    }
+
+    let num_bytes = num_bytes.try_into().unwrap();
+
+    let ptr = unsafe { c::process_getMutablePtr(process, thread, plugin_ptr, num_bytes) };
+    let ptr = ptr as *mut T;
+    assert!(!ptr.is_null());
+
+    // check pointer alignment
+    assert_eq!((ptr as usize) % std::mem::align_of::<T>(), 0);
+
+    Ok(ptr)
 }


### PR DESCRIPTION
Ideally the memory manager would provide this interface, and these new enums would be passed all the way from there. But until we write the Process and Thread objects in Rust, these wrappers will be good enough.

The PosixFile `read()` and `write()` methods now accept an `Option` for the buffer. Different Linux file types handle NULL buffers differently, so pass this information along to the file object.

I'm open to changing the names for the enums, but I can't think of any better names.