### PR TITLE
Strip topology whitespace when converting from xml to yaml

### DIFF
--- a/src/test/config/convert/CMakeLists.txt
+++ b/src/test/config/convert/CMakeLists.txt
@@ -3,6 +3,9 @@
 # Second, ensure this XML file is understandable by Shadow by running it with the Shadow executable
 # Third, make a diff between the files generated and the example files
 
+# Converting between XML and YAML, and then back again, will not always produce *identical* results
+# if the elements contain leading or trailing whitespace, so this characteristic should not be relied on.
+
 add_executable(test-config-convert test_config.c)
 
 # Convert a XML file to YAML

--- a/src/test/config/convert/shadow.config.xml
+++ b/src/test/config/convert/shadow.config.xml
@@ -16,8 +16,7 @@
       <data key="d4">0.0</data>
     </edge>
   </graph>
-</graphml>
-]]></topology>
+</graphml>]]></topology>
   <kill time="5"/>
   <plugin id="testconfig" path="test-config-convert"/>
   <node id="testclient" quantity="1">

--- a/src/test/config/convert/xml2yaml.yaml
+++ b/src/test/config/convert/xml2yaml.yaml
@@ -1,7 +1,7 @@
 options:
   stoptime: 3600
 topology:
-- graphml: |
+- graphml: |-
     <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
       <key attr.name="packetloss" attr.type="double" for="edge" id="d4" />
       <key attr.name="latency" attr.type="double" for="edge" id="d3" />

--- a/src/test/config/convert/yaml2xml.xml
+++ b/src/test/config/convert/yaml2xml.xml
@@ -17,8 +17,7 @@
       <data key="d4">0.0</data>
     </edge>
   </graph>
-</graphml>
-]]></topology>
+</graphml>]]></topology>
    <kill time="5"/>
    <plugin id="testconfig" path="test-config-convert"/>
    <host id="testclient" quantity="1">


### PR DESCRIPTION
This strips leading and trailing whitespace from the Shadow XML config topology. The conversion process was already losing information here, so we don't lose any more by remove this whitespace.

This change makes the converter work with more XML files. Specifically, files that have space between the `<topology>` and the `<![CDATA[`. For example:

```xml
  <topology>
  <![CDATA[<?xml version="1.0" ...
  </graphml>]]>
  </topology>
```