### PR TITLE
Consolidate cleanup of plugin process in Process

### DIFF
--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -59,7 +59,7 @@ void process_addThread(Process* proc, Thread* thread);
 // without trying to run them again, since otherwise the OS may kill the other
 // thread tasks while we're in the middle of trying to execute them, which can
 // be difficult to recover from cleanly.
-void process_markAsExiting(Process* proc, gint returnCode);
+void process_markAsExiting(Process* proc);
 
 gboolean process_isRunning(Process* proc);
 

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -342,7 +342,8 @@ SysCallReturn syscallhandler_pwrite64(SysCallHandler* sys,
 }
 
 SysCallReturn syscallhandler_exit_group(SysCallHandler* sys, const SysCallArgs* args) {
-    process_markAsExiting(sys->process, args->args[0].as_i64);
+    debug("Exit group with exit code %ld", args->args[0].as_i64);
+    process_markAsExiting(sys->process);
     return (SysCallReturn){.state = SYSCALL_NATIVE};
 }
 


### PR DESCRIPTION
Now that thread_ptrace is getting a pre-death event and can detach
there, Process can reliably cleanup the native process. This
consolidates a fair bit of scattered waitpid's and attempts to propagate
/ figure out the process exit code.