### PR TITLE
Added placeholder 'run_tor.yml' workflow

### DIFF
--- a/.github/workflows/run_tor.yml
+++ b/.github/workflows/run_tor.yml
@@ -1,0 +1,14 @@
+name: Tor Tests
+
+# this is a placeholder workflow so that we can run 'workflow_dispatch'
+# events on other branches
+
+on:
+  workflow_dispatch:
+
+jobs:
+  testing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Always Error
+        run: exit 1


### PR DESCRIPTION
If we want to be able to use the 'workflow_dispatch' event from the dev branch, we need the workflow to exist in the main branch as well. Once we merge this, we can merge main into dev. Then we can replace the workflow in dev with the real workflow.