### PR TITLE
Removed the second test run with '--rerun-failed' in CI script

### DIFF
--- a/ci/container_scripts/test.sh
+++ b/ci/container_scripts/test.sh
@@ -41,7 +41,4 @@ FLAGS+=("-C" "$CONFIG")
 
 FLAGS+=("--output-on-failure")
 
-# Try any that failed once more.
-# TODO: We should only do this for an allowed-list of known-flaky tests,
-# and there should be issues filed for each such test.
-./setup test "${FLAGS[@]}" || ./setup test "${FLAGS[@]}" --rerun-failed
+./setup test "${FLAGS[@]}"


### PR DESCRIPTION
Shadow should be stable enough now that we don't need to filter out flaky tests, and if there are any, we probably want to know about them.