### PR TITLE
Count syscalls

### DIFF
--- a/src/main/bindings/c/bindings-opaque.h
+++ b/src/main/bindings/c/bindings-opaque.h
@@ -15,6 +15,7 @@ typedef struct ByteQueue ByteQueue;
 
 typedef struct CompatDescriptor CompatDescriptor;
 
+// The main counter object that maps individual keys to count values.
 typedef struct Counter Counter;
 
 // Manages the address-space for a plugin process.

--- a/src/main/bindings/c/bindings-opaque.h
+++ b/src/main/bindings/c/bindings-opaque.h
@@ -15,6 +15,8 @@ typedef struct ByteQueue ByteQueue;
 
 typedef struct CompatDescriptor CompatDescriptor;
 
+typedef struct Counter Counter;
+
 // Manages the address-space for a plugin process.
 //
 // The MemoryManager's primary purpose is to make plugin process's memory directly accessible to

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -161,4 +161,14 @@ void bytequeue_push(struct ByteQueue *bq, const unsigned char *src, size_t len);
 
 size_t bytequeue_pop(struct ByteQueue *bq, unsigned char *dst, size_t len);
 
+struct Counter *counter_new(void);
+
+void counter_free(struct Counter *counter_ptr);
+
+uint64_t counter_add_one(struct Counter *counter, const char *id);
+
+char *counter_alloc_string(struct Counter *counter);
+
+void counter_free_string(struct Counter *counter, char *ptr);
+
 #endif /* main_bindings_h */

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -167,8 +167,11 @@ void counter_free(struct Counter *counter_ptr);
 
 uint64_t counter_add_one(struct Counter *counter, const char *id);
 
+// Creates a new string representation of the counter, e.g., for logging.
+// The returned string must be free'd by passing it to counter_free_string.
 char *counter_alloc_string(struct Counter *counter);
 
+// Frees a string previously returned from counter_alloc_string.
 void counter_free_string(struct Counter *counter, char *ptr);
 
 #endif /* main_bindings_h */

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -63,6 +63,11 @@ pub type Host = _Host;
 pub type LegacyDescriptor = [u64; 6usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct Counter {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct PosixFileArc {
     _unused: [u8; 0],
 }
@@ -583,13 +588,14 @@ pub struct _SysCallHandler {
     pub perfSecondsCurrent: gdouble,
     pub perfSecondsTotal: gdouble,
     pub numSyscalls: ::std::os::raw::c_long,
+    pub syscall_counter: *mut Counter,
     pub referenceCount: ::std::os::raw::c_int,
 }
 #[test]
 fn bindgen_test_layout__SysCallHandler() {
     assert_eq!(
         ::std::mem::size_of::<_SysCallHandler>(),
-        88usize,
+        96usize,
         concat!("Size of: ", stringify!(_SysCallHandler))
     );
     assert_eq!(
@@ -704,8 +710,18 @@ fn bindgen_test_layout__SysCallHandler() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).referenceCount as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).syscall_counter as *const _ as usize },
         80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_SysCallHandler),
+            "::",
+            stringify!(syscall_counter)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).referenceCount as *const _ as usize },
+        88usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),

--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -59,6 +59,8 @@ struct _SysCallHandler {
     //#endif
     /* The total number of syscalls that we have handled. */
     long numSyscalls;
+    // A counter for individual syscalls
+    Counter* syscall_counter;
 
     int referenceCount;
 

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -115,7 +115,7 @@ static void _syscallhandler_free(SysCallHandler* sys) {
 
     if (_countSyscalls && sys->syscall_counter) {
         char* str = counter_alloc_string(sys->syscall_counter);
-        message("%s", str);
+        message("Syscall counts: %s", str);
         counter_free_string(sys->syscall_counter, str);
         counter_free(sys->syscall_counter);
     }

--- a/src/main/utility/counter.rs
+++ b/src/main/utility/counter.rs
@@ -1,0 +1,154 @@
+/*
+ * The Shadow Simulator
+ * See LICENSE for licensing information
+ */
+use std::collections::HashMap;
+use std::iter::FromIterator;
+
+pub struct Counter {
+    items: HashMap<String, u64>,
+}
+
+impl Counter {
+    pub fn new() -> Counter {
+        Counter {
+            items: HashMap::new(),
+        }
+    }
+
+    pub fn add_one(&mut self, id: &str) -> u64 {
+        let count = self.items.entry(id.to_string()).or_insert(0);
+        *count = *count + 1;
+        *count
+    }
+
+    // Used for unit test
+    #[allow(dead_code)]
+    pub fn get_value(&mut self, id: &str) -> u64 {
+        match self.items.get(&id.to_string()) {
+            Some(val) => *val,
+            None => 0,
+        }
+    }
+
+    fn to_string(&mut self) -> String {
+        // Sort the counts with the heaviest hitters first
+        let mut item_vec = Vec::from_iter(&self.items);
+        item_vec.sort_by(|&(_, a), &(_, b)| b.cmp(&a));
+
+        // Create a string representation of the counts
+        let mut string = String::from("Counts:");
+        for item in item_vec.iter() {
+            string.push_str(format!(" {}={}", item.0, item.1).as_str());
+        }
+        string
+    }
+}
+
+mod export {
+    use super::*;
+    use std::ffi::CStr;
+    use std::ffi::CString;
+    use std::os::raw::c_char;
+
+    #[no_mangle]
+    pub extern "C" fn counter_new() -> *mut Counter {
+        Box::into_raw(Box::new(Counter::new()))
+    }
+
+    #[no_mangle]
+    pub extern "C" fn counter_free(counter_ptr: *mut Counter) {
+        if counter_ptr.is_null() {
+            return;
+        }
+        unsafe {
+            Box::from_raw(counter_ptr);
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn counter_add_one(counter: *mut Counter, id: *const c_char) -> u64 {
+        assert!(!counter.is_null());
+        assert!(!id.is_null());
+
+        let counter = unsafe { &mut *counter };
+        let id = unsafe { CStr::from_ptr(id) };
+
+        counter.add_one(id.to_str().unwrap())
+    }
+
+    #[no_mangle]
+    pub extern "C" fn counter_alloc_string(counter: *mut Counter) -> *mut c_char {
+        assert!(!counter.is_null());
+
+        let counter = unsafe { &mut *counter };
+        let string = counter.to_string();
+
+        // Transfer ownership back to caller
+        CString::new(string).unwrap().into_raw()
+    }
+
+    #[no_mangle]
+    pub extern "C" fn counter_free_string(counter: *mut Counter, ptr: *mut c_char) {
+        assert!(!counter.is_null());
+        assert!(!ptr.is_null());
+        // Free the previously alloc'd string
+        unsafe { CString::from_raw(ptr) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_value() {
+        let mut counter = Counter::new();
+        assert_eq!(counter.get_value("read"), 0);
+        assert_eq!(counter.get_value("write"), 0);
+        assert_eq!(counter.get_value("close"), 0);
+        counter.add_one("write");
+        counter.add_one("write");
+        counter.add_one("read");
+        counter.add_one("write");
+        assert_eq!(counter.get_value("read"), 1);
+        assert_eq!(counter.get_value("write"), 3);
+        assert_eq!(counter.get_value("close"), 0);
+    }
+
+    #[test]
+    fn test_add_one() {
+        let mut counter = Counter::new();
+        assert_eq!(counter.add_one("read"), 1);
+        assert_eq!(counter.add_one("read"), 2);
+        assert_eq!(counter.add_one("write"), 1);
+        assert_eq!(counter.add_one("read"), 3);
+    }
+
+    #[test]
+    fn test_to_string() {
+        let mut counter = Counter::new();
+
+        counter.add_one("read");
+        counter.add_one("read");
+        counter.add_one("close");
+        counter.add_one("write");
+        counter.add_one("write");
+        counter.add_one("write");
+
+        // Make sure the keys are sorted with the largest count first
+        assert_eq!(
+            counter.to_string(),
+            String::from("Counts: write=3 read=2 close=1")
+        );
+
+        counter.add_one("read");
+        counter.add_one("read");
+
+        // The order should have changed with read first now
+        assert_eq!(
+            counter.to_string(),
+            String::from("Counts: read=4 write=3 close=1")
+        );
+    }
+}

--- a/src/main/utility/counter.rs
+++ b/src/main/utility/counter.rs
@@ -33,9 +33,18 @@ impl Counter {
     /// Increment the counter value for the key given by id.
     /// Returns the value of the counter after it was incremented.
     pub fn add_one(&mut self, id: &str) -> u64 {
-        let count = self.items.entry(id.to_string()).or_insert(0);
-        *count = *count + 1;
-        *count
+        match self.items.get_mut(id) {
+            Some(val) => {
+                // Increment and return the existing value without allocating new key
+                *val = *val + 1;
+                *val
+            }
+            None => {
+                // Allocate new key and insert it with initial count of 1
+                assert_eq!(self.items.insert(id.to_string(), 1), None);
+                1
+            }
+        }
     }
 
     /// Returns the counter value for the key given by id, or 0 if the key has not

--- a/src/main/utility/counter.rs
+++ b/src/main/utility/counter.rs
@@ -14,6 +14,7 @@ generic types.
 */
 
 use std::collections::HashMap;
+use std::fmt::{Display, Formatter, Result};
 use std::iter::FromIterator;
 
 /// The main counter object that maps individual keys to count values.
@@ -55,21 +56,27 @@ impl Counter {
             None => 0,
         }
     }
+}
 
-    /// Returns a string representation of the counter. The string starts with "Counts:"
-    /// and then lists known keys and values as a space-separated list of "key=value"
-    /// pairs sorted by value with the largest value first.
-    fn to_string(&mut self) -> String {
+impl Display for Counter {
+    /// Returns a string representation of the counter in the form
+    ///   `{key1:value1, key2:value2, ..., keyN:valueN}`
+    /// for known keys and values, where the list is sorted by value with the
+    /// largest value first.
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         // Sort the counts with the heaviest hitters first
         let mut item_vec = Vec::from_iter(&self.items);
         item_vec.sort_by(|&(_, a), &(_, b)| b.cmp(&a));
 
-        // Create a string representation of the counts
-        let mut string = String::from("Counts:");
-        for item in item_vec.iter() {
-            string.push_str(format!(" {}={}", item.0, item.1).as_str());
+        // Create a string representation of the counts by iterating over the items.
+        write!(f, "{{")?;
+        for i in 0..item_vec.len() {
+            write!(f, "{}:{}", item_vec[i].0, item_vec[i].1)?;
+            if i < (item_vec.len() - 1) {
+                write!(f, ", ")?;
+            }
         }
-        string
+        write!(f, "}}")
     }
 }
 
@@ -170,7 +177,7 @@ mod tests {
         // Make sure the keys are sorted with the largest count first
         assert_eq!(
             counter.to_string(),
-            String::from("Counts: write=3 read=2 close=1")
+            String::from("{write:3, read:2, close:1}")
         );
 
         counter.add_one("read");
@@ -179,7 +186,7 @@ mod tests {
         // The order should have changed with read first now
         assert_eq!(
             counter.to_string(),
-            String::from("Counts: read=4 write=3 close=1")
+            String::from("{read:4, write:3, close:1}")
         );
     }
 }

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -1,4 +1,5 @@
 pub mod byte_queue;
+pub mod counter;
 pub mod event_queue;
 pub mod interval_map;
 pub mod proc_maps;


### PR DESCRIPTION
This allows us to count the frequency with which each syscall is made by each processing running in shadow. No counting is done unless the new `--count-syscalls` option is specified. If the option is given, we track the counts for each syscall and log the counts at the end of the simulation.