### PR TITLE
work stealing sched: Fix swapped parameter order setting cpu affinity

### DIFF
--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -52,7 +52,7 @@ static void _thread_cleanupSysCallCondition(Thread* thread) {
  */
 static void _thread_syncAffinityWithWorker(Thread *thread) {
     thread->affinity =
-        affinity_setProcessAffinity(thread->nativeTid, thread->affinity, worker_getAffinity());
+        affinity_setProcessAffinity(thread->nativeTid, worker_getAffinity(), thread->affinity);
 }
 
 void thread_ref(Thread* thread) {


### PR DESCRIPTION
This fixes a bug affecting performance when using the work stealing scheduler with cpu pinning.