### PR TITLE
Max concurrency

### DIFF
--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -19,7 +19,6 @@
 #include "main/core/support/definitions.h"
 #include "main/core/support/object_counter.h"
 #include "main/core/support/options.h"
-#include "main/core/worker.h"
 #include "main/host/host.h"
 #include "main/host/network_interface.h"
 #include "main/routing/address.h"
@@ -207,7 +206,7 @@ Manager* manager_new(Controller* controller, Options* options, SimulationTime en
     guint nWorkers = options_getNWorkerThreads(options);
     SchedulerPolicyType policy = _manager_getEventSchedulerPolicy(manager);
     guint schedulerSeed = _manager_nextRandomUInt(manager);
-    manager->scheduler = scheduler_new(policy, nWorkers, manager, schedulerSeed, endTime);
+    manager->scheduler = scheduler_new(manager, policy, nWorkers, manager, schedulerSeed, endTime);
 
     manager->cwdPath = g_get_current_dir();
     manager->dataPath =
@@ -555,6 +554,7 @@ static void _manager_heartbeat(Manager* manager, SimulationTime simClockNow) {
 
 void manager_run(Manager* manager) {
     MAGIC_ASSERT(manager);
+#if 0
     if (scheduler_getPolicy(manager->scheduler) == SP_SERIAL_GLOBAL) {
         scheduler_start(manager->scheduler);
 
@@ -570,45 +570,45 @@ void manager_run(Manager* manager) {
 
         scheduler_finish(manager->scheduler);
     } else {
-        /* we are the main thread, we manage the execution window updates while the workers run
-         * events */
-        SimulationTime windowStart = 0, windowEnd = 1;
-        SimulationTime minNextEventTime = SIMTIME_INVALID;
-        gboolean keepRunning = TRUE;
+#endif
+    /* we are the main thread, we manage the execution window updates while the workers run
+        * events */
+    SimulationTime windowStart = 0, windowEnd = 1;
+    SimulationTime minNextEventTime = SIMTIME_INVALID;
+    gboolean keepRunning = TRUE;
 
-        scheduler_start(manager->scheduler);
+    scheduler_start(manager->scheduler);
 
-        while (keepRunning) {
-            /* release the workers and run next round */
-            scheduler_continueNextRound(manager->scheduler, windowStart, windowEnd);
+    while (keepRunning) {
+        /* release the workers and run next round */
+        scheduler_continueNextRound(manager->scheduler, windowStart, windowEnd);
 
-            /* do some idle processing here if needed */
-            /* TODO the heartbeat should run in single process mode too! */
-            _manager_heartbeat(manager, windowStart);
+        /* do some idle processing here if needed */
+        /* TODO the heartbeat should run in single process mode too! */
+        _manager_heartbeat(manager, windowStart);
 
-            /* flush manager threads messages */
-            shadow_logger_flushRecords(shadow_logger_getDefault(), pthread_self());
+        /* flush manager threads messages */
+        shadow_logger_flushRecords(shadow_logger_getDefault(), pthread_self());
 
-            /* let the logger know it can flush everything prior to this round */
-            shadow_logger_syncToDisk(shadow_logger_getDefault());
+        /* let the logger know it can flush everything prior to this round */
+        shadow_logger_syncToDisk(shadow_logger_getDefault());
 
-            /* wait for the workers to finish processing nodes before we update the execution window
-             */
-            minNextEventTime = scheduler_awaitNextRound(manager->scheduler);
+        /* wait for the workers to finish processing nodes before we update the execution window
+            */
+        minNextEventTime = scheduler_awaitNextRound(manager->scheduler);
 
-            /* we are in control now, the workers are waiting for the next round */
-            info("finished execution window [%" G_GUINT64_FORMAT "--%" G_GUINT64_FORMAT
-                 "] next event at %" G_GUINT64_FORMAT,
-                 windowStart, windowEnd, minNextEventTime);
+        /* we are in control now, the workers are waiting for the next round */
+        info("finished execution window [%" G_GUINT64_FORMAT "--%" G_GUINT64_FORMAT
+                "] next event at %" G_GUINT64_FORMAT,
+                windowStart, windowEnd, minNextEventTime);
 
-            /* notify controller that we finished this round, and the time of our next event
-             * in order to fast-forward our execute window if possible */
-            keepRunning = controller_managerFinishedCurrentRound(
-                manager->controller, minNextEventTime, &windowStart, &windowEnd);
-        }
-
-        scheduler_finish(manager->scheduler);
+        /* notify controller that we finished this round, and the time of our next event
+            * in order to fast-forward our execute window if possible */
+        keepRunning = controller_managerFinishedCurrentRound(
+            manager->controller, minNextEventTime, &windowStart, &windowEnd);
     }
+
+    scheduler_finish(manager->scheduler);
 }
 
 void manager_incrementPluginError(Manager* manager) {

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -24,6 +24,12 @@
 #include "main/utility/utility.h"
 #include "support/logger/logger.h"
 
+static int _maxConcurrency = -1;
+OPTION_EXPERIMENTAL_ENTRY("max-concurrency", 0, 0,
+                          G_OPTION_ARG_INT, &_maxConcurrency,
+                          "Maximum number of workers to allow to run at once. Set to -1 for no limit. [-1]",
+                          "N")
+
 struct _Scheduler {
     /* all worker threads used by the scheduler */
     //GQueue* threadItems;
@@ -150,7 +156,7 @@ Scheduler* scheduler_new(Manager* manager, SchedulerPolicyType policyType, guint
     // Unowned back-pointer
     scheduler->manager = manager;
 
-    scheduler->workerPool = workerpool_new(manager, scheduler, /*nThreads=*/nWorkers, /*nConcurrent=*/-1);
+    scheduler->workerPool = workerpool_new(manager, scheduler, /*nThreads=*/nWorkers, /*nConcurrent=*/_maxConcurrency);
 
     scheduler->endTime = endTime;
     scheduler->currentRound.endTime = scheduler->endTime;// default to one single round

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -26,11 +26,17 @@
 
 struct _Scheduler {
     /* all worker threads used by the scheduler */
-    GQueue* threadItems;
+    //GQueue* threadItems;
+
+    // Unowned back-pointer.
+    Manager* manager;
+    
+    WorkerPool* workerPool;
 
     /* global lock for all threads, hold this as little as possible */
     GMutex globalLock;
 
+#if 0
     /* barrier for worker threads to start and stop running */
     CountDownLatch* startBarrier;
     CountDownLatch* bootBarrier;
@@ -41,6 +47,7 @@ struct _Scheduler {
     CountDownLatch* collectInfoBarrier;
     /* barrier to wait for main thread to finish updating for the next round */
     CountDownLatch* prepareRoundBarrier;
+#endif
 
 #ifdef USE_PERF_TIMERS
     /* holds a timer for each thread to track how long threads wait for execution barrier */
@@ -78,7 +85,10 @@ struct _SchedulerThreadItem {
     CountDownLatch* notifyJoined;
 };
 
-static void _scheduler_startHosts(Scheduler* scheduler) {
+//static void _scheduler_startHosts(Scheduler* scheduler) {
+static void _scheduler_startHostsWorkerTaskFn(void* voidScheduler) {
+    Scheduler* scheduler = voidScheduler;
+    MAGIC_ASSERT(scheduler);
     if(scheduler->policy->getAssignedHosts) {
         GQueue* myHosts = scheduler->policy->getAssignedHosts(scheduler->policy);
         if(myHosts) {
@@ -90,7 +100,16 @@ static void _scheduler_startHosts(Scheduler* scheduler) {
     }
 }
 
-static void _scheduler_stopHosts(Scheduler* scheduler) {
+static void _scheduler_runEventsWorkerTaskFn(void* voidScheduler) {
+    Scheduler* scheduler = voidScheduler;
+    Event* event = NULL;
+    while ((event = scheduler->policy->pop(scheduler->policy, scheduler->currentRound.endTime)) != NULL) {
+        worker_runEvent(event);
+    }
+}
+
+static void _scheduler_finishTaskFn(void* voidScheduler) {
+    Scheduler* scheduler = voidScheduler;
     /* free all applications before freeing any of the hosts since freeing
      * applications may cause close() to get called on sockets which needs
      * other host information. this may cause issues if the hosts are gone.
@@ -104,18 +123,14 @@ static void _scheduler_stopHosts(Scheduler* scheduler) {
      * structs. so if we let a single thread free everything, we run into issues. */
 
 //    GList* allHosts = g_hash_table_get_values(scheduler->hostIDToHostMap);
+    GQueue* myHosts = NULL;
     if(scheduler->policy->getAssignedHosts) {
-        GQueue* myHosts = scheduler->policy->getAssignedHosts(scheduler->policy);
-        if(myHosts) {
-            guint nHosts = g_queue_get_length(myHosts);
-            message("starting to shut down %u hosts", nHosts);
-            worker_freeHosts(myHosts);
-            message("%u hosts are shut down", nHosts);
-        }
+        myHosts = scheduler->policy->getAssignedHosts(scheduler->policy);
     }
+    worker_finish(myHosts);
 }
 
-Scheduler* scheduler_new(SchedulerPolicyType policyType, guint nWorkers, gpointer threadUserData,
+Scheduler* scheduler_new(Manager* manager, SchedulerPolicyType policyType, guint nWorkers, gpointer threadUserData,
         guint schedulerSeed, SimulationTime endTime) {
     Scheduler* scheduler = g_new0(Scheduler, 1);
     MAGIC_INIT(scheduler);
@@ -123,12 +138,19 @@ Scheduler* scheduler_new(SchedulerPolicyType policyType, guint nWorkers, gpointe
     /* global lock */
     g_mutex_init(&(scheduler->globalLock));
 
+/*
     scheduler->startBarrier = countdownlatch_new(nWorkers+1);
     scheduler->bootBarrier = countdownlatch_new(nWorkers + 1);
     scheduler->finishBarrier = countdownlatch_new(nWorkers+1);
     scheduler->executeEventsBarrier = countdownlatch_new(nWorkers+1);
     scheduler->collectInfoBarrier = countdownlatch_new(nWorkers+1);
     scheduler->prepareRoundBarrier = countdownlatch_new(nWorkers+1);
+    */
+
+    // Unowned back-pointer
+    scheduler->manager = manager;
+
+    scheduler->workerPool = workerpool_new(manager, scheduler, /*nThreads=*/nWorkers, /*nConcurrent=*/-1);
 
     scheduler->endTime = endTime;
     scheduler->currentRound.endTime = scheduler->endTime;// default to one single round
@@ -183,13 +205,12 @@ Scheduler* scheduler_new(SchedulerPolicyType policyType, guint nWorkers, gpointe
     /* make sure our ref count is set before starting the threads */
     scheduler->referenceCount = 1;
 
+#if 0
     scheduler->threadItems = g_queue_new();
 
     /* start up threads and create worker storage, each thread will call worker_new,
      * and wait at startBarrier until we are ready to launch */
     for(gint i = 0; i < nWorkers; i++) {
-        GString* name = g_string_new(NULL);
-        g_string_printf(name, "worker-%i", (i));
 
         SchedulerThreadItem* item = g_new0(SchedulerThreadItem, 1);
         item->notifyDoneRunning = countdownlatch_new(1);
@@ -204,23 +225,12 @@ Scheduler* scheduler_new(SchedulerPolicyType policyType, guint nWorkers, gpointe
         runData->notifyReadyToJoin = item->notifyReadyToJoin;
         runData->notifyJoined = item->notifyJoined;
 
-        gint returnVal = pthread_create(&(item->thread), NULL, (void*(*)(void*))worker_run, runData);
-        if(returnVal != 0) {
-            critical("unable to create worker thread");
-            return NULL;
-        }
-
-        returnVal = pthread_setname_np(item->thread, name->str);
-        if(returnVal != 0) {
-            warning("unable to set name of worker thread to '%s'", name->str);
-        }
         utility_assert(item->thread);
 
         g_queue_push_tail(scheduler->threadItems, item);
         shadow_logger_register(shadow_logger_getDefault(), item->thread);
-
-        g_string_free(name, TRUE);
     }
+#endif
     message("main scheduler thread will operate with %u worker threads", nWorkers);
 
     return scheduler;
@@ -245,14 +255,16 @@ void scheduler_shutdown(Scheduler* scheduler) {
     g_hash_table_destroy(scheduler->hostIDToHostMap);
 
     /* join and free spawned worker threads */
-    guint nWorkers = g_queue_get_length(scheduler->threadItems);
+    //guint nWorkers = g_queue_get_length(scheduler->threadItems);
 
-    message("waiting for %u worker threads to finish", nWorkers);
+    message("waiting for %d worker threads to finish", workerpool_getNWorkers(scheduler->workerPool));
+    workerpool_joinAll(scheduler->workerPool);
 
     /* threads need to finish and clean up some local state */
-    g_queue_foreach(scheduler->threadItems, (GFunc)_scheduler_waitForThreadsToStopRunning, scheduler);
+    //g_queue_foreach(scheduler->threadItems, (GFunc)_scheduler_waitForThreadsToStopRunning, scheduler);
 }
 
+#if 0
 static void _scheduler_joinThreads(SchedulerThreadItem* item, Scheduler* scheduler) {
     if(item && item->thread != pthread_self()) {
         /* first tell the thread we are ready to join */
@@ -278,6 +290,7 @@ static void _scheduler_joinThreads(SchedulerThreadItem* item, Scheduler* schedul
 #endif
     }
 }
+#endif
 
 static void _scheduler_free(Scheduler* scheduler) {
     MAGIC_ASSERT(scheduler);
@@ -287,7 +300,7 @@ static void _scheduler_free(Scheduler* scheduler) {
     random_free(scheduler->random);
 
     /* "join" the threads */
-    g_queue_foreach(scheduler->threadItems, (GFunc)_scheduler_joinThreads, scheduler);
+    // g_queue_foreach(scheduler->threadItems, (GFunc)_scheduler_joinThreads, scheduler);
 
     /* dont need the timers anymore now that the threads are joined */
 #ifdef USE_PERF_TIMERS
@@ -296,6 +309,7 @@ static void _scheduler_free(Scheduler* scheduler) {
     }
 #endif
 
+#if 0
     guint nWorkers = g_queue_get_length(scheduler->threadItems);
 
     while(!g_queue_is_empty(scheduler->threadItems)) {
@@ -322,10 +336,12 @@ static void _scheduler_free(Scheduler* scheduler) {
     countdownlatch_free(scheduler->startBarrier);
     countdownlatch_free(scheduler->bootBarrier);
     countdownlatch_free(scheduler->finishBarrier);
+#endif
 
     g_mutex_clear(&(scheduler->globalLock));
 
-    message("%i worker threads finished", nWorkers);
+    message("%d worker threads finished", workerpool_getNWorkers(scheduler->workerPool));
+    workerpool_free(scheduler->workerPool);
 
     MAGIC_CLEAR(scheduler);
     g_free(scheduler);
@@ -369,9 +385,7 @@ gboolean scheduler_push(Scheduler* scheduler, Event* event, Host* sender, Host* 
     return TRUE;
 }
 
-Event* scheduler_pop(Scheduler* scheduler) {
-    MAGIC_ASSERT(scheduler);
-
+#if 0
     /* this function should block until a non-null event is available for the worker to run.
      * return NULL only to signal the worker thread to quit */
 
@@ -428,6 +442,23 @@ Event* scheduler_pop(Scheduler* scheduler) {
 
     /* scheduler is done, return NULL to stop worker */
     return NULL;
+}
+#endif
+
+static void _scheduler_collectInfoWorkerTask(void* voidScheduler) {
+    Scheduler* scheduler = voidScheduler;
+    MAGIC_ASSERT(scheduler);
+
+    if(scheduler->policy->getNextTime) {
+        SimulationTime nextTime = scheduler->policy->getNextTime(scheduler->policy);
+        g_mutex_lock(&(scheduler->globalLock));
+        scheduler->currentRound.minNextEventTime = MIN(scheduler->currentRound.minNextEventTime, nextTime);
+        g_mutex_unlock(&(scheduler->globalLock));
+    }
+
+    /* clear all log messages from the last round */
+    shadow_logger_flushRecords(shadow_logger_getDefault(),
+                                pthread_self());
 }
 
 void scheduler_addHost(Scheduler* scheduler, Host* host) {
@@ -511,16 +542,16 @@ static void _scheduler_assignHosts(Scheduler* scheduler) {
     GQueue* hosts = g_queue_new();
     g_hash_table_foreach(scheduler->hostIDToHostMap, (GHFunc)_scheduler_appendHostToQueue, hosts);
 
-    guint nThreads = g_queue_get_length(scheduler->threadItems);
+    //guint nThreads = g_queue_get_length(scheduler->threadItems);
 
-    if(nThreads <= 1) {
+    int nWorkers = workerpool_getNWorkers(scheduler->workerPool);
+    if(nWorkers <= 1) {
         /* either the main thread or the single worker gets everything */
         pthread_t chosen;
-        if(nThreads == 0) {
+        if(nWorkers == 0) {
             chosen = pthread_self();
         } else {
-            SchedulerThreadItem* item = g_queue_peek_head(scheduler->threadItems);
-            chosen = item->thread;
+            chosen = workerpool_getThread(scheduler->workerPool, 0);
         }
 
         /* assign *all* of the hosts to the chosen thread */
@@ -531,13 +562,14 @@ static void _scheduler_assignHosts(Scheduler* scheduler) {
         _scheduler_shuffleQueue(scheduler, hosts);
 
         /* now that our host order has been randomized, assign them evenly to worker threads */
+        int workeri = 0;
         while(!g_queue_is_empty(hosts)) {
-            SchedulerThreadItem* item = g_queue_pop_head(scheduler->threadItems);
-            pthread_t nextThread = item->thread;
+            //SchedulerThreadItem* item = g_queue_pop_head(scheduler->threadItems);
+            pthread_t nextThread = workerpool_getThread(scheduler->workerPool, workeri++ % workerpool_getNWorkers(scheduler->workerPool));
 
             _scheduler_assignHostsToThread(scheduler, hosts, nextThread, 1);
 
-            g_queue_push_tail(scheduler->threadItems, item);
+            //g_queue_push_tail(scheduler->threadItems, item);
         }
     }
 
@@ -562,13 +594,13 @@ static void _scheduler_rebalanceHosts(Scheduler* scheduler) {
     /* now that our host order has been randomized, assign them evenly to worker threads */
     while(!g_queue_is_empty(hosts)) {
         Host* host = g_queue_pop_head(hosts);
-        SchedulerThreadItem* item = g_queue_pop_head(scheduler->threadItems);
-        pthread_t newThread = item->thread;
+        //SchedulerThreadItem* item = g_queue_pop_head(scheduler->threadItems);
+        //pthread_t newThread = item->thread;
 
 //        TODO this needs to get uncommented/updated when migration code is added
 //        scheduler->policy->migrateHost(scheduler->policy, host, newThread);
 
-        g_queue_push_tail(scheduler->threadItems, item);
+        //g_queue_push_tail(scheduler->threadItems, item);
     }
 
     if(hosts) {
@@ -586,6 +618,7 @@ gboolean scheduler_isRunning(Scheduler* scheduler) {
     return scheduler->isRunning;
 }
 
+#if 0
 void scheduler_awaitStart(Scheduler* scheduler) {
     /* Called by worker threads. When we are in single thread mode, all of the barriers have a count
      * of 1 so the countDownAwait functions always return immediately here. */
@@ -613,21 +646,27 @@ void scheduler_awaitStart(Scheduler* scheduler) {
     /* everyone will wait for the next round to be ready */
     countdownlatch_countDownAwait(scheduler->prepareRoundBarrier);
 }
+#endif
 
-void scheduler_awaitFinish(Scheduler* scheduler) {
+#if 0
+void _scheduler_stopHostsTaskFn(void* voidScheduler) {
+    Scheduler* scheduler = voidScheduler;
     /* Called by worker threads. When we are in single thread mode, all of the barriers have a count
      * of 1 so the countDownAwait functions always return immediately here. */
 
+#if 0
     /* each thread will run cleanup on their own hosts */
     g_mutex_lock(&scheduler->globalLock);
     scheduler->isRunning = FALSE;
     g_mutex_unlock(&scheduler->globalLock);
+#endif
 
     _scheduler_stopHosts(scheduler);
 
     /* wait until all threads are waiting to finish */
-    countdownlatch_countDownAwait(scheduler->finishBarrier);
+    //countdownlatch_countDownAwait(scheduler->finishBarrier);
 }
+#endif
 
 void scheduler_start(Scheduler* scheduler) {
     /* Called by the scheduler thread. */
@@ -638,6 +677,9 @@ void scheduler_start(Scheduler* scheduler) {
     scheduler->isRunning = TRUE;
     g_mutex_unlock(&scheduler->globalLock);
 
+    workerpool_startTaskFn(scheduler->workerPool, _scheduler_startHostsWorkerTaskFn, scheduler);
+    workerpool_awaitTaskFn(scheduler->workerPool);
+#if 0
     if(scheduler->policyType != SP_SERIAL_GLOBAL) {
         /* this will cause all workers to start their hosts in awaitStart */
         countdownlatch_countDownAwait(scheduler->startBarrier);
@@ -645,6 +687,7 @@ void scheduler_start(Scheduler* scheduler) {
          * round 1 */
         countdownlatch_countDownAwait(scheduler->bootBarrier);
     }
+#endif
 }
 
 void scheduler_continueNextRound(Scheduler* scheduler, SimulationTime windowStart, SimulationTime windowEnd) {
@@ -655,6 +698,9 @@ void scheduler_continueNextRound(Scheduler* scheduler, SimulationTime windowStar
     scheduler->currentRound.minNextEventTime = SIMTIME_MAX;
     g_mutex_unlock(&scheduler->globalLock);
 
+    workerpool_startTaskFn(scheduler->workerPool, _scheduler_runEventsWorkerTaskFn, scheduler);
+
+#if 0
     if(scheduler->policyType != SP_SERIAL_GLOBAL) {
         /* workers are waiting for preparation of the next round
          * this will cause them to start running events */
@@ -664,11 +710,20 @@ void scheduler_continueNextRound(Scheduler* scheduler, SimulationTime windowStar
          * when blocked because there are no more events available in the current round */
         countdownlatch_reset(scheduler->prepareRoundBarrier);
     }
+#endif
 }
 
 SimulationTime scheduler_awaitNextRound(Scheduler* scheduler) {
     /* Called by the scheduler thread. */
 
+    // Await completion of _scheduler_runEventsWorkerTaskFn
+    workerpool_awaitTaskFn(scheduler->workerPool);
+
+    // XXX Can we merge this into the execution task? e.g. track event times as we're scheduling them?
+    workerpool_startTaskFn(scheduler->workerPool, _scheduler_collectInfoWorkerTask, scheduler);
+    workerpool_awaitTaskFn(scheduler->workerPool);
+
+#if 0
     if(scheduler->policyType != SP_SERIAL_GLOBAL) {
         /* other workers will also wait at this barrier when they are finished with their events */
         countdownlatch_countDownAwait(scheduler->executeEventsBarrier);
@@ -677,6 +732,7 @@ SimulationTime scheduler_awaitNextRound(Scheduler* scheduler) {
         countdownlatch_countDownAwait(scheduler->collectInfoBarrier);
         countdownlatch_reset(scheduler->collectInfoBarrier);
     }
+    #endif
 
     SimulationTime minNextEventTime = SIMTIME_MAX;
     g_mutex_lock(&scheduler->globalLock);
@@ -691,6 +747,9 @@ void scheduler_finish(Scheduler* scheduler) {
     scheduler->isRunning = FALSE;
     g_mutex_unlock(&scheduler->globalLock);
 
+    workerpool_startTaskFn(scheduler->workerPool, _scheduler_finishTaskFn, scheduler);
+    workerpool_awaitTaskFn(scheduler->workerPool);
+#if 0
     if(scheduler->policyType != SP_SERIAL_GLOBAL) {
         /* wake up threads from their waiting for the next round.
          * because isRunning is now false, they will all exit and wait at finishBarrier */
@@ -699,6 +758,7 @@ void scheduler_finish(Scheduler* scheduler) {
         /* wait for them to be ready to finish */
         countdownlatch_countDownAwait(scheduler->finishBarrier);
     }
+#endif
 
     g_mutex_lock(&scheduler->globalLock);
     if(g_hash_table_size(scheduler->hostIDToHostMap) > 0) {

--- a/src/main/core/scheduler/scheduler.h
+++ b/src/main/core/scheduler/scheduler.h
@@ -9,6 +9,7 @@
 
 #include <glib.h>
 
+#include "main/core/manager.h"
 #include "main/core/scheduler/scheduler_policy.h"
 #include "main/core/support/definitions.h"
 #include "main/core/work/event.h"
@@ -16,7 +17,7 @@
 
 typedef struct _Scheduler Scheduler;
 
-Scheduler* scheduler_new(SchedulerPolicyType policyType, guint nWorkers, gpointer threadUserData,
+Scheduler* scheduler_new(Manager* manager, SchedulerPolicyType policyType, guint nWorkers, gpointer threadUserData,
         guint schedulerSeed, SimulationTime endTime);
 void scheduler_ref(Scheduler*);
 void scheduler_unref(Scheduler*);

--- a/src/main/core/support/definitions.h
+++ b/src/main/core/support/definitions.h
@@ -81,7 +81,7 @@ typedef guint64 EmulatedTime;
 /**
  * Conversion from emulated time to simulated time.
  */
-#define EMULATED_TIME_TO_SIMULATED_TIME(emtime) ((SimulationTime)(emtime-EMULATED_TIME_OFFSET))
+#define EMULATED_TIME_TO_SIMULATED_TIME(emtime) ((SimulationTime)((emtime)-EMULATED_TIME_OFFSET))
 
 /**
  * The start of our random port range in host order, used if application doesn't
@@ -117,14 +117,14 @@ typedef guint64 EmulatedTime;
  */
 #define NET_TCP_HZ 1000
 #define CONFIG_TCP_RTO_INIT NET_TCP_HZ
-#define CONFIG_TCP_RTO_MIN NET_TCP_HZ/5
-#define CONFIG_TCP_RTO_MAX NET_TCP_HZ*120
+#define CONFIG_TCP_RTO_MIN (NET_TCP_HZ/5)
+#define CONFIG_TCP_RTO_MAX (NET_TCP_HZ*120)
 
 /**
  * Default delay ack times, from net/tcp.h
  */
-#define CONFIG_TCP_DELACK_MIN NET_TCP_HZ/25
-#define CONFIG_TCP_DELACK_MAX NET_TCP_HZ/5
+#define CONFIG_TCP_DELACK_MIN (NET_TCP_HZ/25)
+#define CONFIG_TCP_DELACK_MAX (NET_TCP_HZ/5)
 
 /**
  * Minimum size of the send buffer per socket when TCP-autotuning is used.

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -10,6 +10,7 @@
 #include <glib.h>
 #include <netinet/in.h>
 
+#include "main/core/manager.h"
 #include "main/core/scheduler/scheduler.h"
 #include "main/core/support/definitions.h"
 #include "main/core/support/object_counter.h"
@@ -23,6 +24,7 @@
 #include "main/utility/count_down_latch.h"
 #include "support/logger/log_level.h"
 
+#if 0
 typedef struct _WorkerRunData WorkerRunData;
 struct _WorkerRunData {
     guint threadID;
@@ -32,14 +34,30 @@ struct _WorkerRunData {
     CountDownLatch* notifyReadyToJoin;
     CountDownLatch* notifyJoined;
 };
+#endif
 
 typedef struct _Worker Worker;
+
+typedef void(*WorkerPoolTaskFn)(void*);
+typedef struct _WorkerPool WorkerPool;
+
+// To be called by scheduler. Consumes `event`
+void worker_runEvent(Event* event);
+// To be called by worker thread
+void worker_finish(GQueue* hosts);
+
+WorkerPool* workerpool_new(Manager* manager, Scheduler* scheduler, int nThreads, int nConcurrent);
+void workerpool_startTaskFn(WorkerPool* pool, WorkerPoolTaskFn taskFn, void* data);
+void workerpool_awaitTaskFn(WorkerPool* pool);
+int workerpool_getNWorkers(WorkerPool* pool);
+void workerpool_joinAll(WorkerPool* pool);
+void workerpool_free(WorkerPool* pool);
+pthread_t workerpool_getThread(WorkerPool* pool, int threadId);
 
 int worker_getAffinity();
 DNS* worker_getDNS();
 Topology* worker_getTopology();
 Options* worker_getOptions();
-gpointer worker_run(WorkerRunData*);
 gboolean worker_scheduleTask(Task* task, SimulationTime nanoDelay);
 void worker_sendPacket(Packet* packet);
 gboolean worker_isAlive();

--- a/src/main/host/affinity.h
+++ b/src/main/host/affinity.h
@@ -51,6 +51,11 @@ int affinity_initPlatformInfo();
 int affinity_setProcessAffinity(pid_t pid, int new_cpu_num, int old_cpu_num);
 
 /*
+ * As `affinity_setProcessAffinity`, but takes a pthread.
+ */
+int affinity_setPthreadAffinity(pthread_t thread, int new_cpu_num, int old_cpu_num);
+
+/*
  * Helper function. Same semantics as affinity_setProcessAffinity but sets the
  * affinity of the calling thread/process.
  */


### PR DESCRIPTION
* Encapsulates scheduling of worker threads in a WorkerPool, which runs a single callback at a time. IMO this is easier to follow than the old way, but it also made it easier to implement:
* Adds command-line option --max-concurrency=N, which only allows N workers to execute at once. In particular this is useful for allowing more threads in ptrace + host-mode to avoid having to detach/reattach and avoid expensive waitpid calls. Using host mode with a large number of workers but a small N is somewhat analogous to work-stealing mode, but doesn't require ptrace reattaching.

We'll need to experiment a bit to find the right number of workers to use. For "perfect" work balancing, use the number of hosts. For less thread overhead, but coarser grained work balancing, use fewer than that.

e.g. on a machine with 12 cores, running a simulation with 10000 hosts, it might be reasonable to use `--pin-cpus --disable-o-n-waitpid-workarounds --set-sched-fifo -t host --max-concurrency=12` and `-w` somewhere between 100 and 10000.

This PR is WIP. Todo:
* Add back in performance counters.
* Delete dead code.
* Use a mutex per "concurrency queue" instead of a single mutex for all of them. This should completely avoid contention until if/when a worker needs to "steal" from another queue.
* When a worker is finding a next worker to start executing, snoop on its events and skip it completely if it doesn't have any to execute this round.
* See if we can merge the "run round" and "collect stats" steps.