### PR TITLE
Handle hot-path time syscalls in the shim

### DIFF
--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -62,6 +62,16 @@
 
 #include "main/host/thread_ptrace.h"
 
+// We normally attempt to serve hot-path syscalls on the shim-side to avoid a
+// more expensive inter-process syscall. This option disables the optimization.
+// This is defined here in Shadow because it breaks the shim.
+static bool _disable_shim_syscall_handler = false;
+OPTION_EXPERIMENTAL_ENTRY("disable-shim-syscall-handler", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+                          &_disable_shim_syscall_handler,
+                          "Disable shim-side syscall handler to force hot-path syscalls to be "
+                          "handled via an inter-process syscall with shadow.",
+                          NULL)
+
 static gchar* _process_outputFileName(Process* proc, const char* type);
 static void _process_check(Process* proc);
 
@@ -670,6 +680,10 @@ Process* process_new(Host* host, guint processID, SimulationTime startTime,
         gchar* logFileName = _process_outputFileName(proc, "shimlog");
         envv = g_environ_setenv(envv, "SHADOW_LOG_FILE", logFileName, TRUE);
         g_free(logFileName);
+    }
+
+    if (_disable_shim_syscall_handler) {
+        envv = g_environ_setenv(envv, "SHADOW_DISABLE_SHIM_SYSCALL", "TRUE", TRUE);
     }
 
     /* save args and env */

--- a/src/shim/CMakeLists.txt
+++ b/src/shim/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SHIM_FILES
   shim.c
   shim_logger.c
   shim_shmem.c
+  shim_syscall.c
 )
 add_library(${SHIM_LIB} SHARED ${SHIM_FILES})
 set_target_properties(${SHIM_LIB} PROPERTIES LINK_FLAGS "-Wl,--no-as-needed")

--- a/src/shim/preload_syscall.c
+++ b/src/shim/preload_syscall.c
@@ -175,9 +175,9 @@ long syscall(long n, ...) {
     va_start(args, n);
     long rv;
 
-    if (shim_syscall_is_supported(n) && shim_syscall(n, &rv, args)) {
-        // No syscall needed for the time hotpath.
-        debug("Successfully avoided time-related inter-process syscall %ld", n);
+    if (shim_syscall(n, &rv, args)) {
+        // No inter-process syscall needed, we handled it on the shim side! :)
+        debug("Successfully avoided inter-process syscall %ld", n);
         // rv was already set
     } else if (shim_interpositionEnabled()) {
         // The syscall is made using the shmem IPC channel.

--- a/src/shim/preload_syscall.c
+++ b/src/shim/preload_syscall.c
@@ -175,7 +175,7 @@ long syscall(long n, ...) {
     va_start(args, n);
     long rv;
 
-    if (shim_syscall(n, &rv, args)) {
+    if (shim_use_syscall_handler() && shim_syscall(n, &rv, args)) {
         // No inter-process syscall needed, we handled it on the shim side! :)
         debug("Successfully avoided inter-process syscall %ld", n);
         // rv was already set

--- a/src/shim/preload_syscall.c
+++ b/src/shim/preload_syscall.c
@@ -8,8 +8,8 @@
 #include "shim/ipc.h"
 #include "shim/shim.h"
 #include "shim/shim_event.h"
-#include "shim/shim_logger.h"
 #include "shim/shim_shmem.h"
+#include "shim/shim_syscall.h"
 #include "support/logger/logger.h"
 
 // Make sure we don't call any syscalls ourselves after this function is called, otherwise
@@ -91,7 +91,7 @@ static SysCallReg _shadow_syscall_event(const ShimEvent* syscall_event) {
             case SHD_SHIM_EVENT_SYSCALL_COMPLETE: {
                 // Use provided result.
                 SysCallReg rv = res.event_data.syscall_complete.retval;
-                shimlogger_set_simulation_nanos(res.event_data.syscall_complete.simulation_nanos);
+                shim_syscall_set_simtime_nanos(res.event_data.syscall_complete.simulation_nanos);
                 return rv;
             }
             case SHD_SHIM_EVENT_SYSCALL_DO_NATIVE: {
@@ -157,29 +157,9 @@ static long _vshadow_syscall(long n, va_list args) {
     return shadow_retval_to_errno(retval.as_i64);
 }
 
-// Gettimeofday is a frequently requested syscall. Since we cache the current sim time in the shim
-// logger, we fetch that time instead of issuing a more expensive Shadow syscall.
-static long _gettimeofday_cached(va_list args) {
-    uint64_t sim_time_nanos = shimlogger_get_simulation_nanos();
-    if (sim_time_nanos != 0) {
-        struct timeval* tv = va_arg(args, struct timeval*);
-
-        const long nanos_per_sec = 1000000000l;
-        const long micros_per_nano = 1000l;
-
-        tv->tv_sec = sim_time_nanos / nanos_per_sec;
-        tv->tv_usec = (sim_time_nanos % nanos_per_sec) / micros_per_nano;
-
-        debug("Using cached time of %ld.%06ld seconds to avoid gettimeofday syscall", tv->tv_sec,
-              tv->tv_usec);
-        return 0;
-    } else {
-        return -1;
-    }
-}
-
 long syscall(long n, ...) {
     shim_ensure_init();
+
     // Ensure that subsequent stack frames are on a different page than any
     // local variables passed through to the syscall. This ensures that even
     // if any of the syscall arguments are pointers, and those pointers cause
@@ -194,20 +174,21 @@ long syscall(long n, ...) {
     va_list(args);
     va_start(args, n);
     long rv;
-    if (shim_interpositionEnabled()) {
-        // If the syscall is gettimeofday, try to get the cached time first.
-        if (n != SYS_gettimeofday || _gettimeofday_cached(args) != 0) {
-            // Either the syscall is not gettimeofday, or getting the cached time failed.
-            debug("Making interposed syscall %ld", n);
-            rv = _vshadow_syscall(n, args);
-        } else {
-            // We successfully got the cached time without a syscall.
-            rv = 0;
-        }
+
+    if (shim_syscall_is_supported(n) && shim_syscall(n, &rv, args)) {
+        // No syscall needed for the time hotpath.
+        debug("Successfully avoided time-related inter-process syscall %ld", n);
+        // rv was already set
+    } else if (shim_interpositionEnabled()) {
+        // The syscall is made using the shmem IPC channel.
+        debug("Making interposed syscall %ld", n);
+        rv = _vshadow_syscall(n, args);
     } else {
+        // The syscall is made directly; ptrace will get the syscall signal.
         debug("Making real syscall %ld", n);
         rv = _vreal_syscall(n, args);
     }
+
     va_end(args);
     return rv;
 }

--- a/src/shim/shim.c
+++ b/src/shim/shim.c
@@ -17,7 +17,7 @@
 #include "shim/ipc.h"
 #include "shim/shim_event.h"
 #include "shim/shim_logger.h"
-#include "shim/shim_time.h"
+#include "shim/shim_syscall.h"
 #include "support/logger/logger.h"
 
 // Whether Shadow is using preload-based interposition.
@@ -246,7 +246,7 @@ static void _shim_ipc_wait_for_start_event() {
     debug("waiting for start event on %p", _shim_ipc_blk.p);
     shimevent_recvEventFromShadow(_shim_ipc_blk.p, &event, /* spin= */ true);
     assert(event.event_id == SHD_SHIM_EVENT_START);
-    shimtime_set_cached_simulation_nanos(event.event_data.start.simulation_nanos);
+    shim_syscall_set_simtime_nanos(event.event_data.start.simulation_nanos);
 }
 
 static void _shim_parent_init_hybrid() {

--- a/src/shim/shim.h
+++ b/src/shim/shim.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <time.h>
 
 #include <arpa/inet.h>
 #include <sys/socket.h>
@@ -11,24 +12,28 @@
 
 #include "main/shmem/shmem_allocator.h"
 
-ShMemBlock shim_thisThreadEventIPCBlk();
-
 // Should be called by all syscall wrappers to ensure the shim is initialized.
 void shim_ensure_init();
 
+// Disables syscall interposition for the current thread if it's enabled.
+// Every call to this function should be matched with a call to shim_enableInterposition().
+// Returns true if interposition was enabled before this call (and so this call caused it
+// to become disabled), or false if it was already disabled.
+bool shim_disableInterposition();
 
-// Disables syscall interposition for the current thread if it's enabled. (And
-// if not, increments a counter). Should be matched with a call to
-// _shim_enable_interposition.
-//
-// Every call to this function should have corresponding call(s) to
-// _shim_return.
-void shim_disableInterposition();
-
-// Re-enables syscall interposition for the current thread.
-void shim_enableInterposition();
+// Re-enabled syscall interposition for the current thread if it's disabled.
+// Every call to this function should be matched with a call to shim_disableInterposition().
+// Returns true if interposition was disabled before this call (and so this call caused it
+// to become enabled), or false if it was already enabled.
+bool shim_enableInterposition();
 
 // Whether syscall interposition is currently enabled.
 bool shim_interpositionEnabled();
+
+// Returns the shmem block used for IPC, which may be uninitialized.
+ShMemBlock shim_thisThreadEventIPCBlk();
+
+// Return the location of the time object in shared memory, or NULL if unavailable.
+struct timespec* shim_get_shared_time_location();
 
 #endif // SHD_SHIM_SHIM_H_

--- a/src/shim/shim.h
+++ b/src/shim/shim.h
@@ -30,6 +30,9 @@ bool shim_enableInterposition();
 // Whether syscall interposition is currently enabled.
 bool shim_interpositionEnabled();
 
+// Whether we are using the shim-side syscall handler.
+bool shim_use_syscall_handler();
+
 // Returns the shmem block used for IPC, which may be uninitialized.
 ShMemBlock shim_thisThreadEventIPCBlk();
 

--- a/src/shim/shim_event.c
+++ b/src/shim/shim_event.c
@@ -10,6 +10,10 @@ int shadow_get_ipc_blk(ShMemBlockSerialized* ipc_blk_serialized) {
     return syscall(SYS_shadow_get_ipc_blk, ipc_blk_serialized);
 }
 
+int shadow_get_shm_blk(ShMemBlockSerialized* shm_blk_serialized) {
+    return syscall(SYS_shadow_get_shm_blk, shm_blk_serialized);
+}
+
 static inline void shim_determinedSend(int sock_fd, const void* ptr,
                                        size_t nbytes) {
     const char* buf = (const char*)(ptr);

--- a/src/shim/shim_event.h
+++ b/src/shim/shim_event.h
@@ -17,16 +17,22 @@
 typedef struct _ShimSharedMem {
     // While true, Shadow allows syscalls to be executed natively.
     bool ptrace_allow_native_syscalls;
+    // Store the latest simulation time to avoid inter-process time syscalls.
+    struct timespec sim_time;
 } ShimSharedMem;
 
 #define SYS_shadow_set_ptrace_allow_native_syscalls 1000
 #define SYS_shadow_get_ipc_blk 1001
+#define SYS_shadow_get_shm_blk 1002
 
 // Returns 0 on success. Non-zero and sets errno on failure.
 int shadow_set_ptrace_allow_native_syscalls(bool val);
 
 // Returns 0 on success. Non-zero and sets errno on failure.
 int shadow_get_ipc_blk(ShMemBlockSerialized* ipc_blk_serialized);
+
+// Returns 0 on success. Non-zero and sets errno on failure.
+int shadow_get_shm_blk(ShMemBlockSerialized* shm_blk_serialized);
 
 typedef enum {
     // Next val: 11
@@ -50,8 +56,6 @@ typedef struct _ShimEvent {
         struct {
             // Update shim-side simulation clock
             uint64_t simulation_nanos;
-            // Shared memory pointer to a ShimSharedMem.
-            ShMemBlockSerialized shim_shared_mem;
         } start;
 
         struct {

--- a/src/shim/shim_logger.c
+++ b/src/shim/shim_logger.c
@@ -1,5 +1,6 @@
 #include "shim/shim_logger.h"
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -9,6 +10,7 @@
 #include <time.h>
 
 #include "shim/shim.h"
+#include "shim/shim_syscall.h"
 #include "support/logger/log_level.h"
 #include "support/logger/logger.h"
 
@@ -17,16 +19,11 @@ typedef struct _ShimLogger {
     FILE* file;
 } ShimLogger;
 
-static uint64_t _simulation_nanos = 0;
-void shimlogger_set_simulation_nanos(uint64_t simulation_nanos) {
-    _simulation_nanos = simulation_nanos;
-}
-uint64_t shimlogger_get_simulation_nanos() { return _simulation_nanos; }
-
 static size_t _simulation_nanos_string(char* dst, size_t size) {
+    uint64_t simulation_nanos = shim_syscall_get_simtime_nanos();
     const long nanos_per_sec = 1000000000l;
-    time_t seconds = _simulation_nanos / nanos_per_sec;
-    uint64_t nanos = _simulation_nanos % nanos_per_sec;
+    time_t seconds = simulation_nanos / nanos_per_sec;
+    uint64_t nanos = simulation_nanos % nanos_per_sec;
     struct tm tm;
     gmtime_r(&seconds, &tm);
     return snprintf(

--- a/src/shim/shim_logger.h
+++ b/src/shim/shim_logger.h
@@ -1,20 +1,10 @@
 #ifndef SHIM_SHIM_LOGGER_H_
 #define SHIM_SHIM_LOGGER_H_
 
-#include <inttypes.h>
-
 #include "support/logger/logger.h"
 
 #include <stdio.h>
 
 Logger* shimlogger_new(FILE* file);
-
-// Caches the current simulation time to avoid invoking syscalls to get it.
-// Not thread safe, but doesn't matter since Shadow only permits
-// one thread at a time to run anyway.
-void shimlogger_set_simulation_nanos(uint64_t simulation_nanos);
-
-// Returns the current cached simulation time, or 0 if it has not yet been set.
-uint64_t shimlogger_get_simulation_nanos();
 
 #endif

--- a/src/shim/shim_syscall.c
+++ b/src/shim/shim_syscall.c
@@ -11,24 +11,22 @@
 #include <sys/time.h>
 #include <time.h>
 
+#include "main/core/support/definitions.h" // for SIMTIME definitions
 #include "shim/shim.h"
 #include "shim/shim_syscall.h"
 #include "support/logger/logger.h"
-
-#define SIMTIME_NANOS_PER_SEC 1000000000l
-#define SIMTIME_MICROS_PER_NANOSEC 1000l
 
 // We store the simulation time using timespec to reduce the number of
 // conversions that we need to do while servicing syscalls.
 static struct timespec _cached_simulation_time = {0};
 
 void shim_syscall_set_simtime_nanos(uint64_t simulation_nanos) {
-    _cached_simulation_time.tv_sec = simulation_nanos / SIMTIME_NANOS_PER_SEC;
-    _cached_simulation_time.tv_nsec = simulation_nanos % SIMTIME_NANOS_PER_SEC;
+    _cached_simulation_time.tv_sec = simulation_nanos / SIMTIME_ONE_SECOND;
+    _cached_simulation_time.tv_nsec = simulation_nanos % SIMTIME_ONE_SECOND;
 }
 
 uint64_t shim_syscall_get_simtime_nanos() {
-    return (uint64_t)(_cached_simulation_time.tv_sec * SIMTIME_NANOS_PER_SEC) +
+    return (uint64_t)(_cached_simulation_time.tv_sec * SIMTIME_ONE_SECOND) +
            _cached_simulation_time.tv_nsec;
 }
 
@@ -118,7 +116,7 @@ bool shim_syscall(long syscall_num, long* rv, va_list args) {
 
             if (tp) {
                 tp->tv_sec = simtime_ts->tv_sec;
-                tp->tv_usec = simtime_ts->tv_nsec / SIMTIME_MICROS_PER_NANOSEC;
+                tp->tv_usec = simtime_ts->tv_nsec / SIMTIME_ONE_MICROSECOND;
                 debug("gettimeofday() successfully copied time");
             }
             *rv = 0;

--- a/src/shim/shim_syscall.c
+++ b/src/shim/shim_syscall.c
@@ -1,0 +1,134 @@
+/*
+ * The Shadow Simulator
+ * See LICENSE for licensing information
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <time.h>
+
+#include "shim/shim.h"
+#include "shim/shim_syscall.h"
+#include "support/logger/logger.h"
+
+#define SIMTIME_NANOS_PER_SEC 1000000000l
+#define SIMTIME_MICROS_PER_NANOSEC 1000l
+
+// We store the simulation time using timespec to reduce the number of
+// conversions that we need to do while servicing syscalls.
+static struct timespec _cached_simulation_time = {0};
+
+void shim_syscall_set_simtime_nanos(uint64_t simulation_nanos) {
+    _cached_simulation_time.tv_sec = simulation_nanos / SIMTIME_NANOS_PER_SEC;
+    _cached_simulation_time.tv_nsec = simulation_nanos % SIMTIME_NANOS_PER_SEC;
+}
+
+uint64_t shim_syscall_get_simtime_nanos() {
+    return (uint64_t)(_cached_simulation_time.tv_sec * SIMTIME_NANOS_PER_SEC) +
+           _cached_simulation_time.tv_nsec;
+}
+
+bool shim_syscall_is_supported(long syscall_num) {
+    return syscall_num == SYS_clock_gettime || syscall_num == SYS_time ||
+           syscall_num == SYS_gettimeofday;
+}
+
+static struct timespec* _shim_syscall_get_time() {
+    // First try to get time from shared mem.
+    struct timespec* simtime_ts = shim_get_shared_time_location();
+
+    // If that's unavailable, check if the time has been cached before.
+    if (simtime_ts == NULL) {
+        simtime_ts = &_cached_simulation_time;
+    }
+
+    // If the time is not set, then we fail.
+    if (simtime_ts->tv_sec == 0 && simtime_ts->tv_nsec == 0) {
+        return NULL;
+    }
+
+#ifdef DEBUG
+    if (simtime_ts == &_cached_simulation_time) {
+        debug("simtime is available in the shim using cached time");
+    } else {
+        debug("simtime is available in the shim using shared memory");
+    }
+#endif
+
+    return simtime_ts;
+}
+
+bool shim_syscall(long syscall_num, long* rv, va_list args) {
+#ifdef DEBUG
+    assert(shim_syscall_is_supported(syscall_num));
+#endif
+
+    // We currently only support time syscalls, so return if we don't have the time.
+    struct timespec* simtime_ts = _shim_syscall_get_time();
+    if (!simtime_ts) {
+        return false;
+    }
+
+    switch (syscall_num) {
+        case SYS_clock_gettime: {
+            debug("servicing syscall %ld:clock_gettime from the shim", syscall_num);
+
+            clockid_t clk_id = va_arg(args, clockid_t);
+            struct timespec* tp = va_arg(args, struct timespec*);
+
+            if (tp) {
+                *tp = *simtime_ts;
+                debug("clock_gettime() successfully copied time");
+                *rv = 0;
+            } else {
+                debug("found NULL timespec pointer in clock_gettime");
+                *rv = -1;
+                errno = EFAULT;
+            }
+
+            break;
+        }
+
+        case SYS_time: {
+            debug("servicing syscall %ld:time from the shim", syscall_num);
+
+            time_t* tp = va_arg(args, time_t*);
+
+            if (tp) {
+                *tp = simtime_ts->tv_sec;
+                debug("time() successfully copied time");
+            }
+            *rv = simtime_ts->tv_sec;
+
+            break;
+        }
+
+        case SYS_gettimeofday: {
+            debug("servicing syscall %ld:gettimeofday from the shim", syscall_num);
+
+            struct timeval* tp = va_arg(args, struct timeval*);
+
+            if (tp) {
+                tp->tv_sec = simtime_ts->tv_sec;
+                tp->tv_usec = simtime_ts->tv_nsec / SIMTIME_MICROS_PER_NANOSEC;
+                debug("gettimeofday() successfully copied time");
+            }
+            *rv = 0;
+
+            break;
+        }
+
+        default: {
+            debug("syscall %ld is not a supported time-related syscall", syscall_num);
+            // the syscall was not handled
+            return false;
+        }
+    }
+
+    // the syscall was handled
+    return true;
+}

--- a/src/shim/shim_syscall.h
+++ b/src/shim/shim_syscall.h
@@ -5,8 +5,8 @@
 #include <stdbool.h>
 
 /// This module allows us to short-circuit syscalls that can be handled directly
-/// in the shim without neededing to perform a more expensive inter-pocess
-/// syscall operation with shadow.
+/// in the shim without needing to perform a more expensive inter-pocess syscall
+/// operation with shadow.
 
 // Caches the current simulation time to avoid invoking syscalls to get it.
 // Not thread safe, but doesn't matter since Shadow only permits
@@ -16,19 +16,14 @@ void shim_syscall_set_simtime_nanos(uint64_t simulation_nanos);
 // Returns the current cached simulation time, or 0 if it has not yet been set.
 uint64_t shim_syscall_get_simtime_nanos();
 
-// Returns true if the syscall is supported in shimtime_syscall, false otherwise.
-// Supported syscalls are clock_gettime(), time(), and gettimeofday().
-bool shim_syscall_is_supported(long syscall_num);
-
-// Attempt to service a time-related syscall using a previously-cached
-// simulation time or using shared memory if available.
+// Attempt to service a syscall using shared memory if available.
 //
 // Returns true on success, meaning we indeed handled the syscall.
-// Returns false on failure, meaning the simulation time is not
-// available from our sources.
+// Returns false on failure, meaning we do not have the necessary information to
+// properly handle the syscall.
 //
 // If this function returns true, then either:
-// - the syscall succeeded, the time is written to args, and rv is set
+// - the syscall succeeded, results are written to args as needed, and rv is set
 // - the syscall failed, rv and errno are set
 bool shim_syscall(long syscall_num, long* rv, va_list args);
 

--- a/src/shim/shim_syscall.h
+++ b/src/shim/shim_syscall.h
@@ -1,0 +1,35 @@
+#ifndef SRC_SHIM_SHIM_SYSCALL_H_
+#define SRC_SHIM_SHIM_SYSCALL_H_
+
+#include <stdarg.h>
+#include <stdbool.h>
+
+/// This module allows us to short-circuit syscalls that can be handled directly
+/// in the shim without neededing to perform a more expensive inter-pocess
+/// syscall operation with shadow.
+
+// Caches the current simulation time to avoid invoking syscalls to get it.
+// Not thread safe, but doesn't matter since Shadow only permits
+// one thread at a time to run anyway.
+void shim_syscall_set_simtime_nanos(uint64_t simulation_nanos);
+
+// Returns the current cached simulation time, or 0 if it has not yet been set.
+uint64_t shim_syscall_get_simtime_nanos();
+
+// Returns true if the syscall is supported in shimtime_syscall, false otherwise.
+// Supported syscalls are clock_gettime(), time(), and gettimeofday().
+bool shim_syscall_is_supported(long syscall_num);
+
+// Attempt to service a time-related syscall using a previously-cached
+// simulation time or using shared memory if available.
+//
+// Returns true on success, meaning we indeed handled the syscall.
+// Returns false on failure, meaning the simulation time is not
+// available from our sources.
+//
+// If this function returns true, then either:
+// - the syscall succeeded, the time is written to args, and rv is set
+// - the syscall failed, rv and errno are set
+bool shim_syscall(long syscall_num, long* rv, va_list args);
+
+#endif // SRC_SHIM_SHIM_SYSCALL_H_

--- a/src/support/logger/logger.c
+++ b/src/support/logger/logger.c
@@ -113,7 +113,7 @@ static void _logger_default_log(LogLevel level, const char* fileName, const char
     offset += logger_elapsed_string(&buf[offset], sizeof(buf) - offset);
     offset = MIN(offset, sizeof(buf));
 
-    offset += snprintf(&buf[offset], sizeof(buf) - offset, "%s [%s:%i] [%s] ",
+    offset += snprintf(&buf[offset], sizeof(buf) - offset, " %s [%s:%i] [%s] ",
                        loglevel_toStr(level), logger_base_name(fileName), lineNumber, functionName);
     offset = MIN(offset, sizeof(buf));
 


### PR DESCRIPTION
Shadow stores the latest sim time in memory shared with the shim. When time-related syscalls are executed, the shim side can read the latest simulation time directly from shared memory and avoid the more expensive inter-process syscall serviced by shadow.

Fixes #1141