### PR TITLE
Extensions for counters for tracking global syscall counts

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -169,6 +169,10 @@ uint64_t counter_add_value(struct Counter *counter, const char *id, uint64_t val
 
 uint64_t counter_sub_value(struct Counter *counter, const char *id, uint64_t value);
 
+void counter_add_counter(struct Counter *counter, struct Counter *other);
+
+void counter_sub_counter(struct Counter *counter, struct Counter *other);
+
 // Creates a new string representation of the counter, e.g., for logging.
 // The returned string must be free'd by passing it to counter_free_string.
 char *counter_alloc_string(struct Counter *counter);

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -165,7 +165,9 @@ struct Counter *counter_new(void);
 
 void counter_free(struct Counter *counter_ptr);
 
-uint64_t counter_add_one(struct Counter *counter, const char *id);
+uint64_t counter_add_value(struct Counter *counter, const char *id, uint64_t value);
+
+uint64_t counter_sub_value(struct Counter *counter, const char *id, uint64_t value);
 
 // Creates a new string representation of the counter, e.g., for logging.
 // The returned string must be free'd by passing it to counter_free_string.

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -165,9 +165,9 @@ struct Counter *counter_new(void);
 
 void counter_free(struct Counter *counter_ptr);
 
-uint64_t counter_add_value(struct Counter *counter, const char *id, uint64_t value);
+int64_t counter_add_value(struct Counter *counter, const char *id, int64_t value);
 
-uint64_t counter_sub_value(struct Counter *counter, const char *id, uint64_t value);
+int64_t counter_sub_value(struct Counter *counter, const char *id, int64_t value);
 
 void counter_add_counter(struct Counter *counter, struct Counter *other);
 

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -69,4 +69,9 @@ void manager_addNewVirtualProcess(Manager* manager, gchar* hostName, gchar* plug
 void manager_storeCounts(Manager* manager, ObjectCounter* objectCounter);
 void manager_countObject(ObjectType otype, CounterType ctype);
 
+// Add the given syscall counts into a global manager counter.
+void manager_add_syscall_counts(Manager* manager, Counter* syscall_counts);
+// Add the given syscall counts, used when the worker is no longer alive.
+void manager_add_syscall_counts_global(Counter* syscall_counts);
+
 #endif /* SHD_MANAGER_H_ */

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -72,4 +72,7 @@ void worker_incrementPluginError();
 Address* worker_resolveIPToAddress(in_addr_t ip);
 Address* worker_resolveNameToAddress(const gchar* name);
 
+// Aggregate the given syscall counts in a worker syscall counter.
+void worker_add_syscall_counts(Counter* syscall_counts);
+
 #endif /* SHD_WORKER_H_ */

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -59,7 +59,7 @@ OPTION_EXPERIMENTAL_ENTRY("disable-memory-manager", 0, G_OPTION_FLAG_REVERSE, G_
 
 static bool _countSyscalls = false;
 OPTION_EXPERIMENTAL_ENTRY(
-    "count-syscalls", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &_countSyscalls,
+    "enable-syscall-counters", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &_countSyscalls,
     "Count the frequency with which each syscall is made by each plugin process.", NULL)
 
 SysCallHandler* syscallhandler_new(Host* host, Process* process,
@@ -172,7 +172,7 @@ static void _syscallhandler_pre_syscall(SysCallHandler* sys, long number,
     // This avoids double counting in the case where the initial call blocked at first,
     // but then later became unblocked and is now being handled again here.
     if (sys->syscall_counter && !_syscallhandler_wasBlocked(sys)) {
-        counter_add_one(sys->syscall_counter, name);
+        counter_add_value(sys->syscall_counter, name, 1);
     }
 
 #ifdef USE_PERF_TIMERS

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -114,9 +114,16 @@ static void _syscallhandler_free(SysCallHandler* sys) {
 #endif
 
     if (_countSyscalls && sys->syscall_counter) {
+        // Log the plugin thread specific counts
         char* str = counter_alloc_string(sys->syscall_counter);
-        message("Syscall counts: %s", str);
+        message("Thread %d (%s) syscall counts: %s", thread_getID(sys->thread),
+                process_getPluginName(sys->process), str);
         counter_free_string(sys->syscall_counter, str);
+
+        // Add up the counts at the worker level
+        worker_add_syscall_counts(sys->syscall_counter);
+
+        // Cleanup
         counter_free(sys->syscall_counter);
     }
 

--- a/src/main/utility/counter.rs
+++ b/src/main/utility/counter.rs
@@ -112,7 +112,12 @@ impl Counter {
                     }
                     CounterOperation::Set => *val = value,
                 }
-                *val
+                if *val > 0 {
+                    *val
+                } else {
+                    assert_eq!(self.items.remove(id), Some(0));
+                    0
+                }
             }
             None => {
                 // Allocate new key and insert it with initial value of 0.
@@ -304,6 +309,7 @@ mod tests {
         assert_eq!(counter.sub_one("read"), 1);
         assert_eq!(counter.sub_one("read"), 0);
         assert_eq!(counter.sub_one("read"), 0);
+        assert_eq!(counter.get_value("read"), 0);
         counter.set_value("read", 100);
         counter.set_value("write", 100);
         assert_eq!(counter.sub_one("read"), 99);


### PR DESCRIPTION
With these changes, it will be easier to profile hot-path syscalls - the global totals for each syscall will be logged at the end of the simulation.