### PR TITLE
Switch from lazy_static to once_cell

### DIFF
--- a/src/main/Cargo.lock
+++ b/src/main/Cargo.lock
@@ -45,12 +45,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +80,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "ppv-lite86"
@@ -156,11 +156,11 @@ version = "2.0.0-pre"
 dependencies = [
  "atomic_refcell",
  "bitflags",
- "lazy_static",
  "libc",
  "log",
  "log-bindings",
  "nix",
+ "once_cell",
  "rand",
  "rand_chacha",
  "rand_core",

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -11,12 +11,12 @@ crate-type = ["staticlib"]
 [dependencies]
 atomic_refcell = "0.1"
 bitflags = "1.2"
-lazy_static = "1.4.0"
 libc = "0.2"
 # don't log debug or trace levels in release mode
 log = { version = "0.4", features = ["release_max_level_info"] }
 log-bindings = { path = "../support/logger/rust_bindings" }
 nix = "0.20.0"
+once_cell = "1.7"
 rand = "0.8.0"
 rand_chacha = "0.3.0"
 rand_core = "0.6.0"

--- a/src/main/utility/proc_maps.rs
+++ b/src/main/utility/proc_maps.rs
@@ -1,4 +1,4 @@
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use std::error::Error;
 use std::fmt::Display;
@@ -39,10 +39,8 @@ pub enum MappingPath {
 impl FromStr for MappingPath {
     type Err = Box<dyn Error>;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        lazy_static! {
-            static ref SPECIAL_RE: Regex = Regex::new(r"^\[(\S+)\]$").unwrap();
-            static ref THREAD_STACK_RE: Regex = Regex::new(r"^stack:(\d+)$").unwrap();
-        }
+        static SPECIAL_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\[(\S+)\]$").unwrap());
+        static THREAD_STACK_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^stack:(\d+)$").unwrap());
 
         if s.starts_with('/') {
             return Ok(MappingPath::Path(PathBuf::from(s)));
@@ -104,12 +102,12 @@ where
 impl FromStr for Mapping {
     type Err = Box<dyn Error>;
     fn from_str(line: &str) -> Result<Self, Self::Err> {
-        lazy_static! {
-            static ref RE: Regex = Regex::new(
-                r"^(\S+)-(\S+)\s+(\S)(\S)(\S)(\S)\s+(\S+)\s+(\S+):(\S+)\s+(\S+)\s*(\S*)\s*(\S*)$"
+        static RE: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(
+                r"^(\S+)-(\S+)\s+(\S)(\S)(\S)(\S)\s+(\S+)\s+(\S+):(\S+)\s+(\S+)\s*(\S*)\s*(\S*)$",
             )
-            .unwrap();
-        }
+            .unwrap()
+        });
 
         let caps = RE
             .captures(line)


### PR DESCRIPTION
The `once_cell` library is more flexible, and seems to be the recommended library now. It also has a tracking issue for merging into the standard library (some parts already have been and it exists in rust nightly), so I think it's a good idea to switch. ~(Also I'm using once_cell in some other code at the moment, and it would be nice to use just a single package.)~