### PR TITLE
Decouple # of worker threads from max concurrency

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -32,6 +32,7 @@ endif(SHADOW_PROFILE STREQUAL ON)
 
 ## sources for our main shadow program
 set(shadow_srcs
+    core/logical_processor.c
     core/logger/logger_helper.c
     core/logger/log_record.c
     core/logger/shadow_logger.c

--- a/src/main/core/logical_processor.c
+++ b/src/main/core/logical_processor.c
@@ -1,0 +1,176 @@
+/*
+
+ * The Shadow Simulator
+ * Copyright (c) 2010-2011, Rob Jansen
+ * See LICENSE for licensing information
+ */
+
+#include "main/core/logical_processor.h"
+
+#include <glib.h>
+
+#include "main/core/worker.h"
+#include "main/host/affinity.h"
+
+typedef struct _LogicalProcessor LogicalProcessor;
+struct _LogicalProcessor {
+    /* physical cpuId that this LogicalProcessor will run on, for use with
+     * affinity_*. Immutable after initialization, so don't need mutex to
+     * access. */
+    int cpuId;
+
+    /* Worker*'s to run on this LogicalProcessor. */
+    GAsyncQueue* readyWorkers;
+
+    /* Worker*'s that have completed the current task on this LogicalProcessor.
+     */
+    GAsyncQueue* doneWorkers;
+
+#ifdef USE_PERF_TIMERS
+    /* Protects members below */
+    GMutex mutex;
+
+    /* Total time that this LogicalProcessor has been idle (Not executing a
+     * task). */
+    GTimer* idleTimer;
+#endif
+
+    MAGIC_DECLARE;
+};
+
+struct _LogicalProcessors {
+    LogicalProcessor* lps;
+    size_t n;
+    MAGIC_DECLARE;
+};
+
+static LogicalProcessor* _idx(LogicalProcessors* lps, int n) {
+    MAGIC_ASSERT(lps);
+    utility_assert(n >= 0);
+    utility_assert(n < lps->n);
+    LogicalProcessor* lp = &lps->lps[n];
+    MAGIC_ASSERT(lp);
+    return lp;
+}
+
+LogicalProcessors* lps_new(int n) {
+    LogicalProcessors* lps = g_new(LogicalProcessors, 1);
+    *lps = (LogicalProcessors){
+        .lps = g_new(LogicalProcessor, n),
+        .n = n,
+    };
+    MAGIC_INIT(lps);
+
+    for (int i = 0; i < n; ++i) {
+        LogicalProcessor* lp = &lps->lps[i];
+        *lp = (LogicalProcessor){
+            .cpuId = affinity_getGoodWorkerAffinity(),
+            .readyWorkers = g_async_queue_new(),
+            .doneWorkers = g_async_queue_new(),
+#ifdef USE_PERF_TIMERS
+            .idleTimer = g_timer_new(),
+#endif
+        };
+#ifdef USE_PERF_TIMERS
+        g_mutex_init(&lp->mutex);
+#endif
+        MAGIC_INIT(lp);
+    }
+    return lps;
+}
+
+void lps_free(LogicalProcessors* lps) {
+    MAGIC_ASSERT(lps);
+
+    for (int i = 0; i < lps->n; ++i) {
+        LogicalProcessor* lp = _idx(lps, i);
+        MAGIC_ASSERT(lp);
+        g_clear_pointer(&lp->readyWorkers, g_async_queue_unref);
+        g_clear_pointer(&lp->doneWorkers, g_async_queue_unref);
+#ifdef USE_PERF_TIMERS
+        g_clear_pointer(&lp->idleTimer, g_timer_destroy);
+        g_mutex_clear(&lp->mutex);
+#endif
+        MAGIC_CLEAR(lp);
+    }
+
+    MAGIC_CLEAR(lps);
+    g_free(lps);
+}
+
+int lps_n(LogicalProcessors* lps) {
+    MAGIC_ASSERT(lps);
+    return lps->n;
+}
+
+#ifdef USE_PERF_TIMERS
+void lps_idleTimerContinue(LogicalProcessors* lps, int lpi) {
+    LogicalProcessor* lp = _idx(lps, lpi);
+    g_mutex_lock(&lp->mutex);
+    g_timer_continue(lp->idleTimer);
+    g_mutex_unlock(&lp->mutex);
+}
+
+void lps_idleTimerStop(LogicalProcessors* lps, int lpi) {
+    LogicalProcessor* lp = _idx(lps, lpi);
+    g_mutex_lock(&lp->mutex);
+    g_timer_stop(lp->idleTimer);
+    g_mutex_unlock(&lp->mutex);
+}
+
+double lps_idleTimerElapsed(LogicalProcessors* lps, int lpi) {
+    LogicalProcessor* lp = _idx(lps, lpi);
+    g_mutex_lock(&lp->mutex);
+    double rv = g_timer_elapsed(lp->idleTimer, NULL);
+    g_mutex_unlock(&lp->mutex);
+    return rv;
+}
+#endif
+
+void lps_readyPush(LogicalProcessors* lps, int lpi, Worker* worker) {
+    LogicalProcessor* lp = _idx(lps, lpi);
+    g_async_queue_push_front(lp->readyWorkers, worker);
+}
+
+Worker* lps_popWorkerToRunOn(LogicalProcessors* lps, int lpi) {
+    LogicalProcessor* lp = _idx(lps, lpi);
+    for (int i = 0; i < lps_n(lps); ++i) {
+        // Start with workers that last ran on `lpi`; if none are available
+        // steal from another in round-robin order.
+        int fromLpi = (lpi + i) % lps_n(lps);
+        LogicalProcessor* fromLp = _idx(lps, fromLpi);
+        Worker* worker = g_async_queue_try_pop(fromLp->readyWorkers);
+        if (worker) {
+            return worker;
+        }
+    }
+    return NULL;
+}
+
+void lps_donePush(LogicalProcessors* lps, int lpi, Worker* worker) {
+    LogicalProcessor* lp = _idx(lps, lpi);
+    // Push to the *front* of the queue so that the last workers to run the
+    // current task, which are freshest in cache, are the first ones to run the
+    // next task.
+    g_async_queue_push_front(lp->doneWorkers, worker);
+}
+
+void lps_finishTask(LogicalProcessors* lps) {
+    for (int lpi = 0; lpi < lps->n; ++lpi) {
+        LogicalProcessor* lp = _idx(lps, lpi);
+        utility_assert(g_async_queue_length(lp->readyWorkers) == 0);
+
+        // Swap `ready` and `done` Qs
+        GAsyncQueue* tmp = lp->readyWorkers;
+        lp->readyWorkers = lp->doneWorkers;
+        lp->doneWorkers = tmp;
+    }
+}
+
+int lps_cpuId(LogicalProcessors* lps, int lpi) {
+    LogicalProcessor* lp = _idx(lps, lpi);
+
+    // No synchronization needed since cpus are never mutated after
+    // construction.
+    return lp->cpuId;
+}

--- a/src/main/core/logical_processor.h
+++ b/src/main/core/logical_processor.h
@@ -1,0 +1,59 @@
+/*
+
+ * The Shadow Simulator
+ * Copyright (c) 2010-2011, Rob Jansen
+ * See LICENSE for licensing information
+ */
+
+/*
+ * Represents a pool of logical processors on which `Worker` threads may run.
+ */
+
+#include "main/core/worker.h"
+
+/*
+ * Logical processor on which a WorkerPool runs Worker threads.
+ */
+typedef struct _LogicalProcessors LogicalProcessors;
+
+/* A set of `n` logical processors */
+LogicalProcessors* lps_new(int n);
+void lps_free(LogicalProcessors* lps);
+
+/* Number of logical processors. Thread safe. */
+int lps_n(LogicalProcessors* lps);
+
+#ifdef USE_PERF_TIMERS
+/* Track idle time. Thread safe. */
+double lps_idleTimerElapsed(LogicalProcessors* lps, int lpi);
+
+/* Call to mark the processor idle. Thread safe. */
+void lps_idleTimerContinue(LogicalProcessors* lps, int lpi);
+
+/* Call to mark the processor not-idle. Thread safe. */
+void lps_idleTimerStop(LogicalProcessors* lps, int lpi);
+#else
+// define macros that do nothing
+#define lps_idleTimerContinue(lps, lpi)
+#define lps_idleTimerStop(lps, lpi);
+#endif
+
+/* Add a worker to be run on `lpi`. Caller retains ownership of `worker`. Thread
+ * safe. */
+void lps_readyPush(LogicalProcessors* lps, int lpi, Worker* worker);
+
+/* Get a worker to run on `lpi`. Returns NULL if there are no more workers to
+ * run. Thread safe. */
+Worker* lps_popWorkerToRunOn(LogicalProcessors* lps, int lpi);
+
+/* Record that the `worker` previously returned by `lp_readyPopFor` has
+ * completed its task. Starts idle timer. Thread safe. */
+void lps_donePush(LogicalProcessors* lps, int lpi, Worker* worker);
+
+/* Call after finishing running a task on all workers to mark all workers ready
+ * to run again. NOT thread safe. */
+void lps_finishTask(LogicalProcessors* lps);
+
+/* Returns the cpu id that should be used with the `affinity_*` module to run a
+ * thread on `lpi` */
+int lps_cpuId(LogicalProcessors* lps, int lpi);

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -18,7 +18,6 @@
 #include "main/core/support/definitions.h"
 #include "main/core/support/object_counter.h"
 #include "main/core/support/options.h"
-#include "main/core/worker.h"
 #include "main/host/host.h"
 #include "main/host/network_interface.h"
 #include "main/routing/address.h"
@@ -197,7 +196,8 @@ Manager* manager_new(Controller* controller, Options* options, SimulationTime en
     guint nWorkers = options_getNWorkerThreads(options);
     SchedulerPolicyType policy = _manager_getEventSchedulerPolicy(manager);
     guint schedulerSeed = _manager_nextRandomUInt(manager);
-    manager->scheduler = scheduler_new(policy, nWorkers, manager, schedulerSeed, endTime);
+    manager->scheduler =
+        scheduler_new(manager, policy, nWorkers, schedulerSeed, endTime);
 
     manager->cwdPath = g_get_current_dir();
     manager->dataPath = g_build_filename(manager->cwdPath, options_getDataOutputPath(options), NULL);
@@ -413,57 +413,44 @@ static void _manager_heartbeat(Manager* manager, SimulationTime simClockNow) {
 
 void manager_run(Manager* manager) {
     MAGIC_ASSERT(manager);
-    if(scheduler_getPolicy(manager->scheduler) == SP_SERIAL_GLOBAL) {
-        scheduler_start(manager->scheduler);
+    /* we are the main thread, we manage the execution window updates while the
+     * workers run events */
+    SimulationTime windowStart = 0, windowEnd = 1;
+    SimulationTime minNextEventTime = SIMTIME_INVALID;
+    gboolean keepRunning = TRUE;
 
-        /* the main manager thread becomes the only worker and runs everything */
-        WorkerRunData* data = g_new0(WorkerRunData, 1);
-        data->threadID = 0;
-        data->scheduler = manager->scheduler;
-        data->userData = manager;
-        data->notifyDoneRunning = NULL; // we don't need to be notified in single thread mode
+    scheduler_start(manager->scheduler);
 
-        /* the worker takes control of data pointer and frees it */
-        worker_run(data);
+    while (keepRunning) {
+        /* release the workers and run next round */
+        scheduler_continueNextRound(manager->scheduler, windowStart, windowEnd);
 
-        scheduler_finish(manager->scheduler);
-    } else {
-        /* we are the main thread, we manage the execution window updates while the workers run events */
-        SimulationTime windowStart = 0, windowEnd = 1;
-        SimulationTime minNextEventTime = SIMTIME_INVALID;
-        gboolean keepRunning = TRUE;
+        /* do some idle processing here if needed */
+        _manager_heartbeat(manager, windowStart);
 
-        scheduler_start(manager->scheduler);
+        /* flush manager threads messages */
+        shadow_logger_flushRecords(shadow_logger_getDefault(), pthread_self());
 
-        while(keepRunning) {
-            /* release the workers and run next round */
-            scheduler_continueNextRound(manager->scheduler, windowStart, windowEnd);
+        /* let the logger know it can flush everything prior to this round */
+        shadow_logger_syncToDisk(shadow_logger_getDefault());
 
-            /* do some idle processing here if needed */
-            /* TODO the heartbeat should run in single process mode too! */
-            _manager_heartbeat(manager, windowStart);
+        /* wait for the workers to finish processing nodes before we update the
+         * execution window
+         */
+        minNextEventTime = scheduler_awaitNextRound(manager->scheduler);
 
-            /* flush manager threads messages */
-            shadow_logger_flushRecords(shadow_logger_getDefault(),
-                                       pthread_self());
+        /* we are in control now, the workers are waiting for the next round */
+        info("finished execution window [%" G_GUINT64_FORMAT
+             "--%" G_GUINT64_FORMAT "] next event at %" G_GUINT64_FORMAT,
+             windowStart, windowEnd, minNextEventTime);
 
-            /* let the logger know it can flush everything prior to this round */
-            shadow_logger_syncToDisk(shadow_logger_getDefault());
-
-            /* wait for the workers to finish processing nodes before we update the execution window */
-            minNextEventTime = scheduler_awaitNextRound(manager->scheduler);
-
-            /* we are in control now, the workers are waiting for the next round */
-            info("finished execution window [%"G_GUINT64_FORMAT"--%"G_GUINT64_FORMAT"] next event at %"G_GUINT64_FORMAT,
-                    windowStart, windowEnd, minNextEventTime);
-
-            /* notify controller that we finished this round, and the time of our next event
-             * in order to fast-forward our execute window if possible */
-            keepRunning = controller_managerFinishedCurrentRound(manager->controller, minNextEventTime, &windowStart, &windowEnd);
-        }
-
-        scheduler_finish(manager->scheduler);
+        /* notify controller that we finished this round, and the time of our
+         * next event in order to fast-forward our execute window if possible */
+        keepRunning = controller_managerFinishedCurrentRound(
+            manager->controller, minNextEventTime, &windowStart, &windowEnd);
     }
+
+    scheduler_finish(manager->scheduler);
 }
 
 void manager_incrementPluginError(Manager* manager) {

--- a/src/main/core/scheduler/scheduler.h
+++ b/src/main/core/scheduler/scheduler.h
@@ -9,6 +9,7 @@
 
 #include <glib.h>
 
+#include "main/core/manager.h"
 #include "main/core/scheduler/scheduler_policy.h"
 #include "main/core/support/definitions.h"
 #include "main/core/work/event.h"
@@ -16,8 +17,9 @@
 
 typedef struct _Scheduler Scheduler;
 
-Scheduler* scheduler_new(SchedulerPolicyType policyType, guint nWorkers, gpointer threadUserData,
-        guint schedulerSeed, SimulationTime endTime);
+Scheduler* scheduler_new(Manager* manager, SchedulerPolicyType policyType,
+                         guint nWorkers, guint schedulerSeed,
+                         SimulationTime endTime);
 void scheduler_ref(Scheduler*);
 void scheduler_unref(Scheduler*);
 void scheduler_shutdown(Scheduler* scheduler);

--- a/src/main/core/support/definitions.h
+++ b/src/main/core/support/definitions.h
@@ -80,7 +80,8 @@ typedef guint64 EmulatedTime;
 /**
  * Conversion from emulated time to simulated time.
  */
-#define EMULATED_TIME_TO_SIMULATED_TIME(emtime) ((SimulationTime)(emtime-EMULATED_TIME_OFFSET))
+#define EMULATED_TIME_TO_SIMULATED_TIME(emtime)                                \
+    ((SimulationTime)((emtime)-EMULATED_TIME_OFFSET))
 
 /**
  * The minimum file descriptor shadow returns to the plugin.
@@ -121,14 +122,14 @@ typedef guint64 EmulatedTime;
  */
 #define NET_TCP_HZ 1000
 #define CONFIG_TCP_RTO_INIT NET_TCP_HZ
-#define CONFIG_TCP_RTO_MIN NET_TCP_HZ/5
-#define CONFIG_TCP_RTO_MAX NET_TCP_HZ*120
+#define CONFIG_TCP_RTO_MIN (NET_TCP_HZ / 5)
+#define CONFIG_TCP_RTO_MAX (NET_TCP_HZ * 120)
 
 /**
  * Default delay ack times, from net/tcp.h
  */
-#define CONFIG_TCP_DELACK_MIN NET_TCP_HZ/25
-#define CONFIG_TCP_DELACK_MAX NET_TCP_HZ/5
+#define CONFIG_TCP_DELACK_MIN (NET_TCP_HZ / 25)
+#define CONFIG_TCP_DELACK_MAX (NET_TCP_HZ / 5)
 
 /**
  * Minimum size of the send buffer per socket when TCP-autotuning is used.

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -1,25 +1,31 @@
 /*
+
  * The Shadow Simulator
  * Copyright (c) 2010-2011, Rob Jansen
  * See LICENSE for licensing information
  */
+#include "main/core/worker.h"
 
 /* thread-level storage structure */
+#include <errno.h>
 #include <glib.h>
 #include <math.h>
 #include <netinet/in.h>
 #include <pthread.h>
+#include <semaphore.h>
 #include <stddef.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
 
 #include "main/core/logger/shadow_logger.h"
-#include "main/core/scheduler/scheduler.h"
+#include "main/core/logical_processor.h"
 #include "main/core/manager.h"
+#include "main/core/scheduler/scheduler.h"
 #include "main/core/support/definitions.h"
 #include "main/core/support/object_counter.h"
 #include "main/core/support/options.h"
 #include "main/core/work/event.h"
 #include "main/core/work/task.h"
-#include "main/core/worker.h"
 #include "main/host/affinity.h"
 #include "main/host/host.h"
 #include "main/host/process.h"
@@ -34,18 +40,23 @@
 #include "support/logger/log_level.h"
 #include "support/logger/logger.h"
 
+static void* _worker_run(void* voidWorker);
+static void _worker_free(Worker* worker);
+static void _worker_freeHostProcesses(Host* host, Worker* worker);
+static void _worker_shutdownHost(Host* host, Worker* worker);
+static void _workerpool_setLogicalProcessorIdx(WorkerPool* workerpool,
+                                               Worker* worker, int cpuId);
+
 struct _Worker {
+    WorkerPool* workerPool;
+
     /* our thread and an id that is unique among all threads */
     pthread_t thread;
-    guint threadID;
+    int threadID;
+    pid_t nativeThreadID;
 
-    /* affinity of the worker. */
-    int cpu_num_affinity;
-
-    /* pointer to the object that communicates with the controller process */
-    Manager* manager;
-    /* pointer to the per-manager parallel scheduler object that feeds events to all workers */
-    Scheduler* scheduler;
+    /* Index into workerPool->logicalProcessors */
+    int logicalProcessorIdx;
 
     /* timing information tracked by this worker */
     struct {
@@ -65,56 +76,311 @@ struct _Worker {
 
     ObjectCounter* objectCounts;
 
+    /* Used by the WorkerPool to start the Worker for each task */
+    sem_t beginSem;
+
     MAGIC_DECLARE;
 };
 
-static Worker* _worker_new(Manager*, guint);
+struct _WorkerPool {
+    /* Unowned pointer to the object that communicates with the controller
+     * process */
+    Manager* manager;
+
+    /* Unowned pointer to the per-manager parallel scheduler object that feeds
+     * events to all workers */
+    Scheduler* scheduler;
+
+    /* Number of Worker threads */
+    int nWorkers;
+    /* Array of size `nWorkers`. */
+    Worker** workers;
+
+    /* Tracks completion of the current task */
+    CountDownLatch* finishLatch;
+
+    /* Current task being executed by workers */
+    WorkerPoolTaskFn taskFn;
+    void* taskData;
+
+    /* Whether the worker threads have been joined */
+    gboolean joined;
+
+    /* Set of logical processors on which workers run */
+    LogicalProcessors* logicalProcessors;
+
+    MAGIC_DECLARE;
+};
+
+static Worker* _worker_new(WorkerPool*, int);
 static void _worker_free(Worker*);
 
-/* holds a thread-private key that each thread references to get a private
- * instance of a worker object */
-static GPrivate workerKey = G_PRIVATE_INIT((GDestroyNotify)_worker_free);
+WorkerPool* workerpool_new(Manager* manager, Scheduler* scheduler, int nWorkers,
+                           int nConcurrent) {
+    int nLogicalProcessors = 0;
+    if (nWorkers == 0 || nConcurrent == 0) {
+        // With no concurrency, we still use a single logical processor.
+        nLogicalProcessors = 1;
+    } else if (nConcurrent < 0 || nConcurrent > nWorkers) {
+        // Never makes sense to use more logical processors than workers.
+        nLogicalProcessors = nWorkers;
+    } else {
+        nLogicalProcessors = nConcurrent;
+    }
 
-static Worker* _worker_getPrivate() {
-    /* get current thread's private worker object */
-    Worker* worker = g_private_get(&workerKey);
-    MAGIC_ASSERT(worker);
-    return worker;
+    WorkerPool* pool = g_new(WorkerPool, 1);
+    *pool = (WorkerPool){
+        .manager = manager,
+        .scheduler = scheduler,
+        .nWorkers = nWorkers,
+        .finishLatch = countdownlatch_new(nWorkers),
+        .joined = FALSE,
+        .logicalProcessors = lps_new(nLogicalProcessors),
+    };
+    MAGIC_INIT(pool);
+
+    if (nWorkers == 0) {
+        // Create singleton worker object, which will run on this thread.
+        pool->workers = g_new(Worker*, 1);
+        Worker* worker = _worker_new(pool, -1);
+        // The worker runs on the single shadow thread. tid=0 refers to "this"
+        // thread.
+        worker->nativeThreadID = 0;
+        pool->workers[0] = worker;
+        _workerpool_setLogicalProcessorIdx(pool, worker, 0);
+        return pool;
+    }
+
+    pool->workers = g_new(Worker*, nWorkers);
+    for (int i = 0; i < nWorkers; ++i) {
+        pool->workers[i] = _worker_new(pool, i);
+    }
+
+    // Wait for all threads to set their tid
+    countdownlatch_await(pool->finishLatch);
+    countdownlatch_reset(pool->finishLatch);
+
+    for (int i = 0; i < nWorkers; ++i) {
+        Worker* worker = pool->workers[i];
+        utility_assert(worker->nativeThreadID > 0);
+        int lpi = i % nLogicalProcessors;
+        lps_readyPush(pool->logicalProcessors, lpi, worker);
+        _workerpool_setLogicalProcessorIdx(pool, worker, lpi);
+    }
+
+    return pool;
 }
 
-gboolean worker_isAlive() { return g_private_get(&workerKey) != NULL; }
+// Find and return a Worker to run the current or next task on `toLpi`. Prefers
+// a Worker that last ran on `toLpi`, but if none is available will take one
+// from another logical processor.
+//
+// TODO: Take locality into account when finding another LogicalProcessor to
+// migrate from, when needed.
+static Worker* _workerpool_getNextWorkerForLogicalProcessorIdx(WorkerPool* pool,
+                                                               int toLpi) {
+    Worker* nextWorker = lps_popWorkerToRunOn(pool->logicalProcessors, toLpi);
+    if (nextWorker) {
+        _workerpool_setLogicalProcessorIdx(pool, nextWorker, toLpi);
+    }
+    return nextWorker;
+}
 
-static Worker* _worker_new(Manager* manager, guint threadID) {
-    /* make sure this isnt called twice on the same thread! */
-    utility_assert(!worker_isAlive());
+// Internal runner. *Does* support NULL `taskFn`, which is used to signal
+// cancellation.
+void _workerpool_startTaskFn(WorkerPool* pool, WorkerPoolTaskFn taskFn,
+                             void* data) {
+    MAGIC_ASSERT(pool);
 
+    if (pool->nWorkers == 0) {
+        if (taskFn) {
+            taskFn(data);
+        }
+        return;
+    }
+
+    // Only supports one task at a time.
+    utility_assert(pool->taskFn == NULL);
+
+    pool->taskFn = taskFn;
+    pool->taskData = data;
+
+    for (int i = 0; i < lps_n(pool->logicalProcessors); ++i) {
+        Worker* worker =
+            _workerpool_getNextWorkerForLogicalProcessorIdx(pool, i);
+        if (worker) {
+            MAGIC_ASSERT(worker);
+            lps_idleTimerStop(pool->logicalProcessors, i);
+            if (sem_post(&worker->beginSem) != 0) {
+                error("sem_post: %s", g_strerror(errno));
+            }
+        } else {
+            // There's no more work to do.
+            break;
+        }
+    }
+}
+
+void workerpool_joinAll(WorkerPool* pool) {
+    MAGIC_ASSERT(pool);
+    utility_assert(!pool->joined);
+
+    // Signal threads to exit.
+    _workerpool_startTaskFn(pool, NULL, NULL);
+
+    // Not strictly necessary, but could help clarity/debugging.
+    workerpool_awaitTaskFn(pool);
+
+#ifdef USE_PERF_TIMERS
+    for (int i = 0; i < lps_n(pool->logicalProcessors); ++i) {
+        message("Logical Processor %d total idle time was %f seconds", i,
+                lps_idleTimerElapsed(pool->logicalProcessors, i));
+    }
+#endif
+
+    // Join each pthread. (Alternatively we could use pthread_detach on startup)
+    for (int i = 0; i < pool->nWorkers; ++i) {
+        void* threadRetval;
+        int rv = pthread_join(pool->workers[i]->thread, &threadRetval);
+        if (rv != 0) {
+            error("pthread_join: %s", g_strerror(rv));
+        }
+        utility_assert(threadRetval == NULL);
+    }
+
+    pool->joined = TRUE;
+}
+
+void workerpool_free(WorkerPool* pool) {
+    MAGIC_ASSERT(pool);
+    utility_assert(pool->joined);
+
+    // When there are 0 worker threads, we still have a single worker object.
+    int workersToFree = MAX(pool->nWorkers, 1);
+
+    // Free threads.
+    for (int i = 0; i < workersToFree; ++i) {
+        g_clear_pointer(&pool->workers[i], _worker_free);
+    }
+    g_clear_pointer(&pool->workers, g_free);
+    g_clear_pointer(&pool->finishLatch, countdownlatch_free);
+
+    g_clear_pointer(&pool->logicalProcessors, lps_free);
+
+    MAGIC_CLEAR(pool);
+}
+
+void workerpool_startTaskFn(WorkerPool* pool, WorkerPoolTaskFn taskFn,
+                            void* taskData) {
+    MAGIC_ASSERT(pool);
+    // Public interface doesn't support NULL taskFn
+    utility_assert(taskFn);
+    _workerpool_startTaskFn(pool, taskFn, taskData);
+}
+
+void workerpool_awaitTaskFn(WorkerPool* pool) {
+    MAGIC_ASSERT(pool);
+    if (pool->nWorkers == 0) {
+        return;
+    }
+    countdownlatch_await(pool->finishLatch);
+    countdownlatch_reset(pool->finishLatch);
+    pool->taskFn = NULL;
+    pool->taskData = NULL;
+
+    lps_finishTask(pool->logicalProcessors);
+}
+
+pthread_t workerpool_getThread(WorkerPool* pool, int threadId) {
+    MAGIC_ASSERT(pool);
+    utility_assert(threadId < pool->nWorkers);
+    return pool->workers[threadId]->thread;
+}
+
+int workerpool_getNWorkers(WorkerPool* pool) {
+    MAGIC_ASSERT(pool);
+    return pool->nWorkers;
+}
+
+static void _workerpool_setLogicalProcessorIdx(WorkerPool* workerPool,
+                                               Worker* worker,
+                                               int logicalProcessorIdx) {
+    MAGIC_ASSERT(workerPool);
+    MAGIC_ASSERT(worker);
+    utility_assert(logicalProcessorIdx < lps_n(workerPool->logicalProcessors));
+    utility_assert(logicalProcessorIdx >= 0);
+
+    int oldCpuId = worker->logicalProcessorIdx >= 0
+                       ? lps_cpuId(workerPool->logicalProcessors,
+                                   worker->logicalProcessorIdx)
+                       : AFFINITY_UNINIT;
+    worker->logicalProcessorIdx = logicalProcessorIdx;
+    int newCpuId =
+        lps_cpuId(workerPool->logicalProcessors, logicalProcessorIdx);
+
+    // Set affinity of the worker thread to match that of the logical processor.
+    affinity_setProcessAffinity(worker->nativeThreadID, newCpuId, oldCpuId);
+}
+
+static __thread Worker* _threadWorker = NULL;
+
+static Worker* _worker_getPrivate() {
+    MAGIC_ASSERT(_threadWorker);
+    return _threadWorker;
+}
+
+gboolean worker_isAlive() { return _threadWorker != NULL; }
+
+static Worker* _worker_new(WorkerPool* workerPool, int threadID) {
     Worker* worker = g_new0(Worker, 1);
     MAGIC_INIT(worker);
 
-    worker->cpu_num_affinity = AFFINITY_UNINIT;
-    worker->manager = manager;
-    worker->thread = pthread_self();
+    worker->workerPool = workerPool;
     worker->threadID = threadID;
     worker->clock.now = SIMTIME_INVALID;
     worker->clock.last = SIMTIME_INVALID;
     worker->clock.barrier = SIMTIME_INVALID;
     worker->objectCounts = objectcounter_new();
+    worker->logicalProcessorIdx = -1;
 
-    worker->bootstrapEndTime = manager_getBootstrapEndTime(worker->manager);
+    worker->bootstrapEndTime = manager_getBootstrapEndTime(workerPool->manager);
 
-    g_private_replace(&workerKey, worker);
+    // Calling thread is the sole worker thread
+    if (threadID < 0) {
+        _threadWorker = worker;
+        return worker;
+    }
+
+    sem_init(&worker->beginSem, 0, 0);
+
+    int rv = pthread_create(&worker->thread, NULL, _worker_run, worker);
+    if (rv != 0) {
+        error("pthread_create: %s", g_strerror(rv));
+    }
+
+    GString* name = g_string_new(NULL);
+    g_string_printf(name, "worker-%i", threadID);
+    rv = pthread_setname_np(worker->thread, name->str);
+    if (rv != 0) {
+        warning("unable to set name of worker thread to '%s': %s", name->str,
+                g_strerror(rv));
+    }
+    g_string_free(name, TRUE);
+
+    shadow_logger_register(shadow_logger_getDefault(), worker->thread);
 
     return worker;
 }
 
 static void _worker_free(Worker* worker) {
     MAGIC_ASSERT(worker);
+    utility_assert(!worker->active.host);
+    utility_assert(!worker->active.process);
+    utility_assert(worker->objectCounts);
 
-    if (worker->objectCounts != NULL) {
-        objectcounter_free(worker->objectCounts);
-    }
+    objectcounter_free(worker->objectCounts);
 
-    g_private_set(&workerKey, NULL);
+    _threadWorker = NULL;
 
     MAGIC_CLEAR(worker);
     g_free(worker);
@@ -122,114 +388,118 @@ static void _worker_free(Worker* worker) {
 
 int worker_getAffinity() {
     Worker* worker = _worker_getPrivate();
-    return worker->cpu_num_affinity;
+    return lps_cpuId(worker->workerPool->logicalProcessors,
+                     worker->logicalProcessorIdx);
 }
 
 DNS* worker_getDNS() {
     Worker* worker = _worker_getPrivate();
-    return manager_getDNS(worker->manager);
+    return manager_getDNS(worker->workerPool->manager);
 }
 
 Address* worker_resolveIPToAddress(in_addr_t ip) {
     Worker* worker = _worker_getPrivate();
-    DNS* dns = manager_getDNS(worker->manager);
+    DNS* dns = manager_getDNS(worker->workerPool->manager);
     return dns_resolveIPToAddress(dns, ip);
 }
 
 Address* worker_resolveNameToAddress(const gchar* name) {
     Worker* worker = _worker_getPrivate();
-    DNS* dns = manager_getDNS(worker->manager);
+    DNS* dns = manager_getDNS(worker->workerPool->manager);
     return dns_resolveNameToAddress(dns, name);
 }
 
 Topology* worker_getTopology() {
     Worker* worker = _worker_getPrivate();
-    return manager_getTopology(worker->manager);
+    return manager_getTopology(worker->workerPool->manager);
 }
 
 Options* worker_getOptions() {
     Worker* worker = _worker_getPrivate();
-    return manager_getOptions(worker->manager);
-}
-
-static void _worker_setAffinity(Worker* worker) {
-    MAGIC_ASSERT(worker);
-    int good_cpu_num = affinity_getGoodWorkerAffinity(worker->threadID);
-    worker->cpu_num_affinity =
-        affinity_setThisProcessAffinity(good_cpu_num, worker->cpu_num_affinity);
+    return manager_getOptions(worker->workerPool->manager);
 }
 
 /* this is the entry point for worker threads when running in parallel mode,
  * and otherwise is the main event loop when running in serial mode */
-gpointer worker_run(WorkerRunData* data) {
-    utility_assert(data && data->userData && data->scheduler);
+void* _worker_run(void* voidWorker) {
+    Worker* worker = voidWorker;
+    MAGIC_ASSERT(worker);
+    WorkerPool* workerPool = worker->workerPool;
+    MAGIC_ASSERT(workerPool);
+    LogicalProcessors* lps = workerPool->logicalProcessors;
 
-    /* create the worker object for this worker thread */
-    Worker* worker = _worker_new((Manager*)data->userData, data->threadID);
-    utility_assert(worker_isAlive());
+    _threadWorker = worker;
 
-    _worker_setAffinity(worker);
+    // We can't report any errors here, since parent might not have registered
+    // this thread with the logger yet. Parent thread will check the result.
+    worker->nativeThreadID = syscall(SYS_gettid);
 
-    worker->scheduler = data->scheduler;
-    scheduler_ref(worker->scheduler);
+    // Signal parent thread that we've set the nativeThreadID.
+    countdownlatch_countDown(workerPool->finishLatch);
 
-    /* wait until the manager is done with initialization */
-    scheduler_awaitStart(worker->scheduler);
+    WorkerPoolTaskFn taskFn = NULL;
+    do {
+        // Wait for work to do.
+        if (sem_wait(&worker->beginSem) != 0) {
+            error("sem_wait: %s", g_strerror(errno));
+        }
+        int lpi = worker->logicalProcessorIdx;
 
-    /* ask the manager for the next event, blocking until one is available that
-     * we are allowed to run. when this returns NULL, we should stop. */
-    Event* event = NULL;
-    while ((event = scheduler_pop(worker->scheduler)) != NULL) {
-        /* update cache, reset clocks */
-        worker->clock.now = event_getTime(event);
+        taskFn = workerPool->taskFn;
+        if (taskFn != NULL) {
+            taskFn(workerPool->taskData);
+        }
 
-        /* process the local event */
-        event_execute(event);
-        event_unref(event);
+        lps_donePush(lps, lpi, worker);
 
-        /* update times */
-        worker->clock.last = worker->clock.now;
-        worker->clock.now = SIMTIME_INVALID;
+        Worker* nextWorker = _workerpool_getNextWorkerForLogicalProcessorIdx(
+            workerPool, worker->logicalProcessorIdx);
+        if (nextWorker) {
+            // Start running the next worker.
+            if (sem_post(&nextWorker->beginSem) != 0) {
+                error("sem_post: %s", g_strerror(errno));
+            }
+        } else {
+            // No more workers to run; lpi is now idle.
+            lps_idleTimerContinue(workerPool->logicalProcessors, lpi);
+        }
+        countdownlatch_countDown(workerPool->finishLatch);
+    } while (taskFn != NULL);
+    debug("Worker finished");
+    return NULL;
+}
+
+void worker_runEvent(Event* event) {
+    Worker* worker = _worker_getPrivate();
+
+    /* update cache, reset clocks */
+    worker->clock.now = event_getTime(event);
+
+    /* process the local event */
+    event_execute(event);
+    event_unref(event);
+
+    /* update times */
+    worker->clock.last = worker->clock.now;
+    worker->clock.now = SIMTIME_INVALID;
+}
+
+void worker_finish(GQueue* hosts) {
+    Worker* worker = _worker_getPrivate();
+
+    if (hosts) {
+        guint nHosts = g_queue_get_length(hosts);
+        message("starting to shut down %u hosts", nHosts);
+        g_queue_foreach(hosts, (GFunc)_worker_freeHostProcesses, worker);
+        g_queue_foreach(hosts, (GFunc)_worker_shutdownHost, worker);
+        message("%u hosts are shut down", nHosts);
     }
 
-    /* this will free the host data that we have been managing */
-    scheduler_awaitFinish(worker->scheduler);
-
-    scheduler_unref(worker->scheduler);
-
-    /* tell that we are done running */
-    if (data->notifyDoneRunning) {
-        countdownlatch_countDown(data->notifyDoneRunning);
-    }
-
-    /* wait for other cleanup to finish */
-    if (data->notifyReadyToJoin) {
-        countdownlatch_await(data->notifyReadyToJoin);
-    }
+    // Flushes any remaining message buffered for this thread.
+    shadow_logger_flushRecords(shadow_logger_getDefault(), pthread_self());
 
     /* cleanup is all done, send object counts to manager */
-    manager_storeCounts(worker->manager, worker->objectCounts);
-
-    /* synchronize thread join */
-    CountDownLatch* notifyJoined = data->notifyJoined;
-
-    /* this is a hack so that we don't free the worker before the scheduler is
-     * finished with object cleanup when running in global mode.
-     * normally, the if statement would not be necessary and we just free
-     * the worker in all cases. */
-    if (notifyJoined) {
-        _worker_free(worker);
-        g_free(data);
-    }
-
-    /* now the thread has ended */
-    if (notifyJoined) {
-        countdownlatch_countDown(notifyJoined);
-    }
-
-    /* calling pthread_exit(NULL) is equivalent to returning NULL for spawned threads
-     * returning NULL means we don't have to worry about calling pthread_exit on the main thread */
-    return NULL;
+    manager_storeCounts(worker->workerPool->manager, worker->objectCounts);
 }
 
 gboolean worker_scheduleTask(Task* task, SimulationTime nanoDelay) {
@@ -237,14 +507,15 @@ gboolean worker_scheduleTask(Task* task, SimulationTime nanoDelay) {
 
     Worker* worker = _worker_getPrivate();
 
-    if (manager_schedulerIsRunning(worker->manager)) {
+    if (manager_schedulerIsRunning(worker->workerPool->manager)) {
         utility_assert(worker->clock.now != SIMTIME_INVALID);
         utility_assert(worker->active.host != NULL);
 
         Host* srcHost = worker->active.host;
         Host* dstHost = srcHost;
         Event* event = event_new_(task, worker->clock.now + nanoDelay, srcHost, dstHost);
-        return scheduler_push(worker->scheduler, event, srcHost, dstHost);
+        return scheduler_push(worker->workerPool->scheduler, event, srcHost,
+                              dstHost);
     } else {
         return FALSE;
     }
@@ -262,7 +533,7 @@ void worker_sendPacket(Packet* packet) {
 
     /* get our thread-private worker */
     Worker* worker = _worker_getPrivate();
-    if (!manager_schedulerIsRunning(worker->manager)) {
+    if (!manager_schedulerIsRunning(worker->workerPool->manager)) {
         /* the simulation is over, don't bother */
         return;
     }
@@ -300,7 +571,7 @@ void worker_sendPacket(Packet* packet) {
 
         Host* srcHost = worker->active.host;
         GQuark dstID = (GQuark)address_getID(dstAddress);
-        Host* dstHost = scheduler_getHost(worker->scheduler, dstID);
+        Host* dstHost = scheduler_getHost(worker->workerPool->scheduler, dstID);
         utility_assert(dstHost);
 
         packet_addDeliveryStatus(packet, PDS_INET_SENT);
@@ -314,7 +585,8 @@ void worker_sendPacket(Packet* packet) {
         Event* packetEvent = event_new_(packetTask, deliverTime, srcHost, dstHost);
         task_unref(packetTask);
 
-        scheduler_push(worker->scheduler, packetEvent, srcHost, dstHost);
+        scheduler_push(worker->workerPool->scheduler, packetEvent, srcHost,
+                       dstHost);
     } else {
         packet_addDeliveryStatus(packet, PDS_INET_DROPPED);
     }
@@ -348,12 +620,6 @@ static void _worker_shutdownHost(Host* host, Worker* worker) {
     host_shutdown(host);
     worker_setActiveHost(NULL);
     host_unref(host);
-}
-
-void worker_freeHosts(GQueue* hosts) {
-    Worker* worker = _worker_getPrivate();
-    g_queue_foreach(hosts, (GFunc)_worker_freeHostProcesses, worker);
-    g_queue_foreach(hosts, (GFunc)_worker_shutdownHost, worker);
 }
 
 Process* worker_getActiveProcess() {
@@ -408,17 +674,19 @@ EmulatedTime worker_getEmulatedTime() {
 
 guint32 worker_getNodeBandwidthUp(GQuark nodeID, in_addr_t ip) {
     Worker* worker = _worker_getPrivate();
-    return manager_getNodeBandwidthUp(worker->manager, nodeID, ip);
+    return manager_getNodeBandwidthUp(worker->workerPool->manager, nodeID, ip);
 }
 
 guint32 worker_getNodeBandwidthDown(GQuark nodeID, in_addr_t ip) {
     Worker* worker = _worker_getPrivate();
-    return manager_getNodeBandwidthDown(worker->manager, nodeID, ip);
+    return manager_getNodeBandwidthDown(worker->workerPool->manager, nodeID,
+                                        ip);
 }
 
 gdouble worker_getLatency(GQuark sourceNodeID, GQuark destinationNodeID) {
     Worker* worker = _worker_getPrivate();
-    return manager_getLatency(worker->manager, sourceNodeID, destinationNodeID);
+    return manager_getLatency(worker->workerPool->manager, sourceNodeID,
+                              destinationNodeID);
 }
 
 gint worker_getThreadID() {
@@ -428,7 +696,7 @@ gint worker_getThreadID() {
 
 void worker_updateMinTimeJump(gdouble minPathLatency) {
     Worker* worker = _worker_getPrivate();
-    manager_updateMinTimeJump(worker->manager, minPathLatency);
+    manager_updateMinTimeJump(worker->workerPool->manager, minPathLatency);
 }
 
 void worker_setCurrentTime(SimulationTime time) {
@@ -442,7 +710,7 @@ gboolean worker_isFiltered(LogLevel level) {
 
 void worker_incrementPluginError() {
     Worker* worker = _worker_getPrivate();
-    manager_incrementPluginError(worker->manager);
+    manager_incrementPluginError(worker->workerPool->manager);
 }
 
 void worker_countObject(ObjectType otype, CounterType ctype) {

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -10,6 +10,7 @@
 #include <glib.h>
 #include <netinet/in.h>
 
+#include "main/core/manager.h"
 #include "main/core/scheduler/scheduler.h"
 #include "main/core/support/definitions.h"
 #include "main/core/support/object_counter.h"
@@ -23,23 +24,38 @@
 #include "main/utility/count_down_latch.h"
 #include "support/logger/log_level.h"
 
-typedef struct _WorkerRunData WorkerRunData;
-struct _WorkerRunData {
-    guint threadID;
-    Scheduler* scheduler;
-    gpointer userData;
-    CountDownLatch* notifyDoneRunning;
-    CountDownLatch* notifyReadyToJoin;
-    CountDownLatch* notifyJoined;
-};
-
+// A single worker thread.
 typedef struct _Worker Worker;
+// A pool of worker threads.
+typedef struct _WorkerPool WorkerPool;
+// Task to be executed on a worker thread.
+typedef void (*WorkerPoolTaskFn)(void*);
+
+// To be called by scheduler. Consumes `event`
+void worker_runEvent(Event* event);
+// To be called by worker thread
+void worker_finish(GQueue* hosts);
+
+// Create a workerpool with `nThreads` threads, allowing up to `nConcurrent` to
+// run at a time.
+WorkerPool* workerpool_new(Manager* manager, Scheduler* scheduler, int nThreads,
+                           int nConcurrent);
+
+// Begin executing taskFn(data) on each worker thread in the pool.
+void workerpool_startTaskFn(WorkerPool* pool, WorkerPoolTaskFn taskFn,
+                            void* data);
+// Await completion of a taskFn on every thread in the pool.
+void workerpool_awaitTaskFn(WorkerPool* pool);
+int workerpool_getNWorkers(WorkerPool* pool);
+// Signal worker threads to exit and wait for them to do so.
+void workerpool_joinAll(WorkerPool* pool);
+void workerpool_free(WorkerPool* pool);
+pthread_t workerpool_getThread(WorkerPool* pool, int threadId);
 
 int worker_getAffinity();
 DNS* worker_getDNS();
 Topology* worker_getTopology();
 Options* worker_getOptions();
-gpointer worker_run(WorkerRunData*);
 gboolean worker_scheduleTask(Task* task, SimulationTime nanoDelay);
 void worker_sendPacket(Packet* packet);
 gboolean worker_isAlive();

--- a/src/main/routing/packet.c
+++ b/src/main/routing/packet.c
@@ -205,7 +205,8 @@ void packet_setPriority(Packet *packet, double value) {
 }
 
 gint packet_compareTCPSequence(Packet* packet1, Packet* packet2, gpointer user_data) {
-    MAGIC_ASSERT(packet1 && packet2);
+    MAGIC_ASSERT(packet1);
+    MAGIC_ASSERT(packet2);
 
     /* packet1 for one worker might be packet2 for another, dont lock both
      * at once or a deadlock will occur */

--- a/src/main/utility/utility.h
+++ b/src/main/utility/utility.h
@@ -51,13 +51,14 @@ do { \
 /**
  * Initialize a value declared with MAGIC_DECLARE to MAGIC_VALUE
  */
-#define MAGIC_INIT(object) object->magic = MAGIC_VALUE
+#define MAGIC_INIT(object) (object)->magic = MAGIC_VALUE
 
 /**
  * Assert that a struct declared with MAGIC_DECLARE and initialized with
  * MAGIC_INIT still holds the value MAGIC_VALUE.
  */
-#define MAGIC_ASSERT(object) utility_assert(object && (object->magic == MAGIC_VALUE))
+#define MAGIC_ASSERT(object)                                                   \
+    utility_assert((object) && ((object)->magic == MAGIC_VALUE))
 
 /**
  * CLear a magic value. Future assertions with MAGIC_ASSERT will fail.
@@ -88,6 +89,7 @@ GString* utility_getFileContents(const gchar* fileName);
 gchar* utility_getNewTemporaryFilename(const gchar* templateStr);
 gboolean utility_copyFile(const gchar* fromPath, const gchar* toPath);
 
-void utility_handleError(const gchar* file, gint line, const gchar* funtcion, const gchar* message);
+_Noreturn void utility_handleError(const gchar* file, gint line,
+                                   const gchar* funtcion, const gchar* message);
 
 #endif /* SHD_UTILITY_H_ */


### PR DESCRIPTION
1. Adds a WorkerPool with a callback-style interface instead of having a
   series of coordinated barriers.

2. Adds a --max-concurrency option that allows us to restrict the number
   of workers that can run concurrently. The WorkerPool also implements
   "worker stealing" to try to keep all --max-concurrency CPUs utilized.
   e.g. setting the # of workers to the # of hosts, max concurrency to
   the number of CPUs, and using the "host" scheduler is somewhat analagous
   to using the work-stealing scheduler.

These changes are intended primarily for the dev/phantom branch, since
ptrace has better performance with a smaller number of tracees per
thread. We're including it here in main for apples-to-apples performance
comparison between the shadow 'classic' and 'phantom' architectures.

Originally I tried to keep 1. as a separate commit from 2., but after a
series of fixup commits 1. and 2. got too tangled together.