### PR TITLE
thread_ptrace: Make shutdown more robust

### DIFF
--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -217,7 +217,10 @@ static void _process_handleProcessExit(Process* proc) {
     while (g_hash_table_iter_next(&iter, &key, &value)) {
         Thread* thread = value;
         thread_handleProcessExit(thread);
+        utility_assert(!thread_isRunning(thread));
         _process_reapThread(proc, thread);
+
+        // Must be last, since it unrefs the thread.
         g_hash_table_iter_remove(&iter);
     }
 


### PR DESCRIPTION
In particular this fixes the deadlock at end of shutdown that happens in
tor simulations in the max-concurrency branch (not yet merged) when
using more workers than the max-concurrency. I don't think it's directly
related to that, but I haven't been able to reproduce it in any other
scenario.