### PR TITLE
Do not use subroutine execution timers by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ option(SHADOW_PROFILE "build with profile settings (default: OFF)" OFF)
 option(SHADOW_TEST "build tests (default: OFF)" OFF)
 option(SHADOW_EXPORT "export service libraries and headers (default: OFF)" OFF)
 option(SHADOW_WERROR "turn compiler warnings into errors. (default: OFF)" OFF)
+option(SHADOW_USE_PERF_TIMERS "compile in timers for tracking the run time of various internal operations. (default: OFF)" OFF)
 
 ## display selected user options
 MESSAGE(STATUS)
@@ -101,6 +102,7 @@ MESSAGE(STATUS "SHADOW_PROFILE=${SHADOW_PROFILE}")
 MESSAGE(STATUS "SHADOW_TEST=${SHADOW_TEST}")
 MESSAGE(STATUS "SHADOW_EXPORT=${SHADOW_EXPORT}")
 MESSAGE(STATUS "SHADOW_WERROR=${SHADOW_WERROR}")
+MESSAGE(STATUS "SHADOW_USE_PERF_TIMERS=${SHADOW_USE_PERF_TIMERS}")
 MESSAGE(STATUS "-------------------------------------------------------------------------------")
 MESSAGE(STATUS)
 
@@ -130,6 +132,11 @@ endif()
 if(SHADOW_WERROR STREQUAL ON)
     add_compile_options(-Werror)
 endif(SHADOW_WERROR STREQUAL ON)
+
+if(SHADOW_USE_PERF_TIMERS STREQUAL ON)
+    message(STATUS "Perf timers enabled")
+    add_definitions(-DUSE_PERF_TIMERS)
+endif()
 
 if($ENV{VERBOSE})
     add_definitions(-DVERBOSE)

--- a/setup
+++ b/setup
@@ -62,6 +62,11 @@ def main():
         action="store_true", dest="do_debug",
         default=False)
 
+    parser_build.add_argument('--use-perf-timers',
+        help="compile in timers for tracking the run time of various internal operations",
+        action="store_true", dest="do_use_perf_timers",
+        default=False)
+
     parser_build.add_argument('-v', '--verbose',
         help="print verbose output from the compiler",
         action="store_true", dest="do_verbose",
@@ -179,6 +184,7 @@ def build(args):
     if args.disable_tgen: cmake_cmd += " -DBUILD_TGEN=OFF"
     if args.do_valgrind: cmake_cmd += " -DLOADER_VALGRIND=ON"
     if args.do_werror: cmake_cmd += " -DSHADOW_WERROR=ON"
+    if args.do_use_perf_timers: cmake_cmd += " -DSHADOW_USE_PERF_TIMERS=ON"
 
     # we will run from build directory
     calledDirectory = os.getcwd()

--- a/src/main/core/scheduler/scheduler_policy_host_steal.c
+++ b/src/main/core/scheduler/scheduler_policy_host_steal.c
@@ -38,8 +38,10 @@ struct _HostStealThreadData {
     /* the host this worker is running; belongs to neither unprocessedHosts nor processedHosts */
     Host* runningHost;
     SimulationTime currentBarrier;
+#ifdef USE_PERF_TIMERS
     GTimer* pushIdleTime;
     GTimer* popIdleTime;
+#endif
     /* which worker thread this is */
     guint tnumber;
     GMutex lock;
@@ -69,6 +71,7 @@ static HostStealThreadData* _hoststealthreaddata_new() {
     tdata->unprocessedHosts = g_queue_new();
     tdata->processedHosts = g_queue_new();
 
+#ifdef USE_PERF_TIMERS
     /* Create new timers to track thread idle times. The timers start in a 'started' state,
      * so we want to stop them immediately so we can continue/stop later around blocking code
      * to collect total elapsed idle time in the scheduling process throughout the entire
@@ -77,6 +80,7 @@ static HostStealThreadData* _hoststealthreaddata_new() {
     g_timer_stop(tdata->pushIdleTime);
     tdata->popIdleTime = g_timer_new();
     g_timer_stop(tdata->popIdleTime);
+#endif
     g_mutex_init(&(tdata->lock));
     tdata->runningHost = NULL;
     return tdata;
@@ -94,6 +98,7 @@ static void _hoststealthreaddata_free(HostStealThreadData* tdata) {
             g_queue_free(tdata->processedHosts);
         }
 
+#ifdef USE_PERF_TIMERS
         gdouble totalPushWaitTime = 0.0;
         if(tdata->pushIdleTime) {
             totalPushWaitTime = g_timer_elapsed(tdata->pushIdleTime, NULL);
@@ -105,9 +110,10 @@ static void _hoststealthreaddata_free(HostStealThreadData* tdata) {
             g_timer_destroy(tdata->popIdleTime);
         }
 
-        g_free(tdata);
         message("scheduler thread data destroyed, total push wait time was %f seconds, "
                 "total pop wait time was %f seconds", totalPushWaitTime, totalPopWaitTime);
+#endif
+        g_free(tdata);
     }
 }
 
@@ -254,13 +260,17 @@ static void _schedulerpolicyhoststeal_push(SchedulerPolicy* policy, Event* event
 
     /* tracking idle time spent waiting for the destination queue lock */
     if(tdata) {
+#ifdef USE_PERF_TIMERS
         g_timer_continue(tdata->pushIdleTime);
+#endif
         g_mutex_lock(&(tdata->lock));
     }
     g_mutex_lock(&(qdata->lock));
+#ifdef USE_PERF_TIMERS
     if(tdata) {
         g_timer_stop(tdata->pushIdleTime);
     }
+#endif
 
     /* 'deliver' the event to the destination queue */
     priorityqueue_push(qdata->pq, event);
@@ -340,9 +350,13 @@ static Event* _schedulerpolicyhoststeal_pop(SchedulerPolicy* policy, SimulationT
     }
 
     /* we only need to lock this thread's lock, since it's our own queue */
+#ifdef USE_PERF_TIMERS
     g_timer_continue(tdata->popIdleTime);
+#endif
     g_mutex_lock(&(tdata->lock));
+#ifdef USE_PERF_TIMERS
     g_timer_stop(tdata->popIdleTime);
+#endif
 
     if(barrier > tdata->currentBarrier) {
         tdata->currentBarrier = barrier;
@@ -408,7 +422,9 @@ static Event* _schedulerpolicyhoststeal_pop(SchedulerPolicy* policy, SimulationT
          * what we just stole. But we also need to do this in a well-ordered manner, to
          * prevent deadlocks. To do this, we always lock the lock with the smaller thread
          * number first. */
+#ifdef USE_PERF_TIMERS
         g_timer_continue(tdata->popIdleTime);
+#endif
         if(tdata->tnumber < stolenTnumber) {
             g_mutex_lock(&(tdata->lock));
             g_mutex_lock(&(stolenTdata->lock));
@@ -416,7 +432,9 @@ static Event* _schedulerpolicyhoststeal_pop(SchedulerPolicy* policy, SimulationT
             g_mutex_lock(&(stolenTdata->lock));
             g_mutex_lock(&(tdata->lock));
         }
+#ifdef USE_PERF_TIMERS
         g_timer_stop(tdata->popIdleTime);
+#endif
 
         /* attempt to get event from the other thread's queue, likely moving a host from its
          * unprocessedHosts into this threads runningHost (and eventually processedHosts) */

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -95,8 +95,10 @@ struct _Host {
     /* random stream */
     Random* random;
 
+#ifdef USE_PERF_TIMERS
     /* track the time spent executing this host */
     GTimer* executionTimer;
+#endif
 
     gchar* dataDirPath;
 
@@ -111,9 +113,11 @@ Host* host_new(HostParameters* params) {
     Host* host = g_new0(Host, 1);
     MAGIC_INIT(host);
 
+#ifdef USE_PERF_TIMERS
     /* start tracking execution time for this host.
      * creating the timer automatically starts it. */
     host->executionTimer = g_timer_new();
+#endif
 
     /* first copy the entire struct of params */
     host->params = *params;
@@ -150,8 +154,10 @@ Host* host_new(HostParameters* params) {
     host->processIDCounter = 1000;
     host->referenceCount = 1;
 
+#ifdef USE_PERF_TIMERS
     /* we go back to the manager setup process here, so stop counting this host execution */
     g_timer_stop(host->executionTimer);
+#endif
 
     worker_countObject(OBJECT_TYPE_HOST, COUNTER_TYPE_NEW);
 
@@ -231,7 +237,9 @@ static void _host_free(Host* host) {
  * process that actually hold references to the host. if you just called host_unref instead
  * of this function, then host_free would never actually get called. */
 void host_shutdown(Host* host) {
+#ifdef USE_PERF_TIMERS
     g_timer_continue(host->executionTimer);
+#endif
 
     info("shutting down host %s", host->params.hostname);
 
@@ -311,14 +319,17 @@ void host_shutdown(Host* host) {
         g_free(host->dataDirPath);
     }
 
+#ifdef USE_PERF_TIMERS
     gdouble totalExecutionTime = g_timer_elapsed(host->executionTimer, NULL);
-
+    g_timer_destroy(host->executionTimer);
     message("host '%s' has been shut down, total execution time was %f seconds",
             host->params.hostname, totalExecutionTime);
+#else
+    message("host '%s' has been shut down", host->params.hostname);
+#endif
 
     if(host->defaultAddress) address_unref(host->defaultAddress);
     if(host->params.hostname) g_free(host->params.hostname);
-    g_timer_destroy(host->executionTimer);
 }
 
 void host_ref(Host* host) {
@@ -345,6 +356,7 @@ void host_unlock(Host* host) {
     g_mutex_unlock(&(host->lock));
 }
 
+#ifdef USE_PERF_TIMERS
 /* resumes the execution timer for this host */
 void host_continueExecutionTimer(Host* host) {
     MAGIC_ASSERT(host);
@@ -356,12 +368,7 @@ void host_stopExecutionTimer(Host* host) {
     MAGIC_ASSERT(host);
     g_timer_stop(host->executionTimer);
 }
-
-/* returns the fractional number of seconds that have been spent executing this host */
-gdouble host_getElapsedExecutionTime(Host* host) {
-    MAGIC_ASSERT(host);
-    return g_timer_elapsed(host->executionTimer, NULL);
-}
+#endif
 
 GQuark host_getID(Host* host) {
     MAGIC_ASSERT(host);

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -66,9 +66,14 @@ void host_unref(Host* host);
 void host_lock(Host* host);
 void host_unlock(Host* host);
 
+#ifdef USE_PERF_TIMERS
 void host_continueExecutionTimer(Host* host);
 void host_stopExecutionTimer(Host* host);
-gdouble host_getElapsedExecutionTime(Host* host);
+#else
+// define macros that do nothing
+#define host_continueExecutionTimer(host)
+#define host_stopExecutionTimer(host)
+#endif
 
 void host_setup(Host* host, DNS* dns, Topology* topology, guint rawCPUFreq, const gchar* hostRootPath);
 void host_boot(Host* host);


### PR DESCRIPTION
Shadow includes internal performance timers to help us track execution
time of various subroutines. The timer-related functions have shown
up on performance profiles as causing significant overhead. These timers
are now disabled by default.

We add a new --use-perf-timers option to the setup script, and a new
USE_PERF_TIMERS option to cmake that allows us to toggle the performance
timers back on if desired.

Closes #1141

(cherry-picked from commit e9004c2ce06a8bf5a8876188b2ef644e5463c4b4)