### PR TITLE
Support Fedora 33 instead of 32

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,7 +27,7 @@ jobs:
       options: '--shm-size="1g"'
     strategy:
       matrix:
-        container: ['ubuntu:16.04', 'ubuntu:18.04', 'ubuntu:20.04', 'debian:10-slim', 'fedora:32', 'centos:7', 'centos:8']
+        container: ['ubuntu:16.04', 'ubuntu:18.04', 'ubuntu:20.04', 'debian:10-slim', 'fedora:33', 'centos:7', 'centos:8']
         cc: ['gcc', 'clang']
         buildtype: ['debug', 'release']
         include:

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -11,7 +11,7 @@ CONTAINERS=(
     ubuntu:18.04
     ubuntu:20.04
     debian:10-slim
-    fedora:32
+    fedora:33
     centos:7
     centos:8
     )

--- a/docs/1.1-Shadow.md
+++ b/docs/1.1-Shadow.md
@@ -6,7 +6,7 @@ Shadow officially supports the following platforms:
 
   + Ubuntu 16.04, 18.04, and 20.04
   + Debian 10
-  + Fedora 32
+  + Fedora 33
   + CentOS 7, 8
 
 If you are installing Shadow within a Docker container, you must increase the size of the container's `/dev/shm` mount by passing `--shm-size="1g"` (with a suitable size for your system and experiments) to `docker run`.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -35,7 +35,7 @@ you'll want to only run some smaller set of configurations locally.
 To run only the configurations you specify, use the `-o` flag:
 
 ```{.bash}
-sudo ci/run.sh -i -o "ubuntu:18.04;clang;debug fedora:32;gcc;release"
+sudo ci/run.sh -i -o "ubuntu:18.04;clang;debug fedora:33;gcc;release"
 ```
 
 For additional options, run `ci/run.sh -h`.


### PR DESCRIPTION
We could also support both Fedora 32 and 33, but I think it's simpler to just switch to supporting 33.