### PR TITLE
Small changes to GitHub workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - run: |
         docker build . -t shadow --shm-size="1g"
         docker run --shm-size="1g" --privileged --rm --entrypoint /src/ci/container_scripts/test.sh shadow

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-        - name: Block autosquash commits
-          uses: xt0rted/block-autosquash-commits-action@3c9ba6760eba3c160eead6ed4b6449024ec406ad
-          with:
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Block autosquash commits
+      # before updating the version of this untrusted action, check the code manually
+      uses: xt0rted/block-autosquash-commits-action@3c9ba6760eba3c160eead6ed4b6449024ec406ad
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,9 @@ jobs:
       matrix:
         python-version: [3.8]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@master
         with:
           python-version: ${{ matrix.python-version }}
@@ -30,7 +32,7 @@ jobs:
   lint-rust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Rustfmt check
         run: |
           (cd src/main && cargo fmt -- --check)
@@ -51,7 +53,9 @@ jobs:
         run: |
           apt-get update
           DEBIAN_FRONTEND=noninteractive apt-get install -y git
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           ci/container_scripts/install_deps.sh

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run_tor.yml
+++ b/.github/workflows/run_tor.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: shadow
+          persist-credentials: false
 
       - name: Checkout tor
         uses: actions/checkout@v2
@@ -55,6 +56,7 @@ jobs:
           # and allows us to simplify our CI script
           repository: torproject/tor
           ref: ${{ matrix.tor }}
+          persist-credentials: false
 
       - name: Checkout tgen
         uses: actions/checkout@v2
@@ -62,6 +64,7 @@ jobs:
           path: tgen
           repository: shadow/tgen
           ref: 47d5eb385195
+          persist-credentials: false
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This disables the 'persist-credentials' feature of the checkout action. I don't think this is really important for our workflows, but seems like a good defence-in-depth thing to do.

This also changes all of our checkout action uses to 'v2'.