### PR TITLE
Fix descriptor bugs and support dup() on regular files for Python

### DIFF
--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -23,6 +23,7 @@ void descriptor_init(LegacyDescriptor* descriptor, LegacyDescriptorType type,
     MAGIC_INIT(funcTable);
     descriptor->funcTable = funcTable;
     descriptor->type = type;
+    descriptor->handle = -1;
     descriptor->listeners = g_hash_table_new_full(
         g_direct_hash, g_direct_equal, NULL, (GDestroyNotify)statuslistener_unref);
     descriptor->referenceCount = 1;

--- a/src/main/host/descriptor/file.c
+++ b/src/main/host/descriptor/file.c
@@ -235,6 +235,11 @@ int file_openat(File* file, File* dir, const char* pathname, int flags, mode_t m
     }
 #endif
 
+    int fd = _file_getFD(file);
+    if (fd < 0) {
+        error("Cannot openat() on an unregistered descriptor object with fd %d", fd);
+    }
+
     /* The default case is a regular file. We do this first so that we have
      * an absolute path to compare for special files. */
     char* abspath = _file_getPath(file, dir, pathname, workingDir);
@@ -292,7 +297,8 @@ int file_openat(File* file, File* dir, const char* pathname, int flags, mode_t m
     /* The os-backed file is now ready. */
     descriptor_adjustStatus(&file->super, STATUS_DESCRIPTOR_ACTIVE, TRUE);
 
-    return _file_getFD(file);
+    /* We checked above that fd is non-negative. */
+    return fd;
 }
 
 int file_open(File* file, const char* pathname, int flags, mode_t mode, const char* workingDir) {

--- a/src/main/host/descriptor/file.h
+++ b/src/main/host/descriptor/file.h
@@ -39,6 +39,7 @@ typedef struct _File File;
 // ************************
 
 File* file_new(); // Close the file with descriptor_close()
+File* file_dup(File* file, int* dupError);
 int file_open(File* file, const char* pathname, int flags, mode_t mode, const char* workingDir);
 int file_openat(File* file, File* dir, const char* pathname, int flags, mode_t mode,
                 const char* workingDir);

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -372,6 +372,9 @@ static File* _process_openStdIOFileHelper(Process* proc, int fd, gchar* fileName
 
     File* stdfile = file_new();
 
+    CompatDescriptor* compatDesc = compatdescriptor_fromLegacy((LegacyDescriptor*)stdfile);
+    descriptortable_set(proc->descTable, fd, compatDesc);
+
     char* cwd = getcwd(NULL, 0);
     if (!cwd) {
         error("getcwd unable to allocate string buffer, error %i: %s", errno, strerror(errno));
@@ -383,14 +386,9 @@ static File* _process_openStdIOFileHelper(Process* proc, int fd, gchar* fileName
 
     if (errcode < 0) {
         error("Opening %s: %s", fileName, strerror(-errcode));
-        /* Unref and free the file object. */
-        descriptor_close((LegacyDescriptor*)stdfile);
-    } else {
-        debug("Successfully opened fd %d at %s", fd, fileName);
-
-        CompatDescriptor* compatDesc = compatdescriptor_fromLegacy((LegacyDescriptor*)stdfile);
-        descriptortable_set(proc->descTable, fd, compatDesc);
     }
+
+    debug("Successfully opened fd %d at %s", fd, fileName);
 
     return stdfile;
 }

--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -25,7 +25,7 @@
 static int _syscallhandler_validateFileHelper(SysCallHandler* sys, int filefd,
                                               File** file_desc_out) {
     /* Check that fd is within bounds. */
-    if (filefd <= 0) {
+    if (filefd < 0) {
         info("descriptor %i out of bounds", filefd);
         return -EBADF;
     }

--- a/src/main/host/syscall/fileat.c
+++ b/src/main/host/syscall/fileat.c
@@ -34,7 +34,7 @@ static int _syscallhandler_validateDirHelper(SysCallHandler* sys, int dirfd,
             *dir_desc_out = NULL;
         }
         return 0;
-    } else if (dirfd <= 0) {
+    } else if (dirfd < 0) {
         info("descriptor %i out of bounds", dirfd);
         return -EBADF;
     }

--- a/src/main/host/syscall/timerfd.c
+++ b/src/main/host/syscall/timerfd.c
@@ -23,7 +23,7 @@
 static int _syscallhandler_validateTimerHelper(SysCallHandler* sys, int tfd,
                                                Timer** timer_desc_out) {
     /* Check that fd is within bounds. */
-    if (tfd <= 0) {
+    if (tfd < 0) {
         info("descriptor %i out of bounds", tfd);
         return -EBADF;
     }

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -279,7 +279,7 @@ SysCallReturn syscallhandler_close(SysCallHandler* sys,
     debug("Trying to close fd %i", fd);
 
     /* Check that fd is within bounds. */
-    if (fd <= 0) {
+    if (fd < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EBADF};
     }
 

--- a/src/main/host/syscall/unistd.rs
+++ b/src/main/host/syscall/unistd.rs
@@ -79,8 +79,12 @@ pub fn dup_helper(
 ) -> c::SysCallReturn {
     debug!("Duping fd {} ({:?})", fd, desc);
 
-    // clone the descriptor and register it
-    let new_desc = CompatDescriptor::New(desc.clone());
+    // clone the descriptor (but not the flags)
+    let mut new_desc = desc.clone();
+    new_desc.set_flags(DescriptorFlags::empty());
+
+    // register the descriptor
+    let new_desc = CompatDescriptor::New(new_desc);
     let new_fd = unsafe {
         c::process_registerCompatDescriptor(
             sys.process,


### PR DESCRIPTION
Fixes a few descriptor bugs and implements `dup()` for regular files, which is required for Python. (Python uses `dup()` on stdin, stdout, and stderr to check if they are valid descriptors. See [`create_stdio()` in CPython](https://github.com/python/cpython/blob/442ad74fc2928b095760eb89aba93c28eab17f9b/Python/pylifecycle.c#L2108).)

Shadow is still missing syscalls to use things like the built-in http server (I see futex errors, missing socket options, and IPv6 issues). Python also make heavy use of `select()`, so things like [`time.sleep()`](https://github.com/python/cpython/blob/b2a91e0c9ee18b50cc86b21211c2258520a9f5d0/Modules/timemodule.c#L360) don't work in Shadow.

```
options:
  stoptime: 10
topology:
- graphml: |
    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
      <key attr.name="packetloss" attr.type="double" for="edge" id="d4" />
      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
      <key attr.name="bandwidthup" attr.type="int" for="node" id="d2" />
      <key attr.name="bandwidthdown" attr.type="int" for="node" id="d1" />
      <key attr.name="countrycode" attr.type="string" for="node" id="d0" />
      <graph edgedefault="undirected">
        <node id="poi-1">
          <data key="d0">US</data>
          <data key="d1">10240</data>
          <data key="d2">10240</data>
        </node>
        <edge source="poi-1" target="poi-1">
          <data key="d3">50.0</data>
          <data key="d4">0.0</data>
        </edge>
      </graph>
    </graphml>
plugins:
- id: python
  path: /usr/bin/python3
hosts:
- id: test
  quantity: 1
  processes:
  - plugin: python
    starttime: 1
    arguments: -c print(1234)
```