### PR TITLE
Remove inter-round collect info step in scheduler

### DIFF
--- a/src/main/core/scheduler/scheduler_policy_host_steal.c
+++ b/src/main/core/scheduler/scheduler_policy_host_steal.c
@@ -394,6 +394,19 @@ static Event* _schedulerpolicyhoststeal_pop(SchedulerPolicy* policy, SimulationT
         HostStealThreadData* stolenTdata = g_array_index(data->threadList, HostStealThreadData*, stolenTnumber);
         g_rw_lock_reader_unlock(&data->lock);
 
+        // We only need to spin if the other thread has not yet initialized for
+        // this round.
+        g_mutex_lock(&(stolenTdata->lock));
+        gboolean spinForInit = barrier > stolenTdata->currentBarrier;
+        if (spinForInit) {
+            // They still have not initialized yet.
+            // Make sure the atomic is set to false so we'll detect the flip to
+            // true
+            __atomic_store_n(&stolenTdata->isStealable, false,
+                             __ATOMIC_RELEASE);
+        }
+        g_mutex_unlock(&(stolenTdata->lock));
+
         /* Make sure the workload has been updated for this round.
          * This boolean is preventing race conditions upon the start of each
          * round, and since we don't expect it to take long for the other
@@ -405,9 +418,12 @@ static Event* _schedulerpolicyhoststeal_pop(SchedulerPolicy* policy, SimulationT
          * performance even without the realtime scheduler, despite incurring
          * the overhead of a syscall.
          */
-        while (!__atomic_load_n(&stolenTdata->isStealable, __ATOMIC_ACQUIRE)) {
-            sched_yield();
-        };
+        if (spinForInit) {
+            while (
+                !__atomic_load_n(&stolenTdata->isStealable, __ATOMIC_ACQUIRE)) {
+                sched_yield();
+            };
+        }
 
         /* We don't need a lock here, because we're only reading, and a misread just means either
          * we read as empty when it's not, in which case the assigned thread (or one of the others)
@@ -488,9 +504,6 @@ static SimulationTime _schedulerpolicyhoststeal_getNextTime(SchedulerPolicy* pol
         /* make sure we get all hosts, which are probably held in the processedHosts queue between rounds */
         g_queue_foreach(tdata->unprocessedHosts, (GFunc)_schedulerpolicyhoststeal_findMinTime, &searchState);
         g_queue_foreach(tdata->processedHosts, (GFunc)_schedulerpolicyhoststeal_findMinTime, &searchState);
-
-        /* since we are in-between rounds, reset our stealable flag */
-        __atomic_store_n(&tdata->isStealable, false, __ATOMIC_RELEASE);
     }
 
     info("next event at time %"G_GUINT64_FORMAT, searchState.nextEventTime);

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -52,6 +52,23 @@ void workerpool_joinAll(WorkerPool* pool);
 void workerpool_free(WorkerPool* pool);
 pthread_t workerpool_getThread(WorkerPool* pool, int threadId);
 
+// Compute the global min event time across all workers. We dynamically compute
+// the minimum time that we'll need for the next event round as the minimum of
+// i.) all events pushed by all workers during this round, and
+// ii.) the next queued event for all worker at the point when they stop
+// executing events.
+//
+// This func is not thread safe, so only call from the scheduler thread when the
+// workers are idle.
+SimulationTime workerpool_getGlobalNextEventTime(WorkerPool* workerPool);
+
+// The worker either pushed an event or finished executing its events and is
+// reporting the min time of events in their event queue.
+void worker_setMinEventTimeNextRound(SimulationTime simtime);
+
+// When a new scheduling round starts, set the end time of the new round.
+void worker_setRoundEndTime(SimulationTime newRoundEndTime);
+
 int worker_getAffinity();
 DNS* worker_getDNS();
 Topology* worker_getTopology();


### PR DESCRIPTION
We stop waking threads up in between rounds in order to compute
the minimum next event time. Instead we keep track of the min time
during the execution of the round.

Closes #1249 