### PR TITLE
Add worker_readPtr and worker_writePtr and use where feasible

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -351,6 +351,30 @@ extern "C" {
     pub fn thread_getReturnCode(thread: *mut Thread) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn thread_readPtr(
+        thread: *mut Thread,
+        dst: *mut ::std::os::raw::c_void,
+        src: PluginVirtualPtr,
+        n: size_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn thread_readStringPtr(
+        base: *mut Thread,
+        dst: *mut ::std::os::raw::c_char,
+        src: PluginVirtualPtr,
+        n: size_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn thread_writePtr(
+        thread: *mut Thread,
+        dst: PluginVirtualPtr,
+        src: *mut ::std::os::raw::c_void,
+        n: size_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn thread_getReadablePtr(
         thread: *mut Thread,
         plugin_src: PluginPtr,

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -895,3 +895,23 @@ int worker_writePtr(PluginVirtualPtr dst, void* src, size_t n) {
     Worker* worker = _worker_getPrivate();
     return process_writePtr(worker->active.process, worker->active.thread, dst, src, n);
 }
+
+const void* worker_getReadablePtr(PluginVirtualPtr src, size_t n) {
+    Worker* worker = _worker_getPrivate();
+    return process_getReadablePtr(worker->active.process, worker->active.thread, src, n);
+}
+
+void* worker_getWritablePtr(PluginVirtualPtr dst, size_t n) {
+    Worker* worker = _worker_getPrivate();
+    return process_getWriteablePtr(worker->active.process, worker->active.thread, dst, n);
+}
+
+void* worker_getMutablePtr(PluginVirtualPtr dst, size_t n) {
+    Worker* worker = _worker_getPrivate();
+    return process_getMutablePtr(worker->active.process, worker->active.thread, dst, n);
+}
+
+void worker_flushPtrs() {
+    Worker* worker = _worker_getPrivate();
+    return process_flushPtrs(worker->active.process, worker->active.thread);
+}

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -96,11 +96,22 @@ Host* worker_getActiveHost();
 void worker_setActiveHost(Host* host);
 Process* worker_getActiveProcess();
 void worker_setActiveProcess(Process* proc);
+Thread* worker_getActiveThread();
+void worker_setActiveThread(Thread* thread);
 
 void worker_incrementPluginError();
 
 Address* worker_resolveIPToAddress(in_addr_t ip);
 Address* worker_resolveNameToAddress(const gchar* name);
+
+// Copy `n` bytes from `src` in the current active Process to `dst`. Returns 0
+// on success or EFAULT if any of the specified range couldn't be accessed.
+int worker_readPtr(void* dst, PluginVirtualPtr src, size_t n);
+
+// Copy `n` bytes from `src` to `dst` in the current active Process. Returns 0
+// on success or EFAULT if any of the specified range couldn't be accessed. The
+// write is flushed immediately.
+int worker_writePtr(PluginVirtualPtr dst, void* src, size_t n);
 
 // Implementation for counting allocated objects. Do not use this function directly.
 // Use worker_count_allocation instead from the call site.

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -16,6 +16,7 @@
 #include "main/core/support/options.h"
 #include "main/core/work/task.h"
 #include "main/host/host.h"
+#include "main/host/syscall_types.h"
 #include "main/routing/address.h"
 #include "main/routing/dns.h"
 #include "main/routing/packet.h"
@@ -103,6 +104,19 @@ void worker_incrementPluginError();
 
 Address* worker_resolveIPToAddress(in_addr_t ip);
 Address* worker_resolveNameToAddress(const gchar* name);
+
+// Get a readable pointer in the current active Process.
+const void* worker_getReadablePtr(PluginVirtualPtr src, size_t n);
+
+// Get a writable pointer in the current active Process.
+void* worker_getWritablePtr(PluginVirtualPtr dst, size_t n);
+
+// Get a mutable pointer containing the data at `dst`.
+void* worker_getMutablePtr(PluginVirtualPtr dst, size_t n);
+
+// Flushes and invalidates previously returned readable, writable, and mutable
+// pointers.
+void worker_flushPtrs();
 
 // Copy `n` bytes from `src` in the current active Process to `dst`. Returns 0
 // on success or EFAULT if any of the specified range couldn't be accessed.

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -78,17 +78,16 @@ static gboolean _socket_close(LegacyDescriptor* descriptor) {
     return socket->vtable->close((LegacyDescriptor*)socket);
 }
 
-static gssize _socket_sendUserData(Transport* transport, gconstpointer buffer,
-                                   gsize nBytes, in_addr_t ip, in_port_t port) {
+static gssize _socket_sendUserData(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
+                                   in_addr_t ip, in_port_t port) {
     Socket* socket = _socket_fromLegacyDescriptor((LegacyDescriptor*)transport);
     MAGIC_ASSERT(socket);
     MAGIC_ASSERT(socket->vtable);
     return socket->vtable->send((Transport*)socket, buffer, nBytes, ip, port);
 }
 
-static gssize _socket_receiveUserData(Transport* transport, gpointer buffer,
-                                      gsize nBytes, in_addr_t* ip,
-                                      in_port_t* port) {
+static gssize _socket_receiveUserData(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
+                                      in_addr_t* ip, in_port_t* port) {
     Socket* socket = _socket_fromLegacyDescriptor((LegacyDescriptor*)transport);
     MAGIC_ASSERT(socket);
     MAGIC_ASSERT(socket->vtable);

--- a/src/main/host/descriptor/transport.c
+++ b/src/main/host/descriptor/transport.c
@@ -10,6 +10,7 @@
 #include "main/core/support/definitions.h"
 #include "main/host/descriptor/descriptor.h"
 #include "main/host/descriptor/transport.h"
+#include "main/host/syscall_types.h"
 #include "main/utility/utility.h"
 
 static Transport* _transport_fromLegacyDescriptor(LegacyDescriptor* descriptor) {
@@ -54,15 +55,15 @@ void transport_init(Transport* transport, TransportFunctionTable* vtable,
     transport->vtable = vtable;
 }
 
-gssize transport_sendUserData(Transport* transport, gconstpointer buffer, gsize nBytes,
-        in_addr_t ip, in_port_t port) {
+gssize transport_sendUserData(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
+                              in_addr_t ip, in_port_t port) {
     MAGIC_ASSERT(transport);
     MAGIC_ASSERT(transport->vtable);
     return transport->vtable->send(transport, buffer, nBytes, ip, port);
 }
 
-gssize transport_receiveUserData(Transport* transport, gpointer buffer, gsize nBytes,
-        in_addr_t* ip, in_port_t* port) {
+gssize transport_receiveUserData(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
+                                 in_addr_t* ip, in_port_t* port) {
     MAGIC_ASSERT(transport);
     MAGIC_ASSERT(transport->vtable);
     return transport->vtable->receive(transport, buffer, nBytes, ip, port);

--- a/src/main/host/descriptor/transport.h
+++ b/src/main/host/descriptor/transport.h
@@ -12,13 +12,16 @@
 
 #include "main/core/support/definitions.h"
 #include "main/host/descriptor/descriptor.h"
+#include "main/host/syscall_types.h"
 #include "main/utility/utility.h"
 
 typedef struct _Transport Transport;
 typedef struct _TransportFunctionTable TransportFunctionTable;
 
-typedef gssize (*TransportSendFunc)(Transport* transport, gconstpointer buffer, gsize nBytes, in_addr_t ip, in_port_t port);
-typedef gssize (*TransportReceiveFunc)(Transport* transport, gpointer buffer, gsize nBytes, in_addr_t* ip, in_port_t* port);
+typedef gssize (*TransportSendFunc)(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
+                                    in_addr_t ip, in_port_t port);
+typedef gssize (*TransportReceiveFunc)(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
+                                       in_addr_t* ip, in_port_t* port);
 
 struct _TransportFunctionTable {
     DescriptorCloseFunc close;
@@ -38,9 +41,9 @@ struct _Transport {
 void transport_init(Transport* transport, TransportFunctionTable* vtable,
                     LegacyDescriptorType type);
 
-gssize transport_sendUserData(Transport* transport, gconstpointer buffer, gsize nBytes,
-        in_addr_t ip, in_port_t port);
-gssize transport_receiveUserData(Transport* transport, gpointer buffer, gsize nBytes,
-        in_addr_t* ip, in_port_t* port);
+gssize transport_sendUserData(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
+                              in_addr_t ip, in_port_t port);
+gssize transport_receiveUserData(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
+                                 in_addr_t* ip, in_port_t* port);
 
 #endif /* SHD_TRANSPORT_H_ */

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -351,7 +351,7 @@ static void _networkinterface_capturePacket(NetworkInterface* interface, Packet*
 
     if(pcapPacket->payloadLength > 0) {
         pcapPacket->payload = g_new0(guchar, pcapPacket->payloadLength);
-        packet_copyPayload(packet, 0, pcapPacket->payload, pcapPacket->payloadLength);
+        packet_copyPayloadShadow(packet, 0, pcapPacket->payload, pcapPacket->payloadLength);
     }
 
     PacketTCPHeader* tcpHeader = packet_getTCPHeader(packet);

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -833,6 +833,28 @@ PluginPhysicalPtr process_getPhysicalAddress(Process* proc, PluginVirtualPtr vPt
     return (PluginPhysicalPtr){.val = low | high};
 }
 
+int process_readPtr(Process* proc, Thread* thread, void* dst, PluginVirtualPtr src, size_t n) {
+    MAGIC_ASSERT(proc);
+    if (proc->memoryManager) {
+        const void* mapped = memorymanager_getReadablePtr(proc->memoryManager, thread, src, n);
+        memcpy(dst, mapped, n);
+        return 0;
+    } else {
+        return thread_readPtr(thread, dst, src, n);
+    }
+}
+
+int process_writePtr(Process* proc, Thread* thread, PluginVirtualPtr dst, void* src, size_t n) {
+    MAGIC_ASSERT(proc);
+    if (proc->memoryManager) {
+        void* mapped = memorymanager_getWriteablePtr(proc->memoryManager, thread, dst, n);
+        memcpy(mapped, src, n);
+        return 0;
+    } else {
+        return thread_writePtr(thread, dst, src, n);
+    }
+}
+
 const void* process_getReadablePtr(Process* proc, Thread* thread, PluginPtr plugin_src, size_t n) {
     MAGIC_ASSERT(proc);
     if (proc->memoryManager) {

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -434,6 +434,7 @@ static void _process_start(Process* proc) {
 
     /* now we will execute in the pth/plugin context, so we need to load the state */
     worker_setActiveProcess(proc);
+    worker_setActiveThread(mainThread);
 
 #ifdef USE_PERF_TIMERS
     /* time how long we execute the program */
@@ -450,6 +451,7 @@ static void _process_start(Process* proc) {
 #endif
 
     worker_setActiveProcess(NULL);
+    worker_setActiveThread(NULL);
 
 #ifdef USE_PERF_TIMERS
     message(
@@ -510,6 +512,7 @@ void process_continue(Process* proc, Thread* thread) {
          process_getName(proc));
 
     worker_setActiveProcess(proc);
+    worker_setActiveThread(thread);
 
 #ifdef USE_PERF_TIMERS
     /* time how long we execute the program */
@@ -526,6 +529,7 @@ void process_continue(Process* proc, Thread* thread) {
 #endif
 
     worker_setActiveProcess(NULL);
+    worker_setActiveThread(NULL);
 
 #ifdef USE_PERF_TIMERS
     info("process '%s' ran for %f seconds", process_getName(proc), elapsed);

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -130,7 +130,7 @@ void* process_getWriteablePtr(Process* proc, Thread* thread, PluginPtr plugin_sr
 // The returned pointer is automatically invalidated when the plugin runs again.
 void* process_getMutablePtr(Process* proc, Thread* thread, PluginPtr plugin_src, size_t n);
 
-// Flushes and invalidates all previously returned readable/writeable plugin
+// Flushes and invalidates all previously returned readable/writable plugin
 // pointers, as if returning control to the plugin. This can be useful in
 // conjunction with `thread_nativeSyscall` operations that touch memory.
 void process_flushPtrs(Process* proc, Thread* thread);

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -104,6 +104,14 @@ LegacyDescriptor* process_getRegisteredLegacyDescriptor(Process* proc, int handl
 // Convert a virtual ptr in the plugin address space to a globally unique physical ptr
 PluginPhysicalPtr process_getPhysicalAddress(Process* proc, PluginVirtualPtr vPtr);
 
+// Copy `n` bytes from `src` to `dst`. Returns 0 on success or EFAULT if any of
+// the specified range couldn't be accessed.
+int process_readPtr(Process* proc, Thread* thread, void* dst, PluginVirtualPtr src, size_t n);
+
+// Copy `n` bytes from `src` to `dst`. Returns 0 on success or EFAULT if any of
+// the specified range couldn't be accessed. The write is flushed immediately.
+int process_writePtr(Process* proc, Thread* thread, PluginVirtualPtr dst, void* src, size_t n);
+
 // Make the data at plugin_src available in shadow's address space.
 //
 // The returned pointer is read-only, and is automatically invalidated when the

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -486,14 +486,8 @@ SysCallReturn _syscallhandler_recvfromHelper(SysCallHandler* sys, int sockfd,
             sizeNeeded = MIN(sizeNeeded, CONFIG_DATAGRAM_MAX_SIZE + 1);
         }
 
-        void* buf = NULL;
-        if (bufPtr.val) {
-            // if sizeNeeded is 0, process_getWriteablePtr() will always return a null pointer
-            buf = process_getWriteablePtr(sys->process, sys->thread, bufPtr, sizeNeeded);
-        }
-
-        retval = transport_receiveUserData((Transport*)socket_desc, buf, sizeNeeded,
-                                               &inet_addr.sin_addr.s_addr, &inet_addr.sin_port);
+        retval = transport_receiveUserData((Transport*)socket_desc, bufPtr, sizeNeeded,
+                                           &inet_addr.sin_addr.s_addr, &inet_addr.sin_port);
 
         debug("recv returned %zd", retval);
     }
@@ -650,10 +644,8 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
             sizeNeeded = MIN(sizeNeeded, CONFIG_DATAGRAM_MAX_SIZE + 1);
         }
 
-        const void* buf = process_getReadablePtr(sys->process, sys->thread, bufPtr, sizeNeeded);
-
-        retval = transport_sendUserData(
-            (Transport*)socket_desc, buf, sizeNeeded, dest_ip, dest_port);
+        retval =
+            transport_sendUserData((Transport*)socket_desc, bufPtr, sizeNeeded, dest_ip, dest_port);
 
         debug("send returned %zd", retval);
     }

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -144,9 +144,8 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                     break;
                 }
                 case DT_PIPE: {
-                    void* buf = process_getWriteablePtr(sys->process, sys->thread, bufPtr, bufSize);
-                    result = transport_receiveUserData(
-                        (Transport*)desc, buf, bufSize, NULL, NULL);
+                    result =
+                        transport_receiveUserData((Transport*)desc, bufPtr, bufSize, NULL, NULL);
                     break;
                 }
                 case DT_TCPSOCKET:
@@ -263,10 +262,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                     break;
                 }
                 case DT_PIPE: {
-                    const void* buf =
-                        process_getReadablePtr(sys->process, sys->thread, bufPtr, bufSize);
-                    result = transport_sendUserData(
-                        (Transport*)desc, buf, bufSize, 0, 0);
+                    result = transport_sendUserData((Transport*)desc, bufPtr, bufSize, 0, 0);
                     break;
                 }
                 case DT_TCPSOCKET:

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -253,3 +253,21 @@ bool thread_isLeader(Thread* thread) {
     MAGIC_ASSERT(thread);
     return thread->tid == process_getProcessID(thread->process);
 }
+
+int thread_readPtr(Thread* thread, void* dst, PluginVirtualPtr src, size_t n) {
+    MAGIC_ASSERT(thread);
+    utility_assert(thread->methods.readPtr);
+    return thread->methods.readPtr(thread, dst, src, n);
+}
+
+int thread_readStringPtr(Thread* thread, char* dst, PluginVirtualPtr src, size_t n) {
+    MAGIC_ASSERT(thread);
+    utility_assert(thread->methods.readStringPtr);
+    return thread->methods.readStringPtr(thread, dst, src, n);
+}
+
+int thread_writePtr(Thread* thread, PluginVirtualPtr dst, void* src, size_t n) {
+    MAGIC_ASSERT(thread);
+    utility_assert(thread->methods.writePtr);
+    return thread->methods.writePtr(thread, dst, src, n);
+}

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -24,6 +24,19 @@ void thread_resume(Thread* thread);
 void thread_handleProcessExit(Thread* thread);
 int thread_getReturnCode(Thread* thread);
 
+// Copy `n` bytes from `src` to `dst`. Returns 0 on success or EFAULT if any of
+// the specified range couldn't be accessed.
+int thread_readPtr(Thread* thread, void* dst, PluginVirtualPtr src, size_t n);
+
+// Copy a string of at most `n` bytes from `src` to `dst`. Returns 0 on success,
+// EFAULT if any of the specified memory couldn't be accessed, or ENAMETOOLONG
+// if there was no NULL byte in the first `n` bytes.
+int thread_readStringPtr(Thread* base, char* dst, PluginVirtualPtr src, size_t n);
+
+// Copy `n` bytes from `src` to `dst`. Returns 0 on success or EFAULT if any of
+// the specified range couldn't be accessed. The write is flushed immediately.
+int thread_writePtr(Thread* thread, PluginVirtualPtr dst, void* src, size_t n);
+
 // Make the data at plugin_src available in shadow's address space.
 //
 // The returned pointer is read-only, and is automatically invalidated when the

--- a/src/main/host/thread_protected.h
+++ b/src/main/host/thread_protected.h
@@ -34,6 +34,9 @@ typedef struct _ThreadMethods {
                  PluginPtr ctid, unsigned long newtls, Thread** child);
     ShMemBlock* (*getIPCBlock)(Thread* thread);
     ShMemBlock* (*getShMBlock)(Thread* thread);
+    int (*readPtr)(Thread* thread, void* dst, PluginVirtualPtr src, size_t n);
+    int (*readStringPtr)(Thread* thread, char* dst, PluginVirtualPtr src, size_t n);
+    int (*writePtr)(Thread* thread, PluginVirtualPtr dst, void* src, size_t n);
 } ThreadMethods;
 
 struct _Thread {

--- a/src/main/routing/packet.h
+++ b/src/main/routing/packet.h
@@ -12,6 +12,7 @@
 
 #include "main/core/support/definitions.h"
 #include "main/host/protocol.h"
+#include "main/host/syscall_types.h"
 
 typedef struct _Packet Packet;
 
@@ -57,7 +58,7 @@ struct _PacketTCPHeader {
 
 const gchar* protocol_toString(ProtocolType type);
 
-Packet* packet_new(gconstpointer payload, gsize payloadLength, guint hostID, guint64 packetID);
+Packet* packet_new(PluginVirtualPtr payload, gsize payloadLength, guint hostID, guint64 packetID);
 Packet* packet_copy(Packet* packet);
 
 void packet_ref(Packet* packet);
@@ -77,7 +78,7 @@ void packet_setTCP(Packet* packet, enum ProtocolTCPFlags flags,
 void packet_updateTCP(Packet* packet, guint acknowledgement, GList* selectiveACKs,
         guint window, SimulationTime timestampValue, SimulationTime timestampEcho);
 
-guint packet_getPayloadLength(Packet* packet);
+guint packet_getPayloadLength(const Packet* packet);
 gdouble packet_getPriority(const Packet* packet);
 guint packet_getHeaderSize(Packet* packet);
 
@@ -87,7 +88,10 @@ in_addr_t packet_getSourceIP(Packet* packet);
 in_port_t packet_getSourcePort(Packet* packet);
 ProtocolType packet_getProtocol(Packet* packet);
 
-guint packet_copyPayload(Packet* packet, gsize payloadOffset, gpointer buffer, gsize bufferLength);
+gssize packet_copyPayload(const Packet* packet, gsize payloadOffset, PluginVirtualPtr buffer,
+                          gsize bufferLength);
+guint packet_copyPayloadShadow(Packet* packet, gsize payloadOffset, void* buffer,
+                               gsize bufferLength);
 GList* packet_copyTCPSelectiveACKs(Packet* packet);
 PacketTCPHeader* packet_getTCPHeader(Packet* packet);
 gint packet_compareTCPSequence(Packet* packet1, Packet* packet2, gpointer user_data);

--- a/src/main/routing/payload.h
+++ b/src/main/routing/payload.h
@@ -9,14 +9,20 @@
 
 #include <glib.h>
 
+#include "main/host/syscall_types.h"
+
 typedef struct _Payload Payload;
 
-Payload* payload_new(gconstpointer data, gsize dataLength);
+Payload* payload_new(PluginVirtualPtr data, gsize dataLength);
 
 void payload_ref(Payload* payload);
 void payload_unref(Payload* payload);
 
 gsize payload_getLength(Payload* payload);
-gsize payload_getData(Payload* payload, gsize offset, gpointer destBuffer, gsize destBufferLength);
+gssize payload_getData(Payload* payload, gsize offset, PluginVirtualPtr destBuffer,
+                       gsize destBufferLength);
+
+gsize payload_getDataShadow(Payload* payload, gsize offset, void* destBuffer,
+                            gsize destBufferLength);
 
 #endif /* SRC_MAIN_ROUTING_SHD_PAYLOAD_H_ */


### PR DESCRIPTION
  These APIs are potentially more efficient than process_getReadablePluginPtr and process_getWriteablePluginPtr when the data must be copied to or from some other Shadow-owned buffer (such as a packet). The latter can fall back to thread_* when the MemoryManager is disabled or doesn't handle the given memory region.
    
For thread_ptrace, thread_getXPluginPtr involves an extra allocation and copy to a buffer owned by ThreadPtrace, while thread_readPtr and thread_writePtr doesn't.
    
These APIs also lend themselves to safe, clean Rust APIs. We should be able to build generically typed interfaces for reading and writing primitives, without having to deal with the lifetime issues we'd have to contend with if returning some kind of borrowed pointer.