### PR TITLE
better parameters handling - handles quotes as well

### DIFF
--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -774,10 +774,9 @@ static void _process_handleTimerResult(Process* proc, gdouble elapsedTimeSec) {
 #endif
 
 static gint _process_getArguments(Process* proc, gchar** argvOut[]) {
-    /* first argument is the name of the program */
     const gchar* pluginName = _process_getPluginName(proc);
 
-    /* parse the full argument string into separate strings */
+    /* build the full argument string (with plugin name as first argument) */
     gchar* arguments = NULL;
     if(proc->arguments && proc->arguments->len > 0 && g_ascii_strncasecmp(proc->arguments->str, "\0", (gsize) 1) != 0) {
         arguments = g_strconcat(pluginName, " ", proc->arguments->str, NULL);
@@ -790,6 +789,7 @@ static gint _process_getArguments(Process* proc, gchar** argvOut[]) {
     /* a pointer to an array that holds pointers */
     gchar** argv = NULL;
 
+    /* parse the full argument string into argc and argv */
     GError *error = NULL;
     if (!g_shell_parse_argv(arguments, &argc, &argv, &error)) {
         error("unable to parse arguments for plugin '%s': %s", pluginName, error->message);

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -784,7 +784,7 @@ static gint _process_getArguments(Process* proc, gchar** argvOut[]) {
 
     /* parse the full argument string into separate strings */
     if(proc->arguments && proc->arguments->len > 0 && g_ascii_strncasecmp(proc->arguments->str, "\0", (gsize) 1) != 0) {
-        arguments = g_strconcat(arguments, " ", proc->arguments->str);
+        arguments = g_strconcat(arguments, " ", proc->arguments->str, NULL);
     }
 
     /* setup for creating new plug-in, i.e. format into argc and argv */

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -776,15 +776,15 @@ static void _process_handleTimerResult(Process* proc, gdouble elapsedTimeSec) {
 static gint _process_getArguments(Process* proc, gchar** argvOut[]) {
     gchar* threadBuffer;
 
-    gchar* arguments = NULL;
-
     /* first argument is the name of the program */
     const gchar* pluginName = _process_getPluginName(proc);
-    arguments = g_strdup(pluginName);
 
     /* parse the full argument string into separate strings */
+    gchar* arguments = NULL;
     if(proc->arguments && proc->arguments->len > 0 && g_ascii_strncasecmp(proc->arguments->str, "\0", (gsize) 1) != 0) {
-        arguments = g_strconcat(arguments, " ", proc->arguments->str, NULL);
+        arguments = g_strconcat(pluginName, " ", proc->arguments->str, NULL);
+    } else {
+        arguments = g_strdup(pluginName);
     }
 
     /* setup for creating new plug-in, i.e. format into argc and argv */
@@ -7718,4 +7718,3 @@ int process_emu_pthread_cond_timedwait(Process* proc, pthread_cond_t *cond, pthr
 #include "main/host/process_undefined.h"
 
 #undef PROCESS_EMU_UNSUPPORTED
-

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -774,8 +774,6 @@ static void _process_handleTimerResult(Process* proc, gdouble elapsedTimeSec) {
 #endif
 
 static gint _process_getArguments(Process* proc, gchar** argvOut[]) {
-    gchar* threadBuffer;
-
     /* first argument is the name of the program */
     const gchar* pluginName = _process_getPluginName(proc);
 


### PR DESCRIPTION
closes #1265

Couple of questions:

- rather than manually splitting & parsing, I've used g_shell_parse_argv() here (see https://developer.gnome.org/glib/stable/glib-Shell-related-Utilities.html#g-shell-parse-argv). this will also handle special cases like quoted arguments containing spaces (not not expansions and other special cases, see the referenced docs). do you have any concern?

- should I add a test case? I don't see any test cases for process.c, I'm not sure if you want them or not.
