### PR TITLE
Removed the TCP congestion control option

### DIFF
--- a/src/main/core/support/options.c
+++ b/src/main/core/support/options.c
@@ -40,7 +40,6 @@ struct _Options {
     gchar* eventSchedulingPolicy;
     gchar* interposeMethod;
     SimulationTime interfaceBatchTime;
-    gchar* tcpCongestionControl;
 
     gboolean pinCPUs;
 
@@ -145,7 +144,6 @@ Options* options_new(gint argc, gchar* argv[]) {
       { "interface-qdisc", 0, 0, G_OPTION_ARG_STRING, &(options->interfaceQueuingDiscipline), "The interface queuing discipline QDISC used to select the next sendable socket ('fifo' or 'rr') ['fifo']", "QDISC" },
       { "socket-recv-buffer", 0, 0, G_OPTION_ARG_INT, &(options->initialSocketReceiveBufferSize), sockrecv->str, "N" },
       { "socket-send-buffer", 0, 0, G_OPTION_ARG_INT, &(options->initialSocketSendBufferSize), socksend->str, "N" },
-      { "tcp-congestion-control", 0, 0, G_OPTION_ARG_STRING, &(options->tcpCongestionControl), "Congestion control algorithm to use for TCP ('aimd', 'reno', 'cubic') ['reno']", "TCPCC" },
       { NULL },
     };
 
@@ -224,9 +222,6 @@ Options* options_new(gint argc, gchar* argv[]) {
         options->initialSocketSendBufferSize = CONFIG_SEND_BUFFER_SIZE;
         options->autotuneSocketSendBuffer = TRUE;
     }
-    if(options->tcpCongestionControl == NULL) {
-        options->tcpCongestionControl = g_strdup("reno");
-    }
     if(options->dataDirPath == NULL) {
         options->dataDirPath = g_strdup("shadow.data");
     }
@@ -254,7 +249,6 @@ void options_free(Options* options) {
     g_free(options->heartbeatLogInfo);
     g_free(options->interfaceQueuingDiscipline);
     g_free(options->eventSchedulingPolicy);
-    g_free(options->tcpCongestionControl);
     if(options->argstr) {
         g_free(options->argstr);
     }
@@ -381,11 +375,6 @@ gboolean options_shouldExitAfterShmCleanup(Options* options) {
 gint options_getMinRunAhead(Options* options) {
     MAGIC_ASSERT(options);
     return options->minRunAhead;
-}
-
-const gchar* options_getTCPCongestionControl(Options* options) {
-    MAGIC_ASSERT(options);
-    return options->tcpCongestionControl;
 }
 
 SimulationTime options_getInterfaceBatchTime(Options* options) {

--- a/src/main/core/support/options.h
+++ b/src/main/core/support/options.h
@@ -114,7 +114,6 @@ gboolean options_doRunPrintVersion(Options* options);
 gboolean options_doRunDebug(Options* options);
 
 gint options_getMinRunAhead(Options* options);
-const gchar* options_getTCPCongestionControl(Options* options);
 SimulationTime options_getInterfaceBatchTime(Options* options);
 gint options_getInterfaceBufferSize(Options* options);
 gint options_getSocketReceiveBufferSize(Options* options);

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -2555,21 +2555,11 @@ TCP* tcp_new(guint receiveBufferSize, guint sendBufferSize) {
 
     Options* options = worker_getOptions();
     guint32 initial_window = 10;
-    const gchar* tcpCC = options_getTCPCongestionControl(options);
     gint tcpSSThresh = 0;
 
-    TCPCongestionType congestionType = tcpCongestion_getType(tcpCC);
-
-    switch(congestionType) {
-        default:
-            warning("CC %s not implemented, falling back to reno", tcpCC);
-        case TCP_CC_RENO:
-            tcp_cong_reno_init(tcp);
-            break;
-        case TCP_CC_UNKNOWN:
-            error("Failed to initialize TCP congestion control for %s", tcpCC);
-            break;
-    }
+    /* in the future we'd like to support more congestion control types
+     * and allow it to be set as a host option */
+    tcp_cong_reno_init(tcp);
 
     tcp->send.window = initial_window;
     tcp->send.lastWindow = initial_window;
@@ -2607,12 +2597,4 @@ TCP* tcp_new(guint receiveBufferSize, guint sendBufferSize) {
 
     worker_count_allocation(TCP);
     return tcp;
-}
-
-TCPCongestionType tcpCongestion_getType(const gchar* type) {
-    if(!g_ascii_strcasecmp(type, "reno")) {
-        return TCP_CC_RENO;
-    }
-
-    return TCP_CC_UNKNOWN;
 }


### PR DESCRIPTION
There is only a single congestion control method implemented in the dev branch (reno), so we should remove this option until we support others. Part of #1220.