### PR TITLE
ByteQueue: Avoid unnecessary initialization, and take Read objs

### DIFF
--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -28,6 +28,7 @@ add_custom_command(OUTPUT wrapper.rs
         --whitelist-function "process_parseArgStr.*"
         --whitelist-function "process_read.*Ptr"
         --whitelist-function "process_write.*Ptr"
+        --whitelist-function "process_flushPtrs"
         --whitelist-function "shadow_logger_getDefault"
         --whitelist-function "shadow_logger_shouldFilter"
         --whitelist-function "statuslistener_ref"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -528,6 +528,9 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    pub fn process_flushPtrs(proc_: *mut Process);
+}
+extern "C" {
     pub fn process_parseArgStr(
         commandLine: *const ::std::os::raw::c_char,
         argc: *mut ::std::os::raw::c_int,

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1,8 +1,10 @@
 use crate::cshadow;
-use crate::host::syscall_types::PluginPtr;
+use crate::host::syscall_types::TypedPluginPtr;
 use crate::utility::pod::Pod;
 use log::*;
-use std::mem::{align_of, size_of, MaybeUninit};
+use nix::errno::Errno;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::mem::align_of;
 
 pub struct Process {
     cprocess: *mut cshadow::Process,
@@ -20,103 +22,132 @@ impl Process {
         Process { cprocess: p }
     }
 
-    /// Read data from `src` into `dst`.
-    /// Always succeeds for zero-size `dst`.
-    ///
-    /// Use when:
-    /// * We need to copy the data into a Shadow-owned buffer (such as a packet).
-    /// * Or: when the cost of copying the data is small (e.g. < 1kB).
-    pub fn read_ptr_into_slice<T: Pod>(&self, dst: &mut [T], src: PluginPtr) -> nix::Result<()> {
-        let status = unsafe {
-            cshadow::process_readPtr(
-                self.cprocess,
-                dst.as_mut_ptr() as *mut std::os::raw::c_void,
-                src.into(),
-                (dst.len() * size_of::<T>()) as u64,
-            )
-        };
-        if status == 0 {
-            Ok(())
-        } else {
-            Err(nix::Error::from_errno(nix::errno::from_i32(status as i32)))
+    /// Create an object to read `count` elements of type `T` from the specified
+    /// pointer.
+    pub fn reader<T>(&self, dst: TypedPluginPtr<T>) -> ProcessMemoryReader<T> {
+        ProcessMemoryReader::<T> {
+            process: self,
+            ptr: dst,
         }
     }
 
-    /// Read data from `src` into `dst`.
-    ///
-    /// Use when:
-    /// * We need to copy the data into a Shadow-owned buffer (such as a packet).
-    /// * Or: when the cost of copying the data is small (e.g. < 1kB).
-    pub fn read_ptr_into_val<'a, T: Pod>(&self, dst: &mut T, src: PluginPtr) -> nix::Result<()> {
-        let mut slice = std::slice::from_mut(dst);
-        self.read_ptr_into_slice(&mut slice, src)?;
-        Ok(())
-    }
-
-    /// Convenience wrapper around `read_ptr_into_val`.
-    pub fn read_ptr_as_val<T: Pod>(&self, src: PluginPtr) -> nix::Result<T> {
-        // SAFETY: Since `T` is Pod, any bit pattern is a valid `T`.
-        let mut val: T = unsafe { MaybeUninit::uninit().assume_init() };
-        self.read_ptr_into_val(&mut val, src)?;
-        Ok(val)
-    }
-
-    /// Write data from `src` into `dst`.
-    /// Always succeeds for zero-size `dst`.
-    pub fn write_ptr_from_slice<T: Copy>(&mut self, dst: PluginPtr, src: &[T]) -> nix::Result<()> {
-        let status = unsafe {
-            cshadow::process_writePtr(
-                self.cprocess,
-                dst.into(),
-                src.as_ptr() as *const std::os::raw::c_void,
-                (src.len() * size_of::<T>()) as u64,
-            )
-        };
-        if status == 0 {
-            Ok(())
-        } else {
-            Err(nix::Error::from_errno(nix::errno::from_i32(status as i32)))
+    /// Create an object to write `count` elements of type `T` to the specified
+    /// pointer.
+    pub fn writer<T>(&mut self, src: TypedPluginPtr<T>) -> ProcessMemoryWriter<T> {
+        ProcessMemoryWriter::<T> {
+            process: self,
+            ptr: src,
         }
     }
+}
 
-    /// Write `src` into `dst` in the current Process.
-    pub fn write_ptr_from_val<T: Copy>(&mut self, dst: PluginPtr, src: &T) -> nix::Result<()> {
-        let src = std::slice::from_ref(src);
-        self.write_ptr_from_slice(dst, src)
-    }
+pub struct ProcessMemoryReader<'a, T> {
+    process: &'a Process,
+    ptr: TypedPluginPtr<T>,
+}
 
-    /// Get a read-only slice at `src`. If memory can't be accessed, may return
-    /// an error, or may cause a Shadow error later when flushing.
+impl<'a, T> ProcessMemoryReader<'a, T>
+where
+    T: Pod,
+{
+    /// Get a read-only slice.
     ///
-    /// Prefer the `read_ptr_*` methods unless you specifically need a slice, and
-    /// the data is of non-trivial size.
-    pub fn get_slice<T>(&self, src: PluginPtr, len: usize) -> nix::Result<&[T]> {
-        if len == 0 {
+    /// This *may* have to copy the data. If you need a copy anyway use the
+    /// `std::io::Read` trait implementation avoid an extra copy.
+    ///
+    /// Fails if the source pointer is unaligned.
+    ///
+    /// Result's lifetime is intentionally bound to that of the underlying
+    /// `Process` reference rather than the lifetime of this object. That allows
+    /// this object to be discarded. e.g.:
+    ///
+    /// ```
+    /// let tv : &timeval = process.reader(ptr, 1).as_ref().unwrap()[0];
+    /// ```
+    pub fn as_ref(&self) -> Result<&'a [T], Errno> {
+        if self.ptr.items_remaining()? == 0 {
             return Ok(&[][..]);
         }
-
         // SAFETY: This never returns an invalid pointer. Passing a `p` outside
         // of the plugin's addressable memory will return a NULL pointer.
         let ptr = unsafe {
             cshadow::process_getReadablePtr(
-                self.cprocess,
-                src.into(),
-                (size_of::<T>() * len) as u64,
+                self.process.cprocess,
+                self.ptr.ptr()?.into(),
+                self.ptr.bytes_remaining()? as u64,
             )
         } as *const T;
 
         if ptr.is_null() {
-            return Err(nix::Error::from_errno(nix::errno::Errno::EFAULT));
+            let e = Errno::EFAULT;
+            warn!("Reading {:?}: {}", self.ptr, e);
+            return Err(e);
         }
-
         if ptr.align_offset(align_of::<T>()) != 0 {
-            debug!("Unaligned pointer {:?}", ptr);
-            return Err(nix::Error::from_errno(nix::errno::Errno::EFAULT));
+            warn!("Unaligned pointer {:?}", ptr);
+            return Err(Errno::EFAULT);
         }
 
-        // SAFETY: `process_getReadablePtr` already checked bounds; we've
-        // checked alignment, and since T is Pod, any data is a valid T.
-        Ok(unsafe { std::slice::from_raw_parts(ptr, len) })
+        // SAFETY: Any values are ok because T is Pod. We've validated the
+        // pointer is accessible and aligned.
+        Ok(unsafe { std::slice::from_raw_parts(ptr, self.ptr.items_remaining()?) })
+    }
+}
+
+impl<'a> Seek for ProcessMemoryReader<'a, u8> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.ptr.seek(pos)
+    }
+}
+
+impl<'a> Read for ProcessMemoryReader<'a, u8> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let toread = std::cmp::min(buf.len(), self.ptr.bytes_remaining()?);
+        debug!(
+            "Preparing to read {:?} into buffer of size {}",
+            self.ptr,
+            buf.len()
+        );
+
+        if toread == 0 {
+            return Ok(0);
+        }
+
+        let status = unsafe {
+            cshadow::process_readPtr(
+                self.process.cprocess,
+                buf.as_mut_ptr() as *mut std::os::raw::c_void,
+                self.ptr.ptr()?.into(),
+                toread as u64,
+            )
+        };
+        if status != 0 {
+            let e = std::io::Error::from_raw_os_error(status);
+            warn!("Reading {} bytes from {:?}: {}", toread, self.ptr, e);
+            return Err(e);
+        }
+        self.ptr.seek(SeekFrom::Current(toread as i64)).unwrap();
+
+        Ok(toread)
+    }
+}
+
+pub struct ProcessMemoryWriter<'a, T> {
+    process: &'a mut Process,
+    ptr: TypedPluginPtr<T>,
+}
+
+impl<'a> Seek for ProcessMemoryWriter<'a, u8> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.ptr.seek(pos)
+    }
+}
+
+impl<'a, T> ProcessMemoryWriter<'a, T> {
+    pub fn flush(&mut self) -> Result<(), Errno> {
+        // TODO: Change process_flushPtrs to propagate errors.
+        unsafe { cshadow::process_flushPtrs(self.process.cprocess) };
+        Ok(())
     }
 
     /// Get a mutable slice to `src`. May return an error if the memory can't
@@ -124,84 +155,129 @@ impl Process {
     /// will be flushed later, in which case any errors will be deferred until
     /// then. Returns an empty slice for len == 0.
     ///
-    /// Prefer the `write_ptr_*` methods unless you need a mutable slice to pass
-    /// to another API, and prefer `get_writable_slice` when you don't need the
-    /// original value stored at `src`.
-    pub fn get_mut_slice<T>(&mut self, src: PluginPtr, len: usize) -> nix::Result<&mut [T]> {
-        if len == 0 {
-            return Ok(unsafe {
-                std::slice::from_raw_parts_mut(std::ptr::NonNull::dangling().as_ptr(), 0)
-            });
-        }
-
-        // SAFETY: This never returns an invalid pointer. Passing a `p` outside
-        // of the plugin's addressable memory will either result in returning a
-        // NULL pointer (if we end up going through the MemoryManager), or
-        // result in a failure later when the thread attempts to flush the
-        // write. Such a failure is undesirable, but should at least fail in a
-        // well-defined way.
-        //
-        // TODO: When the MemoryManager is available, use it to validate the
-        // bounds of the pointer even if it doesn't have the pointer mmap'd into
-        // Shadow.
-        let ptr = unsafe {
-            cshadow::process_getMutablePtr(self.cprocess, src.into(), (size_of::<T>() * len) as u64)
-        } as *mut T;
-
-        if ptr.is_null() {
-            return Err(nix::Error::from_errno(nix::errno::Errno::EFAULT));
-        }
-
-        if ptr.align_offset(align_of::<T>()) != 0 {
-            debug!("Unaligned pointer {:?}", ptr);
-            return Err(nix::Error::from_errno(nix::errno::Errno::EFAULT));
-        }
-
-        // SAFETY: `process_getMutablePtr` already checked bounds; we've checked
-        // alignment, and since T is Pod, any data is a valid T.
-        Ok(unsafe { std::slice::from_raw_parts_mut(ptr, len) })
-    }
-
-    /// As `get_mut_slice`, but the initial value is unspecified.
+    /// The initial contents of the returned slice is unspecified.
     ///
-    /// Prefer the `write_ptr_*` methods unless you need a mutable slice to pass
-    /// to another API.
-    pub fn get_writable_slice<T>(&mut self, src: PluginPtr, len: usize) -> nix::Result<&mut [T]> {
-        if len == 0 {
-            return Ok(unsafe {
-                std::slice::from_raw_parts_mut(std::ptr::NonNull::dangling().as_ptr(), 0)
-            });
+    /// *May* return a temporary buffer that will later be written back into the
+    /// process. Use the `std::io::Write` trait when feasible to avoid this
+    /// potential extra copy.
+    ///
+    /// Unlike `ProcessMemoryReader::as_ref`, the result's lifetime is bound to
+    /// that of *this* object, so that we can ensure writes are flushed.
+    pub fn as_mut_uninit(&mut self) -> Result<&mut [T], Errno>
+    where
+        T: Pod,
+    {
+        if self.ptr.bytes_remaining()? == 0 {
+            debug!("as_mut_init returning empty slice");
+            return Ok(&mut [][..]);
         }
 
         // SAFETY: This never returns an invalid pointer. Passing a `p` outside
-        // of the plugin's addressable memory will either result in returning a
-        // NULL pointer (if we end up going through the MemoryManager), or
-        // result in a failure later when the thread attempts to flush the
-        // write. Such a failure is undesirable, but should at least fail in a
-        // well-defined way.
-        //
-        // TODO: When the MemoryManager is available, use it to validate the
-        // bounds of the pointer even if it doesn't have the pointer mmap'd into
-        // Shadow.
+        // of the plugin's addressable memory will return a NULL pointer.
         let ptr = unsafe {
             cshadow::process_getWriteablePtr(
-                self.cprocess,
-                src.into(),
-                (size_of::<T>() * len) as u64,
+                self.process.cprocess,
+                self.ptr.ptr()?.into(),
+                self.ptr.bytes_remaining()? as u64,
             )
         } as *mut T;
 
         if ptr.is_null() {
-            return Err(nix::Error::from_errno(nix::errno::Errno::EFAULT));
+            warn!("Couldn't write {:?}", self.ptr);
+            return Err(Errno::EFAULT);
         }
-
         if ptr.align_offset(align_of::<T>()) != 0 {
-            debug!("Unaligned pointer {:?}", ptr);
-            return Err(nix::Error::from_errno(nix::errno::Errno::EFAULT));
+            warn!("Unaligned pointer {:?}", ptr);
+            return Err(Errno::EFAULT);
         }
 
-        // SAFETY: `process_getWriteablePtr` already checked bounds; we've checked
-        // alignment, and since T is Pod, any data is a valid T.
-        Ok(unsafe { std::slice::from_raw_parts_mut(ptr, len) })
+        debug!("as_mut_uninit got {:?}", ptr);
+
+        // SAFETY: Any values are ok because T is Pod. We've validated the
+        // pointer is accessible and aligned.
+        Ok(unsafe { std::slice::from_raw_parts_mut(ptr, self.ptr.items_remaining()?) })
+    }
+
+    /// Get a mutable slice to `src`. Returns an error if the memory can't
+    /// be accessed. Returns an empty slice for len == 0.
+    ///
+    /// *May* return a temporary buffer that will later be written back into the
+    /// process. Use the `std::io::Write` trait when feasible to avoid this
+    /// potential extra copy.
+    ///
+    /// When a temporary buffer is needed, also needs to copy the original
+    /// contents of the specified memory. Prefer `as_mut_uninit` if you don't
+    /// need the initial state.
+    ///
+    /// Unlike `ProcessMemoryReader::as_ref`, the result's lifetime is bound to
+    /// that of *this* object, so that we can ensure writes are flushed.
+    pub fn as_mut(&mut self) -> Result<&mut [T], Errno>
+    where
+        T: Pod,
+    {
+        if self.ptr.items_remaining()? == 0 {
+            return Ok(&mut [][..]);
+        }
+
+        // SAFETY: This never returns an invalid pointer. Passing a `p` outside
+        // of the plugin's addressable memory will return a NULL pointer.
+        let ptr = unsafe {
+            cshadow::process_getMutablePtr(
+                self.process.cprocess,
+                self.ptr.ptr()?.into(),
+                self.ptr.bytes_remaining()? as u64,
+            )
+        } as *mut T;
+
+        if ptr.is_null() {
+            warn!("Couldn't write {:?}", ptr);
+            return Err(Errno::EFAULT);
+        }
+        if ptr.align_offset(align_of::<T>()) != 0 {
+            warn!("Unaligned pointer {:?}", ptr);
+            return Err(Errno::EFAULT);
+        }
+
+        // SAFETY: Any values are ok because T is Pod. We've validated the
+        // pointer is accessible and aligned.
+        Ok(unsafe { std::slice::from_raw_parts_mut(ptr, self.ptr.items_remaining()?) })
+    }
+}
+
+impl<'a> Write for ProcessMemoryWriter<'a, u8> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        // Don't write more than we have
+        let towrite = std::cmp::min(buf.len(), self.ptr.bytes_remaining()?);
+        debug!("Preparing to write {} bytes into {:?}", towrite, self.ptr);
+        if towrite == 0 {
+            return Ok(0);
+        }
+
+        let status = unsafe {
+            cshadow::process_writePtr(
+                self.process.cprocess,
+                self.ptr.ptr()?.into(),
+                buf.as_ptr() as *const std::os::raw::c_void,
+                towrite as u64,
+            )
+        };
+        if status != 0 {
+            let e = std::io::Error::from_raw_os_error(status);
+            warn!("Writing {} bytes to {:?}: {}", towrite, self.ptr, e);
+            return Err(std::io::Error::from_raw_os_error(status));
+        }
+        self.ptr.seek(SeekFrom::Current(towrite as i64)).unwrap();
+        Ok(towrite)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        ProcessMemoryWriter::flush(self).map_err(|e| std::io::Error::from_raw_os_error(e as i32))
+    }
+}
+
+impl<'a, T> Drop for ProcessMemoryWriter<'a, T> {
+    fn drop(&mut self) {
+        // Avoid syscall handlers needing to flush explicitly.
+        self.flush().unwrap()
     }
 }

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -4,4 +4,5 @@ pub mod event_queue;
 pub mod interval_map;
 pub mod pod;
 pub mod proc_maps;
+pub mod stream_len;
 pub mod syscall;

--- a/src/main/utility/stream_len.rs
+++ b/src/main/utility/stream_len.rs
@@ -1,0 +1,44 @@
+use std::io::{Seek, SeekFrom};
+
+pub trait StreamLen {
+    /// Backport of std::io::Seek::stream_len from Rust nightly.
+    fn stream_len_bp(&mut self) -> std::io::Result<u64>;
+}
+
+impl<T> StreamLen for T
+where
+    T: Seek,
+{
+    fn stream_len_bp(&mut self) -> std::io::Result<u64> {
+        let current = self.seek(SeekFrom::Current(0))?;
+        let end = self.seek(SeekFrom::End(0))?;
+        if current != end {
+            self.seek(SeekFrom::Start(current))?;
+        }
+        Ok(end)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_stream_len_bp() -> std::io::Result<()> {
+        let data = [0, 1, 2, 3, 4, 5];
+        let mut cursor = Cursor::new(&data);
+
+        assert_eq!(cursor.stream_len_bp()?, 6);
+        assert_eq!(cursor.position(), 0);
+
+        cursor.seek(SeekFrom::Start(2))?;
+        assert_eq!(cursor.stream_len_bp()?, 6);
+        assert_eq!(cursor.position(), 2);
+
+        cursor.seek(SeekFrom::End(0))?;
+        assert_eq!(cursor.stream_len_bp()?, 6);
+        assert_eq!(cursor.position(), 6);
+        Ok(())
+    }
+}


### PR DESCRIPTION
* Extracts pointer-access APIs into `ProcessMemoryReader` and `ProcessMemoryWriter`, which implement `std::io::Read` and `std::io::Write`.
* Use `ProcessMemoryWriter` to ensure writes are flushed. The Drop trait on this object flushes writes, and the object must be dropped to release a mutable reference to its Process.
* Add APIs to `ByteQueue` that take `Read` and `Write` objects.
* In `ByteQueue` use reserved but unfilled buffer capacity to avoid unnecessary initialization.
* Change some internal functions to take `Read` and `Write` objects instead of buffers.