### PR TITLE
Don't use Cargo config.toml to set build target directory

### DIFF
--- a/src/main/.cargo/config.toml
+++ b/src/main/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target-dir = "../../build/src/main/target"

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -206,7 +206,7 @@ ExternalProject_Add(
     BUILD_ALWAYS 1
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND bash -c "${CARGO_ENV_VARS} cargo build ${RUST_BUILD_FLAG} --all-targets"
+    BUILD_COMMAND bash -c "${CARGO_ENV_VARS} cargo build ${RUST_BUILD_FLAG} --all-targets --target-dir \"${CMAKE_CURRENT_BINARY_DIR}/target\""
     BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/target/debug/libshadow_rs.a ${CMAKE_CURRENT_BINARY_DIR}/target/release/libshadow_rs.a
     INSTALL_COMMAND ""
     LOG_BUILD OFF

--- a/src/test/.cargo/config.toml
+++ b/src/test/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target-dir = "../../build/src/test/target"

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -19,7 +19,7 @@ ExternalProject_Add(
    BUILD_ALWAYS 1
    DOWNLOAD_COMMAND ""
    CONFIGURE_COMMAND ""
-   BUILD_COMMAND bash -c "${CARGO_ENV_VARS} cargo build"
+   BUILD_COMMAND bash -c "${CARGO_ENV_VARS} cargo build --target-dir \"${CMAKE_CURRENT_BINARY_DIR}/target\""
    INSTALL_COMMAND ""
    LOG_BUILD OFF
 )


### PR DESCRIPTION
Our CMake build process sets environment variables and options when running Cargo to build our Rust code. When other tools run Cargo (for example `cargo check`, `cargo doc`), they use the same target directory. Since the environment variables and options are different, Cargo invalidates the cached build files, and when using something like Rust Analyzer, we lose incremental builds altogether.

Instead, only CMake should use a target directory within Shadow's `build/` directory.

Also requires us to update the workflow in https://github.com/shadow/docs.