### PR TITLE
Changes to experimental options

### DIFF
--- a/src/main/host/shimipc.c
+++ b/src/main/host/shimipc.c
@@ -10,12 +10,13 @@
 
 // We use an int here because the option parsing library doesn't provide a way
 // to set a boolean flag to false explicitly.
-static gint _sendExplicitBlockMessage = true;
+static bool _disableExplicitBlockMessage = false;
 OPTION_EXPERIMENTAL_ENTRY(
-    "send-explicit-block-message", 0, 0, G_OPTION_ARG_INT, &_sendExplicitBlockMessage,
-    "Send message to plugin telling it to stop spinning when a syscall blocks", "[0|1]")
+    "disable-explicit-block-message", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+    &_disableExplicitBlockMessage,
+    "Don't send a \"stop spinning\" message to the plugin when a syscall blocks", NULL)
 
-bool shimipc_sendExplicitBlockMessageEnabled() { return _sendExplicitBlockMessage; }
+bool shimipc_sendExplicitBlockMessageEnabled() { return !_disableExplicitBlockMessage; }
 
 static gint _spinMax = 8096;
 OPTION_EXPERIMENTAL_ENTRY("preload-spin-max", 0, 0, G_OPTION_ARG_INT, &_spinMax,

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -52,9 +52,9 @@
 #define SYS_copy_file_range 326
 #endif
 
-static bool _useMM = true;
-OPTION_EXPERIMENTAL_ENTRY("disable-memory-manager", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE,
-                          &_useMM,
+static bool _disableMM = false;
+OPTION_EXPERIMENTAL_ENTRY("disable-memory-manager", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+                          &_disableMM,
                           "Disable the MemoryManager. This can be useful for debugging, but will "
                           "hurt performance in most cases.",
                           NULL)
@@ -257,7 +257,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
     // syscall after an `exec` (which destroys the MemoryManager). It's done
     // here because the MemoryManager needs a plugin thread that's ready to
     // make syscalls in order to perform its initialization.
-    if (_useMM && !process_getMemoryManager(sys->process)) {
+    if (!_disableMM && !process_getMemoryManager(sys->process)) {
         process_setMemoryManager(sys->process, memorymanager_new(sys->thread));
     }
     SysCallReturn scr;


### PR DESCRIPTION
This PR has two changes:

1. The `--send-explicit-block-message` option (which defaulted to 1) has been renamed to `--disable-explicit-block-message` (which defaults to false).
2. The variables representing two of the experimental options have been inverted to better match their corresponding option.

The default behaviour of Shadow has not changed.

These are changes that will be helpful when adding Rust option/config support.