### PR TITLE
Avoid library calls after vfork

### DIFF
--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -142,19 +142,16 @@ static pid_t _threadpreload_fork_exec(ThreadPreload* thread, const char* file, c
             // child
 
             // Set the working directory
-            utility_assert(workingDir != NULL);
             if (chdir(workingDir) < 0) {
-                error("chdir(%s): %s", workingDir, g_strerror(errno));
+                die_after_vfork();
             }
 
             int rc = execvpe(file, argv, envp);
             if (rc == -1) {
-                error("execvpe() call failed");
-                return -1;
+                die_after_vfork();
             }
-            while (1) {
-            } // here for compiler optimization
-            break;
+            // Unreachable
+            die_after_vfork();
         }
         default: // parent
             info("started process %s with PID %d", file, pid);

--- a/src/main/utility/utility.h
+++ b/src/main/utility/utility.h
@@ -114,4 +114,9 @@ struct timespec utility_timespecFromMillis(int64_t millis);
 /* If a process exited by a signal, use this return code. */
 int return_code_for_signal(int signal);
 
+/* Calling anything other than a thin syscall wrapper between `vfork` and `exec`
+ can lead to confusing behavior and crashes. Use this function on errors to
+ safely abort the process (with a core dump, if enabled). */
+_Noreturn void die_after_vfork();
+
 #endif /* SHD_UTILITY_H_ */


### PR DESCRIPTION
In between vfork and exec we share an address space with the parent
process. This can lead to surprising, difficult to debug behavior.

We should restrict ourselves to only making syscalls; e.g. functions in
`man` section 2. Higher level functions could try to allocate,
manipulate locks, etc, which is problematic.

Fixes #1243