### PR TITLE
fixed markdown typo in docs

### DIFF
--- a/docs/1.2-Shadow-with-Docker.md
+++ b/docs/1.2-Shadow-with-Docker.md
@@ -20,7 +20,8 @@ There are many ways to do this.  Below, we base our install off of Fedora 22.
 	```bash
 	dnf install -y gcc gcc-c++ clang clang-devel llvm llvm-devel glib2 glib2-devel 	igraph igraph-devel cmake make xz
 	dnf install -y python numpy scipy python-matplotlib python-networkx python-lxml
-	dnf install -y git dstat screen htop```
+	dnf install -y git dstat screen htop
+ 	```
 
 1. Become the shadow user: ```sudo -u shadow -s```
 1. Change to the shadow user's home directory: ```cd```


### PR DESCRIPTION
Fixed a markdown typo in `docs/1.2-Shadow-with-Docker.md`.
3 back-ticks were on the wrong line, making it seem as if they were a part of the command.

Signed-off-by: Mathis Van Eetvelde <mathis.vaneetvelde@protonmail.com>