### PR TITLE
Adds a module to disable plugin ASLR

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -149,6 +149,7 @@ set(shadow_srcs
 
     utility/async_priority_queue.c
     utility/count_down_latch.c
+    utility/disable_aslr.c
     utility/fork_proxy.c
     utility/pcap_writer.c
     utility/priority_queue.c

--- a/src/main/core/main.c
+++ b/src/main/core/main.c
@@ -223,6 +223,9 @@ gint main_runShadow(gint argc, gchar* argv[]) {
         }
     }
 
+    // Disable address space layout randomization of processes forked from this
+    // one to ensure determinism in cases when an executable under simulation
+    // branch on memory addresses.
     disable_aslr();
 
     gint returnCode = _main_helper(options);

--- a/src/main/core/main.c
+++ b/src/main/core/main.c
@@ -23,6 +23,7 @@
 #include "main/core/support/options.h"
 #include "main/host/affinity.h"
 #include "main/shmem/shmem_cleanup.h"
+#include "main/utility/disable_aslr.h"
 #include "main/utility/utility.h"
 #include "shd-config.h"
 #include "support/logger/logger.h"
@@ -221,6 +222,8 @@ gint main_runShadow(gint argc, gchar* argv[]) {
             message("Successfully set real-time scheduler mode to SCHED_FIFO");
         }
     }
+
+    disable_aslr();
 
     gint returnCode = _main_helper(options);
 

--- a/src/main/utility/disable_aslr.c
+++ b/src/main/utility/disable_aslr.c
@@ -11,7 +11,7 @@ void disable_aslr() {
     int prev_persona = personality(ADDR_NO_RANDOMIZE);
 
     if (prev_persona != -1) {
-        debug("ASLR disabled for processes forked from this parent process.");
+        message("ASLR disabled for processes forked from this parent process.");
     } else {
         const char *err = strerror(errno);
         warning("Could not disable plugin address space layout randomization: %s",

--- a/src/main/utility/disable_aslr.c
+++ b/src/main/utility/disable_aslr.c
@@ -1,0 +1,20 @@
+#include "disable_aslr.h"
+
+#include <errno.h>
+#include <string.h>
+
+#include <sys/personality.h>
+
+#include "support/logger/logger.h"
+
+void disable_aslr() {
+    int prev_persona = personality(ADDR_NO_RANDOMIZE);
+
+    if (prev_persona != -1) {
+        debug("ASLR disabled for processes forked from this parent process.");
+    } else {
+        const char *err = strerror(errno);
+        warning("Could not disable plugin address space layout randomization: %s",
+                err);
+    }
+}

--- a/src/main/utility/disable_aslr.h
+++ b/src/main/utility/disable_aslr.h
@@ -1,0 +1,14 @@
+#ifndef DISABLE_ASLR_H_
+#define DISABLE_ASLR_H_
+
+/*
+ * Disable address space layout randomization of processes under simulation.
+ * Forked processes inherit this personality trait, so this can be called from
+ * a parent process that's forking simulated processes. Logs a warning if the
+ * routine fails.
+ *
+ * THREAD SAFETY: thread-safe.
+ */
+void disable_aslr();
+
+#endif // DISABLE_ASLR_H_


### PR DESCRIPTION
Disabling ASLR should eliminate cases of non-determinism if a plugin branches on the memory address of any variable reference. I don't think there's any downsides.

Somewhat related:

We're accumulating a bunch of simulator settings in src/main/core/main.c (Lines 206 thru 226). Do these belong somewhere else?