### PR TITLE
Rename some variables used for experimental options

### DIFF
--- a/src/main/core/main.c
+++ b/src/main/core/main.c
@@ -28,9 +28,9 @@
 #include "shd-config.h"
 #include "support/logger/logger.h"
 
-static bool _setSchedFifo = false;
+static bool _useSchedFifo = false;
 OPTION_EXPERIMENTAL_ENTRY(
-    "set-sched-fifo", 0, 0, G_OPTION_ARG_NONE, &_setSchedFifo,
+    "set-sched-fifo", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &_useSchedFifo,
     "Use the SCHED_FIFO scheduler. Requires CAP_SYS_NICE. See sched(7), capabilities(7)", NULL)
 
 static Controller* shadowcontroller;
@@ -210,7 +210,7 @@ gint main_runShadow(gint argc, gchar* argv[]) {
         }
     }
 
-    if (_setSchedFifo) {
+    if (_useSchedFifo) {
         struct sched_param param = {0};
         param.sched_priority = 1;
         int rc = sched_setscheduler(0, SCHED_FIFO, &param);

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -41,9 +41,9 @@
 #include "support/logger/logger.h"
 
 // Allow turning off object counting at run-time.
-static bool _disable_object_counters = false;
-OPTION_EXPERIMENTAL_ENTRY("disable-object-counters", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
-                          &_disable_object_counters,
+static bool _use_object_counters = true;
+OPTION_EXPERIMENTAL_ENTRY("disable-object-counters", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE,
+                          &_use_object_counters,
                           "Disable counting object allocations and deallocations. "
                           "If disabled, we will not be able to detect object memory leaks.",
                           NULL)
@@ -826,7 +826,7 @@ void worker_incrementPluginError() {
 
 void __worker_increment_object_alloc_counter(const char* object_name) {
     // If disabled, we never create the counter (and never send it to the manager).
-    if (_disable_object_counters) {
+    if (!_use_object_counters) {
         return;
     }
     // See COUNTER WARNING above.
@@ -844,7 +844,7 @@ void __worker_increment_object_alloc_counter(const char* object_name) {
 
 void __worker_increment_object_dealloc_counter(const char* object_name) {
     // If disabled, we never create the counter (and never send it to the manager).
-    if (_disable_object_counters) {
+    if (!_use_object_counters) {
         return;
     }
     // See COUNTER WARNING above.

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -64,9 +64,9 @@
 // We normally attempt to serve hot-path syscalls on the shim-side to avoid a
 // more expensive inter-process syscall. This option disables the optimization.
 // This is defined here in Shadow because it breaks the shim.
-static bool _disable_shim_syscall_handler = false;
-OPTION_EXPERIMENTAL_ENTRY("disable-shim-syscall-handler", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
-                          &_disable_shim_syscall_handler,
+static bool _use_shim_syscall_handler = true;
+OPTION_EXPERIMENTAL_ENTRY("disable-shim-syscall-handler", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE,
+                          &_use_shim_syscall_handler,
                           "Disable shim-side syscall handler to force hot-path syscalls to be "
                           "handled via an inter-process syscall with shadow.",
                           NULL)
@@ -684,7 +684,7 @@ Process* process_new(Host* host, guint processID, SimulationTime startTime,
         g_free(logFileName);
     }
 
-    if (_disable_shim_syscall_handler) {
+    if (!_use_shim_syscall_handler) {
         envv = g_environ_setenv(envv, "SHADOW_DISABLE_SHIM_SYSCALL", "TRUE", TRUE);
     }
 

--- a/src/main/host/shimipc.c
+++ b/src/main/host/shimipc.c
@@ -10,12 +10,12 @@
 
 // We use an int here because the option parsing library doesn't provide a way
 // to set a boolean flag to false explicitly.
-static gint _sendExplicitBlockMessage = true;
+static gint _useExplicitBlockMessage = true;
 OPTION_EXPERIMENTAL_ENTRY(
-    "send-explicit-block-message", 0, 0, G_OPTION_ARG_INT, &_sendExplicitBlockMessage,
+    "send-explicit-block-message", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_INT, &_useExplicitBlockMessage,
     "Send message to plugin telling it to stop spinning when a syscall blocks", "[0|1]")
 
-bool shimipc_sendExplicitBlockMessageEnabled() { return _sendExplicitBlockMessage; }
+bool shimipc_sendExplicitBlockMessageEnabled() { return _useExplicitBlockMessage; }
 
 static gint _spinMax = 8096;
 OPTION_EXPERIMENTAL_ENTRY("preload-spin-max", 0, 0, G_OPTION_ARG_INT, &_spinMax,


### PR DESCRIPTION
This does not change the behaviour of Shadow. It only changes some variable names (for example `_disable_shim_syscall_handler` to `_use_shim_syscall_handler`), and changes the GLib option's behaviour to match.

In the future our experimental option names (for example, currently `--disable-shim-syscall-handler`) will follow this format (`--use-shim-syscall-handler`), but this just changes the variable names for now.