### PR TITLE
Added support for ioctl tty requests such as TCGETS

### DIFF
--- a/src/main/host/syscall/ioctl.c
+++ b/src/main/host/syscall/ioctl.c
@@ -30,6 +30,19 @@ static int _syscallhandler_ioctlFileHelper(SysCallHandler* sys, File* file, int 
     // TODO: we should call file_ioctl() here, but depending on the request we may need to
     // copy in the request params first before passing them.
     switch (request) {
+        case TCGETS:
+        case TCSETS:
+        case TCSETSW:
+        case TCSETSF:
+        case TCGETA:
+        case TCSETA:
+        case TCSETAW:
+        case TCSETAF: {
+            // not a terminal
+            result = -ENOTTY;
+            break;
+        }
+
         default: {
             result = -EINVAL;
             warning("We do not yet handle ioctl request %lu on file %i",
@@ -78,6 +91,19 @@ static int _syscallhandler_ioctlTCPHelper(SysCallHandler* sys, TCP* tcp, int fd,
             break;
         }
 
+        case TCGETS:
+        case TCSETS:
+        case TCSETSW:
+        case TCSETSF:
+        case TCGETA:
+        case TCSETA:
+        case TCSETAW:
+        case TCSETAF: {
+            // not a terminal
+            result = -ENOTTY;
+            break;
+        }
+
         default: {
             result = -EINVAL;
             warning("We do not yet handle ioctl request %lu on tcp socket %i", request, fd);
@@ -115,6 +141,19 @@ static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
                 descriptor_addFlags((LegacyDescriptor*)udp, O_NONBLOCK);
             }
             result = 0;
+            break;
+        }
+
+        case TCGETS:
+        case TCSETS:
+        case TCSETSW:
+        case TCSETSF:
+        case TCGETA:
+        case TCSETA:
+        case TCSETAW:
+        case TCSETAF: {
+            // not a terminal
+            result = -ENOTTY;
             break;
         }
 

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -58,6 +58,10 @@ name = "test_sockopt"
 path = "socket/sockopt/test_sockopt.rs"
 
 [[bin]]
+name = "test_ioctl"
+path = "socket/ioctl/test_ioctl.rs"
+
+[[bin]]
 name = "test_random"
 path = "random/test_random.rs"
 

--- a/src/test/socket/CMakeLists.txt
+++ b/src/test/socket/CMakeLists.txt
@@ -12,6 +12,7 @@ add_subdirectory(socketpair)
 add_subdirectory(shutdown)
 add_subdirectory(sendto_recvfrom)
 add_subdirectory(sockopt)
+add_subdirectory(ioctl)
 
 # Now set the variable in the parent scope to ours, which includes subdir tests.
 set(ALL_SHADOW_TESTS "${ALL_SHADOW_TESTS}" PARENT_SCOPE)

--- a/src/test/socket/ioctl/CMakeLists.txt
+++ b/src/test/socket/ioctl/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_linux_tests(BASENAME ioctl COMMAND sh -c "../../target/debug/test_ioctl --libc-passing")
+add_shadow_tests(BASENAME ioctl METHODS hybrid ptrace preload)

--- a/src/test/socket/ioctl/ioctl.yaml
+++ b/src/test/socket/ioctl/ioctl.yaml
@@ -1,0 +1,32 @@
+options:
+  stoptime: 5
+topology:
+- graphml: |
+    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+      <key attr.name="packetloss" attr.type="double" for="edge" id="d4" />
+      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
+      <key attr.name="bandwidthup" attr.type="int" for="node" id="d2" />
+      <key attr.name="bandwidthdown" attr.type="int" for="node" id="d1" />
+      <key attr.name="countrycode" attr.type="string" for="node" id="d0" />
+      <graph edgedefault="undirected">
+        <node id="poi-1">
+          <data key="d0">US</data>
+          <data key="d1">10240</data>
+          <data key="d2">10240</data>
+        </node>
+        <edge source="poi-1" target="poi-1">
+          <data key="d3">50.0</data>
+          <data key="d4">0.0</data>
+        </edge>
+      </graph>
+    </graphml>
+plugins:
+- id: testioctl
+  path: ../../target/debug/test_ioctl
+hosts:
+- id: testnode
+  quantity: 1
+  processes:
+  - plugin: testioctl
+    starttime: 1
+    arguments: --shadow-passing

--- a/src/test/socket/ioctl/test_ioctl.rs
+++ b/src/test/socket/ioctl/test_ioctl.rs
@@ -1,0 +1,101 @@
+/*
+ * The Shadow Simulator
+ * See LICENSE for licensing information
+ */
+
+use test_utils::set;
+use test_utils::TestEnvironment as TestEnv;
+
+fn main() -> Result<(), String> {
+    // should we restrict the tests we run?
+    let filter_shadow_passing = std::env::args().any(|x| x == "--shadow-passing");
+    let filter_libc_passing = std::env::args().any(|x| x == "--libc-passing");
+    // should we summarize the results rather than exit on a failed test
+    let summarize = std::env::args().any(|x| x == "--summarize");
+
+    let mut tests = get_tests();
+    if filter_shadow_passing {
+        tests = tests
+            .into_iter()
+            .filter(|x| x.passing(TestEnv::Shadow))
+            .collect()
+    }
+    if filter_libc_passing {
+        tests = tests
+            .into_iter()
+            .filter(|x| x.passing(TestEnv::Libc))
+            .collect()
+    }
+
+    test_utils::run_tests(&tests, summarize)?;
+
+    println!("Success.");
+    Ok(())
+}
+
+fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
+    let mut tests: Vec<test_utils::ShadowTest<_, _>> = vec![];
+
+    let domains = [libc::AF_INET];
+    let sock_types = [libc::SOCK_STREAM, libc::SOCK_DGRAM];
+
+    for &domain in domains.iter() {
+        for &sock_type in sock_types.iter() {
+            // add details to the test names to avoid duplicates
+            let append_args = |s| format!("{} <domain={},sock_type={}>", s, domain, sock_type);
+
+            let more_tests: Vec<test_utils::ShadowTest<_, _>> = vec![test_utils::ShadowTest::new(
+                &append_args("test_tty"),
+                move || test_tty(domain, sock_type),
+                set![TestEnv::Libc, TestEnv::Shadow],
+            )];
+
+            tests.extend(more_tests);
+        }
+    }
+
+    tests
+}
+
+/// Test ioctl() using the tty-related ioctl requests.
+fn test_tty(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), String> {
+    let fd = unsafe { libc::socket(domain, sock_type, 0) };
+    assert!(fd >= 0);
+
+    let test_tty_request = |request| {
+        // test incorrect fds
+        test_utils::check_system_call!(
+            || unsafe { libc::ioctl(-1, request, &mut std::mem::zeroed::<libc::termios>()) },
+            &[libc::EBADF],
+        )?;
+        test_utils::check_system_call!(
+            || unsafe { libc::ioctl(8934, request, &mut std::mem::zeroed::<libc::termios>()) },
+            &[libc::EBADF],
+        )?;
+
+        // test a valid fd
+        test_utils::check_system_call!(
+            || unsafe { libc::ioctl(fd, request, &mut std::mem::zeroed::<libc::termios>()) },
+            &[libc::ENOTTY],
+        )
+    };
+
+    test_utils::run_and_close_fds(&[fd], || {
+        test_tty_request(libc::TCGETS)?;
+        test_tty_request(libc::TCSETS)?;
+        test_tty_request(libc::TCSETSW)?;
+        test_tty_request(libc::TCSETSF)?;
+        test_tty_request(libc::TCGETA)?;
+        test_tty_request(libc::TCSETA)?;
+        test_tty_request(libc::TCSETAW)?;
+        test_tty_request(libc::TCSETAF)?;
+
+        // in glibc, isatty() calls tcgetattr() which makes the ioctl call
+        let rv = unsafe { libc::isatty(fd) };
+        let errno = test_utils::get_errno();
+        test_utils::result_assert_eq(rv, 0, "Unexpected return value from isatty()")?;
+        test_utils::result_assert_eq(errno, libc::ENOTTY, "Unexpected errno from isatty()")?;
+
+        Ok(())
+    })
+}


### PR DESCRIPTION
The two main descriptor types that shadow supports (files and sockets) aren't ttys, so these ioctl command should always return `ENOTTY`.