### PR TITLE
Added 'TIOCGWINSZ' and 'TIOCSWINSZ'

### DIFF
--- a/src/main/host/syscall/ioctl.c
+++ b/src/main/host/syscall/ioctl.c
@@ -37,7 +37,9 @@ static int _syscallhandler_ioctlFileHelper(SysCallHandler* sys, File* file, int 
         case TCGETA:
         case TCSETA:
         case TCSETAW:
-        case TCSETAF: {
+        case TCSETAF:
+        case TIOCGWINSZ:
+        case TIOCSWINSZ: {
             // not a terminal
             result = -ENOTTY;
             break;
@@ -98,7 +100,9 @@ static int _syscallhandler_ioctlTCPHelper(SysCallHandler* sys, TCP* tcp, int fd,
         case TCGETA:
         case TCSETA:
         case TCSETAW:
-        case TCSETAF: {
+        case TCSETAF:
+        case TIOCGWINSZ:
+        case TIOCSWINSZ: {
             // not a terminal
             result = -ENOTTY;
             break;
@@ -151,7 +155,9 @@ static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
         case TCGETA:
         case TCSETA:
         case TCSETAW:
-        case TCSETAF: {
+        case TCSETAF:
+        case TIOCGWINSZ:
+        case TIOCSWINSZ: {
             // not a terminal
             result = -ENOTTY;
             break;

--- a/src/test/file/test_file.c
+++ b/src/test/file/test_file.c
@@ -315,6 +315,8 @@ static void _test_ioctl_tty() {
     _ioctl_check_enotty(fd, TCSETA);
     _ioctl_check_enotty(fd, TCSETAW);
     _ioctl_check_enotty(fd, TCSETAF);
+    _ioctl_check_enotty(fd, TIOCGWINSZ);
+    _ioctl_check_enotty(fd, TIOCSWINSZ);
 
     // in glibc, isatty() calls tcgetattr() which makes the ioctl call
     int rv = isatty(fd);

--- a/src/test/socket/ioctl/test_ioctl.rs
+++ b/src/test/socket/ioctl/test_ioctl.rs
@@ -89,6 +89,8 @@ fn test_tty(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), String> {
         test_tty_request(libc::TCSETA)?;
         test_tty_request(libc::TCSETAW)?;
         test_tty_request(libc::TCSETAF)?;
+        test_tty_request(libc::TIOCGWINSZ)?;
+        test_tty_request(libc::TIOCSWINSZ)?;
 
         // in glibc, isatty() calls tcgetattr() which makes the ioctl call
         let rv = unsafe { libc::isatty(fd) };


### PR DESCRIPTION
These should also return `ENOTTY`.