### PR TITLE
Contributing updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Homepage:
     
 # Contributing
 
-Contributions can be made by submitting pull requests via GitHub.
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,5 +16,5 @@ documentation](README.md) to get started with building and using
 Shadow.
 
 When you're ready to start coding, please take a look at our [Coding
-style](coding-style.md) and [Version control](version-control.md)
+style](coding-style.md) and [pull request](pull-requests.md)
 guidelines.

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -1,43 +1,60 @@
-## Pull requests
+## Pull requests (PRs)
 
-### Merge strategy
+### Clean commits
 
-When merging pull requests, we currently allow only the
-[Rebase and
-merge](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#rebase-and-merge-your-pull-request-commits)
-strategy. Using this strategy, we maintain a linear history. Each
-individual commit of a pull request ends up in the linear history of
-the master branch.
+Ideally, every commit in history of the `main` branch should:
 
-### Structuring commits
+* Be a focused, self-contained change.
+* Have a commit message that summarizes the change and explains *why* the change
+  is being made, if not self-evident.
+* Build (`./setup build --test`).
+* Pass tests (`./setup test`).
 
-After merging, intermediate commits from merged pull requests are
-indistinguishable from commits that were at the "tip" of the pull
-request when it was merged. Typically only the state of those "tip"
-commits are reviewed and required to pass our continuous integration
-testing. It's helpful though if you make a best-effort to avoid
-having low-quality commits in your pull request at the time it's
-merged; e.g. commits that don't build or have poor log messages.
+### Drafting a PR
 
-If you're asked to make changes in a review, it's usually best to
-create new commits rather than rewriting the history of your pull
-request. However, it's fine to rewrite history (e.g. squash some
-commits) before review begins, or if the reviewer asks you to do so
-before merging your PR.
-
-If you're in the middle of the review process and need to make
-changes that you think should eventually be squashed into another
-commit, consider using the `--squash` flag to `git commit`.
-
-### Creating a pull request
+PRs should be split into smaller, more focused, changes when feasible.
+However, we also want to avoid polluting the history with commits that don't
+build or pass tests, or commits within a single PR that fix a mistake earlier in
+the PR. While iterating on the PR, the `--fixup` and
+`--squash` flags are useful for committing changes that should ultimately be
+merged with one of the earlier commits.
 
 When creating a pull request, we suggest you first create it as a
-[draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
-This will still trigger our continuous-integration checks, and give
-you a chance resolve any issues with those (i.e. broken tests) before
-requesting review.
+[draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/).  This
+will still trigger our continuous-integration checks, and give you a chance
+resolve any issues with those (i.e. broken tests) before requesting review.
 
-Once you are ready for a Shadow developer to start a review, take the
-pull request out of draft mode.
+Once done iterating, first consider using `git rebase -i --autosquash` to clean
+up your commit history, and then force pushing to update your PR.  Finally, take
+the pull request out of draft mode to signal that you're ready for review.
 
+### Responding to review feedback
 
+*During* PR review, please do not rebase or force-push, since this makes it
+difficult to see what's changed between rounds of review. Consider using
+`--fixup` and `--squash` for commits responding to review feedback, so that they
+can be appropriately squashed before the final merge. [git autofixup](
+https://github.com/torbiak/git-autofixup/) can also be useful for generating
+`--fixup` commits.
+
+### Merging
+
+When the PR is ready to be merged, the reviewer might ask you to `git rebase`
+and force push to clean up history, or might do it themselves.
+
+For the maintainer doing the merge:
+
+If the PR is relatively small, or if it's not worth the effort of rewriting
+history into clean commits, use the "squash and merge" strategy.
+
+If the individual commits appear to be useful to keep around in our history,
+instead use the "create a merge commit" strategy. There's no need to review
+every individual commit when using this strategy, but if the intermediate
+commits are obviously low quality consider using the "squash and merge strategy"
+instead. Note that since this strategy creates a merge commit, we can still
+later identify and filter out the intermediate commits if desired, e.g. with
+`git log --first-parent main`.
+
+We've disabled the "Rebase and merge" option, since it does a fast-forward
+merge, which makes the intermediate commits indistingishuable from the validated
+and reviewed final state of the PR.


### PR DESCRIPTION
Update pull request guidelines
    
We've changed which GH merge strategies are allowed. This updates the
contributor guidelines to reflect that.

Also fix broken link to "version-control.md"
    
Fixes #862
