### PR TITLE
Use MemoryManager to allocate plugin memory

### DIFF
--- a/src/main/bindings/c/bindings-opaque.h
+++ b/src/main/bindings/c/bindings-opaque.h
@@ -25,6 +25,9 @@ typedef enum QDiscMode {
   Q_DISC_MODE_ROUND_ROBIN,
 } QDiscMode;
 
+// Memory allocated by Shadow, in a remote address space.
+typedef struct AllocdMem_u8 AllocdMem_u8;
+
 // A queue of byte chunks.
 typedef struct ByteQueue ByteQueue;
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -23,6 +23,9 @@
 #include "main/host/thread.h"
 #include "main/host/tracker.h"
 
+// Memory allocated by Shadow, in a remote address space.
+typedef struct AllocdMem_u8 AllocdMem_u8;
+
 // A queue of byte chunks.
 typedef struct ByteQueue ByteQueue;
 
@@ -249,6 +252,12 @@ struct MemoryManager *memorymanager_new(pid_t pid);
 // # Safety
 // * `mm` must point to a valid object.
 void memorymanager_free(struct MemoryManager *mm);
+
+struct AllocdMem_u8 *allocdmem_new(uintptr_t len);
+
+void allocdmem_free(struct AllocdMem_u8 *allocd_mem);
+
+PluginPtr allocdmem_pluginPtr(const struct AllocdMem_u8 *allocd_mem);
 
 // Initialize the MemoryMapper if it isn't already initialized. `thread` must
 // be running and ready to make native syscalls.

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -374,12 +374,6 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    pub fn thread_mallocPluginPtr(thread: *mut Thread, size: size_t) -> PluginPtr;
-}
-extern "C" {
-    pub fn thread_freePluginPtr(thread: *mut Thread, ptr: PluginPtr, size: size_t);
-}
-extern "C" {
     pub fn thread_isRunning(thread: *mut Thread) -> bool;
 }
 extern "C" {

--- a/src/main/host/syscall/mman.c
+++ b/src/main/host/syscall/mman.c
@@ -137,7 +137,8 @@ static int _syscallhandler_openPluginFile(SysCallHandler* sys, File* file) {
     debug("Opening path '%s' in plugin.", mmap_path);
 
     /* Get some memory in the plugin to write the path of the file to open. */
-    PluginPtr pluginBufPtr = thread_mallocPluginPtr(sys->thread, maplen);
+    AllocdMem_u8 *allocdMem = allocdmem_new(maplen);
+    PluginPtr pluginBufPtr = allocdmem_pluginPtr(allocdMem);
 
     /* Get a writeable pointer that can be flushed to the plugin. */
     char* pluginBuf = process_getWriteablePtr(sys->process, pluginBufPtr, maplen);
@@ -163,7 +164,7 @@ static int _syscallhandler_openPluginFile(SysCallHandler* sys, File* file) {
     }
 
     /* Release the PluginPtr memory. */
-    thread_freePluginPtr(sys->thread, pluginBufPtr, maplen);
+    allocdmem_free(allocdMem);
     free(mmap_path);
 
     return result;

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -34,20 +34,6 @@ int thread_getReturnCode(Thread* thread);
 // You can map to a corresponding errno value with syscall_rawReturnValueToErrno.
 long thread_nativeSyscall(Thread* thread, long n, ...);
 
-// Allocate some memory in the plugin's address space. The returned pointer
-// should be freed with `thread_free`.
-PluginPtr thread_mallocPluginPtr(Thread* thread, size_t size);
-
-// Free memory allocated with `thread_mallocPluginPtr`. `size` should be the
-// original size passed to `thread_mallocPluginPtr`.
-//
-// TODO: It's a bit unfortunate to have to require the size here, but at this
-// time the underlying implementation (based on mmap) needs it. The alternatives
-// to this API awkwardness is either for thread_mallocPluginPtr to return an
-// opaque struct where this can be squirreled away (a different kind of API
-// awkwardness and more boilerplate), or keeping an internal map of ptr->size.
-void thread_freePluginPtr(Thread* thread, PluginPtr ptr, size_t size);
-
 bool thread_isRunning(Thread* thread);
 
 uint32_t thread_getProcessId(Thread* thread);


### PR DESCRIPTION
In particular, we want it to know about allocated regions so that it
doesn't warn when we try to access them.