### PR TITLE
Enable the 'unsafe_op_in_unsafe_fn' lint

### DIFF
--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -135,7 +135,7 @@ impl CThread {
     /// * `cthread` must point to a valid Thread struct.
     pub unsafe fn new(cthread: *mut c::Thread) -> CThread {
         assert!(!cthread.is_null());
-        c::thread_ref(cthread);
+        unsafe { c::thread_ref(cthread) };
         CThread { cthread }
     }
 }

--- a/src/main/lib.rs
+++ b/src/main/lib.rs
@@ -3,6 +3,9 @@
  * See LICENSE for licensing information
  */
 
+// https://github.com/rust-lang/rfcs/blob/master/text/2585-unsafe-block-in-unsafe-fn.md
+#![deny(unsafe_op_in_unsafe_fn)]
+
 mod cshadow {
     // Inline the bindgen-generated Rust bindings, suppressing warnings.
     #![allow(unused)]


### PR DESCRIPTION
The `unsafe_op_in_unsafe_fn` Rust lint [has been stabilized](https://github.com/rust-lang/rust/pull/79208) and I think we should use it. The lint is currently off by default, but they plan to make it a warning and possibly an error in the future.

Edit: Blocked on #1330.