### PR TITLE
MemoryManager: track which ranges of memory have outstanding references

### DIFF
--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -853,27 +853,17 @@ PluginPhysicalPtr process_getPhysicalAddress(Process* proc, PluginVirtualPtr vPt
 int process_readPtr(Process* proc, void* dst, PluginVirtualPtr src, size_t n) {
     MAGIC_ASSERT(proc);
 
-    // Disallow additional references while there's a mutable reference.
-    utility_assert(proc->memoryWriters->len == 0);
-
     return memorymanager_readPtr(proc->memoryManager, dst, src, n);
 }
 
 int process_writePtr(Process* proc, PluginVirtualPtr dst, const void* src, size_t n) {
     MAGIC_ASSERT(proc);
 
-    // Disallow additional references when trying to get a mutable reference.
-    utility_assert(proc->memoryWriters->len == 0);
-    utility_assert(proc->memoryReaders->len == 0);
-
     return memorymanager_writePtr(proc->memoryManager, dst, src, n);
 }
 
 const void* process_getReadablePtr(Process* proc, PluginPtr plugin_src, size_t n) {
     MAGIC_ASSERT(proc);
-
-    // Disallow additional references while there's a mutable reference.
-    utility_assert(proc->memoryWriters->len == 0);
 
     MemoryReader_u8* reader = memorymanager_getReader(proc->memoryManager, plugin_src, n);
     const void* rv = memorymanager_getReadablePtr(reader);
@@ -888,9 +878,6 @@ const void* process_getReadablePtr(Process* proc, PluginPtr plugin_src, size_t n
 int process_getReadableString(Process* proc, PluginPtr plugin_src, size_t n, const char** str,
                               size_t* strlen) {
     MAGIC_ASSERT(proc);
-
-    // Disallow additional references while there's a mutable reference.
-    utility_assert(proc->memoryWriters->len == 0);
 
     MemoryReader_u8* reader = NULL;
     int res = memorymanager_getStringReader(proc->memoryManager, plugin_src, n, &reader, strlen);
@@ -911,10 +898,6 @@ int process_getReadableString(Process* proc, PluginPtr plugin_src, size_t n, con
 void* process_getWriteablePtr(Process* proc, PluginPtr plugin_src, size_t n) {
     MAGIC_ASSERT(proc);
 
-    // Disallow additional references when trying to get a mutable reference.
-    utility_assert(proc->memoryWriters->len == 0);
-    utility_assert(proc->memoryReaders->len == 0);
-
     MemoryWriter_u8* writer = memorymanager_getWriter(proc->memoryManager, plugin_src, n);
     void* rv = memorymanager_getWritablePtr(writer);
     if (rv == NULL) {
@@ -931,10 +914,6 @@ void* process_getWriteablePtr(Process* proc, PluginPtr plugin_src, size_t n) {
 // The returned pointer is automatically invalidated when the plugin runs again.
 void* process_getMutablePtr(Process* proc, PluginPtr plugin_src, size_t n) {
     MAGIC_ASSERT(proc);
-
-    // Disallow additional references when trying to get a mutable reference.
-    utility_assert(proc->memoryWriters->len == 0);
-    utility_assert(proc->memoryReaders->len == 0);
 
     MemoryWriter_u8* writer = memorymanager_getWriter(proc->memoryManager, plugin_src, n);
     void* rv = memorymanager_getMutablePtr(writer);

--- a/src/main/host/syscall/unistd.rs
+++ b/src/main/host/syscall/unistd.rs
@@ -148,7 +148,7 @@ fn read_helper(
         EventQueue::queue_and_run(|event_queue| {
             posix_file.borrow_mut().read(
                 memory
-                    .writer(TypedPluginPtr::<u8>::new(buf_ptr, buf_size).unwrap())
+                    .writer(TypedPluginPtr::<u8>::new(buf_ptr, buf_size).unwrap())?
                     .cursor(),
                 offset,
                 event_queue,
@@ -220,7 +220,7 @@ fn write_helper(
         EventQueue::queue_and_run(|event_queue| {
             posix_file.borrow_mut().write(
                 memory
-                    .reader(TypedPluginPtr::<u8>::new(buf_ptr, buf_size).unwrap())
+                    .reader(TypedPluginPtr::<u8>::new(buf_ptr, buf_size).unwrap())?
                     .cursor(),
                 offset,
                 event_queue,
@@ -324,7 +324,7 @@ fn pipe_helper(sys: &mut c::SysCallHandler, fd_ptr: PluginPtr, flags: i32) -> Sy
     // Try to write them to the caller
     let write_res = Worker::with_active_process_memory_mut(|memory| {
         memory
-            .writer(TypedPluginPtr::<libc::c_int>::new(fd_ptr.into(), 2)?)
+            .writer(TypedPluginPtr::<libc::c_int>::new(fd_ptr.into(), 2)?)?
             .copy(&fds)
     });
 

--- a/src/main/utility/interval_map.rs
+++ b/src/main/utility/interval_map.rs
@@ -110,6 +110,14 @@ impl<V: Clone> IntervalMap<V> {
         ItemIter { map: self, i: idx }
     }
 
+    pub fn overlaps(&self, interval: Interval) -> bool {
+        let mut iter = self.iter_from(interval.start);
+        match iter.next() {
+            None => false,
+            Some((r, _)) => interval.contains(&r.start) || interval.contains(&r.end),
+        }
+    }
+
     /// Mutates the map so that the given range maps to nothing, modifying and removing intervals
     /// as needed. Returns what mutations were performed, including the values of any
     /// completely-removed intervals. If an interval is split (e.g. by inserting \[5,6\] into
@@ -757,5 +765,23 @@ mod tests {
         assert_eq!(m.iter_from(5).collect::<Vec<_>>(), vec![(4..6, &"i2")]);
         assert_eq!(m.iter_from(6).collect::<Vec<_>>(), vec![]);
         assert_eq!(m.iter_from(7).collect::<Vec<_>>(), vec![]);
+    }
+
+    #[test]
+    fn test_overlaps() {
+        let mut m = IntervalMap::<String>::new();
+        m.insert(3..5, "interval".to_string());
+        assert!(!m.overlaps(0..1));
+        assert!(!m.overlaps(0..2));
+        assert!(!m.overlaps(0..3));
+        assert!(m.overlaps(0..4));
+        assert!(m.overlaps(0..5));
+        assert!(m.overlaps(0..6));
+        assert!(m.overlaps(1..6));
+        assert!(m.overlaps(2..6));
+        assert!(m.overlaps(3..6));
+        assert!(m.overlaps(4..6));
+        assert!(!m.overlaps(5..6));
+        assert!(!m.overlaps(6..6));
     }
 }


### PR DESCRIPTION
Rather than requiring exclusive access to the MemoryManager to hold any
mutable references to its memory, add run-time checks to ensure that
mutable references to individual memory ranges are exclusive.

Fixes #1332