### PR TITLE
Moved bandwidth options from host_defaults to the host object

### DIFF
--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -53,8 +53,6 @@ hosts:
 - [`experimental.use_shim_syscall_handler`](#experimentaluse_shim_syscall_handler)
 - [`experimental.use_syscall_counters`](#experimentaluse_syscall_counters)
 - [`host_defaults`](#host_defaults)
-- [`host_defaults.bandwidth_down`](#host_defaultsbandwidth_down)
-- [`host_defaults.bandwidth_up`](#host_defaultsbandwidth_up)
 - [`host_defaults.city_code_hint`](#host_defaultscity_code_hint)
 - [`host_defaults.country_code_hint`](#host_defaultscountry_code_hint)
 - [`host_defaults.heartbeat_interval`](#host_defaultsheartbeat_interval)
@@ -64,6 +62,8 @@ hosts:
 - [`host_defaults.log_level`](#host_defaultslog_level)
 - [`host_defaults.pcap_directory`](#host_defaultspcap_directory)
 - [`hosts`](#hosts)
+- [`hosts.<hostname>.bandwidth_down`](#hostshostnamebandwidth_down)
+- [`hosts.<hostname>.bandwidth_up`](#hostshostnamebandwidth_up)
 - [`hosts.<hostname>.options`](#hostshostnameoptions)
 - [`hosts.<hostname>.quantity`](#hostshostnamequantity)
 - [`hosts.<hostname>.processes`](#hostshostnameprocesses)
@@ -297,24 +297,6 @@ Count the number of occurrences for individual syscalls.
 
 Default options for all hosts. These options can also be overridden for each host individually.
 
-#### `host_defaults.bandwidth_down`
-
-Default: null  
-Type: String OR Integer OR null
-
-Downstream bandwidth capacity of the host.
-
-Overrides any default bandwidth values set in the assigned topology node.
-
-#### `host_defaults.bandwidth_up`
-
-Default: null  
-Type: String OR Integer OR null
-
-Upstream bandwidth capacity of the host.
-
-Overrides any default bandwidth values set in the assigned topology node.
-
 #### `host_defaults.city_code_hint`
 
 Default: null  
@@ -387,6 +369,24 @@ Type: Object
 The simulated hosts which execute processes. Each field corresponds to a host configuration, with the field name being used as the network hostname.
 
 Shadow assigns each host to a node in the [topology](3.2-Network-Config.md).
+
+#### `hosts.<hostname>.bandwidth_down`
+
+Default: null  
+Type: String OR Integer OR null
+
+Downstream bandwidth capacity of the host.
+
+Overrides any default bandwidth values set in the assigned topology node.
+
+#### `hosts.<hostname>.bandwidth_up`
+
+Default: null  
+Type: String OR Integer OR null
+
+Upstream bandwidth capacity of the host.
+
+Overrides any default bandwidth values set in the assigned topology node.
 
 #### `hosts.<hostname>.options`
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -375,16 +375,6 @@ pub struct HostDefaultOptions {
     #[clap(long, value_name = "city")]
     #[clap(about = HOST_HELP.get("city_code_hint").unwrap())]
     city_code_hint: Option<String>,
-
-    /// Downstream bandwidth capacity of the host
-    #[clap(long, value_name = "bits")]
-    #[clap(about = HOST_HELP.get("bandwidth_down").unwrap())]
-    bandwidth_down: Option<units::BitsPerSec<units::SiPrefixUpper>>,
-
-    /// Upstream bandwidth capacity of the host
-    #[clap(long, value_name = "bits")]
-    #[clap(about = HOST_HELP.get("bandwidth_up").unwrap())]
-    bandwidth_up: Option<units::BitsPerSec<units::SiPrefixUpper>>,
 }
 
 impl HostDefaultOptions {
@@ -398,8 +388,6 @@ impl HostDefaultOptions {
             ip_hint: None,
             country_code_hint: None,
             city_code_hint: None,
-            bandwidth_down: None,
-            bandwidth_up: None,
         }
     }
 
@@ -421,8 +409,6 @@ impl Default for HostDefaultOptions {
             ip_hint: None,
             country_code_hint: None,
             city_code_hint: None,
-            bandwidth_down: None,
-            bandwidth_up: None,
         }
     }
 }
@@ -462,6 +448,14 @@ pub struct HostOptions {
     /// Number of hosts to start
     #[serde(default)]
     quantity: Quantity,
+
+    /// Downstream bandwidth capacity of the host
+    #[serde(default)]
+    bandwidth_down: Option<units::BitsPerSec<units::SiPrefixUpper>>,
+
+    /// Upstream bandwidth capacity of the host
+    #[serde(default)]
+    bandwidth_up: Option<units::BitsPerSec<units::SiPrefixUpper>>,
 
     #[serde(default = "HostDefaultOptions::new_empty")]
     options: HostDefaultOptions,
@@ -1431,7 +1425,7 @@ mod export {
         assert!(!host.is_null());
         let host = unsafe { &*host };
 
-        match host.options.bandwidth_down {
+        match host.bandwidth_down {
             Some(x) => x.convert(units::SiPrefixUpper::Base).unwrap().value(),
             None => 0,
         }
@@ -1442,7 +1436,7 @@ mod export {
         assert!(!host.is_null());
         let host = unsafe { &*host };
 
-        match host.options.bandwidth_up {
+        match host.bandwidth_up {
             Some(x) => x.convert(units::SiPrefixUpper::Base).unwrap().value(),
             None => 0,
         }

--- a/src/test/config/convert/shadow.expected.yaml
+++ b/src/test/config/convert/shadow.expected.yaml
@@ -26,6 +26,7 @@ topology:
 hosts:
   testclient:
     quantity: 1
+    bandwidth_down: 8000 Kibit
     processes:
     - start_time: 1
       args: client 5678

--- a/src/test/config/convert/shadow.original.xml
+++ b/src/test/config/convert/shadow.original.xml
@@ -22,7 +22,7 @@
 </graphml>]]></topology>
   <plugin id="testconfig" path="test-config-convert"/>
   <plugin id="shimpath" path="/tor/shim/path.so"/>
-  <node id="testclient" quantity="1">
+  <node id="testclient" quantity="1" bandwidthdown="1000">
     <application plugin="testconfig" starttime="1" arguments="client 5678" preload="shimpath"/>
   </node>
   <node id="testserver" quantity="1">

--- a/src/tools/convert_legacy_config.py
+++ b/src/tools/convert_legacy_config.py
@@ -243,7 +243,7 @@ def shadow_dict_post_processing(shadow: Dict):
             host = shadow['hosts'][host_name]
 
             # add all extra fields to an 'options' field
-            host_non_option_names = ['quantity', 'processes']
+            host_non_option_names = ['quantity', 'processes', 'bandwidth_down', 'bandwidth_up']
             host_options = {x: host[x] for x in host if x not in host_non_option_names}
             host_non_options = {x: host[x] for x in host if x in host_non_option_names}
 
@@ -252,14 +252,14 @@ def shadow_dict_post_processing(shadow: Dict):
                 host['options'] = host_options
             shadow['hosts'][host_name] = host
 
+            # shadow classic uses bandwidth units of KiB/s
+            if 'bandwidth_up' in host:
+                host['bandwidth_up'] = str(host['bandwidth_up'] * 8) + ' Kibit'
+
+            if 'bandwidth_down' in host:
+                host['bandwidth_down'] = str(host['bandwidth_down'] * 8) + ' Kibit'
+
             if 'options' in host:
-                # shadow classic uses bandwidth units of KiB/s
-                if 'bandwidth_up' in host['options']:
-                    host['options']['bandwidth_up'] = str(host['options']['bandwidth_up'] * 8) + ' Kibit'
-
-                if 'bandwidth_down' in host['options']:
-                    host['options']['bandwidth_down'] = str(host['options']['bandwidth_down'] * 8) + ' Kibit'
-
                 # shadow classic automatically disables autotuning if the buffer sizes are set
                 if 'socket_send_buffer' in host['options']:
                     host['options']['socket_send_autotune'] = False


### PR DESCRIPTION
You can only specify the host bandwidth in the topology and the host now, instead of the topology, host_defaults, host options, and command line.

Instead of:

```yaml
host_defaults:
  bandwidth_down: 10 Kbit
hosts:
  myhost:
    options:
      bandwidth_down: 20 Kbit
    processes:
      - ...
```

It's now:

```yaml
hosts:
  myhost:
    bandwidth_down: 20 Kbit
    processes:
      - ...
```