### PR TITLE
Renamed 'plain' topology to '1_gbit_switch'

### DIFF
--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -5,7 +5,7 @@ Example:
 ```yaml
 general:
   stop_time: 2 min
-topology: plain
+topology: 1_gbit_switch
 hosts:
   server:
     processes:
@@ -137,9 +137,9 @@ Run concurrently with N worker threads.
 #### `topology`
 
 *Required*  
-Type: "plain" OR "graphml" OR "path"
+Type: "graphml" OR "path" OR "1\_gbit\_switch"
 
-The topology can be specified as a built-in "plain" topology with a single node, an inline GraphML string, or a path to an external GraphML file.
+The topology can be specified as an inline GraphML string, a path to an external GraphML file, or a built-in "1\_gbit\_switch" topology with a single node.
 
 The topology, a collection of nodes and edges that represent a network topology, should hold an undirected, connected graph with certain attributes specified on the nodes and edges. For more information on how to structure this data, see the [Topology Format](3.2-Network-Config.md).
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -602,7 +602,8 @@ impl std::str::FromStr for QDiscMode {
 enum Topology {
     Path(String),
     GraphMl(String),
-    Plain,
+    #[serde(rename = "1_gbit_switch")]
+    OneGbitSwitch,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -659,7 +660,7 @@ fn default_some_info() -> Option<LogLevel> {
     Some(LogLevel::Info)
 }
 
-const DEFAULT_TOPOLOGY: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+const ONE_GBIT_SWITCH_TOPOLOGY: &str = r#"<?xml version="1.0" encoding="utf-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
     <key attr.name="packet_loss"    attr.type="double" for="edge" id="edge_packet_loss" />
     <key attr.name="jitter"         attr.type="double" for="edge" id="edge_jitter" />
@@ -1270,7 +1271,7 @@ mod export {
         let topology = match &config.topology {
             Topology::Path(f) => std::fs::read_to_string(f).unwrap(),
             Topology::GraphMl(s) => s.clone(),
-            Topology::Plain => DEFAULT_TOPOLOGY.to_string(),
+            Topology::OneGbitSwitch => ONE_GBIT_SWITCH_TOPOLOGY.to_string(),
         };
 
         CString::into_raw(CString::new(topology).unwrap())

--- a/src/test/bindc/bindc.yaml
+++ b/src/test/bindc/bindc.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/clone/clone.yaml
+++ b/src/test/clone/clone.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 10
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/config/read_from_stdin/config-stdin.yaml
+++ b/src/test/config/read_from_stdin/config-stdin.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testclient:
     processes:

--- a/src/test/cpp/cpp.yaml
+++ b/src/test/cpp/cpp.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/dynlink/dynlink.test.shadow.config.yaml
+++ b/src/test/dynlink/dynlink.test.shadow.config.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     quantity: 1

--- a/src/test/epoll/epoll-writeable.yaml
+++ b/src/test/epoll/epoll-writeable.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 60
-topology: plain
+topology: 1_gbit_switch
 hosts:
   server:
     processes:

--- a/src/test/epoll/epoll.yaml
+++ b/src/test/epoll/epoll.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/eventfd/eventfd.yaml
+++ b/src/test/eventfd/eventfd.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 10
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/file/file.yaml
+++ b/src/test/file/file.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/futex/futex.yaml
+++ b/src/test/futex/futex.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 15
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/ifaddrs/ifaddrs.yaml
+++ b/src/test/ifaddrs/ifaddrs.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     options:

--- a/src/test/memory/mmap.yaml
+++ b/src/test/memory/mmap.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   mytesthost:
     processes:

--- a/src/test/pipe/pipe.yaml
+++ b/src/test/pipe/pipe.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/poll/poll.yaml
+++ b/src/test/poll/poll.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/random/random.yaml
+++ b/src/test/random/random.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/signal/signal.yaml
+++ b/src/test/signal/signal.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     quantity: 3

--- a/src/test/sleep/sleep.yaml
+++ b/src/test/sleep/sleep.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 10
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/sockbuf/sockbuf.yaml
+++ b/src/test/sockbuf/sockbuf.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 15
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/accept/accept.yaml
+++ b/src/test/socket/accept/accept.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/bind/bind.yaml
+++ b/src/test/socket/bind/bind.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/connect/connect.yaml
+++ b/src/test/socket/connect/connect.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/getpeername/getpeername.yaml
+++ b/src/test/socket/getpeername/getpeername.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/getsockname/getsockname.yaml
+++ b/src/test/socket/getsockname/getsockname.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/ioctl/ioctl.yaml
+++ b/src/test/socket/ioctl/ioctl.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/listen/listen.yaml
+++ b/src/test/socket/listen/listen.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/sendto_recvfrom/sendto-recvfrom.yaml
+++ b/src/test/socket/sendto_recvfrom/sendto-recvfrom.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/shutdown/shutdown.yaml
+++ b/src/test/socket/shutdown/shutdown.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/socket/socket.yaml
+++ b/src/test/socket/socket/socket.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/socketpair/socketpair.yaml
+++ b/src/test/socket/socketpair/socketpair.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/sockopt/sockopt.yaml
+++ b/src/test/socket/sockopt/sockopt.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/threads/pthreads.yaml
+++ b/src/test/threads/pthreads.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 2
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/threads/threads-group-leader-exits.yaml
+++ b/src/test/threads/threads-group-leader-exits.yaml
@@ -1,7 +1,7 @@
 general:
   # Should be greater than NUM_SECONDS from test_threads_group_leader_exits.rs
   stop_time: 10
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/threads/threads-noexit.yaml
+++ b/src/test/threads/threads-noexit.yaml
@@ -1,7 +1,7 @@
 general:
   # Should be less than NUM_SECONDS from test_threads_noexit.rs
   stop_time: 2
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/timerfd/timerfd.yaml
+++ b/src/test/timerfd/timerfd.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 15
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/udp/udp-uniprocess.yaml
+++ b/src/test/udp/udp-uniprocess.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   node1:
     processes:

--- a/src/test/udp/udp.yaml
+++ b/src/test/udp/udp.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   localnode:
     processes:

--- a/src/test/unistd/unistd.yaml
+++ b/src/test/unistd/unistd.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology: plain
+topology: 1_gbit_switch
 hosts:
   testnode:
     processes:


### PR DESCRIPTION
We had decided to rename this built-in topology to `1_gbit_switch`.