### PR TITLE
Enable 'unused-function' warning for C code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,13 @@ add_compile_options(-fno-omit-frame-pointer)
 add_compile_options(-Wreturn-type)
 add_compile_options(-Wswitch)
 
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    # we only check for unused functions when builing in debug mode since some
+    # functions are only called when logging, which can be #ifdef'd out in
+    # release mode
+    add_compile_options(-Wunused-function)
+endif()
+
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release")
 endif()

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -385,7 +385,7 @@ static void _scheduler_assignHosts(Scheduler* scheduler) {
     g_mutex_unlock(&scheduler->globalLock);
 }
 
-static void _scheduler_rebalanceHosts(Scheduler* scheduler) {
+__attribute__((unused)) static void _scheduler_rebalanceHosts(Scheduler* scheduler) {
     MAGIC_ASSERT(scheduler);
     utility_panic("Unimplemented");
 

--- a/src/main/host/descriptor/tcp_retransmit_tally.cc
+++ b/src/main/host/descriptor/tcp_retransmit_tally.cc
@@ -284,17 +284,12 @@ void retransmit_tally_populate_lost_ranges(const void *p, uint32_t *lost) {
 
 } // extern "C"
 
-static void TEST() {
-   assert(false);
-}
-
 RetransmitTally::RetransmitTally()
    : last_ack_(-1),
      num_dupl_ack_(0),
      magic_num_(kMagicNum),
      marked_lost_{}, sacked_{}, retransmitted_{}, lost_{}
 {
-   // TEST();
 }
 
 RetransmitTally &RetransmitTally::operator=(RetransmitTally &&rhs) {

--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -52,7 +52,7 @@ static ThreadPreload* _threadToThreadPreload(Thread* thread) {
 
 static Thread* _threadPreloadToThread(ThreadPreload* thread) { return (Thread*)thread; }
 
-static void _threadpreload_auxFree(void* p, void* _) {
+__attribute__((unused)) static void _threadpreload_auxFree(void* p, void* _) {
     ShMemBlock* blk = (ShMemBlock*)p;
     shmemallocator_globalFree(blk);
     free(blk);
@@ -317,8 +317,8 @@ bool threadpreload_isRunning(Thread* base) {
  * Helper function, issues a clone/read request to the plugin.
  * The returned ShMemBlock is owned by the caller and needs to be freed.
  */
-static ShMemBlock _threadpreload_readPtrImpl(ThreadPreload* thread, PluginPtr plugin_src, size_t n,
-                                             bool is_string) {
+__attribute__((unused)) static ShMemBlock
+_threadpreload_readPtrImpl(ThreadPreload* thread, PluginPtr plugin_src, size_t n, bool is_string) {
     // Allocate a block for the clone
     ShMemBlock blk = shmemallocator_globalAlloc(n);
     utility_assert(blk.p && blk.nbytes == n);

--- a/src/main/host/thread_ptrace.c
+++ b/src/main/host/thread_ptrace.c
@@ -61,7 +61,7 @@ ADD_CONFIG_HANDLER(config_getUseOnWaitpidWorkarounds, _useONWaitpidWorkarounds)
 // current thread's tracee.
 #define WAITPID_COMMON_OPTIONS __WNOTHREAD
 
-static char SYSCALL_INSTRUCTION[] = {0x0f, 0x05};
+static char SYSCALL_INSTRUCTION[] __attribute__((unused)) = {0x0f, 0x05};
 
 // Number of times to do a non-blocking wait while waiting for traced thread.
 #define THREADPTRACE_MAX_SPIN 8096
@@ -756,8 +756,9 @@ pid_t threadptrace_run(Thread* base, gchar** argv, gchar** envv, const char* wor
     return thread->base.nativePid;
 }
 
-static SysCallReturn _threadptrace_getSerializedBlock(ThreadPtrace* thread, PluginPtr shm_blk_pptr,
-                                                      ShMemBlock* block, const char* syscall_name) {
+__attribute__((unused)) static SysCallReturn
+_threadptrace_getSerializedBlock(ThreadPtrace* thread, PluginPtr shm_blk_pptr, ShMemBlock* block,
+                                 const char* syscall_name) {
     trace("%s %p", syscall_name, (void*)shm_blk_pptr.val);
 
     ShMemBlockSerialized* shm_blk_ptr =

--- a/src/main/routing/topology.c
+++ b/src/main/routing/topology.c
@@ -290,8 +290,9 @@ static gboolean _topology_findVertexAttributeString(Topology* top, igraph_intege
 /* the graph lock should be held when calling this function, since it accesses igraph.
  * if the value is found and not NULL, it's value is returned in valueOut.
  * returns true if valueOut has been set, false otherwise */
-static gboolean _topology_findVertexAttributeDouble(Topology* top, igraph_integer_t vertexIndex,
-        VertexAttribute attr, gdouble* valueOut) {
+__attribute__((unused)) static gboolean
+_topology_findVertexAttributeDouble(Topology* top, igraph_integer_t vertexIndex,
+                                    VertexAttribute attr, gdouble* valueOut) {
     MAGIC_ASSERT(top);
 
     const gchar* name = _topology_vertexAttributeToString(attr);

--- a/src/shim/shim_event.c
+++ b/src/shim/shim_event.c
@@ -47,12 +47,12 @@ static inline void shim_determinedRecv(int sock_fd, void* ptr, size_t nbytes) {
     }
 }
 
-static inline void shim_sendUint32_t(int sock_fd, uint32_t value) {
+__attribute__((unused)) static inline void shim_sendUint32_t(int sock_fd, uint32_t value) {
     value = htonl(value);
     shim_determinedSend(sock_fd, &value, sizeof(uint32_t));
 }
 
-static inline uint32_t shim_recvUint32_t(int sock_fd) {
+__attribute__((unused)) static inline uint32_t shim_recvUint32_t(int sock_fd) {
     uint32_t value;
     shim_determinedRecv(sock_fd, &value, sizeof(uint32_t));
     return ntohl(value);

--- a/src/test/file/test_file.c
+++ b/src/test/file/test_file.c
@@ -347,7 +347,7 @@ static void _test_ioctl_tty() {
     assert_errno_is(ENOTTY);
 }
 
-static void _test_iov() {
+__attribute__((unused)) static void _test_iov() {
     g_auto(AutoDeleteFile) adf = _create_auto_file();
 
     FILE* file;

--- a/src/test/phold/test_phold.c
+++ b/src/test/phold/test_phold.c
@@ -139,20 +139,20 @@ static double _phold_generate_normal_deviate() {
     return x;
 }
 
-static double _phold_generate_normal(double location, double scale) {
+__attribute__((unused)) static double _phold_generate_normal(double location, double scale) {
     // location is mu, mean of normal distribution
     // scale is sigma, sqrt of the variance of normal distribution
     double z = _phold_generate_normal_deviate();
     return location + (scale * z);
 }
 
-static double _phold_generate_exponential(double rate) {
+__attribute__((unused)) static double _phold_generate_exponential(double rate) {
     // inverse transform sampling
     double u = _phold_get_uniform_double();
     return -log(u)/rate;
 }
 
-static in_addr_t _phold_lookupIP(PHold* phold, const gchar* hostname) {
+__attribute__((unused)) static in_addr_t _phold_lookupIP(PHold* phold, const gchar* hostname) {
     PHOLD_ASSERT(phold);
 
     in_addr_t ip = htonl(INADDR_NONE);


### PR DESCRIPTION
This causes a warning if the C code has unused functions, which makes it more similar to how the Rust compiler works. This warning can also help find forgotten functions when refactoring.