### PR TITLE
Fix fstatat

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -265,18 +265,14 @@ struct MemoryReader_u8 *memorymanager_getReader(struct MemoryManager *memory_man
                                                 PluginPtr plugin_src,
                                                 uintptr_t n);
 
-// Get a write-accessor to the specified plugin memory.
-// Must be freed via `memorymanager_flushAndFreeWriter`.
-int32_t memorymanager_getStringReader(struct MemoryManager *memory_manager,
-                                      PluginPtr plugin_src,
-                                      uintptr_t n,
-                                      struct MemoryReader_u8 **reader_out,
-                                      uintptr_t *strlen);
-
 void memorymanager_freeReader(struct MemoryReader_u8 *reader);
 
 // Get a pointer to this reader's memory.
 const void *memorymanager_getReadablePtr(struct MemoryReader_u8 *reader);
+
+int32_t memorymanager_getReadableString(const struct MemoryReader_u8 *reader,
+                                        const char **str,
+                                        size_t *strlen);
 
 // Copy data from this reader's memory.
 int32_t memorymanager_readPtr(struct MemoryManager *memory_manager,

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -274,6 +274,8 @@ int32_t memorymanager_getReadableString(const struct MemoryReader_u8 *reader,
                                         const char **str,
                                         size_t *strlen);
 
+ssize_t memorymanager_readString(const struct MemoryReader_u8 *reader, char *str, size_t strlen);
+
 // Copy data from this reader's memory.
 int32_t memorymanager_readPtr(struct MemoryManager *memory_manager,
                               void *dst,

--- a/src/main/host/memory_manager.rs
+++ b/src/main/host/memory_manager.rs
@@ -1958,6 +1958,7 @@ mod export {
     /// * `mm` must point to a valid object.
     #[no_mangle]
     pub unsafe extern "C" fn memorymanager_free(mm: *mut MemoryManager) {
+        debug_assert!(!mm.is_null());
         mm.as_mut().map(|mm| Box::from_raw(mm));
     }
 
@@ -1968,6 +1969,7 @@ mod export {
 
     #[no_mangle]
     pub unsafe extern "C" fn allocdmem_free(allocd_mem: *mut AllocdMem<u8>) {
+        debug_assert!(!allocd_mem.is_null());
         allocd_mem
             .as_mut()
             .map(|allocd_mem| Box::from_raw(allocd_mem));
@@ -1975,6 +1977,7 @@ mod export {
 
     #[no_mangle]
     pub unsafe extern "C" fn allocdmem_pluginPtr(allocd_mem: *const AllocdMem<u8>) -> c::PluginPtr {
+        debug_assert!(!allocd_mem.is_null());
         allocd_mem.as_ref().unwrap().ptr().ptr().into()
     }
 
@@ -1985,6 +1988,8 @@ mod export {
         memory_manager: *mut MemoryManager,
         thread: *mut c::Thread,
     ) {
+        debug_assert!(!memory_manager.is_null());
+        debug_assert!(!thread.is_null());
         let memory_manager = memory_manager.as_mut().unwrap();
         if !memory_manager.has_mapper() {
             let mut thread = CThread::new(thread);
@@ -2000,6 +2005,7 @@ mod export {
         plugin_src: c::PluginPtr,
         n: usize,
     ) -> *mut MemoryReader<'a, u8> {
+        debug_assert!(!memory_manager.is_null());
         let memory_manager = memory_manager.as_mut().unwrap();
         let plugin_src: PluginPtr = plugin_src.into();
         Box::into_raw(Box::new(
@@ -2009,6 +2015,7 @@ mod export {
 
     #[no_mangle]
     pub unsafe extern "C" fn memorymanager_freeReader<'a>(reader: *mut MemoryReader<'a, u8>) {
+        debug_assert!(!reader.is_null());
         Box::from_raw(reader);
     }
 
@@ -2090,6 +2097,7 @@ mod export {
         plugin_src: c::PluginPtr,
         n: usize,
     ) -> *mut MemoryWriter<'a, u8> {
+        debug_assert!(!memory_manager.is_null());
         let memory_manager = memory_manager.as_mut().unwrap();
         let plugin_src: PluginPtr = plugin_src.into();
         let rv = Box::into_raw(Box::new(
@@ -2103,6 +2111,7 @@ mod export {
     pub unsafe extern "C" fn memorymanager_flushAndFreeWriter<'a>(
         writer: *mut MemoryWriter<'a, u8>,
     ) -> i32 {
+        debug_assert!(!writer.is_null());
         let mut writer = Box::from_raw(writer);
         // No way to safely recover here if the flush fails.
         if writer.flush().is_ok() {
@@ -2121,6 +2130,8 @@ mod export {
         src: *const c_void,
         n: usize,
     ) -> i32 {
+        debug_assert!(!memory_manager.is_null());
+        debug_assert!(!src.is_null());
         let memory_manager = memory_manager.as_mut().unwrap();
         let dst = TypedPluginPtr::<u8>::new(dst.into(), n).unwrap();
         let src = std::slice::from_raw_parts(src as *const u8, n);
@@ -2138,6 +2149,7 @@ mod export {
     pub unsafe extern "C" fn memorymanager_getWritablePtr<'a>(
         writer: *mut MemoryWriter<'a, u8>,
     ) -> *mut c_void {
+        debug_assert!(!writer.is_null());
         let writer = &mut *writer;
         match writer.as_mut_uninit() {
             Ok(p) => p.as_ptr() as *mut c_void,
@@ -2150,6 +2162,7 @@ mod export {
     pub unsafe extern "C" fn memorymanager_getMutablePtr<'a>(
         writer: *mut MemoryWriter<'a, u8>,
     ) -> *mut c_void {
+        debug_assert!(!writer.is_null());
         let writer = &mut *writer;
         match writer.as_mut() {
             Ok(p) => p.as_ptr() as *mut c_void,
@@ -2164,6 +2177,8 @@ mod export {
         thread: *mut c::Thread,
         plugin_src: c::PluginPtr,
     ) -> c::SysCallReturn {
+        debug_assert!(!memory_manager.is_null());
+        debug_assert!(!thread.is_null());
         let memory_manager = memory_manager.as_mut().unwrap();
         let mut thread = CThread::new(thread);
         memory_manager
@@ -2183,6 +2198,8 @@ mod export {
         fd: i32,
         offset: i64,
     ) -> c::SysCallReturn {
+        debug_assert!(!memory_manager.is_null());
+        debug_assert!(!thread.is_null());
         let memory_manager = memory_manager.as_mut().unwrap();
         let mut thread = CThread::new(thread);
         memory_manager
@@ -2206,6 +2223,8 @@ mod export {
         addr: c::PluginPtr,
         len: usize,
     ) -> c::SysCallReturn {
+        debug_assert!(!memory_manager.is_null());
+        debug_assert!(!thread.is_null());
         let memory_manager = memory_manager.as_mut().unwrap();
         let mut thread = CThread::new(thread);
         memory_manager
@@ -2223,6 +2242,8 @@ mod export {
         flags: i32,
         new_addr: c::PluginPtr,
     ) -> c::SysCallReturn {
+        debug_assert!(!memory_manager.is_null());
+        debug_assert!(!thread.is_null());
         let memory_manager = memory_manager.as_mut().unwrap();
         let mut thread = CThread::new(thread);
         memory_manager
@@ -2245,6 +2266,8 @@ mod export {
         size: usize,
         prot: i32,
     ) -> c::SysCallReturn {
+        debug_assert!(!memory_manager.is_null());
+        debug_assert!(!thread.is_null());
         let memory_manager = memory_manager.as_mut().unwrap();
         let mut thread = CThread::new(thread);
         memory_manager

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -903,6 +903,18 @@ int process_getReadableString(Process* proc, PluginPtr plugin_src, size_t n, con
     return res;
 }
 
+ssize_t process_readString(Process* proc, char* str, PluginVirtualPtr src, size_t n) {
+    MAGIC_ASSERT(proc);
+
+    // Disallow additional references while there's a mutable reference.
+    utility_assert(proc->memoryWriters->len == 0);
+
+    MemoryReader_u8* reader = memorymanager_getReader(proc->memoryManager, src, n);
+    ssize_t res = memorymanager_readString(reader, str, n);
+    memorymanager_freeReader(reader);
+    return res;
+}
+
 // Returns a writable pointer corresponding to the named region. The initial
 // contents of the returned memory are unspecified.
 //

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -892,16 +892,15 @@ int process_getReadableString(Process* proc, PluginPtr plugin_src, size_t n, con
     // Disallow additional references while there's a mutable reference.
     utility_assert(proc->memoryWriters->len == 0);
 
-    MemoryReader_u8* reader = NULL;
-    int res = memorymanager_getStringReader(proc->memoryManager, plugin_src, n, &reader, strlen);
+    MemoryReader_u8* reader = memorymanager_getReader(proc->memoryManager, plugin_src, n);
+    int res = memorymanager_getReadableString(reader, str, strlen);
     if (res != 0) {
-        return res;
+        memorymanager_freeReader(reader);
+    } else {
+        g_array_append_val(proc->memoryReaders, reader);
     }
-    *str = memorymanager_getReadablePtr(reader);
-    utility_assert(str);
-    g_array_append_val(proc->memoryReaders, reader);
 
-    return 0;
+    return res;
 }
 
 // Returns a writable pointer corresponding to the named region. The initial

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -120,6 +120,14 @@ int process_readPtr(Process* proc, void* dst, PluginVirtualPtr src, size_t n);
 int process_getReadableString(Process* process, PluginPtr plugin_src, size_t n, const char** str,
                               size_t* strlen);
 
+// Reads up to `n` bytes into `str`.
+//
+// Returns:
+// strlen(str) on success.
+// -ENAMETOOLONG if there was no NULL byte in the first `n` characters.
+// -EFAULT if the string extends beyond the accessible address space.
+ssize_t process_readString(Process* proc, char* str, PluginVirtualPtr src, size_t n);
+
 // Copy `n` bytes from `src` to `dst`. Returns 0 on success or EFAULT if any of
 // the specified range couldn't be accessed. The write is flushed immediately.
 int process_writePtr(Process* proc, PluginVirtualPtr dst, const void* src, size_t n);


### PR DESCRIPTION
* TypedPluginPtr: make slice method generic over RangeBounds
* MemoryManager.read_ptr: let caller slice instead of taking offset
* MemoryManager: generalize read_ptr -> readv_ptr
* Split MemoryReader.copy to read_some and read_exact
* MemoryReader: split as_ref into ref_some and ref_exact
* Reimplement process_getReadableString using new Reader API
* Add process_readString
* fileat syscalls: fix memory access bugs
* Add test for fstatat

Fixes #1332 