### PR TITLE
Disable forkproxy workaround by default

### DIFF
--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -260,10 +260,10 @@ Use the MemoryManager. It can be useful to disable for debugging, but will hurt 
 
 #### `experimental.use_o_n_waitpid_workarounds`
 
-Default: true  
+Default: false  
 Type: Bool
 
-Enable performance workarounds for waitpid being O(n). Beneficial to disable if waitpid is patched to be O(1) or in some cases where it'd otherwise result in excessive detaching and reattaching.
+Use performance workarounds for waitpid being O(n). Beneficial to disable if waitpid is patched to be O(1), if using one logical processor per host, or in some cases where it'd otherwise result in excessive detaching and reattaching.
 
 #### `experimental.use_object_counters`
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -194,9 +194,9 @@ pub struct ExperimentalOptions {
     #[clap(about = EXP_HELP.get("use_sched_fifo").unwrap())]
     use_sched_fifo: Option<bool>,
 
-    /// Enable performance workarounds for waitpid being O(n). Beneficial to disable if waitpid
-    /// is patched to be O(1) or in some cases where it'd otherwise result in excessive detaching
-    /// and reattaching
+    /// Use performance workarounds for waitpid being O(n). Beneficial to disable if waitpid
+    /// is patched to be O(1), if using one logical processor per host, or in some cases where
+    /// it'd otherwise result in excessive detaching and reattaching
     #[clap(long, value_name = "bool")]
     #[clap(about = EXP_HELP.get("use_o_n_waitpid_workarounds").unwrap())]
     use_o_n_waitpid_workarounds: Option<bool>,


### PR DESCRIPTION
We want the default mode to be that Shadow calculates the number
of processors to use based on the number of hosts specified in the
configuration file. (See #1251.) In this case, we do not want to
run the forkproxy workaround, because the fact that waitpid is O(n)
won't matter when each processor only runs a few pids.

Closes #1261