### PR TITLE
Don't ignore unknown topology attributes

### DIFF
--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -665,7 +665,6 @@ const ONE_GBIT_SWITCH_TOPOLOGY: &str = r#"<?xml version="1.0" encoding="utf-8"?>
     <key attr.name="packet_loss"    attr.type="double" for="edge" id="edge_packet_loss" />
     <key attr.name="jitter"         attr.type="double" for="edge" id="edge_jitter" />
     <key attr.name="latency"        attr.type="double" for="edge" id="edge_latency" />
-    <key attr.name="type"           attr.type="string" for="node" id="node_type" />
     <key attr.name="bandwidth_up"   attr.type="string" for="node" id="node_bandwidth_up" />
     <key attr.name="bandwidth_down" attr.type="string" for="node" id="node_bandwidth_down" />
     <key attr.name="country_code"   attr.type="string" for="node" id="node_country_code" />
@@ -678,7 +677,6 @@ const ONE_GBIT_SWITCH_TOPOLOGY: &str = r#"<?xml version="1.0" encoding="utf-8"?>
             <data key="node_country_code">XX</data>
             <data key="node_bandwidth_down">1 Gbit</data>
             <data key="node_bandwidth_up">1 Gbit</data>
-            <data key="node_type">net</data>
         </node>
         <edge source="poi-1" target="poi-1">
             <data key="edge_latency">1.0</data>

--- a/src/main/routing/topology.c
+++ b/src/main/routing/topology.c
@@ -578,7 +578,8 @@ static gboolean _topology_checkGraphAttributes(Topology* top) {
             /* we use a string because there is an error in igraph boolean attribute code. */
             isSuccess = isSuccess && _topology_checkAttributeType(name, type, IGRAPH_ATTRIBUTE_STRING);
         } else {
-            warning("graph attribute '%s' is unsupported and will be ignored", name);
+            error("graph attribute '%s' is unsupported", name);
+            isSuccess = FALSE;
         }
     }
 
@@ -609,7 +610,8 @@ static gboolean _topology_checkGraphAttributes(Topology* top) {
         } else if(_topology_isValidVertexAttributeKey(name, VERTEX_ATTR_PACKETLOSS)) {
             isSuccess = isSuccess && _topology_checkAttributeType(name, type, IGRAPH_ATTRIBUTE_NUMERIC);
         } else {
-            debug("vertex attribute '%s' is unsupported and will be ignored", name);
+            error("vertex attribute '%s' is unsupported", name);
+            isSuccess = FALSE;
         }
     }
 
@@ -651,7 +653,8 @@ static gboolean _topology_checkGraphAttributes(Topology* top) {
         } else if(_topology_isValidEdgeAttributeKey(name, EDGE_ATTR_PACKETLOSS)) {
             isSuccess = isSuccess && _topology_checkAttributeType(name, type, IGRAPH_ATTRIBUTE_NUMERIC);
         } else {
-            debug("edge attribute '%s' is unsupported and will be ignored", name);
+            error("edge attribute '%s' is unsupported", name);
+            isSuccess = FALSE;
         }
     }
 

--- a/src/test/tor/minimal/tor-minimal.yaml
+++ b/src/test/tor/minimal/tor-minimal.yaml
@@ -6,7 +6,6 @@ topology:
       <key attr.name="packet_loss" attr.type="double" for="edge" id="d9" />
       <key attr.name="jitter" attr.type="double" for="edge" id="d8" />
       <key attr.name="latency" attr.type="double" for="edge" id="d7" />
-      <key attr.name="type" attr.type="string" for="node" id="d5" />
       <key attr.name="bandwidth_up" attr.type="string" for="node" id="d4" />
       <key attr.name="bandwidth_down" attr.type="string" for="node" id="d3" />
       <key attr.name="country_code" attr.type="string" for="node" id="d2" />
@@ -19,7 +18,6 @@ topology:
           <data key="d2">US</data>
           <data key="d3">1 Gbit</data>
           <data key="d4">1 Gbit</data>
-          <data key="d5">net</data>
         </node>
         <edge source="poi-1" target="poi-1">
           <data key="d7">50.0</data>


### PR DESCRIPTION
Unknown topology attributes now cause the topology parsing to fail.