### PR TITLE
Update rust nightly and clang versions in converage test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,15 +20,15 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     container:
-      image: 'ubuntu:20.10'
+      image: 'ubuntu:20.04'
       # the default shm-size for ubuntu:18.04, but with the size increased from
       # 65536k. github's default docker seccomp policy seems to disallow
       # process_vm_readv and process_vm_writev; disable it altogether. See
       # https://docs.docker.com/engine/security/seccomp/
       options: '--shm-size="1g" --security-opt seccomp=unconfined'
     env:
-      CC: 'clang-11'
-      CONTAINER: 'ubuntu:20.10'
+      CC: 'clang-12'
+      CONTAINER: 'ubuntu:20.04'
       BUILDTYPE: 'coverage'
       RUSTPROFILE: minimal
 

--- a/ci/container_scripts/build_and_install.sh
+++ b/ci/container_scripts/build_and_install.sh
@@ -9,8 +9,8 @@ gcc)
 clang)
   export CXX="clang++"
   ;;
-clang-11)
-  export CXX="clang++-11"
+clang-12)
+  export CXX="clang++-12"
   ;;
 *)
   echo "Unknown cc $CC"

--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -45,8 +45,21 @@ case "$CC" in
         fi
         install_packages clang
         ;;
-    clang-11)
-        install_packages clang-11
+    clang-12)
+        case "$CONTAINER" in
+            ubuntu:*|debian:*)
+                curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /usr/share/keyrings/llvm-archive-keyring.gpg
+        esac
+        case "$CONTAINER" in
+            ubuntu:20.04)
+                echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main" \
+                  >> /etc/apt/sources.list
+        esac
+        case "$CONTAINER" in
+            ubuntu:*|debian:*)
+                apt-get update
+        esac
+        install_packages clang-12
         ;;
     *)
         echo "Unhandled cc $CC"
@@ -56,7 +69,7 @@ esac
 
 if [ "${BUILDTYPE:-}" = coverage ]
 then
-    RUST_TOOLCHAIN=nightly-2021-03-01
+    RUST_TOOLCHAIN=nightly-2021-05-12
 else
     RUST_TOOLCHAIN=stable
 fi


### PR DESCRIPTION
The coverage CI tests now use the LLVM apt repo to get the required llvm/clang packages rather than trying to use a distro that includes the required versions.

Replaces: #1330