### PR TITLE
Update scheduler options

### DIFF
--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -27,6 +27,7 @@ hosts:
 - [`general.data_directory`](#generaldata_directory)
 - [`general.heartbeat_interval`](#generalheartbeat_interval)
 - [`general.log_level`](#generallog_level)
+- [`general.parallelism`](#generalparallelism)
 - [`general.seed`](#generalseed)
 - [`general.stop_time`](#generalstop_time)
 - [`general.template_directory`](#generaltemplate_directory)
@@ -36,7 +37,6 @@ hosts:
 - [`experimental.interface_buffer`](#experimentalinterface_buffer)
 - [`experimental.interface_qdisc`](#experimentalinterface_qdisc)
 - [`experimental.interpose_method`](#experimentalinterpose_method)
-- [`experimental.max_concurrency`](#experimentalmax_concurrency)
 - [`experimental.preload_spin_max`](#experimentalpreload_spin_max)
 - [`experimental.runahead`](#experimentalrunahead)
 - [`experimental.scheduler_policy`](#experimentalscheduler_policy)
@@ -105,6 +105,14 @@ Default: "info"
 Type: "error" OR "warning" OR "info" OR "debug" OR "trace"
 
 Log level of output written on stdout. If Shadow was built in release mode, then messages at level 'trace' will always be dropped.
+
+#### `general.parallelism`
+
+Default: null  
+Type: Integer OR null
+
+How many parallel threads to use to run the simulation. Optimal performance is
+usually obtained with `nproc`, or sometimes `nproc/2` with hyperthreading.
 
 #### `general.seed`
 
@@ -180,13 +188,6 @@ Default: "ptrace"
 Type: "ptrace" OR "preload" OR "hybrid"
 
 Which interposition method to use.
-
-#### `experimental.max_concurrency`
-
-Default: null  
-Type: Integer OR null
-
-Maximum number of workers to allow to run at once.
 
 #### `experimental.preload_spin_max`
 

--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -205,7 +205,7 @@ If set, overrides the automatically calculated minimum time workers may run ahea
 
 #### `experimental.scheduler_policy`
 
-Default: "steal"  
+Default: "host"  
 Type: "host" OR "steal" OR "thread" OR "threadxthread" OR "threadxhost"
 
 The event scheduler's policy for thread synchronization.

--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -31,7 +31,6 @@ hosts:
 - [`general.seed`](#generalseed)
 - [`general.stop_time`](#generalstop_time)
 - [`general.template_directory`](#generaltemplate_directory)
-- [`general.workers`](#generalworkers)
 - [`topology`](#topology)
 - [`experimental`](#experimental)
 - [`experimental.interface_buffer`](#experimentalinterface_buffer)
@@ -52,6 +51,7 @@ hosts:
 - [`experimental.use_sched_fifo`](#experimentaluse_sched_fifo)
 - [`experimental.use_shim_syscall_handler`](#experimentaluse_shim_syscall_handler)
 - [`experimental.use_syscall_counters`](#experimentaluse_syscall_counters)
+- [`experimental.worker_threads`](#experimentalworker_threads)
 - [`host_defaults`](#host_defaults)
 - [`host_defaults.city_code_hint`](#host_defaultscity_code_hint)
 - [`host_defaults.country_code_hint`](#host_defaultscountry_code_hint)
@@ -134,13 +134,6 @@ Default: null
 Type: String OR null
 
 Path to recursively copy during startup and use as the data-directory.
-
-#### `general.workers`
-
-Default: 0  
-Type: Integer
-
-Run concurrently with N worker threads.
 
 #### `topology`
 
@@ -293,6 +286,19 @@ Default: false
 Type: Bool
 
 Count the number of occurrences for individual syscalls.
+
+#### `experimental.worker_threads`
+
+Default: # of hosts in the simulation  
+Type: Integer
+
+Create N worker threads. Note though, that `general.parallelism` of them will be
+allowed to run simultaneously. If unset, will create a thread for each simulated
+Host. This is to work around limitations in ptrace, and may change in the
+future.
+
+"0" is a valid value, and will cause the simulation to be run directly on the
+main Shadow thread, but this functionality may be removed in the future.
 
 #### `host_defaults`
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -118,7 +118,7 @@ bool config_getUseShimSyscallHandler(const struct ConfigOptions *config);
 
 int32_t config_getPreloadSpinMax(const struct ConfigOptions *config);
 
-int32_t config_getMaxConcurrency(const struct ConfigOptions *config);
+uint32_t config_getParallelism(const struct ConfigOptions *config);
 
 SimulationTime config_getStopTime(const struct ConfigOptions *config);
 

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -26,7 +26,7 @@
 #include "main/utility/utility.h"
 #include "support/logger/logger.h"
 
-static int _parallelism = -1;
+static int _parallelism;
 ADD_CONFIG_HANDLER(config_getParallelism, _parallelism)
 
 struct _Scheduler {

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -313,7 +313,7 @@ impl Default for ExperimentalOptions {
             use_cpu_pinning: Some(true),
             interpose_method: Some(InterposeMethod::Ptrace),
             runahead: None,
-            scheduler_policy: Some(SchedulerPolicy::Steal),
+            scheduler_policy: Some(SchedulerPolicy::Host),
             socket_send_buffer: Some(units::Bytes::new(131_072, units::SiPrefixUpper::Base)),
             socket_send_autotune: Some(true),
             socket_recv_buffer: Some(units::Bytes::new(174_760, units::SiPrefixUpper::Base)),

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -9,6 +9,7 @@ use once_cell::sync::Lazy;
 use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
+use std::num::NonZeroU32;
 
 use super::simulation_time::{SIMTIME_ONE_NANOSECOND, SIMTIME_ONE_SECOND};
 use super::units::{self, Unit};
@@ -139,8 +140,8 @@ pub struct GeneralOptions {
     /// with hyperthreading.
     #[clap(long, short = 'p', value_name = "cores")]
     #[clap(about = GENERAL_HELP.get("parallelism").unwrap())]
-    #[serde(default = "default_some_0")]
-    parallelism: Option<u32>,
+    #[serde(default = "default_some_nz_1")]
+    parallelism: Option<NonZeroU32>,
 
     #[clap(long, value_name = "seconds")]
     #[clap(about = GENERAL_HELP.get("bootstrap_end_time").unwrap())]
@@ -648,14 +649,14 @@ fn default_some_time_0() -> Option<units::Time<units::TimePrefixUpper>> {
     Some(units::Time::new(0, units::TimePrefixUpper::Sec))
 }
 
-/// Helper function for serde default `Some(0)` values.
-fn default_some_0() -> Option<u32> {
-    Some(0)
-}
-
 /// Helper function for serde default `Some(1)` values.
 fn default_some_1() -> Option<u32> {
     Some(1)
+}
+
+/// Helper function for serde default `Some(1)` values.
+fn default_some_nz_1() -> Option<NonZeroU32> {
+    Some(std::num::NonZeroU32::new(1).unwrap())
 }
 
 /// Helper function for serde default `Some(0)` values.
@@ -1114,7 +1115,7 @@ mod export {
     }
 
     #[no_mangle]
-    pub extern "C" fn config_getParallelism(config: *const ConfigOptions) -> u32 {
+    pub extern "C" fn config_getParallelism(config: *const ConfigOptions) -> NonZeroU32 {
         assert!(!config.is_null());
         let config = unsafe { &*config };
         config.general.parallelism.unwrap()

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -134,16 +134,16 @@ static Worker* _worker_new(WorkerPool*, int);
 static void _worker_free(Worker*);
 
 WorkerPool* workerpool_new(Manager* manager, Scheduler* scheduler, int nWorkers,
-                           int nConcurrent) {
+                           int nParallel) {
     int nLogicalProcessors = 0;
-    if (nWorkers == 0 || nConcurrent == 0) {
+    if (nWorkers == 0 || nParallel == 0) {
         // With no concurrency, we still use a single logical processor.
         nLogicalProcessors = 1;
-    } else if (nConcurrent < 0 || nConcurrent > nWorkers) {
+    } else if (nParallel < 0 || nParallel > nWorkers) {
         // Never makes sense to use more logical processors than workers.
         nLogicalProcessors = nWorkers;
     } else {
-        nLogicalProcessors = nConcurrent;
+        nLogicalProcessors = nParallel;
     }
 
     WorkerPool* pool = g_new(WorkerPool, 1);

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -135,16 +135,11 @@ static void _worker_free(Worker*);
 
 WorkerPool* workerpool_new(Manager* manager, Scheduler* scheduler, int nWorkers,
                            int nParallel) {
-    int nLogicalProcessors = 0;
-    if (nWorkers == 0 || nParallel == 0) {
-        // With no concurrency, we still use a single logical processor.
-        nLogicalProcessors = 1;
-    } else if (nParallel < 0 || nParallel > nWorkers) {
-        // Never makes sense to use more logical processors than workers.
-        nLogicalProcessors = nWorkers;
-    } else {
-        nLogicalProcessors = nParallel;
-    }
+    // Should have been ensured earlier by `config_getParallelism`.
+    utility_assert(nParallel >= 1);
+
+    // Never makes sense to use more logical processors than workers.
+    int nLogicalProcessors = MIN(nParallel, nWorkers);
 
     WorkerPool* pool = g_new(WorkerPool, 1);
     *pool = (WorkerPool){

--- a/src/test/determinism/CMakeLists.txt
+++ b/src/test/determinism/CMakeLists.txt
@@ -11,13 +11,13 @@ foreach(METHOD ptrace hybrid)
         BASENAME determinism1a
         METHODS ${METHOD}
         SHADOW_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/determinism1.test.shadow.config.yaml
-        ARGS --use-cpu-pinning true --workers 2
+        ARGS --use-cpu-pinning true --parallelism 2
         PROPERTIES RUN_SERIAL TRUE)
     add_shadow_tests(
         BASENAME determinism1b
         METHODS ${METHOD}
         SHADOW_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/determinism1.test.shadow.config.yaml
-        ARGS --use-cpu-pinning true --workers 2
+        ARGS --use-cpu-pinning true --parallelism 2
         PROPERTIES RUN_SERIAL TRUE)
     add_test(
         NAME determinism1-compare-shadow-${METHOD}
@@ -39,13 +39,13 @@ foreach(METHOD ptrace hybrid)
         BASENAME determinism2a
         METHODS ${METHOD}
         SHADOW_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/determinism2.test.shadow.config.yaml
-        ARGS --use-cpu-pinning true --workers 2
+        ARGS --use-cpu-pinning true --parallelism 2
         PROPERTIES RUN_SERIAL TRUE)
     add_shadow_tests(
         BASENAME determinism2b
         METHODS ${METHOD}
         SHADOW_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/determinism2.test.shadow.config.yaml
-        ARGS --use-cpu-pinning true --workers 2
+        ARGS --use-cpu-pinning true --parallelism 2
         PROPERTIES RUN_SERIAL TRUE)
     ## now compare the output
     ## TODO enable this test and fix the remaining determinism issue

--- a/src/test/phold/CMakeLists.txt
+++ b/src/test/phold/CMakeLists.txt
@@ -27,13 +27,13 @@ add_shadow_tests(
     BASENAME phold-parallel
     METHODS hybrid ptrace
     LOGLEVEL info
-    ARGS --use-cpu-pinning true --workers 2
+    ARGS --use-cpu-pinning true --parallelism 2
     PROPERTIES RUN_SERIAL TRUE)
 add_shadow_tests(
     BASENAME phold-parallel
     METHODS preload
     LOGLEVEL info
-    ARGS --use-cpu-pinning true --workers 2
+    ARGS --use-cpu-pinning true --parallelism 2
     PROPERTIES RUN_SERIAL TRUE
     CONFIGURATIONS ilibc)
 

--- a/src/test/tor/minimal/CMakeLists.txt
+++ b/src/test/tor/minimal/CMakeLists.txt
@@ -25,7 +25,7 @@ add_shadow_tests(BASENAME tor-minimal
                  LOGLEVEL info
                  ARGS
                    --use-cpu-pinning true
-                   --workers 2
+                   --parallelism 2
                    --template-directory "shadow.data.template"
                  POST_CMD "${CMAKE_CURRENT_SOURCE_DIR}/verify.sh"
                  PROPERTIES


### PR DESCRIPTION
* The Experimental option `max-concurrency` is now the General option `parallelism`.
* The default scheduler policy is now Host.
* The General option `workers` is now the Experimental option `worker-threads`, and no longer has the `-w` shortcut. Users should use `parallelism` instead. If not set explicitly, the number of worker threads will be set to the number of hosts in the simulation.


