### PR TITLE
Switch from graphml to gml

### DIFF
--- a/.github/workflows/run_tor.yml
+++ b/.github/workflows/run_tor.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Test
         run: |
           cd shadow
-          ./setup test -- --build-config tor --label-regex tor
+          ./setup test -- --build-config extra --label-regex tor
 
       - name: Last 200 log lines
         if: failure()

--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -49,6 +49,7 @@ RPM_CI_PACKAGES="
 
 PYTHON_PACKAGES="
   PyYaml
+  networkx>=2.5
   "
 
 case "$CONTAINER" in

--- a/ci/container_scripts/test.sh
+++ b/ci/container_scripts/test.sh
@@ -14,14 +14,16 @@ else
     EXCLUDE=""
 fi
 
-# On centos:7 we enable extra tests that currently require a patched libc.
-# https://github.com/shadow/shadow/issues/892
 EXTRA_FLAGS=""
 if [ "$CONTAINER" = "centos:7" ]
 then
+    # On centos:7 we enable extra tests that currently require a patched libc.
+    # https://github.com/shadow/shadow/issues/892
     CONFIG="ilibc"
 else
-    CONFIG=""
+    # On all other platforms, we run extra tests that we don't generally require (for
+    # example tests that require additional dependencies).
+    CONFIG="extra"
 fi
 
 # Array of flags to be passed on to setup script
@@ -38,6 +40,9 @@ FLAGS+=("-E" "$EXCLUDE")
 
 # Pass through an optional config-name, which can enable more tests
 FLAGS+=("-C" "$CONFIG")
+
+# Exclude tor tests as we test them in a different workflow
+FLAGS+=("-LE" "tor")
 
 FLAGS+=("--output-on-failure")
 

--- a/ci/container_scripts/test.sh
+++ b/ci/container_scripts/test.sh
@@ -36,13 +36,13 @@ FLAGS+=("-j$(nproc)")
 FLAGS+=("--")
 
 # We exclude some tests in some configurations.
-FLAGS+=("-E" "$EXCLUDE")
+FLAGS+=("--exclude-regex" "$EXCLUDE")
 
 # Pass through an optional config-name, which can enable more tests
-FLAGS+=("-C" "$CONFIG")
+FLAGS+=("--build-config" "$CONFIG")
 
 # Exclude tor tests as we test them in a different workflow
-FLAGS+=("-LE" "tor")
+FLAGS+=("--label-exclude" "tor")
 
 FLAGS+=("--output-on-failure")
 

--- a/docs/5-Developer-Guide.md
+++ b/docs/5-Developer-Guide.md
@@ -23,7 +23,7 @@ cargo install --force --version 0.57.0 bindgen
 Shadow includes tests that use Tor and TGen. These are not run by default. To run them, first make sure that both tor and tgen are located at `~/.shadow/bin/{tor,tgen}`. These can be symlinks to tor and tgen binaries elsewhere in the filesystem. It is recommended to build Shadow in release mode, otherwise the tests may take much longer to complete.
 
 ```bash
-./setup test -- -C tor -L tor
+./setup test -- -C extra -L tor
 ```
 
 If you change the tor version by updating the version at `~/.shadow/bin/tor`, make sure to re-run `./setup build --test`.

--- a/docs/5-Developer-Guide.md
+++ b/docs/5-Developer-Guide.md
@@ -23,7 +23,7 @@ cargo install --force --version 0.57.0 bindgen
 Shadow includes tests that use Tor and TGen. These are not run by default. To run them, first make sure that both tor and tgen are located at `~/.shadow/bin/{tor,tgen}`. These can be symlinks to tor and tgen binaries elsewhere in the filesystem. It is recommended to build Shadow in release mode, otherwise the tests may take much longer to complete.
 
 ```bash
-./setup test -- -C extra -L tor
+./setup test -- --build-config extra --label-regex tor
 ```
 
 If you change the tor version by updating the version at `~/.shadow/bin/tor`, make sure to re-run `./setup build --test`.

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -156,7 +156,7 @@ static gboolean _controller_loadTopology(Controller* controller) {
     MAGIC_ASSERT(controller);
 
     gchar* temporaryFilename =
-        utility_getNewTemporaryFilename("shadow-topology-XXXXXX.graphml.xml");
+        utility_getNewTemporaryFilename("shadow-topology-XXXXXX.gml");
 
     char* topologyString = config_getTopology(controller->config);
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -611,7 +611,7 @@ impl std::str::FromStr for QDiscMode {
 #[serde(rename_all = "lowercase")]
 enum Topology {
     Path(String),
-    GraphMl(String),
+    Gml(String),
     #[serde(rename = "1_gbit_switch")]
     OneGbitSwitch,
 }
@@ -670,29 +670,23 @@ fn default_some_info() -> Option<LogLevel> {
     Some(LogLevel::Info)
 }
 
-const ONE_GBIT_SWITCH_TOPOLOGY: &str = r#"<?xml version="1.0" encoding="utf-8"?>
-<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-    <key attr.name="packet_loss"    attr.type="double" for="edge" id="edge_packet_loss" />
-    <key attr.name="jitter"         attr.type="double" for="edge" id="edge_jitter" />
-    <key attr.name="latency"        attr.type="double" for="edge" id="edge_latency" />
-    <key attr.name="bandwidth_up"   attr.type="string" for="node" id="node_bandwidth_up" />
-    <key attr.name="bandwidth_down" attr.type="string" for="node" id="node_bandwidth_down" />
-    <key attr.name="country_code"   attr.type="string" for="node" id="node_country_code" />
-    <key attr.name="ip_address"     attr.type="string" for="node" id="node_ip_address" />
-    <graph edgedefault="undirected">
-        <node id="poi-1">
-            <data key="node_ip_address">0.0.0.0</data>
-            <data key="node_country_code">XX</data>
-            <data key="node_bandwidth_down">1 Gbit</data>
-            <data key="node_bandwidth_up">1 Gbit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-            <data key="edge_latency">1.0</data>
-            <data key="edge_jitter">0.0</data>
-            <data key="edge_packet_loss">0.0</data>
-        </edge>
-    </graph>
-</graphml>"#;
+const ONE_GBIT_SWITCH_TOPOLOGY: &str = r#"graph [
+  directed 0
+  node [
+    id 0
+    ip_address "0.0.0.0"
+    country_code "XX"
+    bandwidth_up "1 Gbit"
+    bandwidth_down "1 Gbit"
+  ]
+  edge [
+    source 0
+    target 0
+    latency 1.0
+    jitter 0.0
+    packet_loss 0.0
+  ]
+]"#;
 
 /// Generate help strings for objects in a JSON schema, including the Serde defaults if available.
 fn generate_help_strs(
@@ -1279,7 +1273,7 @@ mod export {
 
         let topology = match &config.topology {
             Topology::Path(f) => std::fs::read_to_string(f).unwrap(),
-            Topology::GraphMl(s) => s.clone(),
+            Topology::Gml(s) => s.clone(),
             Topology::OneGbitSwitch => ONE_GBIT_SWITCH_TOPOLOGY.to_string(),
         };
 

--- a/src/main/routing/topology.c
+++ b/src/main/routing/topology.c
@@ -358,18 +358,18 @@ static gboolean _topology_loadGraph(Topology* top, const gchar* graphPath) {
     }
 
     _topology_lockGraph(top);
-    info("reading graphml topology graph at '%s'...", graphPath);
+    info("reading gml topology graph at '%s'...", graphPath);
     gint result = igraph_read_graph_gml(&top->graph, graphFile);
     _topology_unlockGraph(top);
 
     fclose(graphFile);
 
     if(result != IGRAPH_SUCCESS) {
-        error("igraph_read_graph_graphml return non-success code %i", result);
+        error("igraph_read_graph_gml return non-success code %i", result);
         return FALSE;
     }
 
-    info("successfully read graphml topology graph at '%s'", graphPath);
+    info("successfully read gml topology graph at '%s'", graphPath);
 
     return TRUE;
 }
@@ -1111,7 +1111,7 @@ static gboolean _topology_checkGraph(Topology* top) {
         isSuccess = FALSE;
     } else {
         isSuccess = TRUE;
-        info("successfully parsed graphml and validated topology: "
+        info("successfully parsed gml and validated topology: "
              "graph is %s with %u %s, %u %s, and %u %s",
              top->isConnected ? "strongly connected" : "disconnected", (guint)top->clusterCount,
              top->clusterCount == 1 ? "cluster" : "clusters", (guint)top->vertexCount,
@@ -2335,7 +2335,7 @@ Topology* topology_new(const gchar* graphPath) {
             !_topology_extractEdgeWeights(top)) {
         topology_free(top);
         error("we failed to create the simulation topology because we were unable to validate the "
-              "topology graphml file");
+              "topology gml file");
         return NULL;
     }
 

--- a/src/main/routing/topology.c
+++ b/src/main/routing/topology.c
@@ -618,14 +618,14 @@ static gboolean _topology_checkGraphAttributes(Topology* top) {
             _topology_vertexAttributeToString(VERTEX_ATTR_BANDWIDTHDOWN))) {
         warning("the vertex attribute '%s' of type '%s' is required but not provided",
                 _topology_vertexAttributeToString(VERTEX_ATTR_BANDWIDTHDOWN),
-                _topology_igraphAttributeTypeToString(IGRAPH_ATTRIBUTE_NUMERIC));
+                _topology_igraphAttributeTypeToString(IGRAPH_ATTRIBUTE_STRING));
         isSuccess = FALSE;
     }
     if(!igraph_cattribute_has_attr(&top->graph, IGRAPH_ATTRIBUTE_VERTEX,
             _topology_vertexAttributeToString(VERTEX_ATTR_BANDWIDTHUP))) {
         warning("the vertex attribute '%s' of type '%s' is required but not provided",
                 _topology_vertexAttributeToString(VERTEX_ATTR_BANDWIDTHUP),
-                _topology_igraphAttributeTypeToString(IGRAPH_ATTRIBUTE_NUMERIC));
+                _topology_igraphAttributeTypeToString(IGRAPH_ATTRIBUTE_STRING));
         isSuccess = FALSE;
     }
 

--- a/src/test/config/convert/CMakeLists.txt
+++ b/src/test/config/convert/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(test-config-convert test_config.c)
 add_test(
     NAME config-convert
     COMMAND python3 ${CMAKE_SOURCE_DIR}/src/tools/convert_legacy_config.py --output shadow.generated.yaml ${CMAKE_CURRENT_SOURCE_DIR}/shadow.original.xml
+    CONFIGURATIONS extra
 )
 
 # Launch Shadow to ensure that the previously generated YAML is correct
@@ -13,12 +14,14 @@ add_test(
     rm -rf shadow.data \
     && ${CMAKE_BINARY_DIR}/src/main/shadow -l debug -d shadow.data shadow.generated.yaml \
     "
+    CONFIGURATIONS extra
+    DEPENDS "config-convert"
 )
-set_tests_properties(config-convert-run-shadow PROPERTIES DEPENDS "config-convert")
 
 # Ensure the format of the conversion is as expected
 add_test(
     NAME config-convert-check-format
     COMMAND diff -U 5 ${CMAKE_CURRENT_SOURCE_DIR}/shadow.expected.yaml shadow.generated.yaml
+    CONFIGURATIONS extra
+    DEPENDS "config-convert"
 )
-set_tests_properties(config-convert-check-format PROPERTIES DEPENDS "config-convert")

--- a/src/test/config/convert/shadow.expected.yaml
+++ b/src/test/config/convert/shadow.expected.yaml
@@ -1,28 +1,24 @@
 general:
   stop_time: 3600
 topology:
-  graphml: |-
-    <?xml version='1.0' encoding='utf-8'?>
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="prefer_direct_paths" attr.type="string" for="graph" id="d5" />
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <data key="d5">True</data>
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 1
+      prefer_direct_paths 1
+      node [
+        id 0
+        label "poi-1"
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   testclient:
     quantity: 1

--- a/src/test/config/convert/shadow.original.xml
+++ b/src/test/config/convert/shadow.original.xml
@@ -7,7 +7,7 @@
   <key attr.name="bandwidthup" attr.type="int" for="node" id="d2" />
   <key attr.name="bandwidthdown" attr.type="int" for="node" id="d1" />
   <key attr.name="countrycode" attr.type="string" for="node" id="d0" />
-  <graph edgedefault="undirected">
+  <graph edgedefault="directed">
     <data key="d5">True</data>
     <node id="poi-1">
       <data key="d0">US</data>

--- a/src/test/determinism/determinism1.test.shadow.config.yaml
+++ b/src/test/determinism/determinism1.test.shadow.config.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 5
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   testnode:
     quantity: 10

--- a/src/test/determinism/determinism2.test.shadow.config.yaml
+++ b/src/test/determinism/determinism2.test.shadow.config.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 10
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">250.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 250.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   peer:
     quantity: 10

--- a/src/test/phold/phold.yaml
+++ b/src/test/phold/phold.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 10
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   peer:
     quantity: 10

--- a/src/test/tcp/tcp-blocking-loopback.yaml
+++ b/src/test/tcp/tcp-blocking-loopback.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   tcptestnode:
     processes:

--- a/src/test/tcp/tcp-blocking-lossless.yaml
+++ b/src/test/tcp/tcp-blocking-lossless.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   lossless.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-blocking-lossy.yaml
+++ b/src/test/tcp/tcp-blocking-lossy.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.25</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.25
+      ]
+    ]
 hosts:
   lossy.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-iov-loopback.yaml
+++ b/src/test/tcp/tcp-iov-loopback.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 60
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   tcptestnode:
     processes:

--- a/src/test/tcp/tcp-iov-lossless.yaml
+++ b/src/test/tcp/tcp-iov-lossless.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 60
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   lossless.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-iov-lossy.yaml
+++ b/src/test/tcp/tcp-iov-lossy.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 60
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.25</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.25
+      ]
+    ]
 hosts:
   lossy.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-epoll-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-loopback.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   tcptestnode:
     processes:

--- a/src/test/tcp/tcp-nonblocking-epoll-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-lossless.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   lossless.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-epoll-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-lossy.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.25</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.25
+      ]
+    ]
 hosts:
   lossy.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-poll-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-loopback.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   tcptestnode:
     processes:

--- a/src/test/tcp/tcp-nonblocking-poll-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-lossless.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   lossless.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-poll-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-lossy.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.25</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.25
+      ]
+    ]
 hosts:
   lossy.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-select-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-loopback.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   tcptestnode:
     processes:

--- a/src/test/tcp/tcp-nonblocking-select-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-lossless.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   lossless.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-select-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-lossy.yaml
@@ -1,25 +1,22 @@
 general:
   stop_time: 300
 topology:
-  graphml: |
-    <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d4" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d3" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d2" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d1" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">US</data>
-          <data key="d1">81920 Kibit</data>
-          <data key="d2">81920 Kibit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d3">50.0</data>
-          <data key="d4">0.25</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        country_code "US"
+        bandwidth_down "81920 Kibit"
+        bandwidth_up "81920 Kibit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        packet_loss 0.25
+      ]
+    ]
 hosts:
   lossy.tcpserver.echo:
     processes:

--- a/src/test/tor/minimal/CMakeLists.txt
+++ b/src/test/tor/minimal/CMakeLists.txt
@@ -31,5 +31,5 @@ add_shadow_tests(BASENAME tor-minimal
                  PROPERTIES
                    TIMEOUT 180
                    LABELS tor
-                   CONFIGURATIONS tor
+                   CONFIGURATIONS extra
                    RUN_SERIAL TRUE)

--- a/src/test/tor/minimal/tor-minimal.yaml
+++ b/src/test/tor/minimal/tor-minimal.yaml
@@ -1,29 +1,24 @@
 general:
   stop_time: 30 min
 topology:
-  graphml: |-
-    <?xml version="1.0" encoding="utf-8"?><graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-      <key attr.name="packet_loss" attr.type="double" for="edge" id="d6" />
-      <key attr.name="jitter" attr.type="double" for="edge" id="d5" />
-      <key attr.name="latency" attr.type="double" for="edge" id="d4" />
-      <key attr.name="bandwidth_up" attr.type="string" for="node" id="d3" />
-      <key attr.name="bandwidth_down" attr.type="string" for="node" id="d2" />
-      <key attr.name="country_code" attr.type="string" for="node" id="d1" />
-      <key attr.name="ip_address" attr.type="string" for="node" id="d0" />
-      <graph edgedefault="undirected">
-        <node id="poi-1">
-          <data key="d0">0.0.0.0</data>
-          <data key="d1">US</data>
-          <data key="d2">1 Gbit</data>
-          <data key="d3">1 Gbit</data>
-        </node>
-        <edge source="poi-1" target="poi-1">
-          <data key="d4">50.0</data>
-          <data key="d5">0.0</data>
-          <data key="d6">0.0</data>
-        </edge>
-      </graph>
-    </graphml>
+  gml: |
+    graph [
+      directed 0
+      node [
+        id 0
+        ip_address "0.0.0.0"
+        country_code "US"
+        bandwidth_down "1 Gbit"
+        bandwidth_up "1 Gbit"
+      ]
+      edge [
+        source 0
+        target 0
+        latency 50.0
+        jitter 0.0
+        packet_loss 0.0
+      ]
+    ]
 hosts:
   fileserver:
     processes:

--- a/src/tools/convert_legacy_config.py
+++ b/src/tools/convert_legacy_config.py
@@ -295,15 +295,13 @@ def shadow_dict_post_processing(shadow: Dict):
             print("External topology file '{}' was not converted".format(path), file=sys.stderr)
 
         if 'graphml' in shadow['topology']:
-            tree = ET.ElementTree(ET.fromstring(shadow['topology']['graphml']))
-            convert_topology(tree.getroot())
-
-            # use write() so that we don't lose the xml declaration
+            graphml = shadow['topology'].pop('graphml')
+            tree = ET.ElementTree(ET.fromstring(graphml))
             new_topology = io.BytesIO()
-            tree.write(new_topology, encoding="utf-8", xml_declaration=True)
+            convert_topology(tree.getroot(), new_topology)
             new_topology.seek(0)
 
-            shadow['topology']['graphml'] = new_topology.read().decode("utf-8")
+            shadow['topology']['gml'] = new_topology.read().decode("utf-8")
 
 
 def print_deprecation_msg(field: str, value: str):


### PR DESCRIPTION
This changes igraph to read gml rather than graphml, the conversion scripts to write gml, and the test cases to use gml topologies. The conversion script now requires networkx version >= 2.5, so the config-convert test has been moved out of the required tests.

Part of #778.

Since igraph does not support graph attributes, the `prefers_direct_path` attribute is currently ignored. We plan to remove this attribute and [replace it](https://github.com/shadow/shadow/issues/778#issuecomment-843419313) with a shadow configuration option `use_shortest_path`.