### PR TITLE
Reorganized and renamed config topology field

### DIFF
--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -5,7 +5,9 @@ Example:
 ```yaml
 general:
   stop_time: 2 min
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   server:
     processes:
@@ -32,6 +34,9 @@ hosts:
 - [`general.stop_time`](#generalstop_time)
 - [`general.template_directory`](#generaltemplate_directory)
 - [`topology`](#topology)
+- [`topology.graph`](#topologygraph)
+- [`topology.graph.type`](#topologygraphtype)
+- [`topology.graph.<path|inline>`](#topologygraphpathinline)
 - [`experimental`](#experimental)
 - [`experimental.interface_buffer`](#experimentalinterface_buffer)
 - [`experimental.interface_qdisc`](#experimentalinterface_qdisc)
@@ -137,25 +142,45 @@ Path to recursively copy during startup and use as the data-directory.
 
 #### `topology`
 
-*Required*  
-Type: "graphml" OR "path" OR "1\_gbit\_switch"
+*Required*
 
-The topology can be specified as an inline GraphML string, a path to an external GraphML file, or a built-in "1\_gbit\_switch" topology with a single node.
+Network topology settings.
+
+#### `topology.graph`
+
+*Required*
+
+The network topology graph.
 
 The topology, a collection of nodes and edges that represent a network topology, should hold an undirected, connected graph with certain attributes specified on the nodes and edges. For more information on how to structure this data, see the [Topology Format](3.2-Network-Config.md).
-
-If the path begins with `~/`, it will be considered relative to the current user's home directory.
 
 Example:
 
 ```yaml
 topology:
-  graphml: |-
-    <?xml version="1.0" encoding="utf-8"?>
-    <graphml>
-      ...
-    </graphml>
+  graph:
+    type: gml
+    inline: |
+      graph [
+        ...
+      ]
 ```
+
+#### `topology.graph.type`
+
+*Required*  
+Type: "gml" OR "1\_gbit\_switch"
+
+The topology can be specified in the GML format, or a built-in "1\_gbit\_switch" topology with a single node can be used instead.
+
+#### `topology.graph.<path|inline>`
+
+*Required if `topology.graph.type` is `gml`*  
+Type: String
+
+If the topology type is not a built-in topology, the graph data can be specified as a path to an external file, or as an inline string.
+
+If a path is given and begins with `~/`, it will be considered relative to the current user's home directory.
 
 #### `experimental`
 

--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -5,7 +5,7 @@ Example:
 ```yaml
 general:
   stop_time: 2 min
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:
@@ -33,10 +33,10 @@ hosts:
 - [`general.seed`](#generalseed)
 - [`general.stop_time`](#generalstop_time)
 - [`general.template_directory`](#generaltemplate_directory)
-- [`topology`](#topology)
-- [`topology.graph`](#topologygraph)
-- [`topology.graph.type`](#topologygraphtype)
-- [`topology.graph.<path|inline>`](#topologygraphpathinline)
+- [`network`](#network)
+- [`network.graph`](#networkgraph)
+- [`network.graph.type`](#networkgraphtype)
+- [`network.graph.<path|inline>`](#networkgraphpathinline)
 - [`experimental`](#experimental)
 - [`experimental.interface_buffer`](#experimentalinterface_buffer)
 - [`experimental.interface_qdisc`](#experimentalinterface_qdisc)
@@ -140,24 +140,24 @@ Type: String OR null
 
 Path to recursively copy during startup and use as the data-directory.
 
-#### `topology`
+#### `network`
 
 *Required*
 
 Network topology settings.
 
-#### `topology.graph`
+#### `network.graph`
 
 *Required*
 
 The network topology graph.
 
-The topology, a collection of nodes and edges that represent a network topology, should hold an undirected, connected graph with certain attributes specified on the nodes and edges. For more information on how to structure this data, see the [Topology Format](3.2-Network-Config.md).
+A network topology represented by a connected graph with certain attributes specified on the nodes and edges. For more information on how to structure this data, see the [Topology Format](3.2-Network-Config.md).
 
 Example:
 
 ```yaml
-topology:
+network:
   graph:
     type: gml
     inline: |
@@ -166,19 +166,19 @@ topology:
       ]
 ```
 
-#### `topology.graph.type`
+#### `network.graph.type`
 
 *Required*  
 Type: "gml" OR "1\_gbit\_switch"
 
-The topology can be specified in the GML format, or a built-in "1\_gbit\_switch" topology with a single node can be used instead.
+The network graph can be specified in the GML format, or a built-in "1\_gbit\_switch" graph with a single node can be used instead.
 
-#### `topology.graph.<path|inline>`
+#### `network.graph.<path|inline>`
 
-*Required if `topology.graph.type` is `gml`*  
+*Required if `network.graph.type` is `gml`*  
 Type: String
 
-If the topology type is not a built-in topology, the graph data can be specified as a path to an external file, or as an inline string.
+If the network graph type is not a built-in network graph, the graph data can be specified as a path to an external file, or as an inline string.
 
 If a path is given and begins with `~/`, it will be considered relative to the current user's home directory.
 
@@ -400,7 +400,7 @@ Type: Object
 
 The simulated hosts which execute processes. Each field corresponds to a host configuration, with the field name being used as the network hostname.
 
-Shadow assigns each host to a node in the [topology](3.2-Network-Config.md).
+Shadow assigns each host to a node in the [network topology](3.2-Network-Config.md).
 
 #### `hosts.<hostname>.bandwidth_down`
 
@@ -409,7 +409,7 @@ Type: String OR Integer OR null
 
 Downstream bandwidth capacity of the host.
 
-Overrides any default bandwidth values set in the assigned topology node.
+Overrides any default bandwidth values set in the assigned network topology node.
 
 #### `hosts.<hostname>.bandwidth_up`
 
@@ -418,7 +418,7 @@ Type: String OR Integer OR null
 
 Upstream bandwidth capacity of the host.
 
-Overrides any default bandwidth values set in the assigned topology node.
+Overrides any default bandwidth values set in the assigned network topology node.
 
 #### `hosts.<hostname>.options`
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -190,7 +190,7 @@ uint64_t config_getInterfaceBuffer(const struct ConfigOptions *config);
 
 enum QDiscMode config_getInterfaceQdisc(const struct ConfigOptions *config);
 
-char *config_getTopology(const struct ConfigOptions *config);
+char *config_getTopologyGraph(const struct ConfigOptions *config);
 
 void config_iterHosts(const struct ConfigOptions *config,
                       void (*f)(const char*, const struct ConfigOptions*, const struct HostOptions*, void*),

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -190,7 +190,7 @@ uint64_t config_getInterfaceBuffer(const struct ConfigOptions *config);
 
 enum QDiscMode config_getInterfaceQdisc(const struct ConfigOptions *config);
 
-char *config_getTopologyGraph(const struct ConfigOptions *config);
+char *config_getNetworkGraph(const struct ConfigOptions *config);
 
 void config_iterHosts(const struct ConfigOptions *config,
                       void (*f)(const char*, const struct ConfigOptions*, const struct HostOptions*, void*),

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -158,7 +158,7 @@ static gboolean _controller_loadTopology(Controller* controller) {
     gchar* temporaryFilename =
         utility_getNewTemporaryFilename("shadow-topology-XXXXXX.gml");
 
-    char* topologyString = config_getTopologyGraph(controller->config);
+    char* topologyString = config_getNetworkGraph(controller->config);
 
     /* write the topology to a temporary file */
     GError* error = NULL;

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -158,7 +158,7 @@ static gboolean _controller_loadTopology(Controller* controller) {
     gchar* temporaryFilename =
         utility_getNewTemporaryFilename("shadow-topology-XXXXXX.gml");
 
-    char* topologyString = config_getTopology(controller->config);
+    char* topologyString = config_getTopologyGraph(controller->config);
 
     /* write the topology to a temporary file */
     GError* error = NULL;

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -50,7 +50,7 @@ pub struct CliOptions {
     general: GeneralOptions,
 
     #[clap(flatten)]
-    topology: TopologyOptions,
+    network: NetworkOptions,
 
     #[clap(flatten)]
     host_defaults: HostDefaultOptions,
@@ -65,7 +65,7 @@ pub struct CliOptions {
 pub struct ConfigFileOptions {
     general: GeneralOptions,
 
-    topology: TopologyOptions,
+    network: NetworkOptions,
 
     #[serde(default)]
     host_defaults: HostDefaultOptions,
@@ -82,7 +82,7 @@ pub struct ConfigFileOptions {
 pub struct ConfigOptions {
     general: GeneralOptions,
 
-    topology: TopologyOptions,
+    network: NetworkOptions,
 
     experimental: ExperimentalOptions,
 
@@ -94,7 +94,7 @@ impl ConfigOptions {
     pub fn new(mut config_file: ConfigFileOptions, options: CliOptions) -> Self {
         // override config options with command line options
         config_file.general = options.general.with_defaults(config_file.general);
-        config_file.topology = options.topology.with_defaults(config_file.topology);
+        config_file.network = options.network.with_defaults(config_file.network);
         config_file.host_defaults = options
             .host_defaults
             .with_defaults(config_file.host_defaults);
@@ -110,7 +110,7 @@ impl ConfigOptions {
 
         Self {
             general: config_file.general,
-            topology: config_file.topology,
+            network: config_file.network,
             experimental: config_file.experimental,
             hosts: config_file.hosts,
         }
@@ -188,21 +188,21 @@ impl GeneralOptions {
 
 /// Help messages used by Clap for command line arguments, combining the doc string with
 /// the Serde default.
-static TOPOLOGY_HELP: Lazy<std::collections::HashMap<String, String>> =
-    Lazy::new(|| generate_help_strs(schema_for!(TopologyOptions)));
+static NETWORK_HELP: Lazy<std::collections::HashMap<String, String>> =
+    Lazy::new(|| generate_help_strs(schema_for!(NetworkOptions)));
 
 // these must all be Option types since they aren't required by the CLI, even if they're
 // required in the configuration file
 #[derive(Debug, Clone, Clap, Serialize, Deserialize, Merge, JsonSchema)]
-#[clap(help_heading = "TOPOLOGY (Override topology options)")]
+#[clap(help_heading = "NETWORK (Override network options)")]
 #[serde(deny_unknown_fields)]
-struct TopologyOptions {
+struct NetworkOptions {
     /// The network topology graph
     #[clap(skip)]
     graph: Option<GraphOptions>,
 }
 
-impl TopologyOptions {
+impl NetworkOptions {
     /// Replace unset (`None`) values of `base` with values from `default`.
     pub fn with_defaults(mut self, default: Self) -> Self {
         self.merge(default);
@@ -1306,11 +1306,11 @@ mod export {
     }
 
     #[no_mangle]
-    pub extern "C" fn config_getTopologyGraph(config: *const ConfigOptions) -> *mut libc::c_char {
+    pub extern "C" fn config_getNetworkGraph(config: *const ConfigOptions) -> *mut libc::c_char {
         assert!(!config.is_null());
         let config = unsafe { &*config };
 
-        let graph = match config.topology.graph.as_ref().unwrap() {
+        let graph = match config.network.graph.as_ref().unwrap() {
             GraphOptions::Gml(CustomGraph::Path(f)) => std::fs::read_to_string(f).unwrap(),
             GraphOptions::Gml(CustomGraph::Inline(s)) => s.clone(),
             GraphOptions::OneGbitSwitch => ONE_GBIT_SWITCH_GRAPH.to_string(),

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -192,7 +192,7 @@ static EXP_HELP: Lazy<std::collections::HashMap<String, String>> =
 #[clap(
     help_heading = "EXPERIMENTAL (Unstable and may change or be removed at any time, regardless of Shadow version)"
 )]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ExperimentalOptions {
     /// Use the SCHED_FIFO scheduler. Requires CAP_SYS_NICE. See sched(7), capabilities(7)
     #[clap(long, value_name = "bool")]
@@ -339,7 +339,7 @@ static HOST_HELP: Lazy<std::collections::HashMap<String, String>> =
 
 #[derive(Debug, Clone, Clap, Serialize, Deserialize, Merge, JsonSchema)]
 #[clap(help_heading = "HOST DEFAULTS (Default options for hosts)")]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct HostDefaultOptions {
     /// Log level at which to print node messages
     #[clap(long = "host-log-level", name = "host-log-level")]

--- a/src/test/bindc/bindc.yaml
+++ b/src/test/bindc/bindc.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/bindc/bindc.yaml
+++ b/src/test/bindc/bindc.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/clone/clone.yaml
+++ b/src/test/clone/clone.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 10
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/clone/clone.yaml
+++ b/src/test/clone/clone.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 10
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/config/convert/CMakeLists.txt
+++ b/src/test/config/convert/CMakeLists.txt
@@ -15,13 +15,13 @@ add_test(
     && ${CMAKE_BINARY_DIR}/src/main/shadow -l debug -d shadow.data shadow.generated.yaml \
     "
     CONFIGURATIONS extra
-    DEPENDS "config-convert"
 )
+set_tests_properties(config-convert-run-shadow PROPERTIES DEPENDS "config-convert")
 
 # Ensure the format of the conversion is as expected
 add_test(
     NAME config-convert-check-format
     COMMAND diff -U 5 ${CMAKE_CURRENT_SOURCE_DIR}/shadow.expected.yaml shadow.generated.yaml
     CONFIGURATIONS extra
-    DEPENDS "config-convert"
 )
+set_tests_properties(config-convert-check-format PROPERTIES DEPENDS "config-convert")

--- a/src/test/config/convert/shadow.expected.yaml
+++ b/src/test/config/convert/shadow.expected.yaml
@@ -1,24 +1,26 @@
 general:
   stop_time: 3600
 topology:
-  gml: |
-    graph [
-      directed 1
-      prefer_direct_paths 1
-      node [
-        id 0
-        label "poi-1"
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 1
+        prefer_direct_paths 1
+        node [
+          id 0
+          label "poi-1"
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   testclient:
     quantity: 1

--- a/src/test/config/convert/shadow.expected.yaml
+++ b/src/test/config/convert/shadow.expected.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 3600
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/config/read_from_stdin/config-stdin.yaml
+++ b/src/test/config/read_from_stdin/config-stdin.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/config/read_from_stdin/config-stdin.yaml
+++ b/src/test/config/read_from_stdin/config-stdin.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testclient:
     processes:

--- a/src/test/cpp/cpp.yaml
+++ b/src/test/cpp/cpp.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/cpp/cpp.yaml
+++ b/src/test/cpp/cpp.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/determinism/determinism1.test.shadow.config.yaml
+++ b/src/test/determinism/determinism1.test.shadow.config.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/determinism/determinism1.test.shadow.config.yaml
+++ b/src/test/determinism/determinism1.test.shadow.config.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 5
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   testnode:
     quantity: 10

--- a/src/test/determinism/determinism2.test.shadow.config.yaml
+++ b/src/test/determinism/determinism2.test.shadow.config.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 10
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/determinism/determinism2.test.shadow.config.yaml
+++ b/src/test/determinism/determinism2.test.shadow.config.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 10
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 250.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 250.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   peer:
     quantity: 10

--- a/src/test/dynlink/dynlink.test.shadow.config.yaml
+++ b/src/test/dynlink/dynlink.test.shadow.config.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     quantity: 1

--- a/src/test/dynlink/dynlink.test.shadow.config.yaml
+++ b/src/test/dynlink/dynlink.test.shadow.config.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/epoll/epoll-writeable.yaml
+++ b/src/test/epoll/epoll-writeable.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 60
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/epoll/epoll-writeable.yaml
+++ b/src/test/epoll/epoll-writeable.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 60
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   server:
     processes:

--- a/src/test/epoll/epoll.yaml
+++ b/src/test/epoll/epoll.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/epoll/epoll.yaml
+++ b/src/test/epoll/epoll.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/eventfd/eventfd.yaml
+++ b/src/test/eventfd/eventfd.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 10
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/eventfd/eventfd.yaml
+++ b/src/test/eventfd/eventfd.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 10
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/file/file.yaml
+++ b/src/test/file/file.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/file/file.yaml
+++ b/src/test/file/file.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/futex/futex.yaml
+++ b/src/test/futex/futex.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 15
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/futex/futex.yaml
+++ b/src/test/futex/futex.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 15
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/ifaddrs/ifaddrs.yaml
+++ b/src/test/ifaddrs/ifaddrs.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     options:

--- a/src/test/ifaddrs/ifaddrs.yaml
+++ b/src/test/ifaddrs/ifaddrs.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/memory/mmap.yaml
+++ b/src/test/memory/mmap.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   mytesthost:
     processes:

--- a/src/test/memory/mmap.yaml
+++ b/src/test/memory/mmap.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/phold/phold.yaml
+++ b/src/test/phold/phold.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 10
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/phold/phold.yaml
+++ b/src/test/phold/phold.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 10
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   peer:
     quantity: 10

--- a/src/test/pipe/pipe.yaml
+++ b/src/test/pipe/pipe.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/pipe/pipe.yaml
+++ b/src/test/pipe/pipe.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/poll/poll.yaml
+++ b/src/test/poll/poll.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/poll/poll.yaml
+++ b/src/test/poll/poll.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/random/random.yaml
+++ b/src/test/random/random.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/random/random.yaml
+++ b/src/test/random/random.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/signal/signal.yaml
+++ b/src/test/signal/signal.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     quantity: 3

--- a/src/test/signal/signal.yaml
+++ b/src/test/signal/signal.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/sleep/sleep.yaml
+++ b/src/test/sleep/sleep.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 10
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/sleep/sleep.yaml
+++ b/src/test/sleep/sleep.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 10
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/sockbuf/sockbuf.yaml
+++ b/src/test/sockbuf/sockbuf.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 15
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/sockbuf/sockbuf.yaml
+++ b/src/test/sockbuf/sockbuf.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 15
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/accept/accept.yaml
+++ b/src/test/socket/accept/accept.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/accept/accept.yaml
+++ b/src/test/socket/accept/accept.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/bind/bind.yaml
+++ b/src/test/socket/bind/bind.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/bind/bind.yaml
+++ b/src/test/socket/bind/bind.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/connect/connect.yaml
+++ b/src/test/socket/connect/connect.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/connect/connect.yaml
+++ b/src/test/socket/connect/connect.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/getpeername/getpeername.yaml
+++ b/src/test/socket/getpeername/getpeername.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/getpeername/getpeername.yaml
+++ b/src/test/socket/getpeername/getpeername.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/getsockname/getsockname.yaml
+++ b/src/test/socket/getsockname/getsockname.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/getsockname/getsockname.yaml
+++ b/src/test/socket/getsockname/getsockname.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/ioctl/ioctl.yaml
+++ b/src/test/socket/ioctl/ioctl.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/ioctl/ioctl.yaml
+++ b/src/test/socket/ioctl/ioctl.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/listen/listen.yaml
+++ b/src/test/socket/listen/listen.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/listen/listen.yaml
+++ b/src/test/socket/listen/listen.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/sendto_recvfrom/sendto-recvfrom.yaml
+++ b/src/test/socket/sendto_recvfrom/sendto-recvfrom.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/sendto_recvfrom/sendto-recvfrom.yaml
+++ b/src/test/socket/sendto_recvfrom/sendto-recvfrom.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/shutdown/shutdown.yaml
+++ b/src/test/socket/shutdown/shutdown.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/shutdown/shutdown.yaml
+++ b/src/test/socket/shutdown/shutdown.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/socket/socket.yaml
+++ b/src/test/socket/socket/socket.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/socket/socket.yaml
+++ b/src/test/socket/socket/socket.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/socketpair/socketpair.yaml
+++ b/src/test/socket/socketpair/socketpair.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/socketpair/socketpair.yaml
+++ b/src/test/socket/socketpair/socketpair.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/socket/sockopt/sockopt.yaml
+++ b/src/test/socket/sockopt/sockopt.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/socket/sockopt/sockopt.yaml
+++ b/src/test/socket/sockopt/sockopt.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/tcp/tcp-blocking-loopback.yaml
+++ b/src/test/tcp/tcp-blocking-loopback.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-blocking-loopback.yaml
+++ b/src/test/tcp/tcp-blocking-loopback.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   tcptestnode:
     processes:

--- a/src/test/tcp/tcp-blocking-lossless.yaml
+++ b/src/test/tcp/tcp-blocking-lossless.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   lossless.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-blocking-lossless.yaml
+++ b/src/test/tcp/tcp-blocking-lossless.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-blocking-lossy.yaml
+++ b/src/test/tcp/tcp-blocking-lossy.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-blocking-lossy.yaml
+++ b/src/test/tcp/tcp-blocking-lossy.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.25
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.25
-      ]
-    ]
 hosts:
   lossy.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-iov-loopback.yaml
+++ b/src/test/tcp/tcp-iov-loopback.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 60
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-iov-loopback.yaml
+++ b/src/test/tcp/tcp-iov-loopback.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 60
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   tcptestnode:
     processes:

--- a/src/test/tcp/tcp-iov-lossless.yaml
+++ b/src/test/tcp/tcp-iov-lossless.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 60
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   lossless.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-iov-lossless.yaml
+++ b/src/test/tcp/tcp-iov-lossless.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 60
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-iov-lossy.yaml
+++ b/src/test/tcp/tcp-iov-lossy.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 60
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-iov-lossy.yaml
+++ b/src/test/tcp/tcp-iov-lossy.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 60
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.25
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.25
-      ]
-    ]
 hosts:
   lossy.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-epoll-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-loopback.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-nonblocking-epoll-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-loopback.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   tcptestnode:
     processes:

--- a/src/test/tcp/tcp-nonblocking-epoll-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-lossless.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   lossless.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-epoll-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-lossless.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-nonblocking-epoll-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-lossy.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-nonblocking-epoll-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-lossy.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.25
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.25
-      ]
-    ]
 hosts:
   lossy.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-poll-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-loopback.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-nonblocking-poll-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-loopback.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   tcptestnode:
     processes:

--- a/src/test/tcp/tcp-nonblocking-poll-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-lossless.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   lossless.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-poll-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-lossless.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-nonblocking-poll-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-lossy.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-nonblocking-poll-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-lossy.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.25
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.25
-      ]
-    ]
 hosts:
   lossy.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-select-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-loopback.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-nonblocking-select-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-loopback.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   tcptestnode:
     processes:

--- a/src/test/tcp/tcp-nonblocking-select-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-lossless.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   lossless.tcpserver.echo:
     processes:

--- a/src/test/tcp/tcp-nonblocking-select-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-lossless.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-nonblocking-select-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-lossy.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 300
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/tcp/tcp-nonblocking-select-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-lossy.yaml
@@ -1,22 +1,24 @@
 general:
   stop_time: 300
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        country_code "US"
-        bandwidth_down "81920 Kibit"
-        bandwidth_up "81920 Kibit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          country_code "US"
+          bandwidth_down "81920 Kibit"
+          bandwidth_up "81920 Kibit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          packet_loss 0.25
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        packet_loss 0.25
-      ]
-    ]
 hosts:
   lossy.tcpserver.echo:
     processes:

--- a/src/test/threads/pthreads.yaml
+++ b/src/test/threads/pthreads.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 2
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/threads/pthreads.yaml
+++ b/src/test/threads/pthreads.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 2
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/threads/threads-group-leader-exits.yaml
+++ b/src/test/threads/threads-group-leader-exits.yaml
@@ -1,7 +1,7 @@
 general:
   # Should be greater than NUM_SECONDS from test_threads_group_leader_exits.rs
   stop_time: 10
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/threads/threads-group-leader-exits.yaml
+++ b/src/test/threads/threads-group-leader-exits.yaml
@@ -1,7 +1,9 @@
 general:
   # Should be greater than NUM_SECONDS from test_threads_group_leader_exits.rs
   stop_time: 10
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/threads/threads-noexit.yaml
+++ b/src/test/threads/threads-noexit.yaml
@@ -1,7 +1,9 @@
 general:
   # Should be less than NUM_SECONDS from test_threads_noexit.rs
   stop_time: 2
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/threads/threads-noexit.yaml
+++ b/src/test/threads/threads-noexit.yaml
@@ -1,7 +1,7 @@
 general:
   # Should be less than NUM_SECONDS from test_threads_noexit.rs
   stop_time: 2
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/timerfd/timerfd.yaml
+++ b/src/test/timerfd/timerfd.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 15
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/timerfd/timerfd.yaml
+++ b/src/test/timerfd/timerfd.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 15
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/test/tor/minimal/tor-minimal.yaml
+++ b/src/test/tor/minimal/tor-minimal.yaml
@@ -1,24 +1,26 @@
 general:
   stop_time: 30 min
 topology:
-  gml: |
-    graph [
-      directed 0
-      node [
-        id 0
-        ip_address "0.0.0.0"
-        country_code "US"
-        bandwidth_down "1 Gbit"
-        bandwidth_up "1 Gbit"
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          ip_address "0.0.0.0"
+          country_code "US"
+          bandwidth_down "1 Gbit"
+          bandwidth_up "1 Gbit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency 50.0
+          jitter 0.0
+          packet_loss 0.0
+        ]
       ]
-      edge [
-        source 0
-        target 0
-        latency 50.0
-        jitter 0.0
-        packet_loss 0.0
-      ]
-    ]
 hosts:
   fileserver:
     processes:

--- a/src/test/tor/minimal/tor-minimal.yaml
+++ b/src/test/tor/minimal/tor-minimal.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 30 min
-topology:
+network:
   graph:
     type: gml
     inline: |

--- a/src/test/udp/udp-uniprocess.yaml
+++ b/src/test/udp/udp-uniprocess.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/udp/udp-uniprocess.yaml
+++ b/src/test/udp/udp-uniprocess.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   node1:
     processes:

--- a/src/test/udp/udp.yaml
+++ b/src/test/udp/udp.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/udp/udp.yaml
+++ b/src/test/udp/udp.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   localnode:
     processes:

--- a/src/test/unistd/unistd.yaml
+++ b/src/test/unistd/unistd.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-topology:
+network:
   graph:
     type: 1_gbit_switch
 hosts:

--- a/src/test/unistd/unistd.yaml
+++ b/src/test/unistd/unistd.yaml
@@ -1,6 +1,8 @@
 general:
   stop_time: 5
-topology: 1_gbit_switch
+topology:
+  graph:
+    type: 1_gbit_switch
 hosts:
   testnode:
     processes:

--- a/src/tools/convert_legacy_config.py
+++ b/src/tools/convert_legacy_config.py
@@ -17,6 +17,7 @@ from convert_legacy_topology import convert_topology
 
 XML_TAGS_TO_YAML = {
     'plugin': 'plugins',
+    'topology': 'network',
     'host': 'hosts',
     'node': 'hosts',
     'process': 'processes',
@@ -286,33 +287,33 @@ def shadow_dict_post_processing(shadow: Dict):
                         process['environment'] = ''
                     process['environment'] = append_ld_preload(process['environment'], preload_path)
 
-    if 'topology' in shadow:
-        assert len(shadow['topology']) == 1, "Invalid input: there is more than one topology"
-        shadow['topology'] = shadow['topology'][0]
+    if 'network' in shadow:
+        assert len(shadow['network']) == 1, "Invalid input: there is more than one topology"
+        shadow['network'] = shadow['network'][0]
 
         path = None
         gml = None
 
-        if 'path' in shadow['topology']:
-            path = shadow['topology'].pop('path')
+        if 'path' in shadow['network']:
+            path = shadow['network'].pop('path')
             print("External topology file '{}' was not converted".format(path), file=sys.stderr)
 
-        if 'graphml' in shadow['topology']:
-            graphml = shadow['topology'].pop('graphml')
+        if 'graphml' in shadow['network']:
+            graphml = shadow['network'].pop('graphml')
             tree = ET.ElementTree(ET.fromstring(graphml))
             new_topology = io.BytesIO()
             convert_topology(tree.getroot(), new_topology)
             new_topology.seek(0)
             gml = new_topology.read().decode("utf-8")
 
-        shadow['topology']['graph'] = {}
-        shadow['topology']['graph']['type'] = 'gml'
+        shadow['network']['graph'] = {}
+        shadow['network']['graph']['type'] = 'gml'
 
         if path is not None:
-            shadow['topology']['graph']['path'] = path
+            shadow['network']['graph']['path'] = path
 
         if gml is not None:
-            shadow['topology']['graph']['inline'] = gml
+            shadow['network']['graph']['inline'] = gml
 
 
 def print_deprecation_msg(field: str, value: str):

--- a/src/tools/convert_legacy_config.py
+++ b/src/tools/convert_legacy_config.py
@@ -290,8 +290,11 @@ def shadow_dict_post_processing(shadow: Dict):
         assert len(shadow['topology']) == 1, "Invalid input: there is more than one topology"
         shadow['topology'] = shadow['topology'][0]
 
+        path = None
+        gml = None
+
         if 'path' in shadow['topology']:
-            path = shadow['topology']['path']
+            path = shadow['topology'].pop('path')
             print("External topology file '{}' was not converted".format(path), file=sys.stderr)
 
         if 'graphml' in shadow['topology']:
@@ -300,8 +303,16 @@ def shadow_dict_post_processing(shadow: Dict):
             new_topology = io.BytesIO()
             convert_topology(tree.getroot(), new_topology)
             new_topology.seek(0)
+            gml = new_topology.read().decode("utf-8")
 
-            shadow['topology']['gml'] = new_topology.read().decode("utf-8")
+        shadow['topology']['graph'] = {}
+        shadow['topology']['graph']['type'] = 'gml'
+
+        if path is not None:
+            shadow['topology']['graph']['path'] = path
+
+        if gml is not None:
+            shadow['topology']['graph']['inline'] = gml
 
 
 def print_deprecation_msg(field: str, value: str):


### PR DESCRIPTION
Renames the 'topology' field to 'network', and changes the structure of this field.

Part of #778.

For example:

```yaml
topology:
  gml: |
    graph [ ... ]
```

is now:

```yaml
network:
  graph:
    type: gml
    inline: |
      graph [ ... ]
```