### PR TITLE
Removed the 'prefer_direct_paths' topology option and added the 'use_shortest_path' config option

### DIFF
--- a/docs/3.1-Shadow-Config.md
+++ b/docs/3.1-Shadow-Config.md
@@ -37,6 +37,7 @@ hosts:
 - [`network.graph`](#networkgraph)
 - [`network.graph.type`](#networkgraphtype)
 - [`network.graph.<path|inline>`](#networkgraphpathinline)
+- [`network.use_shortest_path`](#networkuse_shortest_path)
 - [`experimental`](#experimental)
 - [`experimental.interface_buffer`](#experimentalinterface_buffer)
 - [`experimental.interface_qdisc`](#experimentalinterface_qdisc)
@@ -181,6 +182,13 @@ Type: String
 If the network graph type is not a built-in network graph, the graph data can be specified as a path to an external file, or as an inline string.
 
 If a path is given and begins with `~/`, it will be considered relative to the current user's home directory.
+
+#### `network.use_shortest_path`
+
+*Required*
+Type: Bool
+
+When routing packets, follow the shortest path rather than following a direct edge between nodes. If false, the network graph is required to be complete.
 
 #### `experimental`
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -192,6 +192,8 @@ enum QDiscMode config_getInterfaceQdisc(const struct ConfigOptions *config);
 
 char *config_getNetworkGraph(const struct ConfigOptions *config);
 
+bool config_getUseShortestPath(const struct ConfigOptions *config);
+
 void config_iterHosts(const struct ConfigOptions *config,
                       void (*f)(const char*, const struct ConfigOptions*, const struct HostOptions*, void*),
                       void *data);

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -170,7 +170,7 @@ static gboolean _controller_loadTopology(Controller* controller) {
     config_freeString(topologyString);
 
     /* initialize global routing model */
-    controller->topology = topology_new(temporaryFilename);
+    controller->topology = topology_new(temporaryFilename, config_getUseShortestPath(controller->config));
     g_unlink(temporaryFilename);
 
     if (!controller->topology) {

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -200,6 +200,13 @@ struct NetworkOptions {
     /// The network topology graph
     #[clap(skip)]
     graph: Option<GraphOptions>,
+
+    /// When routing packets, follow the shortest path rather than following a direct
+    /// edge between nodes. If false, the network graph is required to be complete.
+    #[serde(default = "default_some_true")]
+    #[clap(long, value_name = "bool")]
+    #[clap(about = NETWORK_HELP.get("use_shortest_path").unwrap())]
+    use_shortest_path: Option<bool>,
 }
 
 impl NetworkOptions {
@@ -1317,6 +1324,14 @@ mod export {
         };
 
         CString::into_raw(CString::new(graph).unwrap())
+    }
+
+    #[no_mangle]
+    pub extern "C" fn config_getUseShortestPath(config: *const ConfigOptions) -> bool {
+        assert!(!config.is_null());
+        let config = unsafe { &*config };
+
+        config.network.use_shortest_path.unwrap()
     }
 
     #[no_mangle]

--- a/src/main/routing/topology.h
+++ b/src/main/routing/topology.h
@@ -14,7 +14,7 @@
 
 typedef struct _Topology Topology;
 
-Topology* topology_new(const gchar* graphPath);
+Topology* topology_new(const gchar* graphPath, gboolean useShortestPath);
 void topology_free(Topology* top);
 
 void topology_attach(Topology* top, Address* address, Random* randomSourcePool, gchar* ipHint,

--- a/src/test/config/convert/CMakeLists.txt
+++ b/src/test/config/convert/CMakeLists.txt
@@ -2,26 +2,45 @@ add_executable(test-config-convert test_config.c)
 
 # Convert an XML file to YAML
 add_test(
-    NAME config-convert
+    NAME convert-config
     COMMAND python3 ${CMAKE_SOURCE_DIR}/src/tools/convert_legacy_config.py --output shadow.generated.yaml ${CMAKE_CURRENT_SOURCE_DIR}/shadow.original.xml
     CONFIGURATIONS extra
 )
 
 # Launch Shadow to ensure that the previously generated YAML is correct
 add_test(
-    NAME config-convert-run-shadow
+    NAME convert-config-run-shadow
     COMMAND sh -c "\
     rm -rf shadow.data \
     && ${CMAKE_BINARY_DIR}/src/main/shadow -l debug -d shadow.data shadow.generated.yaml \
     "
     CONFIGURATIONS extra
 )
-set_tests_properties(config-convert-run-shadow PROPERTIES DEPENDS "config-convert")
+set_tests_properties(convert-config-run-shadow PROPERTIES DEPENDS "convert-config")
 
 # Ensure the format of the conversion is as expected
 add_test(
-    NAME config-convert-check-format
+    NAME convert-config-check-format
     COMMAND diff -U 5 ${CMAKE_CURRENT_SOURCE_DIR}/shadow.expected.yaml shadow.generated.yaml
     CONFIGURATIONS extra
 )
-set_tests_properties(config-convert-check-format PROPERTIES DEPENDS "config-convert")
+set_tests_properties(convert-config-check-format PROPERTIES DEPENDS "convert-config")
+
+# Convert a GraphML file to GML
+add_test(
+    NAME convert-topology
+    COMMAND sh -c "\
+    ${CMAKE_SOURCE_DIR}/src/tools/convert_legacy_topology.py \
+    ${CMAKE_CURRENT_SOURCE_DIR}/topology.original.xml \
+    > topology.generated.gml \
+    "
+    CONFIGURATIONS extra
+)
+
+# Ensure the format of the conversion is as expected
+add_test(
+    NAME convert-topology-check-format
+    COMMAND diff -U 5 ${CMAKE_CURRENT_SOURCE_DIR}/topology.expected.gml topology.generated.gml
+    CONFIGURATIONS extra
+)
+set_tests_properties(convert-topology-check-format PROPERTIES DEPENDS "convert-topology")

--- a/src/test/config/convert/shadow.expected.yaml
+++ b/src/test/config/convert/shadow.expected.yaml
@@ -1,12 +1,12 @@
 general:
   stop_time: 3600
 network:
+  use_shortest_path: false
   graph:
     type: gml
     inline: |
       graph [
         directed 1
-        prefer_direct_paths 1
         node [
           id 0
           label "poi-1"

--- a/src/test/config/convert/topology.expected.gml
+++ b/src/test/config/convert/topology.expected.gml
@@ -1,0 +1,17 @@
+graph [
+  directed 1
+  prefer_direct_paths 1
+  node [
+    id 0
+    label "poi-1"
+    country_code "US"
+    bandwidth_down "81920 Kibit"
+    bandwidth_up "81920 Kibit"
+  ]
+  edge [
+    source 0
+    target 0
+    latency 50.0
+    packet_loss 0.0
+  ]
+]

--- a/src/test/config/convert/topology.expected.gml
+++ b/src/test/config/convert/topology.expected.gml
@@ -1,6 +1,5 @@
 graph [
   directed 1
-  prefer_direct_paths 1
   node [
     id 0
     label "poi-1"

--- a/src/test/config/convert/topology.original.xml
+++ b/src/test/config/convert/topology.original.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='utf-8'?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+  <key attr.name="preferdirectpaths" attr.type="string" for="graph" id="d5" />
+  <key attr.name="packetloss" attr.type="double" for="edge" id="d4" />
+  <key attr.name="latency" attr.type="double" for="edge" id="d3" />
+  <key attr.name="bandwidthup" attr.type="int" for="node" id="d2" />
+  <key attr.name="bandwidthdown" attr.type="int" for="node" id="d1" />
+  <key attr.name="countrycode" attr.type="string" for="node" id="d0" />
+  <graph edgedefault="directed">
+    <data key="d5">True</data>
+    <node id="poi-1">
+      <data key="d0">US</data>
+      <data key="d1">10240</data>
+      <data key="d2">10240</data>
+    </node>
+    <edge source="poi-1" target="poi-1">
+      <data key="d3">50.0</data>
+      <data key="d4">0.0</data>
+    </edge>
+  </graph>
+</graphml>

--- a/src/tools/convert_legacy_config.py
+++ b/src/tools/convert_legacy_config.py
@@ -302,9 +302,17 @@ def shadow_dict_post_processing(shadow: Dict):
             graphml = shadow['network'].pop('graphml')
             tree = ET.ElementTree(ET.fromstring(graphml))
             new_topology = io.BytesIO()
-            convert_topology(tree.getroot(), new_topology)
+            removed_graph_data = convert_topology(tree.getroot(), new_topology)
             new_topology.seek(0)
             gml = new_topology.read().decode("utf-8")
+
+            if 'preferdirectpaths' in removed_graph_data:
+                value = removed_graph_data.pop('preferdirectpaths')
+                value = True if value.lower() == 'true' else False
+                shadow['network']['use_shortest_path'] = not value
+
+            for removed in removed_graph_data:
+                print_deprecation_msg(removed, removed_graph_data[removed])
 
         shadow['network']['graph'] = {}
         shadow['network']['graph']['type'] = 'gml'


### PR DESCRIPTION
Removes the `prefer_direct_paths` topology option and adds a `use_shortest_path` config file option (can also set on the command line).

Part of #778.

The `use_shortest_path` option is essentially the opposite of the `prefer_direct_paths`, but `use_shortest_path` can only be set to false if the graph is complete.

Previously if the graph was complete, Shadow would always use the direct path rather than the shortest path (regardless of the `prefer_direct_paths` setting). Now Shadow requires you to set `use_shortest_path` to false even if using a complete graph.