### PR TITLE
Add the 'use_legacy_working_dir' experimental option

### DIFF
--- a/docs/shadow_config.md
+++ b/docs/shadow_config.md
@@ -51,6 +51,7 @@ hosts:
 - [`experimental.socket_send_buffer`](#experimentalsocket_send_buffer)
 - [`experimental.use_cpu_pinning`](#experimentaluse_cpu_pinning)
 - [`experimental.use_explicit_block_message`](#experimentaluse_explicit_block_message)
+- [`experimental.use_legacy_working_dir`](#experimentaluse_legacy_working_dir)
 - [`experimental.use_memory_manager`](#experimentaluse_memory_manager)
 - [`experimental.use_o_n_waitpid_workarounds`](#experimentaluse_o_n_waitpid_workarounds)
 - [`experimental.use_object_counters`](#experimentaluse_object_counters)
@@ -279,6 +280,13 @@ Default: false
 Type: Bool
 
 Send message to plugin telling it to stop spinning when a syscall blocks.
+
+#### `experimental.use_legacy_working_dir`
+
+Default: false  
+Type: Bool
+
+Don't adjust the working directories of the plugins.
 
 #### `experimental.use_memory_manager`
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -198,6 +198,8 @@ uint64_t config_getInterfaceBuffer(const struct ConfigOptions *config);
 
 enum QDiscMode config_getInterfaceQdisc(const struct ConfigOptions *config);
 
+bool config_getUseLegacyWorkingDir(const struct ConfigOptions *config);
+
 char *config_getNetworkGraph(const struct ConfigOptions *config);
 
 bool config_getUseShortestPath(const struct ConfigOptions *config);

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -328,6 +328,11 @@ pub struct ExperimentalOptions {
     #[clap(long, value_name = "N")]
     #[clap(about = EXP_HELP.get("worker_threads").unwrap())]
     worker_threads: Option<NonZeroU32>,
+
+    /// Don't adjust the working directories of the plugins
+    #[clap(long, value_name = "bool")]
+    #[clap(about = EXP_HELP.get("use_legacy_working_dir").unwrap())]
+    use_legacy_working_dir: Option<bool>,
 }
 
 impl ExperimentalOptions {
@@ -360,6 +365,7 @@ impl Default for ExperimentalOptions {
             interface_buffer: Some(units::Bytes::new(1_024_000, units::SiPrefixUpper::Base)),
             interface_qdisc: Some(QDiscMode::Fifo),
             worker_threads: None,
+            use_legacy_working_dir: Some(false),
         }
     }
 }
@@ -1308,6 +1314,13 @@ mod export {
         let config = unsafe { &*config };
 
         config.experimental.interface_qdisc.unwrap()
+    }
+
+    #[no_mangle]
+    pub extern "C" fn config_getUseLegacyWorkingDir(config: *const ConfigOptions) -> bool {
+        assert!(!config.is_null());
+        let config = unsafe { &*config };
+        config.experimental.use_legacy_working_dir.unwrap()
     }
 
     #[no_mangle]


### PR DESCRIPTION
This option is meant to help run experiments that compare the performance of different versions of Shadow. We have scripts that convert legacy experiment files (xml & graphml) to the new format (yaml & gml), but these scripts don't correct for the different working directories of plugins. This new experimental option allows you to use the same working directory as Shadow 1.x. For example, if old tornettools experiments are converted to the new configuration/graph formats, they should also use this option.