### PR TITLE
More small documentation changes, and install cargo/rustc from rustup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Rust packages
         run: |
           rustup component add rustfmt
-          # when updating these versions, also update the versions in "docs/5-Developer-Guide.md"
+          # when updating these versions, also update the versions in "docs/developer_guide.md"
           cargo install --force --version 0.18.0 cbindgen
           cargo install --force --version 0.57.0 bindgen
       - name: Check bindings (release)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,6 @@ The docs contain important information about installing and using the Shadow dis
    * Developer Guides
      * [Debugging and profiling](developer_guide.md)
      * [Continous integration tests](ci.md)
-   * Advanced usage
      * [Using a recompiled libc](using_recompiled_libc.md) to get higher libc
        API coverage using preload interposition.
  * The Shadow project

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -18,6 +18,8 @@ cargo install --force --version 0.18.0 cbindgen
 cargo install --force --version 0.57.0 bindgen
 ```
 
+The versions of bindgen and cbindgen you install should match the [versions installed in the CI](https://github.com/shadow/shadow/blob/dev/.github/workflows/lint.yml).
+
 ## Extra tests
 
 Shadow includes tests that require additional dependencies, such as Tor, TGen, and networkx. These aren't run by default, but are run as part of the CI tests. To run them locally, first make sure that both tor and tgen are located at `~/.shadow/bin/{tor,tgen}`. These can be symlinks to tor and tgen binaries elsewhere in the filesystem. You should also install all of Shadow's optional dependencies.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -18,15 +18,19 @@ cargo install --force --version 0.18.0 cbindgen
 cargo install --force --version 0.57.0 bindgen
 ```
 
-## Tor tests
+## Extra tests
 
-Shadow includes tests that use Tor and TGen. These are not run by default. To run them, first make sure that both tor and tgen are located at `~/.shadow/bin/{tor,tgen}`. These can be symlinks to tor and tgen binaries elsewhere in the filesystem. It is recommended to build Shadow in release mode, otherwise the tests may take much longer to complete.
+Shadow includes tests that require additional dependencies, such as Tor, TGen, and networkx. These aren't run by default, but are run as part of the CI tests. To run them locally, first make sure that both tor and tgen are located at `~/.shadow/bin/{tor,tgen}`. These can be symlinks to tor and tgen binaries elsewhere in the filesystem. You should also install all of Shadow's optional dependencies.
+
+It is recommended to build Shadow in release mode, otherwise the Tor tests may not complete before the timeout.
 
 ```bash
-./setup test -- --build-config extra --label-regex tor
+./setup test -- --build-config extra
+# To exclude the Tor tests (for example if you built Shadow in debug mode)
+./setup test -- --build-config extra --label-exclude tor
 ```
 
-If you change the tor version by updating the version at `~/.shadow/bin/tor`, make sure to re-run `./setup build --test`.
+If you change the version of tor located at `~/.shadow/bin/tor`, make sure to re-run `./setup build --test`.
 
 ## Debugging
 

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -8,7 +8,6 @@
   + cmake (version >= 3.2)
   + make
   + xz-utils
-  + glibc debuginfo
   + procps
   + cargo, rustc (version \~ latest)
 

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -18,6 +18,43 @@
 #### Recommended System Tools:
   + git, dstat, screen, htop
 
+### APT (Debian/Ubuntu):
+
+```bash
+sudo apt-get install -y \
+    cmake \
+    findutils \
+    libc-dbg \
+    libglib2.0-0 \
+    libglib2.0-dev \
+    libigraph0-dev \
+    libigraph0v5 \
+    libprocps-dev \
+    make \
+    python3 \
+    python3-pip \
+    xz-utils \
+    gcc \
+    g++ \
+    cargo
+
+# Optional dependencies
+
+sudo apt-get install -y \
+    python3-numpy \
+    python3-lxml \
+    python3-matplotlib \
+    python3-networkx \
+    python3-scipy \
+    python3-yaml
+
+sudo apt-get install -y \
+    dstat \
+    git \
+    htop \
+    screen
+```
+
 ### YUM (Fedora/CentOS):
 
 In more recent versions of Fedora and CentOS, `yum` can be exchanged for `dnf` in these commands.
@@ -93,41 +130,4 @@ dnf install -y http://vault.centos.org/centos/7.7.1908/os/x86_64/Packages/procps
 dnf install -y http://vault.centos.org/centos/7.7.1908/os/x86_64/Packages/procps-ng-devel-3.3.10-26.el7.x86_64.rpm
 dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages/i/igraph-0.7.1-12.el7.x86_64.rpm
 dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages/i/igraph-devel-0.7.1-12.el7.x86_64.rpm
-```
-
-### APT (Debian/Ubuntu):
-
-```bash
-sudo apt-get install -y \
-    cmake \
-    findutils \
-    libc-dbg \
-    libglib2.0-0 \
-    libglib2.0-dev \
-    libigraph0-dev \
-    libigraph0v5 \
-    libprocps-dev \
-    make \
-    python3 \
-    python3-pip \
-    xz-utils \
-    gcc \
-    g++ \
-    cargo
-
-# Optional dependencies
-
-sudo apt-get install -y \
-    python3-numpy \
-    python3-lxml \
-    python3-matplotlib \
-    python3-networkx \
-    python3-scipy \
-    python3-yaml
-
-sudo apt-get install -y \
-    dstat \
-    git \
-    htop \
-    screen
 ```

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -10,7 +10,7 @@
   + xz-utils
   + glibc debuginfo
   + procps
-  + cargo
+  + cargo, rustc
 
 #### Recommended Python Modules (for helper/analysis scripts):
   + numpy, scipy, matplotlib, networkx, lxml, pyyaml
@@ -18,12 +18,12 @@
 #### Recommended System Tools:
   + git, dstat, screen, htop
 
-#### YUM (Fedora/CentOS):
+### YUM (Fedora/CentOS):
 
 In more recent versions of Fedora and CentOS, `yum` can be exchanged for `dnf` in these commands.
 Before running these commands, please check any platform-specific requirements below.
 
-**Warning:** YUM and DNF often install 32-bit (`i686`) versions of libraries. You may want to use the `--best` option to make sure you're installing the 64-bit (`x86_64`) versions, which are required by Shadow.
+**Warning:** `yum` and `dnf` often install 32-bit (`i686`) versions of libraries. You may want to use the `--best` option to make sure you're installing the 64-bit (`x86_64`) versions, which are required by Shadow.
 
 ```bash
 sudo yum install -y \
@@ -44,6 +44,9 @@ sudo yum install -y \
     gcc \
     gcc-c++ \
     cargo
+
+# Optional dependencies
+
 sudo yum install -y \
     python3-numpy \
     python3-lxml \
@@ -51,6 +54,7 @@ sudo yum install -y \
     python3-networkx \
     python3-scipy \
     python3-yaml
+
 sudo yum install -y \
     dstat \
     git \
@@ -58,7 +62,7 @@ sudo yum install -y \
     screen
 ```
 
-##### CentOS 7
+#### CentOS 7
 
 You must enable the EPEL repository using:
 
@@ -79,7 +83,7 @@ alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 \
 
 As cargo is not available on CentOS 7, you can install cargo following the steps at https://rustup.rs/.
 
-##### CentOS 8
+#### CentOS 8
 
 As procps-ng-devel, igraph, and igraph-devel are not available on CentOS 8, you must install them manually.
 
@@ -91,9 +95,7 @@ dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages
 dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages/i/igraph-devel-0.7.1-12.el7.x86_64.rpm
 ```
 
-#### APT (Debian/Ubuntu):
-
-Before running these commands, please check any platform-specific requirements below.
+### APT (Debian/Ubuntu):
 
 ```bash
 sudo apt-get install -y \
@@ -112,6 +114,9 @@ sudo apt-get install -y \
     gcc \
     g++ \
     cargo
+
+# Optional dependencies
+
 sudo apt-get install -y \
     python3-numpy \
     python3-lxml \
@@ -119,6 +124,7 @@ sudo apt-get install -y \
     python3-networkx \
     python3-scipy \
     python3-yaml
+
 sudo apt-get install -y \
     dstat \
     git \

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -10,7 +10,7 @@
   + xz-utils
   + glibc debuginfo
   + procps
-  + cargo, rustc
+  + cargo, rustc (version \~ latest)
 
 #### Recommended Python Modules (for helper/analysis scripts):
   + numpy, scipy, matplotlib, networkx, lxml, pyyaml
@@ -35,8 +35,10 @@ sudo apt-get install -y \
     python3-pip \
     xz-utils \
     gcc \
-    g++ \
-    cargo
+    g++
+
+# rustup: https://rustup.rs
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # Optional dependencies
 
@@ -79,8 +81,10 @@ sudo yum install -y \
     yum-utils \
     diffutils \
     gcc \
-    gcc-c++ \
-    cargo
+    gcc-c++
+
+# rustup: https://rustup.rs
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # Optional dependencies
 
@@ -117,8 +121,6 @@ alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 \
     --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 \
     --family cmake
 ```
-
-As cargo is not available on CentOS 7, you can install cargo following the steps at https://rustup.rs/.
 
 #### CentOS 8
 


### PR DESCRIPTION
Mostly small changes, and the APT and DNF/YUM install instructions were re-ordered since the APT instructions are much simpler and shorter.

This also changes the installation docs to install cargo from rustup rather than from the distribution packages. On Debian stable the version of rustc is almost a year and a half old, and Ubuntu [doesn't recommend](https://wiki.ubuntu.com/FoundationsTeam/RustUpdates) using rustc and cargo from the distribution. Shadow currently uses features that aren't available in these versions, and I don't think there's a good reason to hold ourselves back to an older rust version.