### PR TITLE
Pass references explicitly instead of getting from global Worker

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -284,6 +284,18 @@ const WorkerC *workerref_raw(struct WorkerRef *worker_ref);
 // ID of the current thread's Worker. Panics if the thread has no Worker.
 int32_t worker_threadID(void);
 
+void worker_setActiveHost(Host *host);
+
+void worker_setActiveProcess(Process *process);
+
+void worker_setActiveThread(Thread *thread);
+
+Host *worker_getActiveHost(void);
+
+Process *worker_getActiveProcess(void);
+
+Thread *worker_getActiveThread(void);
+
 // Create an object that can be used to store all descriptors created by a
 // process. When the table is no longer required, use descriptortable_free
 // to release the reference.
@@ -374,9 +386,9 @@ struct MemoryManager *memorymanager_new(pid_t pid);
 // * `mm` must point to a valid object.
 void memorymanager_free(struct MemoryManager *mm);
 
-struct AllocdMem_u8 *allocdmem_new(uintptr_t len);
+struct AllocdMem_u8 *allocdmem_new(Thread *thread, uintptr_t len);
 
-void allocdmem_free(struct AllocdMem_u8 *allocd_mem);
+void allocdmem_free(Thread *thread, struct AllocdMem_u8 *allocd_mem);
 
 PluginPtr allocdmem_pluginPtr(const struct AllocdMem_u8 *allocd_mem);
 

--- a/src/main/bindings/c/cbindgen-opaque.toml
+++ b/src/main/bindings/c/cbindgen-opaque.toml
@@ -17,6 +17,6 @@ rename_variants = "ScreamingSnakeCase"
 
 [export]
 # Avoid exporting C types back through again.
-exclude = ["LogLevel", "PluginPtr", "SysCallReg"]
+exclude = ["LogLevel", "PluginPtr", "SysCallReg", "Process", "Host", "Thread"]
 # Generate only opaque and enum types
 item_types = ["opaque", "enums"]

--- a/src/main/bindings/c/cbindgen.toml
+++ b/src/main/bindings/c/cbindgen.toml
@@ -28,7 +28,7 @@ rename_variants = "ScreamingSnakeCase"
 
 [export]
 # Avoid exporting C types back through again.
-exclude = ["LogLevel", "PluginPtr", "SysCallReg", "SysCallArgs"]
+exclude = ["LogLevel", "PluginPtr", "SysCallReg", "SysCallArgs", "Process", "Host", "Thread"]
 # Generate all item types, excluding enum types.
 # 
 # While the opaque items are already exported, and included here via

--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -37,9 +37,7 @@ add_custom_command(OUTPUT wrapper.rs
         # Needs CompatSocket
         --blacklist-function "host_.*Interface"
 
-        --whitelist-function "process_.*CompatDescriptor"
-        --whitelist-function "process_parseArgStr.*"
-        --whitelist-function "process_getMemoryManager"
+        --whitelist-function "process_.*"
         --whitelist-function "shadow_logger_getDefault"
         --whitelist-function "shadow_logger_shouldFilter"
         --whitelist-function "statuslistener_ref"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -20,6 +20,7 @@ pub type __uint32_t = ::std::os::raw::c_uint;
 pub type __int64_t = ::std::os::raw::c_long;
 pub type __uint64_t = ::std::os::raw::c_ulong;
 pub type __pid_t = ::std::os::raw::c_int;
+pub type __ssize_t = ::std::os::raw::c_long;
 pub type pid_t = __pid_t;
 pub type gchar = ::std::os::raw::c_char;
 pub type gint = ::std::os::raw::c_int;
@@ -29,6 +30,7 @@ pub type gdouble = f64;
 pub type gpointer = *mut ::std::os::raw::c_void;
 pub type gconstpointer = *const ::std::os::raw::c_void;
 pub type GQuark = guint32;
+pub type ssize_t = __ssize_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GTimer {
@@ -150,6 +152,7 @@ pub struct _Timer {
 pub type Timer = _Timer;
 pub type PluginVirtualPtr = _PluginVirtualPtr;
 pub type PluginPtr = _PluginVirtualPtr;
+pub type PluginPhysicalPtr = _PluginPhysicalPtr;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _PluginVirtualPtr {
@@ -173,6 +176,34 @@ fn bindgen_test_layout__PluginVirtualPtr() {
         concat!(
             "Offset of field: ",
             stringify!(_PluginVirtualPtr),
+            "::",
+            stringify!(val)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _PluginPhysicalPtr {
+    pub val: u64,
+}
+#[test]
+fn bindgen_test_layout__PluginPhysicalPtr() {
+    assert_eq!(
+        ::std::mem::size_of::<_PluginPhysicalPtr>(),
+        8usize,
+        concat!("Size of: ", stringify!(_PluginPhysicalPtr))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_PluginPhysicalPtr>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_PluginPhysicalPtr))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<_PluginPhysicalPtr>())).val as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_PluginPhysicalPtr),
             "::",
             stringify!(val)
         )
@@ -452,6 +483,72 @@ extern "C" {
     pub fn thread_getShMBlock(thread: *mut Thread) -> *mut ShMemBlock;
 }
 extern "C" {
+    pub fn thread_getSysCallHandler(thread: *mut Thread) -> *mut SysCallHandler;
+}
+extern "C" {
+    pub fn process_new(
+        host: *mut Host,
+        processID: guint,
+        startTime: SimulationTime,
+        stopTime: SimulationTime,
+        interposeMethod: InterposeMethod,
+        hostName: *const gchar,
+        pluginName: *const gchar,
+        pluginPath: *const gchar,
+        envv: *mut *mut gchar,
+        argv: *mut *mut gchar,
+    ) -> *mut Process;
+}
+extern "C" {
+    pub fn process_ref(proc_: *mut Process);
+}
+extern "C" {
+    pub fn process_unref(proc_: *mut Process);
+}
+extern "C" {
+    pub fn process_schedule(proc_: *mut Process, nothing: gpointer);
+}
+extern "C" {
+    pub fn process_continue(proc_: *mut Process, thread: *mut Thread);
+}
+extern "C" {
+    pub fn process_stop(proc_: *mut Process);
+}
+extern "C" {
+    pub fn process_detachPlugin(procptr: gpointer, nothing: gpointer);
+}
+extern "C" {
+    pub fn process_getWorkingDir(proc_: *mut Process) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn process_addThread(proc_: *mut Process, thread: *mut Thread);
+}
+extern "C" {
+    pub fn process_markAsExiting(proc_: *mut Process);
+}
+extern "C" {
+    pub fn process_isRunning(proc_: *mut Process) -> gboolean;
+}
+extern "C" {
+    pub fn process_getName(proc_: *mut Process) -> *const gchar;
+}
+extern "C" {
+    pub fn process_getPluginName(proc_: *mut Process) -> *const gchar;
+}
+extern "C" {
+    pub fn process_getProcessID(proc_: *mut Process) -> guint;
+}
+extern "C" {
+    pub fn process_getNativePid(proc_: *const Process) -> pid_t;
+}
+extern "C" {
+    pub fn process_findNativeTID(
+        proc_: *mut Process,
+        virtualPID: pid_t,
+        virtualTID: pid_t,
+    ) -> pid_t;
+}
+extern "C" {
     pub fn process_registerCompatDescriptor(
         proc_: *mut Process,
         compatDesc: *mut CompatDescriptor,
@@ -470,7 +567,97 @@ extern "C" {
     ) -> *const CompatDescriptor;
 }
 extern "C" {
+    pub fn process_registerLegacyDescriptor(
+        proc_: *mut Process,
+        desc: *mut LegacyDescriptor,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn process_deregisterLegacyDescriptor(proc_: *mut Process, desc: *mut LegacyDescriptor);
+}
+extern "C" {
+    pub fn process_getRegisteredLegacyDescriptor(
+        proc_: *mut Process,
+        handle: ::std::os::raw::c_int,
+    ) -> *mut LegacyDescriptor;
+}
+extern "C" {
+    pub fn process_getPhysicalAddress(
+        proc_: *mut Process,
+        vPtr: PluginVirtualPtr,
+    ) -> PluginPhysicalPtr;
+}
+extern "C" {
+    pub fn process_readPtr(
+        proc_: *mut Process,
+        dst: *mut ::std::os::raw::c_void,
+        src: PluginVirtualPtr,
+        n: size_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn process_getReadableString(
+        process: *mut Process,
+        plugin_src: PluginPtr,
+        n: size_t,
+        str_: *mut *const ::std::os::raw::c_char,
+        strlen: *mut size_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn process_readString(
+        proc_: *mut Process,
+        str_: *mut ::std::os::raw::c_char,
+        src: PluginVirtualPtr,
+        n: size_t,
+    ) -> ssize_t;
+}
+extern "C" {
+    pub fn process_writePtr(
+        proc_: *mut Process,
+        dst: PluginVirtualPtr,
+        src: *const ::std::os::raw::c_void,
+        n: size_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn process_getReadablePtr(
+        proc_: *mut Process,
+        plugin_src: PluginPtr,
+        n: size_t,
+    ) -> *const ::std::os::raw::c_void;
+}
+extern "C" {
+    pub fn process_getWriteablePtr(
+        proc_: *mut Process,
+        plugin_src: PluginPtr,
+        n: size_t,
+    ) -> *mut ::std::os::raw::c_void;
+}
+extern "C" {
+    pub fn process_getMutablePtr(
+        proc_: *mut Process,
+        plugin_src: PluginPtr,
+        n: size_t,
+    ) -> *mut ::std::os::raw::c_void;
+}
+extern "C" {
+    pub fn process_flushPtrs(proc_: *mut Process);
+}
+extern "C" {
+    pub fn process_freePtrsWithoutFlushing(proc_: *mut Process);
+}
+extern "C" {
     pub fn process_getMemoryManager(proc_: *mut Process) -> *mut MemoryManager;
+}
+extern "C" {
+    pub fn process_setMemoryManager(proc_: *mut Process, memoryManager: *mut MemoryManager);
+}
+extern "C" {
+    pub fn process_getHostId(proc_: *const Process) -> u32;
+}
+extern "C" {
+    pub fn process_getInterposeMethod(proc_: *mut Process) -> InterposeMethod;
 }
 extern "C" {
     pub fn process_parseArgStr(
@@ -1145,6 +1332,24 @@ extern "C" {
 extern "C" {
     pub fn worker_threadID() -> i32;
 }
+extern "C" {
+    pub fn worker_setActiveHost(host: *mut Host);
+}
+extern "C" {
+    pub fn worker_setActiveProcess(process: *mut Process);
+}
+extern "C" {
+    pub fn worker_setActiveThread(thread: *mut Thread);
+}
+extern "C" {
+    pub fn worker_getActiveHost() -> *mut Host;
+}
+extern "C" {
+    pub fn worker_getActiveProcess() -> *mut Process;
+}
+extern "C" {
+    pub fn worker_getActiveThread() -> *mut Thread;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _Task {
@@ -1213,24 +1418,6 @@ extern "C" {
 }
 extern "C" {
     pub fn worker_isFiltered(level: LogLevel) -> gboolean;
-}
-extern "C" {
-    pub fn worker_getActiveHost() -> *mut Host;
-}
-extern "C" {
-    pub fn worker_setActiveHost(host: *mut Host);
-}
-extern "C" {
-    pub fn worker_getActiveProcess() -> *mut Process;
-}
-extern "C" {
-    pub fn worker_setActiveProcess(proc_: *mut Process);
-}
-extern "C" {
-    pub fn worker_getActiveThread() -> *mut Thread;
-}
-extern "C" {
-    pub fn worker_setActiveThread(thread: *mut Thread);
 }
 extern "C" {
     pub fn worker_incrementPluginError();

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -92,13 +92,6 @@ gboolean worker_isFiltered(LogLevel level);
 void worker_bootHosts(GQueue* hosts);
 void worker_freeHosts(GQueue* hosts);
 
-Host* worker_getActiveHost();
-void worker_setActiveHost(Host* host);
-Process* worker_getActiveProcess();
-void worker_setActiveProcess(Process* proc);
-Thread* worker_getActiveThread();
-void worker_setActiveThread(Thread* thread);
-
 void worker_incrementPluginError();
 
 Address* worker_resolveIPToAddress(in_addr_t ip);

--- a/src/main/host/context.rs
+++ b/src/main/host/context.rs
@@ -1,0 +1,130 @@
+//! This module provides several *Context* structs, intended to bundle together
+//! current relevant objects in the hierarchy. These are meant to replace
+//! `worker_getActiveThread`, etc. Passing around the current context explicitly
+//! instead of putting them in globals both allows us to avoid interior mutability
+//! (and its associated runtime cost and fallibility), and lets us keep a
+//! hierarchical object structure (e.g. allow holding a mutable Process and a
+//! mutable Thread belonging to that process simultaneously).
+//!
+//! Most code (e.g. syscall handlers) can take a `ThreadContext` argument and use
+//! that to manipulate anything on the Host. The *current* `Thread` and `Process`
+//! should typically be accessed directly. e.g. since a mutable reference to the
+//! current `Thread` exists at `ThreadContext::thread`, it *cannot* also be
+//! accessible via `ThreadContext::process` or `ThreadContext::host`.
+//!
+//! The manner in which they're unavailable isn't implemented yet, but the current
+//! plan is that they'll be temporarily removed from their collections. e.g. something
+//! conceptually like:
+//!
+//! ```
+//! impl Process {
+//!     pub fn continue_thread(&mut self, host_ctx: &mut HostContext, tid: ThreadId) {
+//!         let thread = self.threads.get_mut(tid).take();
+//!         thread.continue(&mut host_ctx.add_process(self));
+//!         self.threads.get_mut(tid).replace(thread);
+//!     }
+//! }
+//! ```
+//!
+//! The Context objects are designed to allow simultaneously borrowing from multiple
+//! of their objects.  This is currently implemented by exposing their fields
+//! directly - Rust then allows each field to be borrowed independently. This could
+//! alternatively be implemented by providing methods that borrow some or all of
+//! their internal references simultaneously.
+
+use super::{
+    host::Host,
+    process::Process,
+    thread::{CThread, Thread},
+};
+use crate::cshadow;
+
+/// Represent the "current" Host.
+pub struct HostContext<'a> {
+    // We expose fields directly rather than through accessors, so that
+    // users can borrow from each field independently.
+    pub host: &'a mut Host,
+}
+
+impl<'a> HostContext<'a> {
+    pub fn new(host: &'a mut Host) -> Self {
+        Self { host }
+    }
+
+    /// Add the given process to the context.
+    pub fn with_process(&'a mut self, process: &'a mut Process) -> ProcessContext<'a> {
+        ProcessContext::new(self.host, process)
+    }
+}
+
+/// Represent the "current" `Host` and `Process`.
+pub struct ProcessContext<'a> {
+    pub host: &'a mut Host,
+    pub process: &'a mut Process,
+}
+
+impl<'a> ProcessContext<'a> {
+    pub fn new(host: &'a mut Host, process: &'a mut Process) -> Self {
+        Self { host, process }
+    }
+
+    pub fn with_thread(&'a mut self, thread: &'a mut dyn Thread) -> ThreadContext<'a> {
+        ThreadContext::new(self.host, self.process, thread)
+    }
+}
+
+/// Represent the "current" `Host`, `Process`, and `Thread`.
+pub struct ThreadContext<'a> {
+    pub host: &'a mut Host,
+    pub process: &'a mut Process,
+    pub thread: &'a mut dyn Thread,
+}
+
+impl<'a> ThreadContext<'a> {
+    pub fn new(host: &'a mut Host, process: &'a mut Process, thread: &'a mut dyn Thread) -> Self {
+        Self {
+            host,
+            process,
+            thread,
+        }
+    }
+}
+
+/// Shadow's C code doesn't know about contexts. In places where C code calls
+/// Rust code, we can build them from C pointers.
+pub struct ThreadContextObjs {
+    host: Host,
+    process: Process,
+    thread: CThread,
+}
+
+impl ThreadContextObjs {
+    pub unsafe fn from_syscallhandler(sys: *mut cshadow::SysCallHandler) -> Self {
+        let sys = unsafe { sys.as_mut().unwrap() };
+        let host = unsafe { Host::borrow_from_c(sys.host) };
+        let process = unsafe { Process::borrow_from_c(sys.process) };
+        let thread = unsafe { CThread::new(sys.thread) };
+        Self {
+            host,
+            process,
+            thread,
+        }
+    }
+
+    pub unsafe fn from_thread(thread: *mut cshadow::Thread) -> Self {
+        let sys = unsafe { cshadow::thread_getSysCallHandler(thread) };
+        let sys = unsafe { sys.as_mut().unwrap() };
+        let host = unsafe { Host::borrow_from_c(sys.host) };
+        let process = unsafe { Process::borrow_from_c(sys.process) };
+        let thread = unsafe { CThread::new(sys.thread) };
+        Self {
+            host,
+            process,
+            thread,
+        }
+    }
+
+    pub fn borrow(&mut self) -> ThreadContext {
+        ThreadContext::new(&mut self.host, &mut self.process, &mut self.thread)
+    }
+}

--- a/src/main/host/memory_manager/memory_copier.rs
+++ b/src/main/host/memory_manager/memory_copier.rs
@@ -153,12 +153,9 @@ impl MemoryCopier {
         // While the documentation for process_vm_readv says to use the pid, in
         // practice it needs to be the tid of a still-running thread. i.e. using the
         // pid after the thread group leader has exited will fail.
-        let (active_tid, active_pid) = Worker::with_active_thread(|thread| {
-            (
-                Pid::from_raw(thread.get_system_tid()),
-                Pid::from_raw(thread.get_system_pid()),
-            )
-        });
+        let active_tid = Worker::active_thread_native_tid().unwrap();
+        let active_pid = Worker::active_process_native_pid().unwrap();
+
         // Don't access another process's memory.
         assert_eq!(active_pid, self.pid);
 
@@ -191,12 +188,9 @@ impl MemoryCopier {
         // While the documentation for process_vm_writev says to use the pid, in
         // practice it needs to be the tid of a still-running thread. i.e. using the
         // pid after the thread group leader has exited will fail.
-        let (active_tid, active_pid) = Worker::with_active_thread(|thread| {
-            (
-                Pid::from_raw(thread.get_system_tid()),
-                Pid::from_raw(thread.get_system_pid()),
-            )
-        });
+        let active_tid = Worker::active_thread_native_tid().unwrap();
+        let active_pid = Worker::active_process_native_pid().unwrap();
+
         // Don't access another process's memory.
         assert_eq!(active_pid, self.pid);
 

--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -329,13 +329,13 @@ impl Drop for MemoryMapper {
 
 impl MemoryMapper {
     pub fn new(memory_manager: &mut MemoryManager, thread: &mut impl Thread) -> MemoryMapper {
-        let memory_copier = MemoryCopier::new(Pid::from_raw(thread.get_process_id() as i32));
+        let memory_copier = MemoryCopier::new(thread.system_pid());
 
         let shm_path = format!(
             "/dev/shm/shadow_memory_manager_{}_{}_{}",
             process::id(),
-            thread.get_host_id(),
-            thread.get_process_id()
+            u32::from(thread.host_id()),
+            u32::from(thread.process_id())
         );
         let shm_file = OpenOptions::new()
             .read(true)
@@ -524,7 +524,7 @@ impl MemoryMapper {
             // sense to eventually move the mechanics of opening the child fd into here (in which
             // case we'll already have it) than to pipe the string through this API.
             Some(MappingPath::Path(
-                std::fs::read_link(format!("/proc/{}/fd/{}", thread.get_system_pid(), fd))
+                std::fs::read_link(format!("/proc/{}/fd/{}", thread.system_pid(), fd))
                     .unwrap_or_else(|_| PathBuf::from(format!("bad-fd-{}", fd))),
             ))
         };

--- a/src/main/host/mod.rs
+++ b/src/main/host/mod.rs
@@ -1,3 +1,4 @@
+pub mod context;
 pub mod descriptor;
 pub mod host;
 pub mod memory_manager;

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -175,6 +175,11 @@ guint process_getProcessID(Process* proc) {
     return proc->processID;
 }
 
+pid_t process_getNativePid(const Process* proc) {
+    MAGIC_ASSERT(proc);
+    return proc->nativePid;
+}
+
 static void _process_reapThread(Process* process, Thread* thread) {
     utility_assert(!thread_isRunning(thread));
 
@@ -819,6 +824,12 @@ void process_setMemoryManager(Process* proc, MemoryManager* memoryManager) {
         memorymanager_free(proc->memoryManager);
     }
     proc->memoryManager = memoryManager;
+}
+
+uint32_t process_getHostId(const Process* proc) {
+    MAGIC_ASSERT(proc);
+    utility_assert(proc->host);
+    return host_getID(proc->host);
 }
 
 InterposeMethod process_getInterposeMethod(Process* proc) {

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -78,6 +78,9 @@ const gchar* process_getPluginName(Process* proc);
 /* Returns the processID that was assigned to us in process_new */
 guint process_getProcessID(Process* proc);
 
+/* Returns the native pid of the process */
+pid_t process_getNativePid(const Process* proc);
+
 /* Returns the native tid of the thread with the given virtual PID and TID.
  * Although the process knows its own virtualPID already, giving it as a param
  * here allows us to control which of the PIF and TID get matched:
@@ -168,6 +171,8 @@ void process_freePtrsWithoutFlushing(Process* proc);
 
 MemoryManager* process_getMemoryManager(Process* proc);
 void process_setMemoryManager(Process* proc, MemoryManager* memoryManager);
+
+uint32_t process_getHostId(const Process* proc);
 
 // Returns the interpose method used by this process.
 InterposeMethod process_getInterposeMethod(Process* proc);

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1,8 +1,27 @@
+use nix::unistd::Pid;
+
 use crate::cshadow;
+
+use super::{host::HostId, memory_manager::MemoryManager};
+
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub struct ProcessId(u32);
+
+impl From<u32> for ProcessId {
+    fn from(val: u32) -> Self {
+        ProcessId(val)
+    }
+}
+
+impl From<ProcessId> for u32 {
+    fn from(val: ProcessId) -> Self {
+        val.0
+    }
+}
 
 pub struct Process {
     // Placeholder. We don't actually use this yet.
-    _cprocess: *mut cshadow::Process,
+    cprocess: *mut cshadow::Process,
 }
 
 impl Process {
@@ -14,6 +33,42 @@ impl Process {
     /// have exclusive access over its lifetime. `p` must outlive the returned object.
     pub unsafe fn borrow_from_c(p: *mut cshadow::Process) -> Self {
         assert!(!p.is_null());
-        Process { _cprocess: p }
+        Process { cprocess: p }
+    }
+
+    pub fn cprocess(&self) -> *mut cshadow::Process {
+        self.cprocess
+    }
+
+    pub fn id(&self) -> ProcessId {
+        ProcessId(unsafe { cshadow::process_getProcessID(self.cprocess) })
+    }
+
+    pub fn host_id(&self) -> HostId {
+        HostId::from(unsafe { cshadow::process_getHostId(self.cprocess) })
+    }
+
+    fn memory_manager_ptr(&self) -> *mut MemoryManager {
+        let mm_ptr: *mut cshadow::MemoryManager =
+            unsafe { cshadow::process_getMemoryManager(self.cprocess) };
+        // MemoryManager and cshadow::MemoryManager are the same type.
+        unsafe { std::mem::transmute(mm_ptr) }
+    }
+
+    pub fn memory_mut(&mut self) -> &mut MemoryManager {
+        unsafe { &mut *self.memory_manager_ptr() }
+    }
+
+    pub fn memory(&self) -> &MemoryManager {
+        unsafe { &*self.memory_manager_ptr() }
+    }
+
+    pub fn native_pid(&self) -> Pid {
+        let pid = unsafe { cshadow::process_getNativePid(self.cprocess) };
+        Pid::from_raw(pid)
+    }
+
+    pub fn raw_mut(&mut self) -> *mut cshadow::Process {
+        self.cprocess
     }
 }

--- a/src/main/host/syscall/mman.c
+++ b/src/main/host/syscall/mman.c
@@ -137,7 +137,7 @@ static int _syscallhandler_openPluginFile(SysCallHandler* sys, File* file) {
     trace("Opening path '%s' in plugin.", mmap_path);
 
     /* Get some memory in the plugin to write the path of the file to open. */
-    AllocdMem_u8 *allocdMem = allocdmem_new(maplen);
+    AllocdMem_u8 *allocdMem = allocdmem_new(sys->thread, maplen);
     PluginPtr pluginBufPtr = allocdmem_pluginPtr(allocdMem);
 
     /* Get a writeable pointer that can be flushed to the plugin. */
@@ -164,7 +164,7 @@ static int _syscallhandler_openPluginFile(SysCallHandler* sys, File* file) {
     }
 
     /* Release the PluginPtr memory. */
-    allocdmem_free(allocdMem);
+    allocdmem_free(sys->thread, allocdMem);
     free(mmap_path);
 
     return result;

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -35,6 +35,10 @@ Thread thread_create(Host* host, Process* process, int threadID, int type_id,
                      MAGIC_INITIALIZER};
     host_ref(host);
     process_ref(process);
+
+    // .sys is created (and destroyed) in implementation, since it needs the
+    // address of the Thread (which we don't have yet).
+
     return thread;
 }
 
@@ -127,6 +131,10 @@ ShMemBlock* thread_getShMBlock(Thread* thread) {
     MAGIC_ASSERT(thread);
     utility_assert(thread->methods.getShMBlock);
     return thread->methods.getShMBlock(thread);
+}
+
+SysCallHandler* thread_getSysCallHandler(Thread* thread) {
+    return thread->sys;
 }
 
 long thread_nativeSyscall(Thread* thread, long n, ...) {

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -13,6 +13,7 @@
 
 typedef struct _Thread Thread;
 
+#include "main/host/syscall_handler.h"
 #include "main/host/syscall_types.h"
 #include "main/shmem/shmem_allocator.h"
 
@@ -70,5 +71,8 @@ ShMemBlock* thread_getIPCBlock(Thread* thread);
 
 // Returns the block used for shared state, or NULL if no such block is is used.
 ShMemBlock* thread_getShMBlock(Thread* thread);
+
+// Get the syscallhandler for this thread.
+SysCallHandler* thread_getSysCallHandler(Thread* thread);
 
 #endif /* SRC_MAIN_HOST_SHD_THREAD_H_ */

--- a/src/main/host/thread_protected.h
+++ b/src/main/host/thread_protected.h
@@ -46,6 +46,8 @@ struct _Thread {
     PluginPtr tidAddress;
     int referenceCount;
 
+    SysCallHandler* sys;
+
     // Non-null if blocked by a syscall.
     SysCallCondition* cond;
 


### PR DESCRIPTION
Adds a `context` module, which provides several *Context* structs,
intended to bundle together current relevant objects in the hierarchy.
These are meant to replace `worker_getActiveThread`, etc. Passing around
the current context explicitly instead of putting them in globals both
allows us to avoid interior mutability (and its associated runtime cost
and fallibility), and lets us keep a hierarchical object structure (e.g.
allow holding a mutable Process and a mutable Thread belonging to that
process simultaneously).

Most code (e.g. syscall handlers) can take a `ThreadContext` argument
and use that to manipulate anything on the Host. The *current* `Thread`
and `Process` should typically be accessed directly. e.g. since a
mutable reference to the current `Thread` exists at
`ThreadContext::thread`, it *cannot* also be accessible via
`ThreadContext::process` or `ThreadContext::host`.

The manner in which they're unavailable isn't implemented yet, but the
current plan is that they'll be temporarily removed from their
collections. e.g. something conceptually like:

```
impl Process {
    pub fn continue_thread(&mut self, host_ctx: &mut HostContext, tid: ThreadId) {
        let thread = self.threads.get_mut(tid).take();
        thread.continue(&mut host_ctx.add_process(self));
        self.threads.get_mut(tid).replace(thread);
    }
}
```

The Context objects are designed to allow simultaneously borrowing from
multiple of their objects.  This is currently implemented by exposing
their fields directly - Rust then allows each field to be borrowed
independently. This could alternatively be implemented by providing
methods that borrow some or all of their internal references
simultaneously.

Also:

* Move implementations of setActive* and getActive* to Rust Worker.  The
Rust Worker *doesn't* expose references to the active objects themselves
via the Rust API; only to some immutable info about those objects.

* The ShadowLogger now clones an Arc with the relevant Host info,
instead of copying the string name itself and rendering the IP address
from the calling thread. I wasn't sure whether this would actually be a
win or not, but experimentally `make test -j12` is ~2% faster cloning
the Arc than copying the data in both debug and release builds.