### PR TITLE
Deny write access to all GitHub workflows

### DIFF
--- a/.github/workflows/ci_maintenance.yml
+++ b/.github/workflows/ci_maintenance.yml
@@ -1,4 +1,5 @@
 name: CI Maintenance
+permissions: read-all
 
 on:
   schedule:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 
 name: Coverage
+permissions: read-all
 
 defaults:
   run:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,7 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 
 name: Build Docker
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,6 +1,7 @@
 # Syntax reference:
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 name: Git Checks
+permissions: read-all
 
 on:
   pull_request:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 
 name: Lint Checks
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,6 +2,7 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 
 name: Shadow Tests
+permissions: read-all
 
 defaults:
   run:

--- a/.github/workflows/run_tor.yml
+++ b/.github/workflows/run_tor.yml
@@ -2,6 +2,7 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 
 name: Tor Tests
+permissions: read-all
 
 defaults:
   run:


### PR DESCRIPTION
GitHub recently added a mechanism for restricting the permissions of
what Workflow actions can do. Since none of our workflows need any
kind of write access to GitHub, it makes sense to only give them read
permission.

We could potentially tighten this further to only give read access to
some parts of Shadow, but since we currently don't keep any secrets in
GitHub, it doesn't seem worth trying to maintain more fine-grained
permissions.