### PR TITLE
Remove C usage of getActiveHost, getActiveProcess, getActiveThread

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -114,8 +114,9 @@ pub type SimulationTime = guint64;
 #[doc = " distinguish each type of time in the code.,"]
 pub type EmulatedTime = guint64;
 pub type LegacyDescriptor = [u64; 7usize];
-pub type DescriptorCloseFunc =
-    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor) -> gboolean>;
+pub type DescriptorCloseFunc = ::std::option::Option<
+    unsafe extern "C" fn(descriptor: *mut LegacyDescriptor, host: *mut Host) -> gboolean,
+>;
 pub type DescriptorFreeFunc =
     ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor)>;
 #[repr(C)]
@@ -483,6 +484,12 @@ extern "C" {
     pub fn thread_getShMBlock(thread: *mut Thread) -> *mut ShMemBlock;
 }
 extern "C" {
+    pub fn thread_getProcess(thread: *mut Thread) -> *mut Process;
+}
+extern "C" {
+    pub fn thread_getHost(thread: *mut Thread) -> *mut Host;
+}
+extern "C" {
     pub fn thread_getSysCallHandler(thread: *mut Thread) -> *mut SysCallHandler;
 }
 extern "C" {
@@ -687,6 +694,7 @@ pub type TransportFunctionTable = _TransportFunctionTable;
 pub type TransportSendFunc = ::std::option::Option<
     unsafe extern "C" fn(
         transport: *mut Transport,
+        thread: *mut Thread,
         buffer: PluginVirtualPtr,
         nBytes: gsize,
         ip: in_addr_t,
@@ -696,6 +704,7 @@ pub type TransportSendFunc = ::std::option::Option<
 pub type TransportReceiveFunc = ::std::option::Option<
     unsafe extern "C" fn(
         transport: *mut Transport,
+        thread: *mut Thread,
         buffer: PluginVirtualPtr,
         nBytes: gsize,
         ip: *mut in_addr_t,
@@ -1384,10 +1393,14 @@ extern "C" {
     pub fn worker_getConfig() -> *const ConfigOptions;
 }
 extern "C" {
-    pub fn worker_scheduleTask(task: *mut Task, nanoDelay: SimulationTime) -> gboolean;
+    pub fn worker_scheduleTask(
+        task: *mut Task,
+        host: *mut Host,
+        nanoDelay: SimulationTime,
+    ) -> gboolean;
 }
 extern "C" {
-    pub fn worker_sendPacket(packet: *mut Packet);
+    pub fn worker_sendPacket(src: *mut Host, packet: *mut Packet);
 }
 extern "C" {
     pub fn worker_isAlive() -> gboolean;

--- a/src/main/core/work/event.c
+++ b/src/main/core/work/event.c
@@ -79,11 +79,11 @@ void event_execute(Event* event) {
         tracker_addVirtualProcessingDelay(host_getTracker(event->dstHost), cpuDelay);
 
         /* this event is delayed due to cpu, so reschedule it to ourselves */
-        worker_scheduleTask(event->task, cpuDelay);
+        worker_scheduleTask(event->task, event->dstHost, cpuDelay);
     } else {
         /* cpu is not blocked, its ok to execute the event */
         host_continueExecutionTimer(event->dstHost);
-        task_execute(event->task);
+        task_execute(event->task, event->dstHost);
         host_stopExecutionTimer(event->dstHost);
     }
 

--- a/src/main/core/work/task.c
+++ b/src/main/core/work/task.c
@@ -64,7 +64,7 @@ void task_unref(Task* task) {
     }
 }
 
-void task_execute(Task* task) {
+void task_execute(Task* task, Host* host) {
     MAGIC_ASSERT(task);
-    task->execute(task->callbackObject, task->callbackArgument);
+    task->execute(host, task->callbackObject, task->callbackArgument);
 }

--- a/src/main/core/work/task.h
+++ b/src/main/core/work/task.h
@@ -8,7 +8,9 @@
 
 #include <glib.h>
 
-typedef void (*TaskCallbackFunc)(gpointer callbackObject, gpointer callbackArgument);
+#include "main/core/support/definitions.h"
+
+typedef void (*TaskCallbackFunc)(Host* host, gpointer callbackObject, gpointer callbackArgument);
 typedef void (*TaskObjectFreeFunc)(gpointer data);
 typedef void (*TaskArgumentFreeFunc)(gpointer data);
 
@@ -21,6 +23,6 @@ Task* task_new(TaskCallbackFunc callback, gpointer callbackObject, gpointer call
         TaskObjectFreeFunc objectFree, TaskArgumentFreeFunc argumentFree);
 void task_ref(Task* task);
 void task_unref(Task* task);
-void task_execute(Task* task);
+void task_execute(Task* task, Host* host);
 
 #endif /* SHD_TASK_H_ */

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -19,7 +19,7 @@
 #include "main/host/thread.h"
 #include "main/routing/address.h"
 #include "main/routing/dns.h"
-#include "main/routing/packet.h"
+#include "main/routing/packet.minimal.h"
 #include "main/routing/topology.h"
 #include "main/utility/count_down_latch.h"
 #include "support/logger/log_level.h"
@@ -73,8 +73,8 @@ int worker_getAffinity();
 DNS* worker_getDNS();
 Topology* worker_getTopology();
 const ConfigOptions* worker_getConfig();
-gboolean worker_scheduleTask(Task* task, SimulationTime nanoDelay);
-void worker_sendPacket(Packet* packet);
+gboolean worker_scheduleTask(Task* task, Host* host, SimulationTime nanoDelay);
+void worker_sendPacket(Host* src, Packet* packet);
 gboolean worker_isAlive();
 
 SimulationTime worker_getCurrentTime();

--- a/src/main/host/descriptor/compat_socket.c
+++ b/src/main/host/descriptor/compat_socket.c
@@ -131,18 +131,19 @@ const Packet* compatsocket_peekNextOutPacket(const CompatSocket* socket) {
     utility_panic("Invalid CompatSocket type");
 }
 
-void compatsocket_pushInPacket(const CompatSocket* socket, Packet* packet) {
+void compatsocket_pushInPacket(const CompatSocket* socket, Host* host, Packet* packet) {
     switch (socket->type) {
-        case CST_LEGACY_SOCKET: return socket_pushInPacket(socket->object.as_legacy_socket, packet);
+        case CST_LEGACY_SOCKET:
+            return socket_pushInPacket(socket->object.as_legacy_socket, host, packet);
         case CST_NONE: utility_panic("Unexpected CompatSocket type");
     }
 
     utility_panic("Invalid CompatSocket type");
 }
 
-Packet* compatsocket_pullOutPacket(const CompatSocket* socket) {
+Packet* compatsocket_pullOutPacket(const CompatSocket* socket, Host* host) {
     switch (socket->type) {
-        case CST_LEGACY_SOCKET: return socket_pullOutPacket(socket->object.as_legacy_socket);
+        case CST_LEGACY_SOCKET: return socket_pullOutPacket(socket->object.as_legacy_socket, host);
         case CST_NONE: utility_panic("Unexpected CompatSocket type");
     }
 

--- a/src/main/host/descriptor/compat_socket.h
+++ b/src/main/host/descriptor/compat_socket.h
@@ -43,7 +43,7 @@ ProtocolType compatsocket_getProtocol(const CompatSocket* socket);
 bool compatsocket_getPeerName(const CompatSocket* socket, in_addr_t* ip, in_port_t* port);
 bool compatsocket_getSocketName(const CompatSocket* socket, in_addr_t* ip, in_port_t* port);
 const Packet* compatsocket_peekNextOutPacket(const CompatSocket* socket);
-void compatsocket_pushInPacket(const CompatSocket* socket, Packet* packet);
-Packet* compatsocket_pullOutPacket(const CompatSocket* socket);
+void compatsocket_pushInPacket(const CompatSocket* socket, Host* host, Packet* packet);
+Packet* compatsocket_pullOutPacket(const CompatSocket* socket, Host* host);
 
 #endif /* SRC_MAIN_HOST_DESCRIPTOR_COMPAT_SOCKET_H_ */

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -78,12 +78,12 @@ void descriptor_unref(gpointer data) {
     }
 }
 
-void descriptor_close(LegacyDescriptor* descriptor) {
+void descriptor_close(LegacyDescriptor* descriptor, Host* host) {
     MAGIC_ASSERT(descriptor);
     MAGIC_ASSERT(descriptor->funcTable);
     trace("Descriptor %i calling vtable close now", descriptor->handle);
     descriptor_adjustStatus(descriptor, STATUS_DESCRIPTOR_CLOSED, TRUE);
-    if (descriptor->funcTable->close(descriptor) && descriptor->ownerProcess) {
+    if (descriptor->funcTable->close(descriptor, host) && descriptor->ownerProcess) {
         process_deregisterLegacyDescriptor(descriptor->ownerProcess, descriptor);
     }
 }

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -23,7 +23,7 @@ void descriptor_clear(LegacyDescriptor* descriptor);
 
 void descriptor_ref(gpointer data);
 void descriptor_unref(gpointer data);
-void descriptor_close(LegacyDescriptor* descriptor);
+void descriptor_close(LegacyDescriptor* descriptor, Host* host);
 gint descriptor_compare(const LegacyDescriptor* foo, const LegacyDescriptor* bar, gpointer user_data);
 
 void descriptor_setHandle(LegacyDescriptor* descriptor, gint handle);

--- a/src/main/host/descriptor/descriptor_types.h
+++ b/src/main/host/descriptor/descriptor_types.h
@@ -32,7 +32,7 @@ typedef struct _DescriptorFunctionTable DescriptorFunctionTable;
 /* Returns TRUE if the descriptor should be deregistered from the owning
  * process upon return from the function, FALSE if the child will handle
  * deregistration on its own. */
-typedef gboolean (*DescriptorCloseFunc)(LegacyDescriptor* descriptor);
+typedef gboolean (*DescriptorCloseFunc)(LegacyDescriptor* descriptor, Host* host);
 typedef void (*DescriptorFreeFunc)(LegacyDescriptor* descriptor);
 
 /*

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -248,7 +248,7 @@ void epoll_reset(Epoll* epoll) {
     g_hash_table_remove_all(epoll->watching);
 }
 
-static gboolean _epoll_close(LegacyDescriptor* descriptor) {
+static gboolean _epoll_close(LegacyDescriptor* descriptor, Host* host) {
     Epoll* epoll = _epoll_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(epoll);
     epoll_clearWatchListeners(epoll);

--- a/src/main/host/descriptor/eventd.c
+++ b/src/main/host/descriptor/eventd.c
@@ -30,7 +30,7 @@ static EventD* _eventfd_fromLegacyDescriptor(LegacyDescriptor* descriptor) {
     return (EventD*)descriptor;
 }
 
-static gboolean _eventd_close(LegacyDescriptor* descriptor) {
+static gboolean _eventd_close(LegacyDescriptor* descriptor, Host* host) {
     EventD* eventd = _eventfd_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(eventd);
 

--- a/src/main/host/descriptor/file.h
+++ b/src/main/host/descriptor/file.h
@@ -16,6 +16,7 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
+#include "main/core/support/definitions.h"
 #include "main/host/syscall/kernel_types.h"
 
 /* Opaque type representing a file-backed file descriptor. */
@@ -61,12 +62,12 @@ int file_getOSBackedFD(File* file);
 // Operations that require a non-null File*
 // ****************************************
 
-ssize_t file_read(File* file, void* buf, size_t bufSize);
-ssize_t file_pread(File* file, void* buf, size_t bufSize, off_t offset);
-ssize_t file_preadv(File* file, const struct iovec* iov, int iovcnt, off_t offset);
+ssize_t file_read(File* file, Host* host, void* buf, size_t bufSize);
+ssize_t file_pread(File* file, Host* host, void* buf, size_t bufSize, off_t offset);
+ssize_t file_preadv(File* file, Host* host, const struct iovec* iov, int iovcnt, off_t offset);
 #ifdef SYS_preadv2
-ssize_t file_preadv2(File* file, const struct iovec* iov, int iovcnt,
-                     off_t offset, int flags);
+ssize_t file_preadv2(File* file, Host* host, const struct iovec* iov, int iovcnt, off_t offset,
+                     int flags);
 #endif
 ssize_t file_write(File* file, const void* buf, size_t bufSize);
 ssize_t file_pwrite(File* file, const void* buf, size_t bufSize, off_t offset);

--- a/src/main/host/descriptor/socket.h
+++ b/src/main/host/descriptor/socket.h
@@ -15,15 +15,16 @@
 #include "main/host/descriptor/descriptor_types.h"
 #include "main/host/descriptor/transport.h"
 #include "main/host/protocol.h"
-#include "main/routing/packet.h"
+#include "main/routing/packet.minimal.h"
 
 typedef struct _Socket Socket;
 typedef struct _SocketFunctionTable SocketFunctionTable;
 
 typedef gboolean (*SocketIsFamilySupportedFunc)(Socket* socket, sa_family_t family);
-typedef gint (*SocketConnectToPeerFunc)(Socket* socket, in_addr_t ip, in_port_t port, sa_family_t family);
-typedef void (*SocketProcessFunc)(Socket* socket, Packet* packet);
-typedef void (*SocketDropFunc)(Socket* socket, Packet* packet);
+typedef gint (*SocketConnectToPeerFunc)(Socket* socket, Host* host, in_addr_t ip, in_port_t port,
+                                        sa_family_t family);
+typedef void (*SocketProcessFunc)(Socket* socket, Host* host, Packet* packet);
+typedef void (*SocketDropFunc)(Socket* socket, Host* host, Packet* packet);
 
 struct _SocketFunctionTable {
     DescriptorCloseFunc close;
@@ -77,13 +78,12 @@ struct _Socket {
     MAGIC_DECLARE_ALWAYS;
 };
 
-void socket_init(Socket* socket, SocketFunctionTable* vtable,
-                 LegacyDescriptorType type, guint receiveBufferSize,
-                 guint sendBufferSize);
+void socket_init(Socket* socket, Host* host, SocketFunctionTable* vtable, LegacyDescriptorType type,
+                 guint receiveBufferSize, guint sendBufferSize);
 
-void socket_pushInPacket(Socket* socket, Packet* packet);
-void socket_dropPacket(Socket* socket, Packet* packet);
-Packet* socket_pullOutPacket(Socket* socket);
+void socket_pushInPacket(Socket* socket, Host* host, Packet* packet);
+void socket_dropPacket(Socket* socket, Host* host, Packet* packet);
+Packet* socket_pullOutPacket(Socket* socket, Host* host);
 Packet* socket_peekNextOutPacket(const Socket* socket);
 Packet* socket_peekNextInPacket(const Socket* socket);
 
@@ -91,15 +91,15 @@ gsize socket_getInputBufferSize(Socket* socket);
 void socket_setInputBufferSize(Socket* socket, gsize newSize);
 gsize socket_getInputBufferLength(Socket* socket);
 gsize socket_getInputBufferSpace(Socket* socket);
-gboolean socket_addToInputBuffer(Socket* socket, Packet* packet);
-Packet* socket_removeFromInputBuffer(Socket* socket);
+gboolean socket_addToInputBuffer(Socket* socket, Host* host, Packet* packet);
+Packet* socket_removeFromInputBuffer(Socket* socket, Host* host);
 
 gsize socket_getOutputBufferSize(Socket* socket);
 void socket_setOutputBufferSize(Socket* socket, gsize newSize);
 gsize socket_getOutputBufferLength(Socket* socket);
 gsize socket_getOutputBufferSpace(Socket* socket);
-gboolean socket_addToOutputBuffer(Socket* socket, Packet* packet);
-Packet* socket_removeFromOutputBuffer(Socket* socket);
+gboolean socket_addToOutputBuffer(Socket* socket, Host* host, Packet* packet);
+Packet* socket_removeFromOutputBuffer(Socket* socket, Host* host);
 
 gboolean socket_isBound(Socket* socket);
 gboolean socket_getPeerName(Socket* socket, in_addr_t* ip, in_port_t* port);
@@ -110,7 +110,8 @@ void socket_setSocketName(Socket* socket, in_addr_t ip, in_port_t port);
 ProtocolType socket_getProtocol(Socket* socket);
 
 gboolean socket_isFamilySupported(Socket* socket, sa_family_t family);
-gint socket_connectToPeer(Socket* socket, in_addr_t ip, in_port_t port, sa_family_t family);
+gint socket_connectToPeer(Socket* socket, Host* host, in_addr_t ip, in_port_t port,
+                          sa_family_t family);
 
 gboolean socket_isUnix(Socket* socket);
 void socket_setUnix(Socket* socket, gboolean isUnixSocket);

--- a/src/main/host/descriptor/tcp.h
+++ b/src/main/host/descriptor/tcp.h
@@ -12,7 +12,8 @@
 #include <netinet/tcp.h>
 #include <sys/un.h>
 
-#include "main/routing/packet.h"
+#include "main/core/support/definitions.h"
+#include "main/routing/packet.minimal.h"
 
 #define TCP_MIN_CWND 10
 
@@ -38,7 +39,7 @@ enum _TCPCongestionType {
     TCP_CC_UNKNOWN, TCP_CC_AIMD, TCP_CC_RENO, TCP_CC_CUBIC,
 };
 
-TCP* tcp_new(guint receiveBufferSize, guint sendBufferSize);
+TCP* tcp_new(Host* host, guint receiveBufferSize, guint sendBufferSize);
 
 // clang-format off
 /* Returns a positive number to indicate that we have not yet sent a SYN
@@ -61,8 +62,9 @@ gint tcp_getConnectionError(TCP* tcp);
 // clang-format on
 
 void tcp_getInfo(TCP* tcp, struct tcp_info *tcpinfo);
-void tcp_enterServerMode(TCP* tcp, gint backlog);
-gint tcp_acceptServerPeer(TCP* tcp, in_addr_t* ip, in_port_t* port, gint* acceptedHandle);
+void tcp_enterServerMode(TCP* tcp, Host* host, gint backlog);
+gint tcp_acceptServerPeer(TCP* tcp, Host* host, in_addr_t* ip, in_port_t* port,
+                          gint* acceptedHandle);
 
 struct TCPCong_ *tcp_cong(TCP *tcp);
 
@@ -78,9 +80,9 @@ void tcp_disableReceiveBufferAutotuning(TCP* tcp);
 gboolean tcp_isValidListener(TCP* tcp);
 gboolean tcp_isListeningAllowed(TCP* tcp);
 
-gint tcp_shutdown(TCP* tcp, gint how);
+gint tcp_shutdown(TCP* tcp, Host* host, gint how);
 
-void tcp_networkInterfaceIsAboutToSendPacket(TCP* tcp, Packet* packet);
+void tcp_networkInterfaceIsAboutToSendPacket(TCP* tcp, Host* host, Packet* packet);
 
 TCPCongestionType tcpCongestion_getType(const gchar* type);
 

--- a/src/main/host/descriptor/timer.h
+++ b/src/main/host/descriptor/timer.h
@@ -9,13 +9,14 @@
 #include <glib.h>
 #include <sys/types.h>
 
+#include "main/core/support/definitions.h"
+
 typedef struct _Timer Timer;
 
 /* free this with descriptor_free() */
 Timer* timer_new();
-gint timer_setTime(Timer* timer, gint flags,
-                   const struct itimerspec *new_value,
-                   struct itimerspec *old_value);
+gint timer_setTime(Timer* timer, Host* host, gint flags, const struct itimerspec* new_value,
+                   struct itimerspec* old_value);
 gint timer_getTime(Timer* timer, struct itimerspec *curr_value);
 ssize_t timer_read(Timer* timer, void *buf, size_t count);
 gint timer_close(Timer* timer);

--- a/src/main/host/descriptor/transport.c
+++ b/src/main/host/descriptor/transport.c
@@ -33,11 +33,11 @@ static void _transport_free(LegacyDescriptor* descriptor) {
     transport->vtable->free(descriptor);
 }
 
-static gboolean _transport_close(LegacyDescriptor* descriptor) {
+static gboolean _transport_close(LegacyDescriptor* descriptor, Host* host) {
     Transport* transport = _transport_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(transport);
     MAGIC_ASSERT(transport->vtable);
-    return transport->vtable->close(descriptor);
+    return transport->vtable->close(descriptor, host);
 }
 
 DescriptorFunctionTable transport_functions = {
@@ -55,16 +55,16 @@ void transport_init(Transport* transport, TransportFunctionTable* vtable,
     transport->vtable = vtable;
 }
 
-gssize transport_sendUserData(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
-                              in_addr_t ip, in_port_t port) {
+gssize transport_sendUserData(Transport* transport, Thread* thread, PluginVirtualPtr buffer,
+                              gsize nBytes, in_addr_t ip, in_port_t port) {
     MAGIC_ASSERT(transport);
     MAGIC_ASSERT(transport->vtable);
-    return transport->vtable->send(transport, buffer, nBytes, ip, port);
+    return transport->vtable->send(transport, thread, buffer, nBytes, ip, port);
 }
 
-gssize transport_receiveUserData(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
-                                 in_addr_t* ip, in_port_t* port) {
+gssize transport_receiveUserData(Transport* transport, Thread* thread, PluginVirtualPtr buffer,
+                                 gsize nBytes, in_addr_t* ip, in_port_t* port) {
     MAGIC_ASSERT(transport);
     MAGIC_ASSERT(transport->vtable);
-    return transport->vtable->receive(transport, buffer, nBytes, ip, port);
+    return transport->vtable->receive(transport, thread, buffer, nBytes, ip, port);
 }

--- a/src/main/host/descriptor/transport.h
+++ b/src/main/host/descriptor/transport.h
@@ -13,15 +13,17 @@
 #include "main/core/support/definitions.h"
 #include "main/host/descriptor/descriptor.h"
 #include "main/host/syscall_types.h"
+#include "main/host/thread.h"
 #include "main/utility/utility.h"
 
 typedef struct _Transport Transport;
 typedef struct _TransportFunctionTable TransportFunctionTable;
 
-typedef gssize (*TransportSendFunc)(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
-                                    in_addr_t ip, in_port_t port);
-typedef gssize (*TransportReceiveFunc)(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
-                                       in_addr_t* ip, in_port_t* port);
+typedef gssize (*TransportSendFunc)(Transport* transport, Thread* thread, PluginVirtualPtr buffer,
+                                    gsize nBytes, in_addr_t ip, in_port_t port);
+typedef gssize (*TransportReceiveFunc)(Transport* transport, Thread* thread,
+                                       PluginVirtualPtr buffer, gsize nBytes, in_addr_t* ip,
+                                       in_port_t* port);
 
 struct _TransportFunctionTable {
     DescriptorCloseFunc close;
@@ -41,9 +43,9 @@ struct _Transport {
 void transport_init(Transport* transport, TransportFunctionTable* vtable,
                     LegacyDescriptorType type);
 
-gssize transport_sendUserData(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
-                              in_addr_t ip, in_port_t port);
-gssize transport_receiveUserData(Transport* transport, PluginVirtualPtr buffer, gsize nBytes,
-                                 in_addr_t* ip, in_port_t* port);
+gssize transport_sendUserData(Transport* transport, Thread* thread, PluginVirtualPtr buffer,
+                              gsize nBytes, in_addr_t ip, in_port_t port);
+gssize transport_receiveUserData(Transport* transport, Thread* thread, PluginVirtualPtr buffer,
+                                 gsize nBytes, in_addr_t* ip, in_port_t* port);
 
 #endif /* SHD_TRANSPORT_H_ */

--- a/src/main/host/descriptor/udp.h
+++ b/src/main/host/descriptor/udp.h
@@ -9,9 +9,11 @@
 
 #include <glib.h>
 
+#include "main/core/support/definitions.h"
+
 typedef struct _UDP UDP;
 
-UDP* udp_new(guint receiveBufferSize, guint sendBufferSize);
+UDP* udp_new(Host* host, guint receiveBufferSize, guint sendBufferSize);
 gint udp_shutdown(UDP* udp, gint how);
 
 #endif /* SHD_UDP_H_ */

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -182,10 +182,12 @@ void host_setup(Host* host, DNS* dns, Topology* topology, guint rawCPUFreq, cons
     }
 
     /* virtual addresses and interfaces for managing network I/O */
-    NetworkInterface* loopback = networkinterface_new(loopbackAddress, G_MAXUINT32, G_MAXUINT32,
-            host->params.pcapDir, host->params.qdisc, host->params.interfaceBufSize);
-    NetworkInterface* ethernet = networkinterface_new(ethernetAddress, bwDownKiBps, bwUpKiBps,
-            host->params.pcapDir, host->params.qdisc, host->params.interfaceBufSize);
+    NetworkInterface* loopback =
+        networkinterface_new(host, loopbackAddress, G_MAXUINT32, G_MAXUINT32, host->params.pcapDir,
+                             host->params.qdisc, host->params.interfaceBufSize);
+    NetworkInterface* ethernet =
+        networkinterface_new(host, ethernetAddress, bwDownKiBps, bwUpKiBps, host->params.pcapDir,
+                             host->params.qdisc, host->params.interfaceBufSize);
 
     g_hash_table_replace(host->interfaces, GUINT_TO_POINTER((guint)address_toNetworkIP(ethernetAddress)), ethernet);
     g_hash_table_replace(host->interfaces, GUINT_TO_POINTER((guint)htonl(INADDR_LOOPBACK)), loopback);
@@ -336,7 +338,8 @@ void host_boot(Host* host) {
     MAGIC_ASSERT(host);
 
     /* must be done after the default IP exists so tracker_heartbeat works */
-    host->tracker = tracker_new(host->params.heartbeatInterval, host->params.heartbeatLogLevel, host->params.heartbeatLogInfo);
+    host->tracker = tracker_new(host, host->params.heartbeatInterval,
+                                host->params.heartbeatLogLevel, host->params.heartbeatLogInfo);
 
     /* start refilling the token buckets for all interfaces */
     GHashTableIter iter;
@@ -345,7 +348,7 @@ void host_boot(Host* host) {
 
     while(g_hash_table_iter_next(&iter, &key, &value)) {
         NetworkInterface* interface = value;
-        networkinterface_startRefillingTokenBuckets(interface);
+        networkinterface_startRefillingTokenBuckets(interface, host);
     }
 
     /* scheduling the starting and stopping of our virtual processes */

--- a/src/main/host/network_interface.h
+++ b/src/main/host/network_interface.h
@@ -10,6 +10,7 @@
 #include <glib.h>
 #include <netinet/in.h>
 
+#include "main/core/support/definitions.h"
 #include "main/host/descriptor/compat_socket.h"
 #include "main/host/descriptor/socket.h"
 #include "main/host/protocol.h"
@@ -18,8 +19,9 @@
 
 typedef struct _NetworkInterface NetworkInterface;
 
-NetworkInterface* networkinterface_new(Address* address, guint64 bwDownKiBps, guint64 bwUpKiBps,
-        gchar* pcapDir, QDiscMode qdisc, guint64 interfaceReceiveLength);
+NetworkInterface* networkinterface_new(Host* host, Address* address, guint64 bwDownKiBps,
+                                       guint64 bwUpKiBps, gchar* pcapDir, QDiscMode qdisc,
+                                       guint64 interfaceReceiveLength);
 void networkinterface_free(NetworkInterface* interface);
 
 Address* networkinterface_getAddress(NetworkInterface* interface);
@@ -32,14 +34,15 @@ gboolean networkinterface_isAssociated(NetworkInterface* interface, ProtocolType
 void networkinterface_associate(NetworkInterface* interface, const CompatSocket* socket);
 void networkinterface_disassociate(NetworkInterface* interface, const CompatSocket* socket);
 
-void networkinterface_wantsSend(NetworkInterface* interface, const CompatSocket* socket);
+void networkinterface_wantsSend(NetworkInterface* interface, Host* host,
+                                const CompatSocket* socket);
 void networkinterface_sent(NetworkInterface* interface);
 
-void networkinterface_startRefillingTokenBuckets(NetworkInterface* interface);
+void networkinterface_startRefillingTokenBuckets(NetworkInterface* interface, Host* host);
 
 void networkinterface_setRouter(NetworkInterface* interface, Router* router);
 Router* networkinterface_getRouter(NetworkInterface* interface);
 
-void networkinterface_receivePackets(NetworkInterface* interface);
+void networkinterface_receivePackets(NetworkInterface* interface, Host* host);
 
 #endif /* SHD_NETWORK_INTERFACE_H_ */

--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -71,7 +71,7 @@ static SysCallReturn _syscallhandler_openHelper(SysCallHandler* sys,
     errcode = file_open(filed, pathname, flags, mode, process_getWorkingDir(sys->process));
     if (errcode < 0) {
         /* This will remove the descriptor entry and unref/free the File. */
-        descriptor_close((LegacyDescriptor*)filed);
+        descriptor_close((LegacyDescriptor*)filed, sys->host);
     } else {
         utility_assert(errcode == handle);
     }

--- a/src/main/host/syscall/fileat.c
+++ b/src/main/host/syscall/fileat.c
@@ -131,7 +131,7 @@ SysCallReturn syscallhandler_openat(SysCallHandler* sys,
     errcode = file_openat(file_desc, dir_desc, pathname, flags, mode, process_getWorkingDir(sys->process));
     if (errcode < 0) {
         /* This will remove the descriptor entry and unref/free the File. */
-        descriptor_close((LegacyDescriptor*)file_desc);
+        descriptor_close((LegacyDescriptor*)file_desc, sys->host);
     } else {
         utility_assert(errcode == handle);
     }

--- a/src/main/host/syscall/protected.c
+++ b/src/main/host/syscall/protected.c
@@ -27,7 +27,7 @@ void _syscallhandler_setListenTimeout(SysCallHandler* sys,
     };
 
     /* This causes us to lose the previous state of the timer. */
-    gint result = timer_setTime(sys->timer, 0, &value, NULL);
+    gint result = timer_setTime(sys->timer, sys->host, 0, &value, NULL);
 
     if (result != 0) {
         utility_panic("syscallhandler failed to set timeout to %lu.%09lu seconds",

--- a/src/main/host/syscall/timerfd.c
+++ b/src/main/host/syscall/timerfd.c
@@ -130,7 +130,7 @@ SysCallReturn syscallhandler_timerfd_settime(SysCallHandler* sys,
     }
 
     /* Service the call in the timer module. */
-    errcode = timer_setTime(timer, flags, &newValue, oldValue);
+    errcode = timer_setTime(timer, sys->host, flags, &newValue, oldValue);
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -117,12 +117,12 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
         }
 
 #ifdef SYS_preadv2
-        result = file_preadv2((File*)desc, buffersv, iovlen, offset, flags);
+        result = file_preadv2((File*)desc, sys->host, buffersv, iovlen, offset, flags);
 #else
         if (flags) {
             warning("Ignoring flags");
         }
-        result = file_preadv((File*)desc, buffersv, iovlen, offset);
+        result = file_preadv((File*)desc, sys->host, buffersv, iovlen, offset);
 #endif
 
         free(buffersv);
@@ -142,8 +142,8 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                     break;
                 }
                 case DT_PIPE: {
-                    result =
-                        transport_receiveUserData((Transport*)desc, bufPtr, bufSize, NULL, NULL);
+                    result = transport_receiveUserData(
+                        (Transport*)desc, sys->thread, bufPtr, bufSize, NULL, NULL);
                     break;
                 }
                 case DT_TCPSOCKET:
@@ -259,7 +259,8 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                     break;
                 }
                 case DT_PIPE: {
-                    result = transport_sendUserData((Transport*)desc, bufPtr, bufSize, 0, 0);
+                    result = transport_sendUserData(
+                        (Transport*)desc, sys->thread, bufPtr, bufSize, 0, 0);
                     break;
                 }
                 case DT_TCPSOCKET:

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -283,7 +283,7 @@ static bool _syscallcondition_statusIsValid(SysCallCondition* cond) {
     return false;
 }
 
-static void _syscallcondition_signal(void* obj, void* arg) {
+static void _syscallcondition_signal(Host* host, void* obj, void* arg) {
     SysCallCondition* cond = obj;
     bool wasTimeout = (bool)arg;
     MAGIC_ASSERT(cond);
@@ -317,7 +317,8 @@ static void _syscallcondition_scheduleSignalTask(SysCallCondition* cond,
     Task* signalTask =
         task_new(_syscallcondition_signal, cond, (void*)wasTimeout,
                  _syscallcondition_unrefcb, NULL);
-    worker_scheduleTask(signalTask, 0); // Call without moving time forward
+    worker_scheduleTask(
+        signalTask, thread_getHost(cond->thread), 0); // Call without moving time forward
 
     syscallcondition_ref(cond);
     task_unref(signalTask);

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -137,6 +137,10 @@ SysCallHandler* thread_getSysCallHandler(Thread* thread) {
     return thread->sys;
 }
 
+Process* thread_getProcess(Thread* thread) { return thread->process; }
+
+Host* thread_getHost(Thread* thread) { return thread->host; }
+
 long thread_nativeSyscall(Thread* thread, long n, ...) {
     MAGIC_ASSERT(thread);
     utility_assert(thread->methods.nativeSyscall);

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -14,6 +14,7 @@
 typedef struct _Thread Thread;
 
 #include "main/host/syscall_handler.h"
+#include "main/host/process.h"
 #include "main/host/syscall_types.h"
 #include "main/shmem/shmem_allocator.h"
 
@@ -72,6 +73,8 @@ ShMemBlock* thread_getIPCBlock(Thread* thread);
 // Returns the block used for shared state, or NULL if no such block is is used.
 ShMemBlock* thread_getShMBlock(Thread* thread);
 
+Process* thread_getProcess(Thread* thread);
+Host* thread_getHost(Thread* thread);
 // Get the syscallhandler for this thread.
 SysCallHandler* thread_getSysCallHandler(Thread* thread);
 

--- a/src/main/host/tracker.c
+++ b/src/main/host/tracker.c
@@ -125,7 +125,7 @@ static void _socketstats_free(SocketStats* ss) {
     }
 }
 
-Tracker* tracker_new(SimulationTime interval, LogLevel loglevel, LogInfoFlags loginfo) {
+Tracker* tracker_new(Host* host, SimulationTime interval, LogLevel loglevel, LogInfoFlags loginfo) {
     Tracker* tracker = g_new0(Tracker, 1);
     MAGIC_INIT(tracker);
 
@@ -137,7 +137,7 @@ Tracker* tracker_new(SimulationTime interval, LogLevel loglevel, LogInfoFlags lo
     tracker->socketStats = g_hash_table_new_full(g_int_hash, g_int_equal, NULL, (GDestroyNotify)_socketstats_free);
 
     /* send an alive message, and start periodic heartbeats */
-    tracker_heartbeat(tracker, NULL);
+    tracker_heartbeat(tracker, host);
 
     return tracker;
 }
@@ -562,7 +562,7 @@ static void _tracker_logRAM(Tracker* tracker, LogLevel level, SimulationTime int
         tracker->allocatedBytesTotal, numptrs, tracker->numFailedFrees);
 }
 
-void tracker_heartbeat(Tracker* tracker, gpointer userData) {
+void tracker_heartbeat(Tracker* tracker, Host* host) {
     MAGIC_ASSERT(tracker);
 
     /* check to see if node info is being logged */
@@ -603,8 +603,7 @@ void tracker_heartbeat(Tracker* tracker, gpointer userData) {
 
     /* schedule the next heartbeat */
     tracker->lastHeartbeat = worker_getCurrentTime();
-    Task* heartbeatTask = task_new((TaskCallbackFunc)tracker_heartbeat,
-            tracker, NULL, NULL, NULL);
-    worker_scheduleTask(heartbeatTask, tracker->interval);
+    Task* heartbeatTask = task_new(tracker_heartbeatTask, tracker, NULL, NULL, NULL);
+    worker_scheduleTask(heartbeatTask, host, tracker->interval);
     task_unref(heartbeatTask);
 }

--- a/src/main/host/tracker.h
+++ b/src/main/host/tracker.h
@@ -13,10 +13,10 @@
 #include "main/core/support/definitions.h"
 #include "main/host/protocol.h"
 #include "main/host/tracker_types.h"
-#include "main/routing/packet.h"
+#include "main/routing/packet.minimal.h"
 #include "support/logger/log_level.h"
 
-Tracker* tracker_new(SimulationTime interval, LogLevel loglevel, LogInfoFlags loginfo);
+Tracker* tracker_new(Host* host, SimulationTime interval, LogLevel loglevel, LogInfoFlags loginfo);
 void tracker_free(Tracker* tracker);
 
 void tracker_addProcessingTime(Tracker* tracker, SimulationTime processingTime);
@@ -30,6 +30,9 @@ void tracker_updateSocketPeer(Tracker* tracker, gint handle, in_addr_t peerIP, i
 void tracker_updateSocketInputBuffer(Tracker* tracker, gint handle, gsize inputBufferLength, gsize inputBufferSize);
 void tracker_updateSocketOutputBuffer(Tracker* tracker, gint handle, gsize outputBufferLength, gsize outputBufferSize);
 void tracker_removeSocket(Tracker* tracker, gint handle);
-void tracker_heartbeat(Tracker* tracker, gpointer userData);
+void tracker_heartbeat(Tracker* tracker, Host* host);
+static inline void tracker_heartbeatTask(Host* host, gpointer tracker, gpointer userData) {
+    tracker_heartbeat(tracker, host);
+}
 
 #endif /* SHD_TRACKER_H_ */

--- a/src/main/routing/packet.minimal.h
+++ b/src/main/routing/packet.minimal.h
@@ -1,0 +1,39 @@
+/*
+ * The Shadow Simulator
+ * Copyright (c) 2010-2011, Rob Jansen
+ * See LICENSE for licensing information
+ */
+
+#ifndef SHD_PACKET_MINIMAL_H_
+#define SHD_PACKET_MINIMAL_H_
+
+typedef struct _Packet Packet;
+
+typedef enum _PacketDeliveryStatusFlags PacketDeliveryStatusFlags;
+enum _PacketDeliveryStatusFlags {
+    PDS_NONE = 0,
+    PDS_SND_CREATED = 1 << 1,
+    PDS_SND_TCP_ENQUEUE_THROTTLED = 1 << 2,
+    PDS_SND_TCP_ENQUEUE_RETRANSMIT = 1 << 3,
+    PDS_SND_TCP_DEQUEUE_RETRANSMIT = 1 << 4,
+    PDS_SND_TCP_RETRANSMITTED = 1 << 5,
+    PDS_SND_SOCKET_BUFFERED = 1 << 6,
+    PDS_SND_INTERFACE_SENT = 1 << 7,
+    PDS_INET_SENT = 1 << 8,
+    PDS_INET_DROPPED = 1 << 9,
+    PDS_ROUTER_ENQUEUED = 1 << 10,
+    PDS_ROUTER_DEQUEUED = 1 << 11,
+    PDS_ROUTER_DROPPED = 1 << 12,
+    PDS_RCV_INTERFACE_RECEIVED = 1 << 13,
+    PDS_RCV_INTERFACE_DROPPED = 1 << 14,
+    PDS_RCV_SOCKET_PROCESSED = 1 << 15,
+    PDS_RCV_SOCKET_DROPPED = 1 << 16,
+    PDS_RCV_TCP_ENQUEUE_UNORDERED = 1 << 17,
+    PDS_RCV_SOCKET_BUFFERED = 1 << 18,
+    PDS_RCV_SOCKET_DELIVERED = 1 << 19,
+    PDS_DESTROYED = 1 << 20,
+};
+
+typedef struct _PacketTCPHeader PacketTCPHeader;
+
+#endif

--- a/src/main/routing/payload.c
+++ b/src/main/routing/payload.c
@@ -22,13 +22,13 @@ struct _Payload {
     MAGIC_DECLARE;
 };
 
-Payload* payload_new(PluginVirtualPtr data, gsize dataLength) {
+Payload* payload_new(Thread* thread, PluginVirtualPtr data, gsize dataLength) {
     Payload* payload = g_new0(Payload, 1);
     MAGIC_INIT(payload);
 
     if (data.val && dataLength > 0) {
         payload->data = g_malloc0(dataLength);
-        if (process_readPtr(worker_getActiveProcess(), payload->data, data, dataLength) != 0) {
+        if (process_readPtr(thread_getProcess(thread), payload->data, data, dataLength) != 0) {
             warning("Couldn't read data for packet");
             g_free(payload);
             return NULL;
@@ -96,7 +96,7 @@ gsize payload_getLength(Payload* payload) {
     return length;
 }
 
-gssize payload_getData(Payload* payload, gsize offset, PluginVirtualPtr destBuffer,
+gssize payload_getData(Payload* payload, Thread* thread, gsize offset, PluginVirtualPtr destBuffer,
                        gsize destBufferLength) {
     MAGIC_ASSERT(payload);
 
@@ -109,7 +109,7 @@ gssize payload_getData(Payload* payload, gsize offset, PluginVirtualPtr destBuff
 
     if (copyLength > 0) {
         int err = process_writePtr(
-            worker_getActiveProcess(), destBuffer, payload->data + offset, copyLength);
+            thread_getProcess(thread), destBuffer, payload->data + offset, copyLength);
         if (err) {
             return -err;
         }

--- a/src/main/routing/payload.h
+++ b/src/main/routing/payload.h
@@ -10,16 +10,17 @@
 #include <glib.h>
 
 #include "main/host/syscall_types.h"
+#include "main/host/thread.h"
 
 typedef struct _Payload Payload;
 
-Payload* payload_new(PluginVirtualPtr data, gsize dataLength);
+Payload* payload_new(Thread* thread, PluginVirtualPtr data, gsize dataLength);
 
 void payload_ref(Payload* payload);
 void payload_unref(Payload* payload);
 
 gsize payload_getLength(Payload* payload);
-gssize payload_getData(Payload* payload, gsize offset, PluginVirtualPtr destBuffer,
+gssize payload_getData(Payload* payload, Thread* thread, gsize offset, PluginVirtualPtr destBuffer,
                        gsize destBufferLength);
 
 gsize payload_getDataShadow(Payload* payload, gsize offset, void* destBuffer,

--- a/src/main/routing/router.c
+++ b/src/main/routing/router.c
@@ -92,15 +92,15 @@ void router_unref(Router* router) {
     }
 }
 
-void router_forward(Router* router, Packet* packet) {
+void router_forward(Router* router, Host* src, Packet* packet) {
     MAGIC_ASSERT(router);
     /* just immediately forward the sending task to the worker, who will compute the
      * path and the appropriate delays to the destination. The packet will arrive
      * at the destination's router after a delay equal to the network latency.  */
-    worker_sendPacket(packet);
+    worker_sendPacket(src, packet);
 }
 
-void router_enqueue(Router* router, Packet* packet) {
+void router_enqueue(Router* router, Host* host, Packet* packet) {
     MAGIC_ASSERT(router);
     utility_assert(packet);
 
@@ -116,7 +116,7 @@ void router_enqueue(Router* router, Packet* packet) {
 
     /* notify the netiface that we have a new packet so it can dequeue it. */
     if(!bufferedPacket && wasQueued) {
-        networkinterface_receivePackets(router->interface);
+        networkinterface_receivePackets(router->interface, host);
     }
 }
 

--- a/src/main/routing/router.h
+++ b/src/main/routing/router.h
@@ -10,7 +10,8 @@
 
 #include <glib.h>
 
-#include "main/routing/packet.h"
+#include "main/core/support/definitions.h"
+#include "main/routing/packet.minimal.h"
 
 typedef struct _Router Router;
 typedef enum _QueueManagerMode QueueManagerMode;
@@ -41,10 +42,10 @@ void router_ref(Router* router);
 void router_unref(Router* router);
 
 /* forward an outgoing packet to the destination's upstream router */
-void router_forward(Router* router, Packet* packet);
+void router_forward(Router* router, Host* src, Packet* packet);
 
 /* enqueue a downstream packet, i.e., buffer it until the host can receive it */
-void router_enqueue(Router* router, Packet* packet);
+void router_enqueue(Router* router, Host* host, Packet* packet);
 /* dequeue a downstream packet, i.e., receive it from the network */
 Packet* router_dequeue(Router* router);
 

--- a/src/main/utility/pcap_writer.c
+++ b/src/main/utility/pcap_writer.c
@@ -136,7 +136,7 @@ void pcapwriter_writePacket(PCapWriter* pcap, PCapPacket* packet) {
     }
 }
 
-PCapWriter* pcapwriter_new(gchar* pcapDirectory, gchar* pcapFilename) {
+PCapWriter* pcapwriter_new(Host* host, gchar* pcapDirectory, gchar* pcapFilename) {
     PCapWriter* pcap = g_new0(PCapWriter, 1);
 
     /* open the PCAP file for writing */
@@ -155,7 +155,7 @@ PCapWriter* pcapwriter_new(gchar* pcapDirectory, gchar* pcapFilename) {
     if(pcapFilename) {
         g_string_append_printf(filename, "%s", pcapFilename);
     } else {
-        g_string_append_printf(filename, "%s", host_getName(worker_getActiveHost()));
+        g_string_append_printf(filename, "%s", host_getName(host));
     }
 
     if (!g_str_has_suffix(filename->str, ".pcap")) {

--- a/src/main/utility/pcap_writer.h
+++ b/src/main/utility/pcap_writer.h
@@ -25,6 +25,8 @@
 #include <glib.h>
 #include <netinet/in.h>
 
+#include "main/core/support/definitions.h"
+
 typedef struct _PCapWriter PCapWriter;
 
 typedef struct _PCapPacket PCapPacket;
@@ -45,7 +47,7 @@ struct _PCapPacket {
     gpointer payload;
 };
 
-PCapWriter* pcapwriter_new(gchar* pcapDirectory, gchar* pcapFilename);
+PCapWriter* pcapwriter_new(Host* host, gchar* pcapDirectory, gchar* pcapFilename);
 void pcapwriter_free(PCapWriter* pcap);
 void pcapwriter_writePacket(PCapWriter* pcap, PCapPacket* packet);
 


### PR DESCRIPTION
This is conceptually a follow-up to #1386, but doesn't actually depend
on it. Once both this and #1386 are in, we can remove getActiveHost,
getActiveProcess, and getActiveThread entirely. This is helpful for
porting to Rust since we don't have or want those to be globals there.

In C code it suffices to pass around the "deepest" current context
object, since they all have "up" pointers. e.g. given a Thread we can
get the corresponding Process and Host. We might eventually want to
replace these parameters with their Context counterparts in #1386, but
this seems like a useful intermediate step.