### PR TITLE
Fix simulation time in log messages

### DIFF
--- a/src/main/core/support/simulation_time.rs
+++ b/src/main/core/support/simulation_time.rs
@@ -20,10 +20,14 @@ impl std::ops::Deref for SimulationTime {
 }
 
 impl SimulationTime {
-    pub fn from_c_simtime(val: u64) -> Self {
-        Self::from(std::time::Duration::from_nanos(
+    pub fn from_c_simtime(val: u64) -> Option<Self> {
+        if val == SIMTIME_INVALID {
+            return None;
+        }
+
+        Some(Self::from(std::time::Duration::from_nanos(
             val * SIMTIME_ONE_NANOSECOND,
-        ))
+        )))
     }
 }
 
@@ -65,7 +69,7 @@ mod tests {
     #[test]
     fn test_from_sim_time() {
         let sim_time = 5 * SIMTIME_ONE_MINUTE + 7 * SIMTIME_ONE_MILLISECOND;
-        let rust_time = SimulationTime::from_c_simtime(sim_time);
+        let rust_time = SimulationTime::from_c_simtime(sim_time).unwrap();
 
         assert_eq!(rust_time.as_secs(), 5 * 60);
         assert_eq!(rust_time.as_millis(), 5 * 60 * 1_000 + 7);

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -198,9 +198,7 @@ impl Worker {
         if !Worker::is_alive() {
             return None;
         }
-        Some(SimulationTime::from_c_simtime(unsafe {
-            cshadow::worker_getCurrentTime()
-        }))
+        SimulationTime::from_c_simtime(unsafe { cshadow::worker_getCurrentTime() })
     }
 
     /// ID of this thread's Worker, if any.


### PR DESCRIPTION
Log messages printed after `worker_runEvent()` would contain simulation times of `5124095:34:33.709551615`:

```
00:00:00.295908 [worker-1] 5124095:34:33.709551615 [INFO] [client2:11.0.0.2] [host.c:284] [host_shutdown] host 'client2' has been shut down
```