### PR TITLE
test_clone: Fix and extend clone_child_exits_after_leader

### DIFF
--- a/src/test/clone/CMakeLists.txt
+++ b/src/test/clone/CMakeLists.txt
@@ -4,6 +4,12 @@ target_compile_options(test_clone PUBLIC "-pthread")
 target_link_libraries(test_clone ${GLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 add_linux_tests(BASENAME clone COMMAND test_clone)
 add_shadow_tests(BASENAME clone METHODS hybrid ptrace)
+
+# The clone test exercises some corner cases in memory management, particularly
+# when the thread leader exits before all the threads. Useful to test it without
+# the memory manager (really the MemoryMapper) enabled.
+add_shadow_tests(BASENAME clone-nomm METHODS hybrid ptrace ARGS --use-memory-manager=false)
+
 # FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
 # FIXME: The interposed libc does not handle this either.
 #add_shadow_tests(BASENAME clone METHODS preload CONFIGURATIONS ilibc)

--- a/src/test/clone/clone-nomm.yaml
+++ b/src/test/clone/clone-nomm.yaml
@@ -1,0 +1,1 @@
+clone.yaml


### PR DESCRIPTION
Allowing `main` to exit was causing the whole process to exit (via
exit_group) instead of just exiting the thread-group-leader.

This resulted in no-longer exercising the edge case where the
MemoryCopier tries to use the task id of a dead thread (the thread group
leader).

Also extended this test to more explicitly test this, by having another
thread validate that Shadow was able to clear the ctid after one of the
other threads exited (both after the thread group leader exited).