### PR TITLE
Remove getActiveThread, getActiveProcess, getActiveWorker

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -290,12 +290,6 @@ void worker_setActiveProcess(Process *process);
 
 void worker_setActiveThread(Thread *thread);
 
-Host *worker_getActiveHost(void);
-
-Process *worker_getActiveProcess(void);
-
-Thread *worker_getActiveThread(void);
-
 // Create an object that can be used to store all descriptors created by a
 // process. When the table is no longer required, use descriptortable_free
 // to release the reference.

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1350,15 +1350,6 @@ extern "C" {
 extern "C" {
     pub fn worker_setActiveThread(thread: *mut Thread);
 }
-extern "C" {
-    pub fn worker_getActiveHost() -> *mut Host;
-}
-extern "C" {
-    pub fn worker_getActiveProcess() -> *mut Process;
-}
-extern "C" {
-    pub fn worker_getActiveThread() -> *mut Thread;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _Task {


### PR DESCRIPTION
We no longer store pointers to the "current" objects in the global
Worker, only some information *about* those objects.