### PR TITLE
Fix and document build errors on CentOS 8

### DIFF
--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -39,6 +39,7 @@ RPM_PACKAGES="
   xz-devel
   yum-utils
   diffutils
+  libarchive
   "
 
 # packages that are only required for our CI environment

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -132,3 +132,9 @@ dnf install -y http://vault.centos.org/centos/7.7.1908/os/x86_64/Packages/procps
 dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages/i/igraph-0.7.1-12.el7.x86_64.rpm
 dnf install -y https://dl.fedoraproject.org/pub/archive/epel/7.7/x86_64/Packages/i/igraph-devel-0.7.1-12.el7.x86_64.rpm
 ```
+
+Due to [a bug](https://bugs.centos.org/view.php?id=18212) in the CentOS 8 CMake package, you must also install libarchive manually.
+
+```bash
+dnf install -y libarchive
+```


### PR DESCRIPTION
An [issue](https://bugs.centos.org/view.php?id=18212) with the CentOS 8 CMake package is causing CMake to fail with the following error when building Shadow:

```
cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd
```

The fix for now is to manually install libarchive.

This bug is causing our CentOS 8 CI tests to fail.