### PR TITLE
Updates to log format, readme, and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,26 @@ efficiency and control of simulation, achieving the best of both approaches.
 
 Quick Setup (installs everything in `~/.shadow`):
 ```
-$ ./setup build --clean --debug
+$ ./setup build --clean
+$ ./setup test
 $ ./setup install
 ```
 
 Detailed Documentation
   + [docs/README.md](docs/README.md)
 
-Questions and Bug Reports:
+Questions:
+  + https://github.com/shadow/shadow/discussions
+
+Bug Reports:
   + https://github.com/shadow/shadow/issues
 
-Shadow Plug-ins and Project Development:
+Shadow Project Development:
   + https://github.com/shadow
         
 Homepage:
   + https://shadow.github.io
     
-# Contributing
+## Contributing
 
 See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ Homepage:
     
 ## Contributing
 
-See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)
+See [docs/contributing.md](docs/contributing.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ The docs contain important information about installing and using the Shadow dis
      * [System Configuration](system_configuration.md)
      * [(Experimental) Shadow with Docker](install_shadow_with_docker.md)
    * [Getting Started](getting_started.md)
+   * [Parsing Statistics](parsing_statistics.md)
+   * [Log Format](log_format.md)
    * Simulation Customization
      * [Shadow Configuration](shadow_config.md)
      * [Network Configuration](network_config.md)

--- a/docs/install_shadow.md
+++ b/docs/install_shadow.md
@@ -1,4 +1,6 @@
-## Shadow Setup
+# Shadow Setup
+
+After building and testing Shadow, the install step is optional. If you do not wish to install Shadow, you can run it directly from the build directory (`./build/src/main/shadow`).
 
 ```bash
 git clone https://github.com/shadow/shadow.git
@@ -8,7 +10,7 @@ cd shadow
 ./setup install
 ```
 
-You should add `/home/${USER}/.shadow/bin` to your shell setup for the PATH environment variable (e.g., in `~/.bashrc` or `~/.bash_profile`).
+If you installed Shadow, you should add `/home/${USER}/.shadow/bin` to your shell setup for the PATH environment variable (e.g., in `~/.bashrc` or `~/.bash_profile`).
 
 ```bash
 echo 'export PATH="${PATH}:/home/${USER}/.shadow/bin"' >> ~/.bashrc && source ~/.bashrc
@@ -21,7 +23,11 @@ shadow --version
 shadow --help
 ```
 
-#### Setup Notes
+## Uninstall Shadow
+
+After running `./setup install`, you can find the list of installed files in `./build/install_manifest.txt`. To uninstall Shadow, remove any files listed.
+
+## Setup Notes
 
   + All build output is generated out-of-source, by default to the `./build` directory.
   + Use `./setup build --help` to see all build options; the most useful build options are:  

--- a/docs/log_format.md
+++ b/docs/log_format.md
@@ -29,13 +29,13 @@ the name of the function logging the message
 - `MESSAGE`:  
 the actual message to be logged
 
-By default, Shadow only prints core messages at or below the `message` log level. This behavior can be changed using the Shadow option `-l` or `--log-level` to increase or decrease the verbosity of the output. As mentioned in the example from the previous section, the output from each application process is stored in separate log files beneath the `shadow.data` directory, and the format of those log files is application-specific (i.e., Shadow writes application output _directly_ to file).
+By default, Shadow only prints core messages at or below the [`info` log level](shadow_config.md#generallog_level). This behavior can be changed using the Shadow option `-l` or `--log-level` to increase or decrease the verbosity of the output. As mentioned in the example from the previous section, the output from each application process is stored in separate log files beneath the `shadow.data` directory, and the format of those log files is application-specific (i.e., Shadow writes application output _directly_ to file).
 
 ## Heartbeat Messages
 
 Shadow logs simulator heartbeat messages that contain useful system information for each virtual node in the experiment, in messages containing the string `shadow-heartbeat`. By default, these heartbeats are logged once per second, but the frequency can be changed using the `--heartbeat-frequency` option to Shadow (see `shadow --help`).
 
-There are currently three heartbeat statistic subsystems: `node`, `socket`, and `ram`. For each subsystem that is enabled, Shadow will print a 'header' message followed by regular message every frequency interval. The 'header' messages generally describe the statistics that are printed in the regular messages for that subsystem.
+There are currently three [heartbeat statistic subsystems](shadow_config.md#host_defaultsheartbeat_log_info): `node`, `socket`, and `ram`. For each subsystem that is enabled, Shadow will print a 'header' message followed by regular message every frequency interval. The 'header' messages generally describe the statistics that are printed in the regular messages for that subsystem.
 
 The following are examples of the statistics that are available for each subsystem:
 


### PR DESCRIPTION
I noticed I missed something in the log format docs, added some notes on uninstalling Shadow, and changed the README "quick setup" to not install the debug version since it's very slow.