### PR TITLE
Updated example in 'parsing_statistics' doc

### DIFF
--- a/src/tools/plot-shadow.py
+++ b/src/tools/plot-shadow.py
@@ -1213,7 +1213,11 @@ def get_relay_capacities(shadow_config_path, bwup=False, bwdown=False):
 def movingaverage(interval, window_size):
     if len(interval) > 0:
         window = numpy.ones(int(window_size))/float(window_size)
-        return numpy.convolve(interval, window, 'same')
+        result = numpy.convolve(interval, window, 'same')
+        # hide the boundary effects
+        result[:int(window_size/2)] = numpy.nan
+        result[-int(window_size/2):] = numpy.nan
+        return result
     else:
         return []
 


### PR DESCRIPTION
The existing example comparing didn't show any difference between traffic queuing disciplines, so the new example uses different socket recv buffer sizes which show a noticeable difference. A small change was made to the plotting scripts to hide boundary effects when calculating a moving average.