### PR TITLE
Add units to topology latency

### DIFF
--- a/docs/network_graph_attributes.md
+++ b/docs/network_graph_attributes.md
@@ -22,7 +22,7 @@ graph [
     source 0
     target 0
     label "path from 1.2.3.4 to 1.2.3.4"
-    latency 10.0
+    latency "10 ms"
     jitter 0.0
     packet_loss 0.0
   ]
@@ -132,9 +132,9 @@ An optional, human-meaningful string description of the edge. The string may be 
 #### `edge.latency`
 
 Required: True  
-Type: Float
+Type: String
 
-The latency that will be added to packets traversing this edge. This value is used as a weight while running Dijkstra's shortest path algorithm.
+The latency that will be added to packets traversing this edge. This value is used as a weight while running Dijkstra's shortest path algorithm. The format of the string specifies the latency and its unit, e.g., `10 ms`. If a unit is not specified, it will be assumed that it is in the base unit of "seconds".
 
 #### `edge.jitter`
 

--- a/docs/parsing_statistics.md
+++ b/docs/parsing_statistics.md
@@ -28,7 +28,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50
+          latency "50 ms"
           packet_loss 0.01
         ]
       ]

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -249,6 +249,9 @@ SimulationTime processoptions_getStopTime(const struct ProcessOptions *proc);
 // Parses a string as bits-per-second. Returns '-1' on error.
 int64_t parse_bandwidth(const char *s);
 
+// Parses a string as a time in milliseconds. Returns '-1' on error.
+int64_t parse_time_ms(const char *s);
+
 // Initialize a Worker for this thread.
 void worker_newForThisThread(WorkerPool *worker_pool,
                              int32_t worker_id,

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -724,15 +724,13 @@ const ONE_GBIT_SWITCH_GRAPH: &str = r#"graph [
   node [
     id 0
     ip_address "0.0.0.0"
-    country_code "XX"
     bandwidth_up "1 Gbit"
     bandwidth_down "1 Gbit"
   ]
   edge [
     source 0
     target 0
-    latency 1.0
-    jitter 0.0
+    latency "1 ms"
     packet_loss 0.0
   ]
 ]"#;

--- a/src/main/core/support/units.rs
+++ b/src/main/core/support/units.rs
@@ -795,4 +795,36 @@ mod export {
 
         rv
     }
+
+    /// Parses a string as a time in milliseconds. Returns '-1' on error.
+    #[no_mangle]
+    pub extern "C" fn parse_time_ms(s: *const libc::c_char) -> i64 {
+        assert!(!s.is_null());
+
+        let s = match unsafe { std::ffi::CStr::from_ptr(s) }.to_str() {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("{}", e.to_string());
+                return -1;
+            }
+        };
+
+        let value = match Time::from_str(s) {
+            Ok(x) => x.convert(TimePrefix::Milli).unwrap().value(),
+            Err(e) => {
+                warn!("{}", e.to_string());
+                return -1;
+            }
+        };
+
+        let rv: i64 = match value.try_into() {
+            Ok(x) => x,
+            Err(e) => {
+                warn!("{}", e.to_string());
+                return -1;
+            }
+        };
+
+        rv
+    }
 }

--- a/src/test/config/convert/shadow.expected.yaml
+++ b/src/test/config/convert/shadow.expected.yaml
@@ -17,7 +17,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/config/convert/topology.expected.gml
+++ b/src/test/config/convert/topology.expected.gml
@@ -10,7 +10,7 @@ graph [
   edge [
     source 0
     target 0
-    latency 50.0
+    latency "50 ms"
     packet_loss 0.0
   ]
 ]

--- a/src/test/determinism/determinism1.test.shadow.config.yaml
+++ b/src/test/determinism/determinism1.test.shadow.config.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/determinism/determinism2.test.shadow.config.yaml
+++ b/src/test/determinism/determinism2.test.shadow.config.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 250.0
+          latency "250 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/phold/phold.yaml
+++ b/src/test/phold/phold.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/tcp/tcp-blocking-loopback.yaml
+++ b/src/test/tcp/tcp-blocking-loopback.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/tcp/tcp-blocking-lossless.yaml
+++ b/src/test/tcp/tcp-blocking-lossless.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/tcp/tcp-blocking-lossy.yaml
+++ b/src/test/tcp/tcp-blocking-lossy.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.25
         ]
       ]

--- a/src/test/tcp/tcp-iov-loopback.yaml
+++ b/src/test/tcp/tcp-iov-loopback.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/tcp/tcp-iov-lossless.yaml
+++ b/src/test/tcp/tcp-iov-lossless.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/tcp/tcp-iov-lossy.yaml
+++ b/src/test/tcp/tcp-iov-lossy.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.25
         ]
       ]

--- a/src/test/tcp/tcp-nonblocking-epoll-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-loopback.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/tcp/tcp-nonblocking-epoll-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-lossless.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/tcp/tcp-nonblocking-epoll-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-lossy.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.25
         ]
       ]

--- a/src/test/tcp/tcp-nonblocking-poll-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-loopback.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/tcp/tcp-nonblocking-poll-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-lossless.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/tcp/tcp-nonblocking-poll-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-lossy.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.25
         ]
       ]

--- a/src/test/tcp/tcp-nonblocking-select-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-loopback.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/tcp/tcp-nonblocking-select-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-lossless.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.0
         ]
       ]

--- a/src/test/tcp/tcp-nonblocking-select-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-lossy.yaml
@@ -15,7 +15,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           packet_loss 0.25
         ]
       ]

--- a/src/test/tor/minimal/tor-minimal.yaml
+++ b/src/test/tor/minimal/tor-minimal.yaml
@@ -16,7 +16,7 @@ network:
         edge [
           source 0
           target 0
-          latency 50.0
+          latency "50 ms"
           jitter 0.0
           packet_loss 0.0
         ]

--- a/src/tools/convert_legacy_topology.py
+++ b/src/tools/convert_legacy_topology.py
@@ -20,10 +20,18 @@ def bandwidth_conversion(x):
     return str(int(x) * 8) + ' Kibit'
 
 
+def latency_conversion(x):
+    # shadow classic uses latency units of milliseconds
+    x = float(x)
+    assert x.is_integer(), 'Sub-millisecond latencies are not supported'
+    return str(int(x)) + ' ms'
+
+
 # original attribute name: (new attribute name, new attribute type, value transform fn)
 ATTR_CONVERSIONS = {
     'bandwidthup': ('bandwidth_up', 'string', bandwidth_conversion),
     'bandwidthdown': ('bandwidth_down', 'string', bandwidth_conversion),
+    'latency': ('latency', 'string', latency_conversion),
     'packetloss': ('packet_loss', None, None),
     'countrycode': ('country_code', None, None),
     'citycode': ('city_code', None, None),


### PR DESCRIPTION
The order of the weights generated by `_topology_extractEdgeWeights()` shouldn't change since the original function used `EANV()`, which is defined as:

https://github.com/igraph/igraph/blob/298c0ac9777869090de2b3bca94a4d17cd5564fa/include/igraph_attributes.h#L564-L565

```c
#define EANV(graph,n,vec) (igraph_cattribute_EANV((graph),(n), \
                           igraph_ess_all(IGRAPH_EDGEORDER_ID), (vec)))
```

And the new code uses:

```c
igraph_eit_create(&top->graph, igraph_ess_all(IGRAPH_EDGEORDER_ID), &edgeIterator)
```

So the edge selector is the same.