### PR TITLE
Accept nanoseconds in the topology latency

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -249,8 +249,8 @@ SimulationTime processoptions_getStopTime(const struct ProcessOptions *proc);
 // Parses a string as bits-per-second. Returns '-1' on error.
 int64_t parse_bandwidth(const char *s);
 
-// Parses a string as a time in milliseconds. Returns '-1' on error.
-int64_t parse_time_ms(const char *s);
+// Parses a string as a time in nanoseconds. Returns '-1' on error.
+int64_t parse_time_nanosec(const char *s);
 
 // Initialize a Worker for this thread.
 void worker_newForThisThread(WorkerPool *worker_pool,

--- a/src/main/core/support/units.rs
+++ b/src/main/core/support/units.rs
@@ -796,9 +796,9 @@ mod export {
         rv
     }
 
-    /// Parses a string as a time in milliseconds. Returns '-1' on error.
+    /// Parses a string as a time in nanoseconds. Returns '-1' on error.
     #[no_mangle]
-    pub extern "C" fn parse_time_ms(s: *const libc::c_char) -> i64 {
+    pub extern "C" fn parse_time_nanosec(s: *const libc::c_char) -> i64 {
         assert!(!s.is_null());
 
         let s = match unsafe { std::ffi::CStr::from_ptr(s) }.to_str() {
@@ -810,7 +810,7 @@ mod export {
         };
 
         let value = match Time::from_str(s) {
-            Ok(x) => x.convert(TimePrefix::Milli).unwrap().value(),
+            Ok(x) => x.convert(TimePrefix::Nano).unwrap().value(),
             Err(e) => {
                 warn!("{}", e.to_string());
                 return -1;


### PR DESCRIPTION
The atlas topology uses floating point latency values, so we need to support a higher precision than just milliseconds. Rounding to microseconds should be enough precision, so we should support microsecond values in Shadow.