### PR TITLE
Plugin -> Managed Process

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -59,15 +59,15 @@ gdb --pid=PID
 > continue
 ```
 
-### Debugging plugins with gdb
+### Debugging managed processes with gdb
 
-In its default mode of operation, Shadow uses ptrace to control its emulated
+In its default mode of operation, Shadow uses ptrace to control its managed
 processes. This means that GDB *cannot* attach to those processes. As long as
 GDB's `follow-fork-mode` is `parent` (which is currently the default), it will
 correctly attach to Shadow and its worker threads, but not attempt to attach to
-forked plugin processes.
+Shadow-managed processes.
 
-If a plugin process is crashing (e.g. being killed by a signal within the
+If a managed process is crashing (e.g. being killed by a signal within the
 simulation), it is still possible to use gdb to help debug it by generating a
 core file, and using gdb to inspect it afterwards:
 
@@ -75,12 +75,12 @@ core file, and using gdb to inspect it afterwards:
 # Enable core dumps
 ulimit -c unlimited
 
-# Run the simulation in which a plugin is crashing
+# Run the simulation in which a managed process is crashing
 shadow shadow.config.xml
 
 # Tell gdb to inspect the core file. From within gdb you'll be able to
 # inspect the state of the process just before it was killed. 
-gdb <path-to-plugin-executable> <path-to-core-file>
+gdb <path-to-process-executable> <path-to-core-file>
 
 # It's often useful to look at the stack backtrace:
 > bt

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -59,23 +59,30 @@ gdb --pid=PID
 > continue
 ```
 
-### Debugging managed processes with gdb
+Note though, that GDB's `follow-fork-mode` setting should be left in its default
+setting of `parent`; see below.
 
-In its default mode of operation, Shadow uses ptrace to control its managed
-processes. This means that GDB *cannot* attach to those processes. As long as
-GDB's `follow-fork-mode` is `parent` (which is currently the default), it will
-correctly attach to Shadow and its worker threads, but not attempt to attach to
-Shadow-managed processes.
+### Debugging virtual processes
 
-If a managed process is crashing (e.g. being killed by a signal within the
-simulation), it is still possible to use gdb to help debug it by generating a
-core file, and using gdb to inspect it afterwards:
+As of Shadow 2.0, virtual processes in the simulation are implemented as native
+OS processes, with their syscalls interposed by Shadow. Since they are native
+processes, many normal tools for inspecting native processes can be used on
+those as well. e.g. `top` will show how much CPU and memory they are using.
+
+However, in its default mode of operation, Shadow uses ptrace to control these
+processes. Since Linux only allows a process to be ptraced by one other process
+at a time, gdb *cannot* attach to those processes.
+
+If a virtual process is crashing (e.g. being killed by a signal within the
+simulation), it is still possible to use gdb to help debug it by causing the
+native process to generate a core file, and then using gdb to inspect it
+afterwards:
 
 ```
 # Enable core dumps
 ulimit -c unlimited
 
-# Run the simulation in which a managed process is crashing
+# Run the simulation in which a process is crashing
 shadow shadow.config.xml
 
 # Tell gdb to inspect the core file. From within gdb you'll be able to

--- a/docs/migrating_from_1x.md
+++ b/docs/migrating_from_1x.md
@@ -16,9 +16,9 @@ shadow/src/tools/convert_legacy_config.py my-shadow-config.xml
 ```
 
 You may have to manually tweak the new configuration file to support the new
-managed process [working directory](https://en.wikipedia.org/wiki/Working_directory). In
-Shadow 1.x, each managed process (then called a plugin) has the same working directory as the Shadow process
-itself. In Shadow 2.x, the working directory of each managed process is its host data
+virtual process [working directory](https://en.wikipedia.org/wiki/Working_directory). In
+Shadow 1.x, each virtual process (then called a plugin) has the same working directory as the Shadow process
+itself. In Shadow 2.x, the working directory of each virtual process is its host data
 directory. For example a process running on host `myhost` would have the working
 directory `shadow.data/hosts/myhost/`. You can use the
 [`experimental.use_legacy_working_dir`](shadow_config_options.md#experimentaluse_legacy_working_dir)

--- a/docs/migrating_from_1x.md
+++ b/docs/migrating_from_1x.md
@@ -15,7 +15,15 @@ The following will create a new configuration file `my-shadow-config.yaml`.
 shadow/src/tools/convert_legacy_config.py my-shadow-config.xml
 ```
 
-You may have to manually tweak the new configuration file to support the new plugin [working directory](https://en.wikipedia.org/wiki/Working_directory). In Shadow 1.x, each plugin has the same working directory as the Shadow process itself. In Shadow 2.x, the working directory of each plugin is its host data directory. For example a plugin running on host `myhost` would have the working directory `shadow.data/hosts/myhost/`. You can use the [`experimental.use_legacy_working_dir`](shadow_config_options.md#experimentaluse_legacy_working_dir) option to use the Shadow 1.x working directory, but this is an experimental option and may be removed in the future.
+You may have to manually tweak the new configuration file to support the new
+managed process [working directory](https://en.wikipedia.org/wiki/Working_directory). In
+Shadow 1.x, each managed process (then called a plugin) has the same working directory as the Shadow process
+itself. In Shadow 2.x, the working directory of each managed process is its host data
+directory. For example a process running on host `myhost` would have the working
+directory `shadow.data/hosts/myhost/`. You can use the
+[`experimental.use_legacy_working_dir`](shadow_config_options.md#experimentaluse_legacy_working_dir)
+option to use the Shadow 1.x working directory, but this is an experimental
+option and may be removed in the future.
 
 ### Converting a topology file to the Shadow 2.0 format
 

--- a/docs/nsf_sponsorship.md
+++ b/docs/nsf_sponsorship.md
@@ -36,7 +36,7 @@ Here we outline some high level tasks that we are completing or plan to complete
    * Improve maintainability and accuracy of TCP implementation - [milestone](https://github.com/shadow/shadow/milestone/18)
    * Simplify event scheduler, implement continuous event execution model
    * Build a distributed core simulation engine
-   * Develop CPU usage model to ensure managed process CPU utilization consumes simulation time
+   * Develop CPU usage model to ensure virtual process CPU utilization consumes simulation time
 
  * **Task 2: Develop User Interface and Visualizations**
    * Design control protocol and API for interacting with Shadow

--- a/docs/nsf_sponsorship.md
+++ b/docs/nsf_sponsorship.md
@@ -36,7 +36,7 @@ Here we outline some high level tasks that we are completing or plan to complete
    * Improve maintainability and accuracy of TCP implementation - [milestone](https://github.com/shadow/shadow/milestone/18)
    * Simplify event scheduler, implement continuous event execution model
    * Build a distributed core simulation engine
-   * Develop CPU usage model to ensure plugin CPU utilization consumes simulation time
+   * Develop CPU usage model to ensure managed process CPU utilization consumes simulation time
 
  * **Task 2: Develop User Interface and Visualizations**
    * Design control protocol and API for interacting with Shadow

--- a/docs/shadow_config_options.md
+++ b/docs/shadow_config_options.md
@@ -288,7 +288,7 @@ Send message to managed process telling it to stop spinning when a syscall block
 Default: false  
 Type: Bool
 
-Don't adjust the working directories of the managed processes.
+Don't adjust the working directories of the virtual processes.
 
 #### `experimental.use_memory_manager`
 

--- a/docs/shadow_config_options.md
+++ b/docs/shadow_config_options.md
@@ -281,14 +281,14 @@ Pin each thread and any processes it executes to the same logical CPU Core to im
 Default: false  
 Type: Bool
 
-Send message to plugin telling it to stop spinning when a syscall blocks.
+Send message to managed process telling it to stop spinning when a syscall blocks.
 
 #### `experimental.use_legacy_working_dir`
 
 Default: false  
 Type: Bool
 
-Don't adjust the working directories of the plugins.
+Don't adjust the working directories of the managed processes.
 
 #### `experimental.use_memory_manager`
 

--- a/docs/using_recompiled_libc.md
+++ b/docs/using_recompiled_libc.md
@@ -128,7 +128,7 @@ cd ~/rpmbuild/SPECS && rpmbuild -ba glibc.spec
 
 ## Using the compiled libc
 
-The patched libc can be injected into a managed process by setting `LD_LIBRARY_PATH` in each process's environment. e.g.:
+The patched libc can be injected into a virtual process by setting `LD_LIBRARY_PATH` in each process's environment. e.g.:
 
 ```
 ...

--- a/docs/using_recompiled_libc.md
+++ b/docs/using_recompiled_libc.md
@@ -128,7 +128,7 @@ cd ~/rpmbuild/SPECS && rpmbuild -ba glibc.spec
 
 ## Using the compiled libc
 
-The patched libc can be injected into a plugin by setting `LD_LIBRARY_PATH` in each target plugin's environment. e.g.:
+The patched libc can be injected into a managed process by setting `LD_LIBRARY_PATH` in each process's environment. e.g.:
 
 ```
 ...


### PR DESCRIPTION
"Plugin" no longer makes sense for Shadow 2.0. Initially we talked about using "managed process" anywhere we would otherwise say "plugin". On further discussion, "virtual" process is a little better when talking about the more abstract concept of a process in the simulation vs the native process used to help implement it.