### PR TITLE
Handle unaligned pointers from managed processes gracefully

### DIFF
--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -580,13 +580,7 @@ impl MemoryManager {
     ) -> SyscallResult {
         let addr = thread.native_mmap(addr, length, prot, flags, fd, offset)?;
         if let Some(mm) = &mut self.memory_mapper {
-            mm.handle_mmap_result(
-                thread,
-                TypedPluginPtr::new_u8(addr, length),
-                prot,
-                flags,
-                fd,
-            );
+            mm.handle_mmap_result(thread, TypedPluginPtr::new(addr, length), prot, flags, fd);
         }
         Ok(addr.into())
     }
@@ -689,7 +683,7 @@ where
         );
 
         Self {
-            ptr: TypedPluginPtr::<T>::new(ptr, len).unwrap(),
+            ptr: TypedPluginPtr::<T>::new(ptr, len),
             freed: false,
         }
     }
@@ -811,7 +805,7 @@ mod export {
     ) -> *mut ProcessMemoryRef<'a, u8> {
         let memory_manager = unsafe { memory_manager.as_ref().unwrap() };
         let plugin_src: PluginPtr = plugin_src.into();
-        let memory_ref = memory_manager.memory_ref(TypedPluginPtr::new_u8(plugin_src.into(), n));
+        let memory_ref = memory_manager.memory_ref(TypedPluginPtr::new(plugin_src.into(), n));
         match memory_ref {
             Ok(mr) => Box::into_raw(Box::new(mr)),
             Err(e) => {
@@ -828,8 +822,7 @@ mod export {
         n: usize,
     ) -> *mut ProcessMemoryRef<'a, u8> {
         let memory_manager = unsafe { memory_manager.as_ref().unwrap() };
-        match memory_manager
-            .memory_ref_prefix(TypedPluginPtr::new_u8(PluginPtr::from(plugin_src), n))
+        match memory_manager.memory_ref_prefix(TypedPluginPtr::new(PluginPtr::from(plugin_src), n))
         {
             Ok(mr) => Box::into_raw(Box::new(mr)),
             Err(e) => {
@@ -850,7 +843,7 @@ mod export {
         let buf =
             unsafe { std::slice::from_raw_parts_mut(notnull_mut_debug(strbuf) as *mut u8, maxlen) };
         let cstr = match memory_manager
-            .copy_str_from_ptr(buf, TypedPluginPtr::new_u8(PluginPtr::from(ptr), maxlen))
+            .copy_str_from_ptr(buf, TypedPluginPtr::new(PluginPtr::from(ptr), maxlen))
         {
             Ok(cstr) => cstr,
             Err(e) => return -(e as libc::ssize_t),
@@ -867,7 +860,7 @@ mod export {
         n: usize,
     ) -> i32 {
         let memory_manager = unsafe { memory_manager.as_ref().unwrap() };
-        let src = TypedPluginPtr::new_u8(src.into(), n);
+        let src = TypedPluginPtr::new(src.into(), n);
         let dst = unsafe { std::slice::from_raw_parts_mut(notnull_mut_debug(dst) as *mut u8, n) };
         match memory_manager.copy_from_ptr(dst, src) {
             Ok(_) => 0,
@@ -887,7 +880,7 @@ mod export {
         n: usize,
     ) -> i32 {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let dst = TypedPluginPtr::new_u8(dst.into(), n);
+        let dst = TypedPluginPtr::new(dst.into(), n);
         let src = unsafe { std::slice::from_raw_parts(notnull_debug(src) as *const u8, n) };
         match memory_manager.copy_to_ptr(dst, src) {
             Ok(_) => 0,
@@ -906,7 +899,7 @@ mod export {
         n: usize,
     ) -> *mut ProcessMemoryRefMut<'a, u8> {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let plugin_src = TypedPluginPtr::<u8>::new(PluginPtr::from(plugin_src), n).unwrap();
+        let plugin_src = TypedPluginPtr::<u8>::new(PluginPtr::from(plugin_src), n);
         let memory_ref = memory_manager.memory_ref_mut_uninit(plugin_src);
         match memory_ref {
             Ok(mr) => Box::into_raw(Box::new(mr)),
@@ -925,7 +918,7 @@ mod export {
         n: usize,
     ) -> *mut ProcessMemoryRefMut<'a, u8> {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let plugin_src = TypedPluginPtr::<u8>::new(PluginPtr::from(plugin_src), n).unwrap();
+        let plugin_src = TypedPluginPtr::<u8>::new(PluginPtr::from(plugin_src), n);
         let memory_ref = memory_manager.memory_ref_mut(plugin_src);
         match memory_ref {
             Ok(mr) => Box::into_raw(Box::new(mr)),

--- a/src/main/host/syscall/unistd.rs
+++ b/src/main/host/syscall/unistd.rs
@@ -140,7 +140,7 @@ fn read_helper(
         // call the file's read(), and run any resulting events
         EventQueue::queue_and_run(|event_queue| {
             posix_file.borrow_mut().read(
-                ctx.process.memory_mut().writer(TypedPluginPtr::new(buf_ptr, buf_size).unwrap()),
+                ctx.process.memory_mut().writer(TypedPluginPtr::new(buf_ptr, buf_size)),
                 offset,
                 event_queue,
             )
@@ -209,7 +209,7 @@ fn write_helper(
         // call the file's write(), and run any resulting events
         EventQueue::queue_and_run(|event_queue| {
             posix_file.borrow_mut().write(
-                ctx.process.memory().reader(TypedPluginPtr::<u8>::new(buf_ptr, buf_size).unwrap()),
+                ctx.process.memory().reader(TypedPluginPtr::<u8>::new(buf_ptr, buf_size)),
                 offset,
                 event_queue,
             )
@@ -312,7 +312,7 @@ fn pipe_helper(ctx: &mut ThreadContext, fd_ptr: PluginPtr, flags: i32) -> Syscal
     let write_res = ctx
         .process
         .memory_mut()
-        .copy_to_ptr(TypedPluginPtr::new(fd_ptr.into(), 2)?, &fds);
+        .copy_to_ptr(TypedPluginPtr::new(fd_ptr.into(), 2), &fds);
 
     // Clean up in case of error
     match write_res {

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -78,6 +78,10 @@ name = "test_mmap"
 path = "memory/test_mmap.rs"
 
 [[bin]]
+name = "test_unaligned"
+path = "memory/test_unaligned.rs"
+
+[[bin]]
 name = "test_eventfd"
 path = "eventfd/test_eventfd.rs"
 

--- a/src/test/memory/CMakeLists.txt
+++ b/src/test/memory/CMakeLists.txt
@@ -5,3 +5,6 @@ add_shadow_tests(BASENAME mmap METHODS hybrid ARGS "--seed 0")
 add_shadow_tests(BASENAME mmap METHODS ptrace ARGS "--seed 1")
 # FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
 add_shadow_tests(BASENAME mmap METHODS preload CONFIGURATIONS ilibc ARGS "--seed 2")
+
+add_linux_tests(BASENAME unaligned COMMAND sh -c "../target/debug/test_unaligned --libc-passing")
+add_shadow_tests(BASENAME unaligned METHODS hybrid ptrace preload)

--- a/src/test/memory/test_unaligned.rs
+++ b/src/test/memory/test_unaligned.rs
@@ -1,0 +1,102 @@
+use nix::errno::Errno;
+use std::error::Error;
+use test_utils::set;
+use test_utils::ShadowTest;
+use test_utils::TestEnvironment as TestEnv;
+
+fn test_unaligned_read() -> Result<(), Box<dyn Error>> {
+    // Force Shadow to read an *unaligned* timespec struct.
+
+    // First create a normal, aligned struct.
+    let t = libc::timespec {
+        tv_sec: 1,
+        tv_nsec: 2,
+    };
+
+    // Create a buf to hold the unaligned version.  We declare this as a buf of
+    // timespecs so that it'll be properly aligned, guaranteeing that adding an
+    // offset < alignment will give us an unaligned pointer.
+    let mut buf = [libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    }; 2];
+
+    let src = unsafe {
+        std::slice::from_raw_parts(
+            &t as *const libc::timespec as *const u8,
+            std::mem::size_of::<libc::timeval>(),
+        )
+    };
+    let unaligned_t = unsafe {
+        std::slice::from_raw_parts_mut(
+            (&mut buf as *mut libc::timespec as *mut u8).add(1),
+            std::mem::size_of::<libc::timeval>(),
+        )
+    };
+    unaligned_t.copy_from_slice(src);
+    let unaligned_t = unaligned_t.as_ptr() as *const libc::timespec;
+
+    // Double-check that that we actually ended up with an unaligned pointer.
+    assert_ne!((unaligned_t as usize) % std::mem::align_of_val(&t), 0);
+
+    // Just validate that nanosleep returns without an error or crashing.
+    Errno::result(unsafe { libc::nanosleep(unaligned_t, std::ptr::null_mut()) })?;
+
+    Ok(())
+}
+
+fn test_unaligned_write() -> Result<(), Box<dyn Error>> {
+    // Force Shadow to write an *unaligned* timeval struct.
+
+    // We declare this as a buf of timevals so that it'll be properly aligned,
+    // guaranteeing that adding an offset < alignment will give us an unaligned
+    // pointer.
+    let mut buf = [libc::timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    }; 2];
+    let unaligned_tv = unsafe { (buf.as_mut_ptr() as *mut u8).add(1) as *mut libc::timeval };
+    // Double-check that that we actually ended up with an unaligned pointer.
+    assert_ne!((unaligned_tv as usize) % std::mem::align_of_val(&buf[0]), 0);
+
+    // Just validate that gettimeofday returns without an error or crashing.
+    Errno::result(unsafe { libc::gettimeofday(unaligned_tv, std::ptr::null_mut()) })?;
+
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // should we restrict the tests we run?
+    let filter_shadow_passing = std::env::args().any(|x| x == "--shadow-passing");
+    let filter_libc_passing = std::env::args().any(|x| x == "--libc-passing");
+    // should we summarize the results rather than exit on a failed test
+    let summarize = std::env::args().any(|x| x == "--summarize");
+
+    let mut tests = vec![
+        ShadowTest::new(
+            "test_unaligned_read",
+            test_unaligned_read,
+            set![TestEnv::Libc, TestEnv::Shadow],
+        ),
+        ShadowTest::new(
+            "test_unaligned_write",
+            test_unaligned_write,
+            set![TestEnv::Libc, TestEnv::Shadow],
+        ),
+    ];
+    if filter_shadow_passing {
+        tests = tests
+            .into_iter()
+            .filter(|x| x.passing(TestEnv::Shadow))
+            .collect()
+    }
+    if filter_libc_passing {
+        tests = tests
+            .into_iter()
+            .filter(|x| x.passing(TestEnv::Libc))
+            .collect()
+    }
+    test_utils::run_tests(&tests, summarize)?;
+    println!("Success.");
+    Ok(())
+}

--- a/src/test/memory/unaligned.yaml
+++ b/src/test/memory/unaligned.yaml
@@ -1,0 +1,15 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  mytesthost:
+    processes:
+    - path: ../target/debug/test_unaligned
+      args: --shadow-passing
+      # The LD_LIBRARY_PATH here points to where we put the patched libc binaries in
+      # our CI, to work around https://github.com/shadow/shadow/issues/892.  It should
+      # have no effect in environments where that directory doesn't exist.
+      environment: LD_LIBRARY_PATH=/opt/libc-interpose-centos7
+      start_time: 1


### PR DESCRIPTION
In Rust code, dereferencing an unaligned pointer is undefined behavior.
For that reason, we were returning errors if a managed plugin passed an
unaligned pointer to a syscall.

In Linux, though, unaligned pointers are permitted and handled
gracefully. https://www.kernel.org/doc/html/latest/core-api/unaligned-memory-access.html

With this change, we now also handle unaligned pointers transparently in
the MemoryManager. The important thing is that we don't try turning them
into a reference in Rust, which we should be able to avoid by falling
back to copying data to and from such pointers (as opaque data).

I think the main way we could run into trouble is if in, say, a
syscallhandler, we ask the MemoryManager for a reference to a u8 pointer
but then cast it to some other type without checking alignment. This can
and should be avoided by asking the MemoryManager for the desired type
in the first place.

Right now, C syscallhandlers always ask for u8 pointers since we don't
have an easy way to convey the type to Rust. This should mostly work out
ok in practice, since in x86 unaligned pointer access is legal for most
instructions (but e.g. not vectorized ones). (This change doesn't make
things any worse, since we weren't catching when this happens before,
either).