### PR TITLE
Add CI lint to check Shadow version in Cargo lockfile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,19 @@ jobs:
           (cd src/test && cargo fmt -- --check)
           (cd src/support/logger/rust_bindings && cargo fmt -- --check)
 
+  lint-cargo-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cargo update check
+        run: |
+          # This will return an error if any versions of local crates in the Cargo.lock
+          # are out of date compared to the crate versions in Cargo.toml. This can fail
+          # if the Shadow version is bumped without using Cargo to update the lock file.
+          (cd src/main && cargo update --locked --workspace)
+          (cd src/test && cargo update --locked --workspace)
+          # the shadow logger bindings crate does not have a lockfile
+
   lint-bindings:
     runs-on: ubuntu-latest
     container:

--- a/docs/maintainer_playbook.md
+++ b/docs/maintainer_playbook.md
@@ -15,6 +15,12 @@ git checkout main
 # that commit.
 bumpversion <patch|minor|major> --tag --commit
 
+# Update the Cargo lock files
+(cd src/main && cargo update --workspace)
+(cd src/test && cargo update --workspace)
+git add src/main/Cargo.lock src/test/Cargo.lock
+git commit --amend --no-edit
+
 # Get the new version number.
 VERSION=`awk -F "=" '/current_version/ {print $2}' .bumpversion.cfg | tr -d ' '`
 


### PR DESCRIPTION
When we update Shadow's version in the Cargo.toml files, we also want to make sure that the Cargo.lock files are also updated. This lint checks only our package versions and not versions of our dependencies.