### PR TITLE
configuration: use quantity when calculating number of hosts

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -201,6 +201,8 @@ void config_iterHosts(const struct ConfigOptions *config,
                       void (*f)(const char*, const struct ConfigOptions*, const struct HostOptions*, void*),
                       void *data);
 
+uint32_t config_getNHosts(const struct ConfigOptions *config);
+
 void hostoptions_freeString(char *string);
 
 unsigned int hostoptions_getQuantity(const struct HostOptions *host);

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -8,7 +8,6 @@ use merge::Merge;
 use once_cell::sync::Lazy;
 use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 use std::num::NonZeroU32;
 
 use super::simulation_time::{SIMTIME_ONE_NANOSECOND, SIMTIME_ONE_SECOND};
@@ -1202,7 +1201,7 @@ mod export {
             Some(w) => *w,
             None => {
                 // By default use 1 worker per host.
-                NonZeroU32::new(config.hosts.len().try_into().unwrap()).unwrap()
+                NonZeroU32::new(config_getNHosts(config)).unwrap()
             }
         }
     }


### PR DESCRIPTION
When auto-configuring the number of worker threads to create, we were
counting the number of host *entries* instead of the number of hosts.
Each entry has a *quantity* field that we must account for.