### PR TITLE
thread_preload: use seccomp to interpose all syscalls

### DIFF
--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -82,8 +82,6 @@ case "$CONTAINER" in
             --slave /usr/local/bin/cpack cpack /usr/bin/cpack3 \
             --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 \
             --family cmake
-        # Install interposable libc to work around https://github.com/shadow/shadow/issues/892
-        (mkdir -p /opt && cd /opt && curl -sSfL https://github.com/sporksmith/glibc/releases/download/interpose-centos7-v0.0.1/libc-interpose-centos7-v0.0.1.tar.xz | tar -xJvf -)
         ;;
     centos:8)
         dnf remove -y procps-ng procps-ng-devel

--- a/ci/container_scripts/test.sh
+++ b/ci/container_scripts/test.sh
@@ -15,16 +15,9 @@ else
 fi
 
 EXTRA_FLAGS=""
-if [ "$CONTAINER" = "centos:7" ]
-then
-    # On centos:7 we enable extra tests that currently require a patched libc.
-    # https://github.com/shadow/shadow/issues/892
-    CONFIG="ilibc"
-else
-    # On all other platforms, we run extra tests that we don't generally require (for
-    # example tests that require additional dependencies).
-    CONFIG="extra"
-fi
+# Run extra tests that we don't generally require (for
+# example tests that require additional dependencies).
+CONFIG="extra"
 
 # Array of flags to be passed on to setup script
 FLAGS=()

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -61,6 +61,7 @@ hosts:
 - [`experimental.use_object_counters`](#experimentaluse_object_counters)
 - [`experimental.use_sched_fifo`](#experimentaluse_sched_fifo)
 - [`experimental.use_shim_syscall_handler`](#experimentaluse_shim_syscall_handler)
+- [`experimental.use_seccomp`](#experimentaluse_seccomp)
 - [`experimental.use_syscall_counters`](#experimentaluse_syscall_counters)
 - [`experimental.worker_threads`](#experimentalworker_threads)
 - [`host_defaults`](#host_defaults)
@@ -347,6 +348,13 @@ Type: Bool
 
 Use shim-side syscall handler to force hot-path syscalls to be handled via an
 inter-process syscall with Shadow.
+
+#### `experimental.use_seccomp`
+
+Default: true iff experimental.interpose_method == preload.
+Type: Bool
+
+Use seccomp to trap syscalls.
 
 #### `experimental.use_syscall_counters`
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -180,6 +180,8 @@ bool config_getUseOnWaitpidWorkarounds(const struct ConfigOptions *config);
 
 bool config_getUseExplicitBlockMessage(const struct ConfigOptions *config);
 
+bool config_getUseSeccomp(const struct ConfigOptions *config);
+
 bool config_getUseSyscallCounters(const struct ConfigOptions *config);
 
 bool config_getUseObjectCounters(const struct ConfigOptions *config);

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -244,6 +244,11 @@ pub struct ExperimentalOptions {
     #[clap(about = EXP_HELP.get("use_explicit_block_message").unwrap())]
     use_explicit_block_message: Option<bool>,
 
+    /// Use seccomp to trap syscalls. Default is true for preload mode, false otherwise.
+    #[clap(long, value_name = "bool")]
+    #[clap(about = EXP_HELP.get("use_seccomp").unwrap())]
+    use_seccomp: Option<bool>,
+
     /// Count the number of occurrences for individual syscalls
     #[clap(long, value_name = "bool")]
     #[clap(about = EXP_HELP.get("use_syscall_counters").unwrap())]
@@ -348,6 +353,7 @@ impl Default for ExperimentalOptions {
             use_sched_fifo: Some(false),
             use_o_n_waitpid_workarounds: Some(false),
             use_explicit_block_message: Some(false),
+            use_seccomp: None,
             use_syscall_counters: Some(false),
             use_object_counters: Some(true),
             preload_spin_max: Some(0),
@@ -1119,6 +1125,16 @@ mod export {
         assert!(!config.is_null());
         let config = unsafe { &*config };
         config.experimental.use_explicit_block_message.unwrap()
+    }
+
+    #[no_mangle]
+    pub extern "C" fn config_getUseSeccomp(config: *const ConfigOptions) -> bool {
+        assert!(!config.is_null());
+        let config = unsafe { &*config };
+        match config.experimental.use_seccomp {
+            Some(b) => b,
+            None => config_getInterposeMethod(config) == InterposeMethod::Preload,
+        }
     }
 
     #[no_mangle]

--- a/src/main/host/shimipc.c
+++ b/src/main/host/shimipc.c
@@ -10,8 +10,11 @@
 
 static bool _useExplicitBlockMessage = true;
 ADD_CONFIG_HANDLER(config_getUseExplicitBlockMessage, _useExplicitBlockMessage)
-
 bool shimipc_sendExplicitBlockMessageEnabled() { return _useExplicitBlockMessage; }
+
+static bool _useSeccomp = true;
+ADD_CONFIG_HANDLER(config_getUseSeccomp, _useSeccomp)
+bool shimipc_getUseSeccomp() { return _useSeccomp; }
 
 static int _spinMax = -1;
 ADD_CONFIG_HANDLER(config_getPreloadSpinMax, _spinMax)

--- a/src/main/host/shimipc.h
+++ b/src/main/host/shimipc.h
@@ -17,3 +17,8 @@ bool shimipc_sendExplicitBlockMessageEnabled();
 // Number of iterations to spin when waiting on IPC between Shadow and the shim
 // before blocking.
 ssize_t shimipc_spinMax();
+
+
+// Whether to use a seccomp filter in the shim to catch syscalls that would
+// otherwise not be interposed.
+bool shimipc_getUseSeccomp();

--- a/src/main/host/syscall/signal.c
+++ b/src/main/host/syscall/signal.c
@@ -10,6 +10,7 @@
 #include <sys/syscall.h>
 
 #include "main/host/host.h"
+#include "main/host/shimipc.h"
 #include "main/host/syscall/protected.h"
 #include "main/host/thread.h"
 #include "main/utility/syscall.h"
@@ -123,4 +124,130 @@ SysCallReturn syscallhandler_tkill(SysCallHandler* sys, const SysCallArgs* args)
 
     trace("translated virtual tid %i to native tid %i", tid, native_tid);
     return _syscallhandler_killHelper(sys, 0, native_tid, sig, SYS_tkill);
+}
+
+// Removes `signal` from the sigset_t pointed to by `maskPtr`, if present.
+// Returns 0 on success (including if the signal wasn't present), or a negative
+// errno on failure.
+static int _removeSignalFromSet(SysCallHandler* sys, PluginPtr maskPtr, int signal) {
+    sigset_t mask;
+    int rv = process_readPtr(sys->process, &mask, maskPtr, sizeof(mask));
+    if (rv < 0) {
+        trace("Error reading %p: %s", (void*)maskPtr.val, g_strerror(-rv));
+        return rv;
+    }
+    rv = sigismember(&mask, SIGSYS);
+    if (rv < 0) {
+        panic("sigismember: %s", g_strerror(errno));
+    }
+    if (!rv) {
+        trace("Signal %d wasn't in set", signal);
+        return 0;
+    }
+    trace("Clearing %d from sigprocmask(SIG_BLOCK) set", signal);
+    rv = sigdelset(&mask, SIGSYS);
+    if (rv < 0) {
+        panic("sigdelset: %s", g_strerror(errno));
+    }
+    rv = process_writePtr(sys->process, maskPtr, &mask, sizeof(mask));
+    if (rv < 0) {
+        trace("Error writing %p: %s", (void*)maskPtr.val, g_strerror(-rv));
+        return rv;
+    }
+    return 0;
+}
+
+SysCallReturn syscallhandler_sigaction(SysCallHandler* sys, const SysCallArgs* args) {
+    utility_assert(sys && args);
+
+    if (!shimipc_getUseSeccomp()) {
+        return (SysCallReturn){.state = SYSCALL_NATIVE};
+    }
+    // Prevent interference with shim's SIGSYS handler.
+
+    int signum = (int)args->args[0].as_i64;
+    PluginPtr sigaction_ptr = args->args[1].as_ptr;
+    PluginPtr sa_mask_ptr = (PluginPtr){sigaction_ptr.val + offsetof(struct sigaction, sa_mask)};
+
+    if (signum == SIGSYS) {
+        warning("Blocking `sigaction` for SIGSYS");
+        return (SysCallReturn){.state = SYSCALL_DONE, .retval = -ENOSYS};
+    }
+    _removeSignalFromSet(sys, sa_mask_ptr, SIGSYS);
+
+    return (SysCallReturn){.state = SYSCALL_NATIVE};
+}
+
+SysCallReturn syscallhandler_rt_sigaction(SysCallHandler* sys, const SysCallArgs* args) {
+    utility_assert(sys && args);
+    if (!shimipc_getUseSeccomp()) {
+        return (SysCallReturn){.state = SYSCALL_NATIVE};
+    }
+    // Prevent interference with shim's SIGSYS handler.
+
+    int signum = (int)args->args[0].as_i64;
+    PluginPtr sigaction_ptr = args->args[1].as_ptr;
+    PluginPtr sa_mask_ptr = (PluginPtr){sigaction_ptr.val + offsetof(struct sigaction, sa_mask)};
+
+    if (signum == SIGSYS) {
+        warning("Blocking `rt_sigaction` for SIGSYS");
+        return (SysCallReturn){.state = SYSCALL_DONE, .retval = -ENOSYS};
+    }
+    _removeSignalFromSet(sys, sa_mask_ptr, SIGSYS);
+
+    return (SysCallReturn){.state = SYSCALL_NATIVE};
+}
+
+SysCallReturn syscallhandler_signal(SysCallHandler* sys, const SysCallArgs* args) {
+    utility_assert(sys && args);
+    if (!shimipc_getUseSeccomp()) {
+        return (SysCallReturn){.state = SYSCALL_NATIVE};
+    }
+    // Prevent interference with shim's SIGSYS handler.
+
+    int signum = (int)args->args[0].as_i64;
+
+    if (signum == SIGSYS) {
+        warning("Blocking `signal` for SIGSYS");
+        return (SysCallReturn){.state = SYSCALL_DONE, .retval = -ENOSYS};
+    }
+    return (SysCallReturn){.state = SYSCALL_NATIVE};
+}
+
+SysCallReturn syscallhandler_sigprocmask(SysCallHandler* sys, const SysCallArgs* args) {
+    utility_assert(sys && args);
+    if (!shimipc_getUseSeccomp()) {
+        return (SysCallReturn){.state = SYSCALL_NATIVE};
+    }
+    // Prevent interference with shim's SIGSYS handler.
+
+    int how = (int)args->args[0].as_i64;
+    PluginPtr maskPtr = args->args[1].as_ptr;
+
+    if (how == SIG_BLOCK || how == SIG_SETMASK) {
+        int rv = _removeSignalFromSet(sys, maskPtr, SIGSYS);
+        if (rv != 0) {
+            return (SysCallReturn){.state = SYSCALL_DONE, .retval = rv};
+        }
+    }
+    return (SysCallReturn){.state = SYSCALL_NATIVE};
+}
+
+SysCallReturn syscallhandler_rt_sigprocmask(SysCallHandler* sys, const SysCallArgs* args) {
+    utility_assert(sys && args);
+    if (!shimipc_getUseSeccomp()) {
+        return (SysCallReturn){.state = SYSCALL_NATIVE};
+    }
+    // Prevent interference with shim's SIGSYS handler.
+
+    int how = (int)args->args[0].as_i64;
+    PluginPtr maskPtr = args->args[1].as_ptr;
+
+    if (how == SIG_BLOCK || how == SIG_SETMASK) {
+        int rv = _removeSignalFromSet(sys, maskPtr, SIGSYS);
+        if (rv != 0) {
+            return (SysCallReturn){.state = SYSCALL_DONE, .retval = rv};
+        }
+    }
+    return (SysCallReturn){.state = SYSCALL_NATIVE};
 }

--- a/src/main/host/syscall/signal.h
+++ b/src/main/host/syscall/signal.h
@@ -11,5 +11,10 @@
 SYSCALL_HANDLER(kill);
 SYSCALL_HANDLER(tgkill);
 SYSCALL_HANDLER(tkill);
+SYSCALL_HANDLER(sigaction);
+SYSCALL_HANDLER(rt_sigaction);
+SYSCALL_HANDLER(signal);
+SYSCALL_HANDLER(sigprocmask);
+SYSCALL_HANDLER(rt_sigprocmask);
 
 #endif

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -367,6 +367,14 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         HANDLE(shadow_hostname_to_addr_ipv4);
         HANDLE(sendto);
         HANDLE(setsockopt);
+        HANDLE(rt_sigaction);
+#ifdef SYS_signal
+        HANDLE(signal);
+#endif
+#ifdef SYS_sigprocmask
+        HANDLE(sigprocmask);
+#endif
+        HANDLE(rt_sigprocmask);
         HANDLE(set_robust_list);
         HANDLE(set_tid_address);
         HANDLE(shutdown);
@@ -456,8 +464,6 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         NATIVE(removexattr);
         NATIVE(rename);
         NATIVE(rmdir);
-        NATIVE(rt_sigaction);
-        NATIVE(rt_sigprocmask);
         NATIVE(rt_sigreturn);
         NATIVE(setfsgid);
         NATIVE(setfsuid);

--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -141,6 +141,11 @@ pid_t threadpreload_run(Thread* base, gchar** argv, gchar** envv, const char* wo
     /* append to the env */
     myenvv = g_environ_setenv(myenvv, "SHADOW_IPC_BLK", ipc_blk_buf, TRUE);
 
+    /* Tell the shim in the managed process whether to enable seccomp */
+    if (shimipc_getUseSeccomp()) {
+        myenvv = g_environ_setenv(myenvv, "SHADOW_USE_SECCOMP", "", TRUE);
+    }
+
     // set shadow's PID in the env so the child can run get_ppid
     myenvv = _add_shadow_pid_to_env(myenvv);
 

--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -31,8 +31,6 @@ struct _ThreadPreload {
 
     /* holds the event id for the most recent call from the plugin/shim */
     ShimEvent currentEvent;
-
-    GHashTable* ptr_to_block;
 };
 
 typedef struct _ShMemWriteBlock {
@@ -59,10 +57,6 @@ void threadpreload_free(Thread* base) {
 
     if (thread->base.sys) {
         syscallhandler_unref(thread->base.sys);
-    }
-
-    if (thread->ptr_to_block) {
-        g_hash_table_destroy(thread->ptr_to_block);
     }
 
     worker_count_deallocation(ThreadPreload);
@@ -375,7 +369,6 @@ Thread* threadpreload_new(Host* host, Process* process, gint threadID) {
                                   .getIPCBlock = _threadpreload_getIPCBlock,
                                   .getShMBlock = _threadpreload_getShMBlock,
                               }),
-        .ptr_to_block = g_hash_table_new(g_int64_hash, g_int64_equal),
     };
     thread->base.sys = syscallhandler_new(host, process, _threadPreloadToThread(thread));
 

--- a/src/shim/preload_syscall.h
+++ b/src/shim/preload_syscall.h
@@ -1,0 +1,14 @@
+#ifndef PRELOAD_SYSCALL_H
+#define PRELOAD_SYSCALL_H
+
+#include <stdarg.h>
+
+// The function the shim uses to execute a bare syscall instruction.
+// Similar to libc's `syscall`, but *doesn't* remap return values to errno.
+long __attribute__((noinline)) shadow_vreal_raw_syscall(long n, va_list args);
+
+// Make a raw syscall (without remapping return val to errno). Internally
+// decides whether to execute a real syscall or emulate.
+long shadow_raw_syscall(long n, ...);
+
+#endif

--- a/src/shim/shim.c
+++ b/src/shim/shim.c
@@ -3,6 +3,8 @@
 #include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
 #include <pthread.h>
 #include <search.h>
 #include <stddef.h>
@@ -10,11 +12,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/prctl.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 
 #include "shim/ipc.h"
+#include "shim/preload_syscall.h"
 #include "shim/shim_event.h"
 #include "shim/shim_logger.h"
 #include "shim/shim_syscall.h"
@@ -298,6 +302,140 @@ static void _shim_parent_init_ptrace() {
     }
 }
 
+static void _handle_sigsys(int sig, siginfo_t* info, void* voidUcontext) {
+    ucontext_t* ctx = (ucontext_t*)(voidUcontext);
+    if (sig != SIGSYS) {
+        abort();
+    }
+    // Make the syscall via the *the shim's* syscall function (which overrides
+    // libc's).  It in turn will either emulate it or (if interposition is
+    // disabled), or make the call natively. In the latter case, the syscall
+    // will be permitted to execute by the seccomp filter.
+    long rv = shadow_raw_syscall(ctx->uc_mcontext.gregs[REG_RAX], ctx->uc_mcontext.gregs[REG_RDI],
+                                 ctx->uc_mcontext.gregs[REG_RSI], ctx->uc_mcontext.gregs[REG_RDX],
+                                 ctx->uc_mcontext.gregs[REG_R10], ctx->uc_mcontext.gregs[REG_R8],
+                                 ctx->uc_mcontext.gregs[REG_R9]);
+    ctx->uc_mcontext.gregs[REG_RAX] = rv;
+}
+
+static void _shim_parent_init_seccomp() {
+    // Install signal sigsys signal handler, which will receive syscalls that
+    // get stopped by the seccomp filter. Shadow's emulation of signal-related
+    // system calls will prevent this action from later being overridden by the
+    // virtual process.
+    struct sigaction old_action;
+    if (sigaction(SIGSYS,
+                  &(struct sigaction){
+                      .sa_sigaction = _handle_sigsys,
+                      // SA_NODEFER: Allow recursive signal handling, to handle a syscall
+                      // being made during the handling of another. For example, we need this
+                      // to properly handle the case that we end up logging from the syscall
+                      // handler, and the IO syscalls themselves are trapped.
+                      // SA_SIGINFO: Required because we're specifying sa_sigaction.
+                      .sa_flags = SA_NODEFER | SA_SIGINFO,
+                  },
+                  &old_action) < 0) {
+        panic("sigaction: %s", strerror(errno));
+    }
+    if (old_action.sa_handler || old_action.sa_sigaction) {
+        warning("Overwrite handler for SIGSYS (%p)", old_action.sa_handler
+                                                         ? (void*)old_action.sa_handler
+                                                         : (void*)old_action.sa_sigaction);
+    }
+
+    // Ensure that SIGSYS isn't blocked. This code runs in the process's first
+    // thread, so the resulting mask will be inherited by subsequent threads.
+    // Shadow's emulation of signal-related system calls will prevent it from
+    // later becoming blocked.
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGSYS);
+    if (sigprocmask(SIG_UNBLOCK, &mask, NULL)) {
+        panic("sigprocmask: %s", strerror(errno));
+    }
+
+    // Setting PR_SET_NO_NEW_PRIVS allows us to install a seccomp filter without
+    // CAP_SYS_ADMIN.
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
+        panic("prctl: %s", strerror(errno));
+    }
+
+    /* A bpf program to be loaded as a `seccomp` filter. Unfortunately the
+     * documentation for how to write this is pretty sparse. There's a useful
+     * example in samples/seccomp/bpf-direct.c of the Linux kernel source tree.
+     * The best reference I've been able to find is a BSD man page:
+     * https://www.freebsd.org/cgi/man.cgi?query=bpf&sektion=4&manpath=FreeBSD+4.7-RELEASE
+     */
+    struct sock_filter filter[] = {
+        /* accumulator := syscall number */
+        BPF_STMT(BPF_LD + BPF_W + BPF_ABS, offsetof(struct seccomp_data, nr)),
+
+        /* Always allow sigreturn; otherwise we'd crash returning from our signal handler. */
+        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SYS_rt_sigreturn, /*true-skip=*/0, /*false-skip=*/1),
+        BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW),
+
+        /* Always allow sched_yield. Sometimes used in IPC with Shadow; emulating
+         * would just add unnecessary overhead.  */
+        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SYS_sched_yield, /*true-skip=*/0, /*false-skip=*/1),
+        BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW),
+
+        /* FIXME: TEMP Always allow futex. This will will end up causing deadlock
+         * if there's actually contention on a futex.  i.e. we'll need to get rid
+         * of this to be compatible with threaded virtual processes. */
+        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SYS_futex, /*true-skip=*/0, /*false-skip=*/1),
+        BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW),
+
+        /* See if instruction pointer is within the shadow_vreal_raw_syscall fn. */
+        /* accumulator := instruction_pointer */
+        BPF_STMT(BPF_LD + BPF_W + BPF_ABS, offsetof(struct seccomp_data, instruction_pointer)),
+        /* If it's in `shadow_vreal_raw_syscall`, allow. We don't know the end address, but it
+         * should be safe-ish to check if it's within a kilobyte or so. We know there are no
+         * other syscall instructions within this library, so the only problem would be if
+         * shadow_vreal_raw_syscall ended up at the very end of the library object, and a syscall
+         * ended up being made from the very beginning of another library object, loaded just
+         * after ours.
+         *
+         * TODO: Consider using the actual bounds of this object file, from /proc/self/maps. */
+        BPF_JUMP(BPF_JMP + BPF_JGT + BPF_K, ((long)shadow_vreal_raw_syscall) + 1000,
+                 /*true-skip=*/2, /*false-skip=*/0),
+        BPF_JUMP(BPF_JMP + BPF_JGE + BPF_K, (long)shadow_vreal_raw_syscall, /*true-skip=*/0,
+                 /*false-skip=*/1),
+        BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW),
+
+    /* This block was intended to whitelist reads and writes to a socket
+     * used to communicate with Shadow. It turns out to be unnecessary though,
+     * because the functions we're using are already wrapped, and so go through
+     * shadow_vreal_raw_syscall, and so end up already being whitelisted above based on that.
+     * (Also ended up switching back to shared-mem-based IPC instead of a socket).
+     *
+     * Keeping the code around for now in case we end up needing it or something similar.
+     */
+#if 0
+        /* check_socket: Allow reads and writes to shadow socket */
+        BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, SYS_read, 0, 2/*check_fd*/),
+        BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, SYS_write, 0, 1/*check_fd*/),
+        /* Skip to instruction pointer check */
+        BPF_JUMP(BPF_JMP+BPF_JA, 3/* check_ip */, 0, 0),
+        /* check_fd */
+        /* accumulator := arg1 */
+        BPF_STMT(BPF_LD+BPF_W+BPF_ABS, offsetof(struct seccomp_data, args[0])),
+        BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, toShadowFd, 0, 1/* check_ip */),
+        BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ALLOW),
+#endif
+
+        /* Trap to our syscall handler */
+        BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_TRAP),
+    };
+    struct sock_fprog prog = {
+        .len = (unsigned short)(sizeof(filter) / sizeof(filter[0])),
+        .filter = filter,
+    };
+
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog)) {
+        panic("prctl: %s", strerror(errno));
+    }
+}
+
 static void _shim_parent_init_preload() {
     shim_disableInterposition();
 
@@ -307,6 +445,9 @@ static void _shim_parent_init_preload() {
     _shim_parent_init_ipc();
     _shim_parent_init_death_signal();
     _shim_ipc_wait_for_start_event();
+    if (getenv("SHADOW_USE_SECCOMP") != NULL) {
+        _shim_parent_init_seccomp();
+    }
 
     shim_enableInterposition();
 }

--- a/src/shim/shim_syscall.c
+++ b/src/shim/shim_syscall.c
@@ -78,8 +78,7 @@ bool shim_syscall(long syscall_num, long* rv, va_list args) {
                 *rv = 0;
             } else {
                 trace("found NULL timespec pointer in clock_gettime");
-                *rv = -1;
-                errno = EFAULT;
+                *rv = -EFAULT;
             }
 
             break;

--- a/src/shim/shim_syscall.h
+++ b/src/shim/shim_syscall.h
@@ -22,9 +22,9 @@ uint64_t shim_syscall_get_simtime_nanos();
 // Returns false on failure, meaning we do not have the necessary information to
 // properly handle the syscall.
 //
-// If this function returns true, then either:
-// - the syscall succeeded, results are written to args as needed, and rv is set
-// - the syscall failed, rv and errno are set
+// If this function returns true, then the raw syscall result is returned
+// through `rv`.  e.g. for a syscall returning an error, it's the caller's
+// responsibility to set errno from `rv`.
 bool shim_syscall(long syscall_num, long* rv, va_list args);
 
 #endif // SRC_SHIM_SHIM_SYSCALL_H_

--- a/src/test/clone/CMakeLists.txt
+++ b/src/test/clone/CMakeLists.txt
@@ -10,6 +10,5 @@ add_shadow_tests(BASENAME clone METHODS hybrid ptrace)
 # the memory manager (really the MemoryMapper) enabled.
 add_shadow_tests(BASENAME clone-nomm METHODS hybrid ptrace ARGS --use-memory-manager=false)
 
-# FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
-# FIXME: The interposed libc does not handle this either.
-#add_shadow_tests(BASENAME clone METHODS preload CONFIGURATIONS ilibc)
+# Preload mode doesn't support threads. https://github.com/shadow/shadow/issues/1454
+#add_shadow_tests(BASENAME clone METHODS preload)

--- a/src/test/file/CMakeLists.txt
+++ b/src/test/file/CMakeLists.txt
@@ -6,5 +6,4 @@ add_linux_tests(BASENAME file COMMAND test-file)
 # run using different rng seeds since we use mkstemp()
 add_shadow_tests(BASENAME file METHODS hybrid ARGS "--seed 0")
 add_shadow_tests(BASENAME file METHODS ptrace ARGS "--seed 1")
-# FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
-add_shadow_tests(BASENAME file METHODS preload CONFIGURATIONS ilibc ARGS "--seed 2")
+add_shadow_tests(BASENAME file METHODS preload ARGS "--seed 2")

--- a/src/test/file/file.yaml
+++ b/src/test/file/file.yaml
@@ -7,8 +7,4 @@ hosts:
   testnode:
     processes:
     - path: test-file
-      # The LD_LIBRARY_PATH here points to where we put the patched libc binaries in
-      # our CI, to work around https://github.com/shadow/shadow/issues/892.  It should
-      # have no effect in environments where that directory doesn't exist.
-      environment: LD_LIBRARY_PATH=/opt/libc-interpose-centos7
       start_time: 1

--- a/src/test/futex/CMakeLists.txt
+++ b/src/test/futex/CMakeLists.txt
@@ -3,6 +3,5 @@ add_executable(test-futex test_futex.c ../test_common.c)
 target_link_libraries(test-futex ${CMAKE_THREAD_LIBS_INIT} ${GLIB_LIBRARIES} logger)
 add_linux_tests(BASENAME futex COMMAND test-futex)
 add_shadow_tests(BASENAME futex METHODS hybrid ptrace)
-# FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
-# FIXME: The interposed libc does not handle this either.
-#add_shadow_tests(BASENAME futex METHODS preload CONFIGURATIONS ilibc)
+# FIXME: Needs threads. https://github.com/shadow/shadow/issues/1454
+#add_shadow_tests(BASENAME futex METHODS preload)

--- a/src/test/memory/CMakeLists.txt
+++ b/src/test/memory/CMakeLists.txt
@@ -3,8 +3,7 @@ add_linux_tests(BASENAME mmap COMMAND sh -c "../target/debug/test_mmap --libc-pa
 # run using different rng seeds since we use mkstemp()
 add_shadow_tests(BASENAME mmap METHODS hybrid ARGS "--seed 0")
 add_shadow_tests(BASENAME mmap METHODS ptrace ARGS "--seed 1")
-# FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
-add_shadow_tests(BASENAME mmap METHODS preload CONFIGURATIONS ilibc ARGS "--seed 2")
+add_shadow_tests(BASENAME mmap METHODS preload ARGS "--seed 2")
 
 add_linux_tests(BASENAME unaligned COMMAND sh -c "../target/debug/test_unaligned --libc-passing")
 add_shadow_tests(BASENAME unaligned METHODS hybrid ptrace preload)

--- a/src/test/memory/mmap.yaml
+++ b/src/test/memory/mmap.yaml
@@ -8,8 +8,4 @@ hosts:
     processes:
     - path: ../target/debug/test_mmap
       args: --shadow-passing
-      # The LD_LIBRARY_PATH here points to where we put the patched libc binaries in
-      # our CI, to work around https://github.com/shadow/shadow/issues/892.  It should
-      # have no effect in environments where that directory doesn't exist.
-      environment: LD_LIBRARY_PATH=/opt/libc-interpose-centos7
       start_time: 1

--- a/src/test/memory/unaligned.yaml
+++ b/src/test/memory/unaligned.yaml
@@ -8,8 +8,4 @@ hosts:
     processes:
     - path: ../target/debug/test_unaligned
       args: --shadow-passing
-      # The LD_LIBRARY_PATH here points to where we put the patched libc binaries in
-      # our CI, to work around https://github.com/shadow/shadow/issues/892.  It should
-      # have no effect in environments where that directory doesn't exist.
-      environment: LD_LIBRARY_PATH=/opt/libc-interpose-centos7
       start_time: 1

--- a/src/test/phold/CMakeLists.txt
+++ b/src/test/phold/CMakeLists.txt
@@ -3,39 +3,23 @@ add_executable(test-phold test_phold.c)
 target_link_libraries(test-phold ${M_LIBRARIES} ${RT_LIBRARIES} ${GLIB_LIBRARIES})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/weights.txt ${CMAKE_CURRENT_BINARY_DIR}/weights.txt COPYONLY)
 
-# FIXME: Enable the preload tests in all configurations. See https://github.com/shadow/shadow/issues/892
-
 # We should run tests using --use-cpu-pinning in serial, otherwise all such tests will be
 # pinned to the same exact CPUs.
 add_shadow_tests(
     BASENAME phold-serial
-    METHODS hybrid ptrace
+    METHODS hybrid ptrace preload
     LOGLEVEL info
     ARGS --use-cpu-pinning true
     PROPERTIES RUN_SERIAL TRUE)
-add_shadow_tests(
-    BASENAME phold-serial
-    METHODS preload
-    LOGLEVEL info
-    ARGS --use-cpu-pinning true
-    PROPERTIES RUN_SERIAL TRUE
-    CONFIGURATIONS ilibc)
 
 # Due to --use-cpu-pinning, we run this in serial. Otherwise we should set the "PROCESSORS 2"
 # property since we use 2 workers here.
 add_shadow_tests(
     BASENAME phold-parallel
-    METHODS hybrid ptrace
+    METHODS hybrid ptrace preload
     LOGLEVEL info
     ARGS --use-cpu-pinning true --parallelism 2
     PROPERTIES RUN_SERIAL TRUE)
-add_shadow_tests(
-    BASENAME phold-parallel
-    METHODS preload
-    LOGLEVEL info
-    ARGS --use-cpu-pinning true --parallelism 2
-    PROPERTIES RUN_SERIAL TRUE
-    CONFIGURATIONS ilibc)
 
 # Run tests with the round-robin queueing discipline (the current default is fifo).
 # Ideally we'd want to test the different queueing displinces on a test that has a lot of
@@ -43,14 +27,7 @@ add_shadow_tests(
 # test that we have to that configuration.
 add_shadow_tests(
     BASENAME phold-rr-qdisc
-    METHODS hybrid ptrace
+    METHODS hybrid ptrace preload
     LOGLEVEL info
     ARGS --use-cpu-pinning true --interface-qdisc roundrobin
     PROPERTIES RUN_SERIAL TRUE)
-add_shadow_tests(
-    BASENAME phold-rr-qdisc
-    METHODS preload
-    LOGLEVEL info
-    ARGS --use-cpu-pinning true --interface-qdisc roundrobin
-    PROPERTIES RUN_SERIAL TRUE
-    CONFIGURATIONS ilibc)

--- a/src/test/phold/phold.yaml
+++ b/src/test/phold/phold.yaml
@@ -26,8 +26,4 @@ hosts:
     - path: test-phold
       args: loglevel=info basename=peer quantity=10 msgload=1 cpuload=1 size=1
         weightsfilepath=../../../weights.txt runtime=5
-      # The LD_LIBRARY_PATH here points to where we put the patched libc binaries in
-      # our CI, to work around https://github.com/shadow/shadow/issues/892.  It should
-      # have no effect in environments where that directory doesn't exist.
-      environment: LD_LIBRARY_PATH=/opt/libc-interpose-centos7
       start_time: 1

--- a/src/test/poll/CMakeLists.txt
+++ b/src/test/poll/CMakeLists.txt
@@ -3,5 +3,4 @@ add_linux_tests(BASENAME poll COMMAND sh -c "../target/debug/test_poll --libc-pa
 # run using different rng seeds since we use mkstemp()
 add_shadow_tests(BASENAME poll METHODS hybrid ARGS "--seed 0")
 add_shadow_tests(BASENAME poll METHODS ptrace ARGS "--seed 1")
-# FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
-add_shadow_tests(BASENAME poll METHODS preload CONFIGURATIONS ilibc ARGS "--seed 2")
+add_shadow_tests(BASENAME poll METHODS preload ARGS "--seed 2")

--- a/src/test/poll/poll.yaml
+++ b/src/test/poll/poll.yaml
@@ -8,8 +8,4 @@ hosts:
     processes:
     - path: ../target/debug/test_poll
       args: --shadow-passing
-      # The LD_LIBRARY_PATH here points to where we put the patched libc binaries in
-      # our CI, to work around https://github.com/shadow/shadow/issues/892.  It should
-      # have no effect in environments where that directory doesn't exist.
-      environment: LD_LIBRARY_PATH=/opt/libc-interpose-centos7
       start_time: 1

--- a/src/test/signal/CMakeLists.txt
+++ b/src/test/signal/CMakeLists.txt
@@ -5,6 +5,5 @@ target_link_libraries(test-signal ${M_LIBRARIES} ${DL_LIBRARIES} ${RT_LIBRARIES}
 ## here we are testing 3 nodes to make sure they don't share signal handlers (in Shadow)
 add_linux_tests(BASENAME signal COMMAND shadow-test-launcher test-signal : test-signal : test-signal)
 add_shadow_tests(BASENAME signal METHODS hybrid ptrace)
-# FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
-# FIXME: The interposed libc does not handle this either.
-#add_shadow_tests(BASENAME signal METHODS preload CONFIGURATIONS ilibc)
+# FIXME: Enable for preload. See https://github.com/shadow/shadow/issues/1455
+# add_shadow_tests(BASENAME signal METHODS preload)

--- a/src/test/threads/CMakeLists.txt
+++ b/src/test/threads/CMakeLists.txt
@@ -7,9 +7,9 @@ add_shadow_tests(BASENAME threads-noexit METHODS hybrid ptrace CHECK_RETVAL FALS
 add_linux_tests(BASENAME threads-group-leader-exits COMMAND sh -c "../target/debug/test_threads_group_leader_exits")
 add_shadow_tests(BASENAME threads-group-leader-exits METHODS hybrid ptrace)
 
-## FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
 ## FIXME: Thread-related syscalls are not currently emulated in Shadow's preload mode.
 ##        `clone()` is currently unimplemented, which means the clone runs natively, bypassing Shadow.
 ##        The interposed libc does not handle this either, because it does not cover the thread apis.
-##add_shadow_tests(BASENAME pthreads METHODS preload CONFIGURATIONS ilibc)
-##add_shadow_tests(BASENAME threads-noexit METHODS preload CONFIGURATIONS ilibc)
+##        See https://github.com/shadow/shadow/issues/1454.
+##add_shadow_tests(BASENAME pthreads METHODS preload)
+##add_shadow_tests(BASENAME threads-noexit METHODS preload)


### PR DESCRIPTION
Installs a seccomp filter from the shim in preload-mode, which catches any syscalls that would otherwise be missed. The filter allows syscalls that originate from the shim itself. Other syscalls cause a SIGSYS; in the SIGSYS handler we can process the syscall as appropriate (e.g. emulate it via Shadow). Can disable with `--use-seccomp=false`

Semi-fixes https://github.com/shadow/shadow/issues/1168. This is a somewhat different approach than described there, but if this approach works out, then we probably don't need the one described in #1168.

Recompiled libc no longer needed to interpose remaining syscalls, fixing https://github.com/shadow/shadow/issues/892