### PR TITLE
kill syscall: kill from Shadow instead of from the managed process

### DIFF
--- a/src/test/signal/CMakeLists.txt
+++ b/src/test/signal/CMakeLists.txt
@@ -4,7 +4,4 @@ target_link_libraries(test-signal ${M_LIBRARIES} ${DL_LIBRARIES} ${RT_LIBRARIES}
 
 ## here we are testing 3 nodes to make sure they don't share signal handlers (in Shadow)
 add_linux_tests(BASENAME signal COMMAND shadow-test-launcher test-signal : test-signal : test-signal)
-add_shadow_tests(BASENAME signal METHODS hybrid ptrace)
-# FIXME: Enable in all configurations. See https://github.com/shadow/shadow/issues/892
-# FIXME: The interposed libc does not handle this either.
-#add_shadow_tests(BASENAME signal METHODS preload CONFIGURATIONS ilibc)
+add_shadow_tests(BASENAME signal METHODS hybrid ptrace preload)


### PR DESCRIPTION
Fixes https://github.com/shadow/shadow/issues/1455.