### PR TITLE
Some determinism fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Shadow directly executes **real applications**:
   (Linux) processes.
 - Shadow co-opts the native processes into a discrete-event simulation by
   interposing at the system call API.
-- The necessary systems calls are emulated such that the applications need not
+- The necessary system calls are emulated such that the applications need not
   be aware that they are running in a Shadow simulation.
 
 Shadow connects the applications in a **simulated network**:

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -139,7 +139,7 @@ pub struct GeneralOptions {
     seed: Option<u32>,
 
     /// How many parallel threads to use to run the simulation. Optimal
-    /// performance is usually obtained with `nproc`, or sometimes `nproc/2`
+    /// performance is usually obtained with `cores`, or sometimes `cores/2`
     /// with hyperthreading.
     #[clap(long, short = 'p', value_name = "cores")]
     #[clap(about = GENERAL_HELP.get("parallelism").unwrap())]

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -69,6 +69,9 @@ union _EpollWatchObject {
 
 typedef struct _EpollWatch EpollWatch;
 struct _EpollWatch {
+    /* A unique id for this watch relative to other watches in this epoll instance.
+     * This id encodes a total ordering of watches so they can be deterministically sorted. */
+    uint64_t id;
     /* the type of object we are watching (for example descriptor or file) */
     EpollWatchTypes watchType;
     /* the object we are watching for events */
@@ -105,6 +108,9 @@ struct _Epoll {
     /* holds the descriptors that we are watching that have events */
     GHashTable* ready;
 
+    /* A counter for sorting watches, for guaranteeing determinism when reporting events. */
+    uint64_t watch_id_counter;
+
     MAGIC_DECLARE;
 };
 
@@ -129,6 +135,12 @@ static gboolean _epollkey_equal(gconstpointer ptr_1, gconstpointer ptr_2) {
     return key_1->fd == key_2->fd && key_1->objectPtr == key_2->objectPtr;
 }
 
+static gint _epollwatch_compare(gconstpointer ptr_1, gconstpointer ptr_2) {
+    const EpollWatch* watch_1 = ptr_1;
+    const EpollWatch* watch_2 = ptr_2;
+    return (watch_1->id < watch_2->id) ? -1 : (watch_1->id > watch_2->id) ? 1 : 0;
+}
+
 /* forward declaration */
 static void _epoll_descriptorStatusChanged(Epoll* epoll, const EpollKey* key);
 
@@ -137,6 +149,7 @@ static EpollWatch* _epollwatch_new(Epoll* epoll, int fd, EpollWatchTypes type,
     EpollWatch* watch = g_new0(EpollWatch, 1);
     MAGIC_INIT(watch);
     utility_assert(event);
+    utility_assert(epoll);
 
     /* ref it for the EpollWatch, which also covers the listener reference
      * (which is freed below in _epollwatch_free) */
@@ -144,6 +157,7 @@ static EpollWatch* _epollwatch_new(Epoll* epoll, int fd, EpollWatchTypes type,
         descriptor_ref(object.as_descriptor);
     }
 
+    watch->id = ++epoll->watch_id_counter;
     watch->watchType = type;
     watch->watchObject = object;
     watch->fd = fd;
@@ -523,11 +537,30 @@ gint epoll_getEvents(Epoll* epoll, struct epoll_event* eventArray, gint eventArr
      * overflow. the number of actual events is returned in nEvents. */
     gint eventIndex = 0;
 
-    GHashTableIter iter;
-    gpointer key, value;
-    g_hash_table_iter_init(&iter, epoll->ready);
-    while(g_hash_table_iter_next(&iter, &key, &value) && (eventIndex < eventArrayLength)) {
-        EpollWatch* watch = value;
+    /* 
+     * We need to guarantee that the events are returned in a determinstic order when the
+     * simulation is run multiple times, so we cannot use hash table iterator. 
+     * Using a list here has some potential performance implications:
+     * - O(n) to loop the hash table and create the list of values
+     * - O(n) to sort the list
+     * - O(n) for our iteration of the list
+     * We think that the ready list is typically small and so 3*O(n) will be small in practice.
+     * If this turns out not to be the case, we could consider maintaining a sorted list of the
+     * ready watch values alongside the epoll->ready hash table instead, which would allow us
+     * to reduce this function to 1*O(n) by avoiding creating and sorting the list here.
+     */
+    GList* ready_list = g_hash_table_get_values(epoll->ready);
+    GList* next_item = NULL;
+
+    /* Prepare the list for deterministic iteration. */
+    if(ready_list != NULL) {
+        ready_list = g_list_sort(ready_list, _epollwatch_compare);
+        next_item = g_list_first(ready_list);
+    }
+
+    /* Iterate the list. */
+    while((next_item != NULL) && (eventIndex < eventArrayLength)) {
+        EpollWatch* watch = next_item->data;
         MAGIC_ASSERT(watch);
 
         if(_epollwatch_isReady(watch)) {
@@ -561,6 +594,13 @@ gint epoll_getEvents(Epoll* epoll, struct epoll_event* eventArray, gint eventArr
                 watch->flags |= EWF_ONESHOT_REPORTED;
             }
         }
+
+        next_item = g_list_next(next_item);
+    }
+
+    /* Cleanup just the list but not the list values, which are owned by the hash table. */
+    if(ready_list) {
+        g_list_free(ready_list);
     }
 
     *nEvents = eventIndex;

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -142,10 +142,10 @@ static gint _epollwatch_compare(gconstpointer ptr_1, gconstpointer ptr_2) {
     const EpollWatch* watch_1 = ptr_1;
     const EpollWatch* watch_2 = ptr_2;
     /* Prioritize watches whose last events were reported longest ago. */
-    if(watch_1->last_reported_event_time < watch_2->last_reported_event_time) {
+    if (watch_1->last_reported_event_time < watch_2->last_reported_event_time) {
         /* watch_1 was reported longest ago and should come first. */
         return -1;
-    } else if(watch_1->last_reported_event_time > watch_2->last_reported_event_time) {
+    } else if (watch_1->last_reported_event_time > watch_2->last_reported_event_time) {
         /* watch_2 was reported longest ago and should come first. */
         return 1;
     } else {
@@ -256,13 +256,13 @@ void epoll_clearWatchListeners(Epoll* epoll) {
     GList* next_item = NULL;
 
     /* Prepare the list for deterministic iteration. */
-    if(watch_list != NULL) {
+    if (watch_list != NULL) {
         watch_list = g_list_sort(watch_list, _epollwatch_compare);
         next_item = g_list_first(watch_list);
     }
 
     /* make sure none of our watch descriptors notify us anymore */
-    while(next_item != NULL) {
+    while (next_item != NULL) {
         EpollWatch* watch = next_item->data;
         MAGIC_ASSERT(watch);
 
@@ -278,7 +278,7 @@ void epoll_clearWatchListeners(Epoll* epoll) {
     }
 
     /* Cleanup just the list but not the list values, which are owned by the hash table. */
-    if(watch_list) {
+    if (watch_list) {
         g_list_free(watch_list);
     }
 }
@@ -566,9 +566,9 @@ gint epoll_getEvents(Epoll* epoll, struct epoll_event* eventArray, gint eventArr
      * overflow. the number of actual events is returned in nEvents. */
     gint eventIndex = 0;
 
-    /* 
+    /*
      * We need to guarantee that the events are returned in a determinstic order when the
-     * simulation is run multiple times, so we cannot use hash table iterator. 
+     * simulation is run multiple times, so we cannot use hash table iterator.
      * Using a list here has some potential performance implications:
      * - O(n) to loop the hash table and create the list of values
      * - O(n) to sort the list
@@ -582,13 +582,13 @@ gint epoll_getEvents(Epoll* epoll, struct epoll_event* eventArray, gint eventArr
     GList* next_item = NULL;
 
     /* Prepare the list for deterministic iteration. */
-    if(ready_list != NULL) {
+    if (ready_list != NULL) {
         ready_list = g_list_sort(ready_list, _epollwatch_compare);
         next_item = g_list_first(ready_list);
     }
 
     /* Iterate the list. */
-    while((next_item != NULL) && (eventIndex < eventArrayLength)) {
+    while ((next_item != NULL) && (eventIndex < eventArrayLength)) {
         EpollWatch* watch = next_item->data;
         MAGIC_ASSERT(watch);
 
@@ -631,7 +631,7 @@ gint epoll_getEvents(Epoll* epoll, struct epoll_event* eventArray, gint eventArr
     }
 
     /* Cleanup just the list but not the list values, which are owned by the hash table. */
-    if(ready_list) {
+    if (ready_list) {
         g_list_free(ready_list);
     }
 

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -151,7 +151,8 @@ static gint _epollwatch_compare(gconstpointer ptr_1, gconstpointer ptr_2) {
     } else {
         /* Both were previously reported at the same time (or never reported yet),
          * so now we fall back to the deterministic unique id ordering. */
-        return (watch_1->id < watch_2->id) ? -1 : (watch_1->id > watch_2->id) ? 1 : 0;
+        utility_assert(watch_1->id != watch_2->id);
+        return (watch_1->id < watch_2->id) ? -1 : 1;
     }
 }
 

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -252,7 +252,7 @@ static void _epoll_free(LegacyDescriptor* descriptor) {
 void epoll_clearWatchListeners(Epoll* epoll) {
     MAGIC_ASSERT(epoll);
 
-    /* Iterate the hash table in a determinsitic order. */
+    /* Iterate the hash table in a deterministic order. */
     GList* watch_list = g_hash_table_get_values(epoll->watching);
     GList* next_item = NULL;
 
@@ -568,7 +568,7 @@ gint epoll_getEvents(Epoll* epoll, struct epoll_event* eventArray, gint eventArr
     gint eventIndex = 0;
 
     /*
-     * We need to guarantee that the events are returned in a determinstic order when the
+     * We need to guarantee that the events are returned in a deterministic order when the
      * simulation is run multiple times, so we cannot use hash table iterator.
      * Using a list here has some potential performance implications:
      * - O(n) to loop the hash table and create the list of values

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -928,7 +928,7 @@ static void _tcp_clearRetransmit(TCP* tcp, guint sequence) {
     // First get the keys that need to be removed
     g_hash_table_iter_init(&iter, tcp->retransmit.queue);
 
-    while(g_hash_table_iter_next(&iter, &key, NULL)) {
+    while (g_hash_table_iter_next(&iter, &key, NULL)) {
         guint ackedSequence = GPOINTER_TO_INT(key);
         if(ackedSequence < sequence) {
             g_queue_insert_sorted(keys_sorted, key, _tcp_compare_sequence, NULL);
@@ -936,10 +936,10 @@ static void _tcp_clearRetransmit(TCP* tcp, guint sequence) {
     }
 
     // Now remove the packets in order
-    while(g_queue_get_length(keys_sorted) > 0) {
+    while (g_queue_get_length(keys_sorted) > 0) {
         key = g_queue_pop_head(keys_sorted);
         Packet* ackedPacket = g_hash_table_lookup(tcp->retransmit.queue, key);
-        if(ackedPacket) {
+        if (ackedPacket) {
             tcp->retransmit.queueLength -= packet_getPayloadLength(ackedPacket);
             packet_addDeliveryStatus(ackedPacket, PDS_SND_TCP_DEQUEUE_RETRANSMIT);
             g_hash_table_remove(tcp->retransmit.queue, key);

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -910,24 +910,44 @@ static void _tcp_addRetransmit(TCP* tcp, Packet* packet) {
     }
 }
 
+static gint _tcp_compare_sequence(gconstpointer ptr_1, gconstpointer ptr_2, gpointer user_data) {
+    const guint seq_1 = GPOINTER_TO_INT(ptr_1);
+    const guint seq_2 = GPOINTER_TO_INT(ptr_2);
+    return (seq_1 < seq_2) ? -1 : (seq_1 > seq_2) ? 1 : 0;
+}
+
 /* remove all packets with a sequence number less than the sequence parameter */
 static void _tcp_clearRetransmit(TCP* tcp, guint sequence) {
     MAGIC_ASSERT(tcp);
 
+    // Clear the retrans packets in a deterministic order
+    GQueue* keys_sorted = g_queue_new();
     GHashTableIter iter;
-    gpointer key, value;
+    gpointer key;
+
+    // First get the keys that need to be removed
     g_hash_table_iter_init(&iter, tcp->retransmit.queue);
 
-    while(g_hash_table_iter_next(&iter, &key, &value)) {
+    while(g_hash_table_iter_next(&iter, &key, NULL)) {
         guint ackedSequence = GPOINTER_TO_INT(key);
-        Packet* ackedPacket = (Packet*)value;
-
         if(ackedSequence < sequence) {
-            tcp->retransmit.queueLength -= packet_getPayloadLength(ackedPacket);
-            packet_addDeliveryStatus(ackedPacket, PDS_SND_TCP_DEQUEUE_RETRANSMIT);
-            g_hash_table_iter_remove(&iter);
+            g_queue_insert_sorted(keys_sorted, key, _tcp_compare_sequence, NULL);
         }
     }
+
+    // Now remove the packets in order
+    while(g_queue_get_length(keys_sorted) > 0) {
+        key = g_queue_pop_head(keys_sorted);
+        Packet* ackedPacket = g_hash_table_lookup(tcp->retransmit.queue, key);
+        if(ackedPacket) {
+            tcp->retransmit.queueLength -= packet_getPayloadLength(ackedPacket);
+            packet_addDeliveryStatus(ackedPacket, PDS_SND_TCP_DEQUEUE_RETRANSMIT);
+            g_hash_table_remove(tcp->retransmit.queue, key);
+        }
+    }
+
+    // Cleanup
+    g_queue_free(keys_sorted);
 
     if(_tcp_getBufferSpaceOut(tcp) > 0) {
         descriptor_adjustStatus((LegacyDescriptor*)tcp, STATUS_DESCRIPTOR_WRITABLE, TRUE);

--- a/src/test/determinism/CMakeLists.txt
+++ b/src/test/determinism/CMakeLists.txt
@@ -47,13 +47,14 @@ foreach(METHOD ptrace hybrid)
         SHADOW_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/determinism2.test.shadow.config.yaml
         ARGS --use-cpu-pinning true --parallelism 2
         PROPERTIES RUN_SERIAL TRUE)
-    ## now compare the output
-    ## TODO enable this test and fix the remaining determinism issue
-    #add_test(NAME determinism2-shadow-${METHOD}-compare COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/determinism2_compare.cmake)
-    ## make sure the tests that produce output finish before we compare the output
-    ## And make sure the test-phold binary was already built, because the test uses it
-    ## TODO enable this at the same time as the above test is enabled
-    #set_tests_properties(determinism2-shadow-${METHOD}-compare PROPERTIES DEPENDS "determinism2a-shadow-${METHOD};determinism2b-shadow-${METHOD};test-phold")
+    ## Now compare the output
+    add_test(
+        NAME determinism2-shadow-${METHOD}-compare
+        COMMAND ${CMAKE_COMMAND} -D METHOD=${METHOD} -P ${CMAKE_CURRENT_SOURCE_DIR}/determinism2_compare.cmake)
+    ## Make sure the tests that produce output finish before we compare the output,
+    ## and make sure the test-phold binary was already built, because this test uses it.
+    set_tests_properties(determinism2-shadow-${METHOD}-compare
+        PROPERTIES DEPENDS "determinism2a-shadow-${METHOD};determinism2b-shadow-${METHOD};test-phold")
 endforeach()
 
 ## copy the file to the build test dir so that the relative path to it is correct

--- a/src/test/determinism/CMakeLists.txt
+++ b/src/test/determinism/CMakeLists.txt
@@ -29,9 +29,16 @@ endforeach()
 ## TEST 2 (Extended packet tests)
 
 ## TODO
-## We could also split the shadow.log file into a separate file for each host
+## We should also split the shadow.log file into a separate file for each host
 ## and then grep each file for "packet_add", and do diffs on the output of that.
 ## That way we could check the order of every packet event at every processing point.
+## For example:
+## for i in {1..10}
+## do
+##     cat shadow-a.log | grep "peer${i}:" | grep "packet_add" | cut -d' ' -f3- > peer${i}-a.log
+##     cat shadow-b.log | grep "peer${i}:" | grep "packet_add" | cut -d' ' -f3- > peer${i}-b.log
+##     diff --brief peer${i}-a.log peer${i}-b.log
+## done
 
 ## now let's run a phold test and compare the order of packet events
 foreach(METHOD ptrace hybrid)

--- a/src/test/determinism/determinism2_compare.cmake
+++ b/src/test/determinism/determinism2_compare.cmake
@@ -1,7 +1,14 @@
 macro(EXEC_DIFF_CHECK FILE1 FILE2)
-    execute_process(COMMAND ${CMAKE_COMMAND} -E compare_files ${FILE1} ${FILE2} RESULT_VARIABLE RESULT OUTPUT_VARIABLE OUTPUT)
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E compare_files ${FILE1} ${FILE2}
+        RESULT_VARIABLE RESULT
+        OUTPUT_VARIABLE STDOUTPUT
+        ERROR_VARIABLE STDERROR)
+    message(STATUS "Diff returned ${RESULT} for 'diff ${FILE1} ${FILE2}'")
     if(RESULT)
-        message(FATAL_ERROR "Error in diff: ${OUTPUT}")
+        message(STATUS "Diff stdout is: ${STDOUTPUT}")
+        message(STATUS "Diff stderr is: ${STDERROR}")
+        message(FATAL_ERROR "Differences found; test failed")
     endif()
 endmacro()
 foreach(LOOPIDX RANGE 1 10)


### PR DESCRIPTION
This primarily includes a fix for a confirmed non-deterministic behavior I found in the epoll getEvents function (in c6039d3cace428349aae167c635cb4cfed9e120d).

I also updated a couple of other places in the code where we iterate a hash table (which is non-deterministic) - these were unconfirmed issues but I suspected they _might_ cause problems. (Probably best if we stop using glib hash table iterators in general, and instead prefer an iterator that guarantees a total ordering; rust probably makes this easier.)

Closes #1294