### PR TITLE
Add an option to use a socket for ipc

### DIFF
--- a/src/main/bindings/c/bindings-opaque.h
+++ b/src/main/bindings/c/bindings-opaque.h
@@ -20,6 +20,13 @@ typedef enum InterposeMethod {
   INTERPOSE_METHOD_HYBRID,
 } InterposeMethod;
 
+typedef enum IpcMethod {
+  // Unix-domain socket
+  IPC_METHOD_SOCKET,
+  // Semaphore + shared memory
+  IPC_METHOD_SEMAPHORE,
+} IpcMethod;
+
 typedef enum QDiscMode {
   Q_DISC_MODE_FIFO,
   Q_DISC_MODE_ROUND_ROBIN,

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -174,6 +174,8 @@ bool config_getUseCpuPinning(const struct ConfigOptions *config);
 
 enum InterposeMethod config_getInterposeMethod(const struct ConfigOptions *config);
 
+enum IpcMethod config_getIpcMethod(const struct ConfigOptions *config);
+
 bool config_getUseSchedFifo(const struct ConfigOptions *config);
 
 bool config_getUseOnWaitpidWorkarounds(const struct ConfigOptions *config);

--- a/src/main/host/shimipc.c
+++ b/src/main/host/shimipc.c
@@ -16,4 +16,8 @@ bool shimipc_sendExplicitBlockMessageEnabled() { return _useExplicitBlockMessage
 static int _spinMax = -1;
 ADD_CONFIG_HANDLER(config_getPreloadSpinMax, _spinMax)
 
+static IpcMethod _ipcMethod;
+ADD_CONFIG_HANDLER(config_getIpcMethod, _ipcMethod)
+IpcMethod shimipc_getIpcMethod() { return _ipcMethod; }
+
 ssize_t shimipc_spinMax() { return _spinMax; }

--- a/src/main/host/shimipc.h
+++ b/src/main/host/shimipc.h
@@ -11,9 +11,14 @@
 #include <stdbool.h>
 #include <sys/types.h>
 
+#include "main/bindings/c/bindings.h"
+
 // Whether to send an explicit message to the shim when its plugin is blocked.
 bool shimipc_sendExplicitBlockMessageEnabled();
 
 // Number of iterations to spin when waiting on IPC between Shadow and the shim
 // before blocking.
 ssize_t shimipc_spinMax();
+
+// Which ipc method to use in shim IPC.
+IpcMethod shimipc_getIpcMethod();

--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -137,7 +137,12 @@ pid_t threadpreload_run(Thread* base, gchar** argv, gchar** envv, const char* wo
 
     thread->ipc_blk = shmemallocator_globalAlloc(ipcData_nbytes());
     utility_assert(thread->ipc_blk.p);
-    ipcData_init(thread->ipc_blk.p, shimipc_spinMax());
+    switch (shimipc_getIpcMethod()) {
+        case IPC_METHOD_SOCKET: ipcData_initSocket(thread->ipc_blk.p, shimipc_spinMax()); break;
+        case IPC_METHOD_SEMAPHORE:
+            ipcData_initSemaphore(thread->ipc_blk.p, shimipc_spinMax());
+            break;
+    }
 
     ShMemBlockSerialized ipc_blk_serial = shmemallocator_globalBlockSerialize(&thread->ipc_blk);
 

--- a/src/main/host/thread_ptrace.c
+++ b/src/main/host/thread_ptrace.c
@@ -1336,7 +1336,14 @@ Thread* threadptrace_new(Host* host, Process* process, int threadID) {
     ThreadPtrace* thread = (ThreadPtrace*)threadptraceonly_new(host, process, threadID);
 
     thread->ipcBlk = shmemallocator_globalAlloc(ipcData_nbytes());
-    ipcData_init(_threadptrace_ipcData(thread), shimipc_spinMax());
+    switch (shimipc_getIpcMethod()) {
+        case IPC_METHOD_SOCKET:
+            ipcData_initSocket(_threadptrace_ipcData(thread), shimipc_spinMax());
+            break;
+        case IPC_METHOD_SEMAPHORE:
+            ipcData_initSemaphore(_threadptrace_ipcData(thread), shimipc_spinMax());
+            break;
+    }
     thread->enableIpc = true;
 
     return _threadPtraceToThread(thread);

--- a/src/shim/ipc.cc
+++ b/src/shim/ipc.cc
@@ -3,58 +3,202 @@
 #include <assert.h>
 #include <errno.h>
 #include <new>
+#include <stdlib.h>
 
 #include "shim/binary_spinning_sem.h"
 
-struct IPCData {
-    IPCData(ssize_t spin_max) : xfer_ctrl_to_plugin(spin_max), xfer_ctrl_to_shadow(spin_max) {}
+typedef enum {
+    IPC_SOCKET,
+    IPC_SEMAPHORE,
+} IPCDataType;
+
+struct SocketIPCData {
+    int to_shadow_fd;
+    int to_plugin_fd;
+    ssize_t spin_max;
+};
+
+struct SemaphoreIPCData {
+    SemaphoreIPCData(ssize_t spin_max)
+        : xfer_ctrl_to_plugin(spin_max), xfer_ctrl_to_shadow(spin_max) {}
     ShimEvent plugin_to_shadow, shadow_to_plugin;
     BinarySpinningSem xfer_ctrl_to_plugin, xfer_ctrl_to_shadow;
 };
 
+struct IPCData {
+    IPCDataType type;
+    union {
+        SocketIPCData socket;
+        SemaphoreIPCData semaphore;
+    };
+};
+
 extern "C" {
 
-void ipcData_init(IPCData* ipc_data, ssize_t spin_max) { new (ipc_data) IPCData(spin_max); }
+static void utility_assert(bool b) {
+    if (!b) {
+        // Save errno for debugger.
+        int e = errno;
+
+        abort();
+    }
+}
+
+void ipcData_initSocket(IPCData* ipc_data, ssize_t spin_max) {
+    int fds[2];
+    int rv = socketpair(PF_LOCAL, SOCK_SEQPACKET, 0, fds);
+    utility_assert(rv == 0);
+    ipc_data->type = IPC_SOCKET;
+    ipc_data->socket = (SocketIPCData){
+        .to_shadow_fd = fds[0],
+        .to_plugin_fd = fds[1],
+        .spin_max = spin_max,
+    };
+}
+
+void ipcData_initSemaphore(IPCData* ipc_data, ssize_t spin_max) {
+    ipc_data->type = IPC_SEMAPHORE;
+    new (&ipc_data->semaphore) SemaphoreIPCData(spin_max);
+}
 
 size_t ipcData_nbytes() { return sizeof(IPCData); }
 
 void shimevent_sendEventToShadow(struct IPCData* data, const ShimEvent* e) {
-    data->plugin_to_shadow = *e;
-    data->xfer_ctrl_to_shadow.post();
+    switch (data->type) {
+        case IPC_SOCKET: {
+            int rv;
+            do {
+                rv = send(data->socket.to_shadow_fd, e, sizeof(*e), 0);
+            } while (rv == -1 && errno == EINTR);
+            utility_assert(rv == sizeof(*e));
+            return;
+        }
+        case IPC_SEMAPHORE: {
+            data->semaphore.plugin_to_shadow = *e;
+            data->semaphore.xfer_ctrl_to_shadow.post();
+            return;
+        }
+            // No default to force exhaustive.
+    }
+    abort();
 }
 
 void shimevent_sendEventToPlugin(struct IPCData* data, const ShimEvent* e) {
-    data->shadow_to_plugin = *e;
-    data->xfer_ctrl_to_plugin.post();
+    switch (data->type) {
+        case IPC_SOCKET: {
+            int rv;
+            do {
+                rv = send(data->socket.to_plugin_fd, e, sizeof(*e), 0);
+            } while (rv == -1 && errno == EINTR);
+            utility_assert(rv == sizeof(*e));
+            return;
+        }
+        case IPC_SEMAPHORE: {
+            data->semaphore.shadow_to_plugin = *e;
+            data->semaphore.xfer_ctrl_to_plugin.post();
+            return;
+        }
+            // No default to force exhaustive.
+    }
+    abort();
 }
 
 void shimevent_recvEventFromShadow(struct IPCData* data, ShimEvent* e, bool spin) {
-    data->xfer_ctrl_to_plugin.wait(spin);
-    *e = data->shadow_to_plugin;
+    switch (data->type) {
+        case IPC_SOCKET: {
+            if (spin) {
+                for (int i = 0; i < data->socket.spin_max; ++i) {
+                    if (shimevent_tryRecvEventFromShadow(data, e) >= 0) {
+                        return;
+                    }
+                }
+            }
+            int rv;
+            do {
+                rv = recv(data->socket.to_shadow_fd, e, sizeof(*e), 0);
+            } while (rv == -1 && errno == EINTR);
+            utility_assert(rv == sizeof(*e));
+            return;
+        }
+        case IPC_SEMAPHORE: {
+            data->semaphore.xfer_ctrl_to_plugin.wait(spin);
+            *e = data->semaphore.shadow_to_plugin;
+            return;
+        }
+            // No default to force exhaustive.
+    }
+    abort();
 }
 
 void shimevent_recvEventFromPlugin(struct IPCData* data, ShimEvent* e) {
-    data->xfer_ctrl_to_shadow.wait();
-    *e = data->plugin_to_shadow;
+    switch (data->type) {
+        case IPC_SOCKET: {
+            for (int i = 0; i < data->socket.spin_max; ++i) {
+                if (shimevent_tryRecvEventFromPlugin(data, e) >= 0) {
+                    return;
+                }
+            }
+            int rv;
+            do {
+                rv = recv(data->socket.to_plugin_fd, e, sizeof(*e), 0);
+            } while (rv == -1 && errno == EINTR);
+            utility_assert(rv == sizeof(*e));
+            return;
+        }
+        case IPC_SEMAPHORE: {
+            data->semaphore.xfer_ctrl_to_shadow.wait();
+            *e = data->semaphore.plugin_to_shadow;
+            return;
+        }
+            // No default to force exhaustive.
+    }
+    abort();
 }
 
 int shimevent_tryRecvEventFromShadow(struct IPCData* data, ShimEvent* e) {
-    int rv = data->xfer_ctrl_to_plugin.trywait();
-    if (rv != 0) {
-        return rv;
+    switch (data->type) {
+        case IPC_SOCKET: {
+            int rv = recv(data->socket.to_shadow_fd, e, sizeof(*e), MSG_DONTWAIT);
+            if (rv >= 0) {
+                utility_assert(rv == sizeof(*e));
+                return 0;
+            }
+            return rv;
+        }
+        case IPC_SEMAPHORE: {
+            int rv = data->semaphore.xfer_ctrl_to_plugin.trywait();
+            if (rv != 0) {
+                return rv;
+            }
+            *e = data->semaphore.shadow_to_plugin;
+            return 0;
+        }
+            // No default to force exhaustive.
     }
-    *e = data->shadow_to_plugin;
-    return 0;
+    abort();
 }
 
 int shimevent_tryRecvEventFromPlugin(struct IPCData* data, ShimEvent* e) {
-    int rv = data->xfer_ctrl_to_shadow.trywait();
-    if (rv != 0) {
-        return rv;
+    switch (data->type) {
+        case IPC_SOCKET: {
+            int rv = recv(data->socket.to_plugin_fd, e, sizeof(*e), MSG_DONTWAIT);
+            if (rv >= 0) {
+                utility_assert(rv == sizeof(*e));
+                return 0;
+            }
+            return rv;
+        }
+        case IPC_SEMAPHORE: {
+            int rv = data->semaphore.xfer_ctrl_to_shadow.trywait();
+            if (rv != 0) {
+                return rv;
+            }
+            *e = data->semaphore.plugin_to_shadow;
+            return 0;
+        }
+            // No default to force exhaustive.
     }
-
-    *e = data->plugin_to_shadow;
-    return 0;
+    abort();
 }
 
 } // extern "C"

--- a/src/shim/ipc.h
+++ b/src/shim/ipc.h
@@ -20,7 +20,8 @@ extern "C" {
 
 struct IPCData;
 
-void ipcData_init(struct IPCData* ipc_data, ssize_t spin_max);
+void ipcData_initSocket(struct IPCData* ipc_data, ssize_t spin_max);
+void ipcData_initSemaphore(struct IPCData* ipc_data, ssize_t spin_max);
 
 size_t ipcData_nbytes();
 


### PR DESCRIPTION
This was motivated by seccomp use-cases of being able to send a
file-descriptor over the socket. As it turns out, I'm not sure we need
that capability after all. It is a bit easier to whitelist the
corresponding IPC in the seccomp filter though, and a bit simpler and
more flexible in general.

It *should* have similar performance to the semaphore approach when
we're not spinning, but I've left it in as an option so we can verify.