### PR TITLE
Fixed github labeler config

### DIFF
--- a/.github/pr_labeler_conf.yml
+++ b/.github/pr_labeler_conf.yml
@@ -1,24 +1,24 @@
 "Component: Build":
-- **/CMakeLists.txt
-- **/Cargo.toml
-- **/Cargo.lock
+- "**/CMakeLists.txt"
+- "**/Cargo.toml"
+- "**/Cargo.lock"
 
 "Component: Documentation":
-- **/*.md
-- docs/**/*
+- "**/*.md"
+- "docs/**/*"
 
 "Component: Libraries":
-- src/shim/**/*
-- src/support/**/*
+- "src/shim/**/*"
+- "src/support/**/*"
 
 "Component: Main":
-- src/main/**/*
+- "src/main/**/*"
 
 "Component: Testing":
-- src/test/**/*
-- .github/**/*.yml
-- !.github/pr_labeler_conf.yml
-- !.github/workflows/pr_metadata.yml
+- "src/test/**/*"
+- ".github/**/*.yml"
+- "!.github/pr_labeler_conf.yml"
+- "!.github/workflows/pr_metadata.yml"
 
 "Component: Tools":
-- src/tools/**/*
+- "src/tools/**/*"


### PR DESCRIPTION
Values that start with a `*` or `!` are not strings in yaml.