### PR TITLE
Custom semaphore implementation

### DIFF
--- a/src/lib/shim/CMakeLists.txt
+++ b/src/lib/shim/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SHIM_HELPER_LIB shadow-shim-helper)
 set(SHIM_HELPER_FILES
   binary_spinning_sem.cc
   ipc.cc
+  shadow_sem.c
   shim_event.c
 )
 add_library(${SHIM_HELPER_LIB} STATIC ${SHIM_HELPER_FILES})

--- a/src/lib/shim/binary_spinning_sem.cc
+++ b/src/lib/shim/binary_spinning_sem.cc
@@ -1,5 +1,7 @@
 #include "binary_spinning_sem.h"
 
+#include "shadow_sem.h"
+
 #include <assert.h>
 #include <cstring>
 #include <errno.h>
@@ -7,23 +9,23 @@
 #include <unistd.h>
 
 BinarySpinningSem::BinarySpinningSem(ssize_t spin_max) : _thresh(spin_max) {
-    sem_init(&_semaphore, 1, 0);
+    shadow_sem_init(&_semaphore, 1, 0);
 }
 
 void BinarySpinningSem::post() {
-    sem_post(&_semaphore);
+    shadow_sem_post(&_semaphore);
     sched_yield();
 }
 
 void BinarySpinningSem::wait(bool spin) {
     if (spin) {
         for (int i = 0; _thresh < 0 || i < _thresh; ++i) {
-            if (sem_trywait(&_semaphore) == 0) {
+            if (shadow_sem_trywait(&_semaphore) == 0) {
                 return;
             }
         }
     }
-    sem_wait(&_semaphore);
+    shadow_sem_wait(&_semaphore);
 }
 
-int BinarySpinningSem::trywait() { return sem_trywait(&_semaphore); }
+int BinarySpinningSem::trywait() { return shadow_sem_trywait(&_semaphore); }

--- a/src/lib/shim/binary_spinning_sem.h
+++ b/src/lib/shim/binary_spinning_sem.h
@@ -3,9 +3,10 @@
 
 #include <atomic>
 #include <cstddef>
-
 #include <pthread.h>
-#include <semaphore.h>
+#include <sys/types.h>
+
+#include "shadow_sem.h"
 
 // Intended to be private to the ipc module.
 
@@ -77,7 +78,13 @@ class BinarySpinningSem {
     BinarySpinningSem &operator=(const BinarySpinningSem &rhs) = delete;
 
   private:
-    sem_t _semaphore;
+    /* We use shadow_sem_t (which implements the same interface as sem_t) instead of sem_t
+     * to ensure that both sides of the IPC see the same definition. If we instead used sem_t,
+     * the shadow would see libc's sem_t implementation, while the shim would see the overridden
+     * definition, which is incompatible.
+     */
+    shadow_sem_t _semaphore;
+
     ssize_t _thresh;
 };
 

--- a/src/lib/shim/shadow_sem.c
+++ b/src/lib/shim/shadow_sem.c
@@ -1,0 +1,155 @@
+#include "lib/shim/shadow_sem.h"
+
+#include "lib/logger/logger.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <linux/futex.h>
+#include <semaphore.h>
+#include <stdalign.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static _Atomic(uint32_t) * _shadow_sem_futex_addr(shadow_sem_t* s) {
+    static_assert(sizeof(s->_value) == 4, "futex must be exactly 4 bytes large");
+    static_assert(alignof(typeof(s->_value)) >= 4, "futex must be >= 4 aligned");
+    return &s->_value;
+}
+
+// Perform a wake operation on the futex in `s`.
+static int _futex_wake(shadow_sem_t* s) {
+    return (int)syscall(SYS_futex, _shadow_sem_futex_addr(s), FUTEX_WAKE, 1, NULL, NULL, 0);
+}
+
+// Perform a wait operation on the futex in `s`, with an absolute timeout.
+static int _futex_wait_abs(shadow_sem_t* s, const struct timespec* timeout) {
+    // Unlike FUTEX_WAIT, FUTEX_WAIT_BITSET uses an absolute timeout.
+    return (int)syscall(SYS_futex, _shadow_sem_futex_addr(s), FUTEX_WAIT_BITSET, 0, timeout, NULL,
+                        FUTEX_BITSET_MATCH_ANY);
+}
+
+int shadow_sem_init(shadow_sem_t* sem, int pshared, unsigned int _value) {
+    if (_value > SEM_VALUE_MAX) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *sem = (shadow_sem_t){
+        ._value = ATOMIC_VAR_INIT(_value),
+        ._nwaiters = ATOMIC_VAR_INIT(0),
+    };
+
+    return 0;
+}
+
+int shadow_sem_destroy(shadow_sem_t* sem) {
+    // Nothing to do.
+    return 0;
+}
+
+int shadow_sem_post(shadow_sem_t* sem) {
+    uint32_t prev_value = atomic_load_explicit(&sem->_value, memory_order_relaxed);
+    while (1) {
+        if (prev_value >= SEM_VALUE_MAX) {
+            errno = EOVERFLOW;
+            return -1;
+        }
+        // We use memory_order_seq_cst to get a global total ordering of the
+        // operations on `_nwaiters` together with the operations on `_value`.
+        if (atomic_compare_exchange_weak_explicit(&sem->_value, &prev_value, prev_value + 1,
+                                                  memory_order_seq_cst, memory_order_relaxed)) {
+            break;
+        }
+    }
+
+    // If we didn't see a futex value of 0, we never need to do a wakeup.  A
+    // concurrent thread that's trying to wait on the semaphore can't end up
+    // sleeping on a non-zero _value, as enforced by the futex operation.
+    if (prev_value != 0) {
+        return 0;
+    }
+
+    // If no threads are asleep on the futex, we don't need to do a wakeup
+    // operation.  While there is some cost and complexity for tracking
+    // `_nwaiters`, this gives about a 5% performance improvement in the phold
+    // mezzo benchmark.
+    uint32_t nwaiters = atomic_load_explicit(&sem->_nwaiters, memory_order_seq_cst);
+    if (nwaiters == 0) {
+        return 0;
+    }
+
+    int futex_rv = _futex_wake(sem);
+    if (futex_rv < 0) {
+        // This shouldn't happen, and there's no good way to recover.
+        panic("futex_wake: %s", strerror(errno));
+    }
+
+    return 0;
+}
+
+int shadow_sem_trywait(shadow_sem_t* sem) {
+    uint32_t prev_value = atomic_load_explicit(&sem->_value, memory_order_relaxed);
+    while (1) {
+        if (prev_value == 0) {
+            errno = EAGAIN;
+            return -1;
+        }
+        // We use memory_order_seq_cst to get a global total ordering of the
+        // operations on `_nwaiters` together with the operations on `_value`.
+        if (atomic_compare_exchange_weak_explicit(&sem->_value, &prev_value, prev_value - 1,
+                                                  memory_order_seq_cst, memory_order_relaxed)) {
+            break;
+        }
+    }
+    return 0;
+}
+
+// `abs_timeout` may be NULL to specify no timeout.
+static int _shadow_sem_timedwait(shadow_sem_t* sem, const struct timespec* abs_timeout) {
+    uint32_t prev_value = atomic_load_explicit(&sem->_value, memory_order_relaxed);
+    while (1) {
+        if (prev_value == 0) {
+            // Wait on the futex.
+
+            // memory_order_seq_cst for global total ordering of with operations
+            // on _value.
+            uint32_t prev_nwaiters =
+                atomic_fetch_add_explicit(&sem->_nwaiters, 1, memory_order_seq_cst);
+            if (prev_nwaiters == UINT32_MAX) {
+                panic("Unhandled %ud + 1 waiters on shadow_sem_t", prev_nwaiters);
+            }
+
+            // We use FUTEX_WAIT_BITSET instead of FUTEX_WAIT so that we can specify an absolute
+            // timeout. See futex(2).
+            //
+            // We use memory_order_seq_cst to get a global total ordering of the
+            // operations on `_nwaiters` together with the operations on `_value`.
+            int futex_res = _futex_wait_abs(sem, abs_timeout);
+            atomic_fetch_sub_explicit(&sem->_nwaiters, 1, memory_order_seq_cst);
+            if (futex_res < 0 && errno != EAGAIN) {
+                // Propagate errno from the futex operation. Notably if the operation timed out,
+                // errno will already be ETIMEDOUT.
+                return -1;
+            }
+            // We either failed to sleep on the futex because the value had
+            // already changed, or there was a futex wake operation. Either way,
+            // get the current value and try again.
+            prev_value = atomic_load_explicit(&sem->_value, memory_order_relaxed);
+            continue;
+        }
+        // Try to take one
+        if (atomic_compare_exchange_weak_explicit(&sem->_value, &prev_value, prev_value - 1,
+                                                  memory_order_seq_cst, memory_order_relaxed)) {
+            return 0;
+        }
+    }
+}
+
+int shadow_sem_timedwait(shadow_sem_t* sem, const struct timespec* abs_timeout) {
+    return _shadow_sem_timedwait(sem, abs_timeout);
+}
+
+int shadow_sem_wait(shadow_sem_t* sem) { return _shadow_sem_timedwait(sem, NULL); }

--- a/src/lib/shim/shadow_sem.h
+++ b/src/lib/shim/shadow_sem.h
@@ -1,0 +1,47 @@
+#ifndef SHIM_SHADOW_SEM_H
+#define SHIM_SHADOW_SEM_H
+
+// Implements the same API as sem_init, sem_destroy, etc. from libc.
+//
+// This is a shared implementation used both in binary_spinning_sem and in
+// preload_libraries.
+
+#include <assert.h>
+#include <stdalign.h>
+#include <stdint.h>
+#include <sys/time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+// Unfortunately C++ and C don't have a mutually compatible atomic type.  These
+// fields shold be treated as opaque anyway though; C++ code just needs to know
+// the size and alignment.
+#define _Atomic(x) x
+#else
+#include <stdatomic.h>
+#endif
+
+typedef struct shadow_sem_t {
+    _Atomic(uint32_t) _value;
+    _Atomic(uint32_t) _nwaiters;
+} shadow_sem_t;
+
+// Validate size and alignment since we lied to C++
+static_assert(sizeof(shadow_sem_t) == 8, "shadow_sem_t has unexpected size");
+static_assert(alignof(shadow_sem_t) == 4, "shadow_sem_t has unexpected alignment");
+
+int shadow_sem_init(shadow_sem_t* sem, int pshared, unsigned int value);
+int shadow_sem_destroy(shadow_sem_t* sem);
+int shadow_sem_post(shadow_sem_t* sem);
+int shadow_sem_trywait(shadow_sem_t* sem);
+int shadow_sem_timedwait(shadow_sem_t* sem, const struct timespec* abs_timeout);
+int shadow_sem_wait(shadow_sem_t* sem);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif


### PR DESCRIPTION
This adds a reimplementation of libc's semaphore interface. Using it instead of libc's semaphore in our binary_spinning_semaphore results in the underlying `syscall` calls going through the shim's overridden `syscall` function, which is whitelisted in the seccomp filter when seccomp is in use. i.e. this allows us to avoid unnecessary seccomp traps in the shim <-> shadow IPC (without the previous workaround of whitelisting *all* futex operations).
 
We also use our implementation of libc's semaphore to override libc's semaphore in the shim.

Progress on #1454