### PR TITLE
interpose-method=preload thread support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
-# this file is also used with rsync --exclude-from
-# in 'ci/run.sh', so avoid globs
-.git
-build
-src/main/target
+# .dockerignore doesn't treat a bare basename as unrooted. e.g. just `target` is
+# equivalent to `./target`; it won't match `./src/test/target`.
+#
+# This file is also used with rsync --exclude-from in 'ci/run.sh', but rsync
+# appears to accept a super-set of patterns recognized by dockerignore.
+**/.git
+**/build
+**/target

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # shadow build dir
-/build
+build
 # area for local temp files
 /local
 /install

--- a/src/lib/shim/CMakeLists.txt
+++ b/src/lib/shim/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SHIM_FILES
   shim_logger.c
   shim_shmem.c
   shim_syscall.c
+  shim_tls.c
 )
 add_library(${SHIM_LIB} SHARED ${SHIM_FILES})
 set_target_properties(${SHIM_LIB} PROPERTIES LINK_FLAGS "-Wl,--no-as-needed")

--- a/src/lib/shim/CMakeLists.txt
+++ b/src/lib/shim/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SHIM_HELPER_FILES
   binary_spinning_sem.cc
   ipc.cc
   shadow_sem.c
+  shadow_spinlock.c
   shim_event.c
 )
 add_library(${SHIM_HELPER_LIB} STATIC ${SHIM_HELPER_FILES})

--- a/src/lib/shim/preload_syscall.h
+++ b/src/lib/shim/preload_syscall.h
@@ -11,4 +11,7 @@ long __attribute__((noinline)) shadow_vreal_raw_syscall(long n, va_list args);
 // decides whether to execute a real syscall or emulate.
 long shadow_raw_syscall(long n, ...);
 
+// Makes a raw syscall natively; never emulates.
+long shadow_real_raw_syscall(long n, ...);
+
 #endif

--- a/src/lib/shim/shadow_spinlock.c
+++ b/src/lib/shim/shadow_spinlock.c
@@ -1,0 +1,36 @@
+#include "lib/shim/shadow_spinlock.h"
+
+#include <assert.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "lib/shim/preload_syscall.h"
+
+int shadow_spin_init(shadow_spinlock_t *lock) {
+    assert(lock);
+    *lock = (shadow_spinlock_t) {
+        ._locked = false,
+    };
+    return 0;
+}
+
+int shadow_spin_lock(shadow_spinlock_t* lock) {
+    assert(lock);
+    while (1) {
+        bool prev_locked = atomic_load_explicit(&lock->_locked, memory_order_relaxed);
+        if (!prev_locked && atomic_compare_exchange_weak_explicit(&lock->_locked, &prev_locked, true,
+                                                        memory_order_acquire, memory_order_relaxed)) {
+            break;
+        }
+        // Always make the real syscall
+        shadow_real_raw_syscall(SYS_sched_yield);
+    }
+    return 0;
+}
+
+int shadow_spin_unlock(shadow_spinlock_t *lock) {
+    assert(lock);
+    assert(atomic_load_explicit(&lock->_locked, memory_order_relaxed));
+    atomic_store_explicit(&lock->_locked, false, memory_order_release);
+    return 0;
+}

--- a/src/lib/shim/shadow_spinlock.h
+++ b/src/lib/shim/shadow_spinlock.h
@@ -1,0 +1,19 @@
+#ifndef SHADOW_SPINLOCK_H
+#define SHADOW_SPINLOCK_H
+
+#include <stdatomic.h>
+#include <stdbool.h>
+
+// Provides a subset of the pthread_spinlock_t interface. Methods
+// are guaranteed to never make syscalls other than sched_yield.
+typedef struct {
+    _Atomic bool _locked;
+} shadow_spinlock_t;
+
+#define SHADOW_SPINLOCK_STATICALLY_INITD ((shadow_spinlock_t){._locked = ATOMIC_VAR_INIT(false)})
+
+int shadow_spin_init(shadow_spinlock_t *lock);
+int shadow_spin_lock(shadow_spinlock_t *lock);
+int shadow_spin_unlock(shadow_spinlock_t *lock);
+
+#endif

--- a/src/lib/shim/shim.h
+++ b/src/lib/shim/shim.h
@@ -34,9 +34,25 @@ bool shim_interpositionEnabled();
 bool shim_use_syscall_handler();
 
 // Returns the shmem block used for IPC, which may be uninitialized.
-ShMemBlock shim_thisThreadEventIPCBlk();
+struct IPCData* shim_thisThreadEventIPC();
 
 // Return the location of the time object in shared memory, or NULL if unavailable.
 struct timespec* shim_get_shared_time_location();
+
+// To be called in parent thread before making the `clone` syscall.
+// It sets up data for the new thread.
+void shim_newThreadStart(ShMemBlockSerialized* block);
+
+// To be called in parent thread after making the `clone` syscall.
+// It doesn't return until after the child has initialized itself.
+void shim_newThreadFinish();
+
+// To be called from a new *child* thread after clone, to notify
+// the parent thread that it is now initialized.
+void shim_newThreadChildInitd();
+
+// Gets and resets the instruction pointer to which the child should resume
+// execution after a clone syscall.
+void* shim_take_clone_rip();
 
 #endif // SHD_SHIM_SHIM_H_

--- a/src/lib/shim/shim_event.h
+++ b/src/lib/shim/shim_event.h
@@ -36,7 +36,7 @@ int shadow_hostname_to_addr_ipv4(const char* name, size_t name_len, uint32_t* ad
                                  size_t addr_len);
 
 typedef enum {
-    // Next val: 11
+    // Next val: 13
     SHD_SHIM_EVENT_NULL = 0,
     SHD_SHIM_EVENT_START = 1,
     SHD_SHIM_EVENT_STOP = 2,
@@ -48,6 +48,8 @@ typedef enum {
     SHD_SHIM_EVENT_SHMEM_COMPLETE = 6,
     SHD_SHIM_EVENT_WRITE_REQ = 7,
     SHD_SHIM_EVENT_BLOCK = 10,
+    SHD_SHIM_EVENT_ADD_THREAD_REQ = 11,
+    SHD_SHIM_EVENT_ADD_THREAD_PARENT_RES = 12,
 } ShimEventID;
 
 typedef struct _ShimEvent {
@@ -83,6 +85,10 @@ typedef struct _ShimEvent {
             PluginPtr plugin_ptr;
             size_t n;
         } shmem_blk;
+
+        struct {
+            ShMemBlockSerialized ipc_block;
+        } add_thread_req;
     } event_data;
 
 } ShimEvent;

--- a/src/lib/shim/shim_logger.c
+++ b/src/lib/shim/shim_logger.c
@@ -99,7 +99,7 @@ void shimlogger_flush(Logger* base) {
 
 bool shimlogger_isEnabled(Logger* base, LogLevel level) {
     ShimLogger* logger = (ShimLogger*)base;
-    return level >= logger->level;
+    return level <= logger->level;
 }
 
 void shimlogger_setLevel(Logger* base, LogLevel level) {

--- a/src/lib/shim/shim_logger.c
+++ b/src/lib/shim/shim_logger.c
@@ -13,6 +13,7 @@
 #include "lib/logger/logger.h"
 #include "lib/shim/shim.h"
 #include "lib/shim/shim_syscall.h"
+#include "lib/shim/shim_tls.h"
 
 typedef struct _ShimLogger {
     Logger base;
@@ -36,15 +37,18 @@ void shimlogger_log(Logger* base, LogLevel level, const char* fileName, const ch
     if (!logger_isEnabled(base, level)) {
         return;
     }
-    static __thread bool in_logger = false;
+
+    static ShimTlsVar in_logger_var = {0};
+    bool* in_logger = shimtlsvar_ptr(&in_logger_var, sizeof(*in_logger));
+
     // Stack-allocated to avoid dynamic allocation.
     char buf[200];
     size_t offset = 0;
-    if (in_logger) {
+    if (*in_logger) {
         // Avoid recursion in logging around syscall handling.
         return;
     }
-    in_logger = true;
+    *in_logger = true;
     shim_disableInterposition();
 
     ShimLogger* logger = (ShimLogger*)base;
@@ -83,7 +87,7 @@ void shimlogger_log(Logger* base, LogLevel level, const char* fileName, const ch
         fflush_unlocked(logger->file);
     }
     shim_enableInterposition();
-    in_logger = false;
+    *in_logger = false;
 }
 
 void shimlogger_destroy(Logger* logger) {

--- a/src/lib/shim/shim_tls.c
+++ b/src/lib/shim/shim_tls.c
@@ -1,0 +1,113 @@
+#include "lib/shim/shim_tls.h"
+
+#include "lib/shim/shim.h"
+
+#include <assert.h>
+#include <stdalign.h>
+
+// XXX: Needs to be big enough for stack in _vshadow_raw_syscall until we get
+// rid of it.
+#define BYTES_PER_THREAD (4096*10 + 1024)
+#define MAX_THREADS 100
+
+// Stores the TLS for a single thread.
+typedef struct ShimThreadLocalStorage {
+    alignas(16) char _bytes[BYTES_PER_THREAD];
+} ShimThreadLocalStorage;
+
+// All TLSs. We could probably make this more dynamic if we need to.
+static ShimThreadLocalStorage _tlss[MAX_THREADS];
+
+int shimtls_getCurrentIdx();
+int shimtls_takeNextIdx();
+
+typedef struct {
+    bool active;
+    const void* parentStackTopBound;
+    int parentTlsIdx;
+    const void* childStackTopBound;
+    int childTlsIdx;
+    bool recursedInChild;
+} ShimTlsCloneState;
+static ShimTlsCloneState _cloneState;
+
+void shimtls_prepareClone(const void *childStackTopBound, const void *parentStackTopBound) {
+    assert(!_cloneState.active);
+    _cloneState = (ShimTlsCloneState) {
+        .active = true,
+        .parentStackTopBound = parentStackTopBound,
+        .parentTlsIdx = shimtls_getCurrentIdx(),
+        .childStackTopBound = childStackTopBound,
+        .childTlsIdx = shimtls_takeNextIdx(),
+        .recursedInChild = false,
+    };
+}
+void shimtls_cloneDone() {
+    assert(_cloneState.active);
+    _cloneState.active = false;
+}
+
+// Each ShimTlsVar is assigned an offset in the ShimThreadLocalStorage's.
+// This is the next free offset.
+static size_t _nextByteOffset = 0;
+
+// Index into _tlss.
+static int _tlsIdx = 0;
+
+// Take an unused TLS index, which can be used for a new thread.
+int shimtls_takeNextIdx() {
+    static int next = 0;
+    assert(next < MAX_THREADS);
+    return next++;
+}
+
+// Use when switching threads.
+int shimtls_getCurrentIdx() {
+    static __thread bool idxInitd = false;
+    static __thread int idx;
+    if (_cloneState.active) {
+        if (_cloneState.recursedInChild) {
+            void* rsp;
+            GET_CURRENT_RSP(rsp);
+            if (rsp > _cloneState.parentStackTopBound) {
+                // We're past the parent bound, so must be in the child stack.
+                return _cloneState.childTlsIdx;
+            } else if (rsp > _cloneState.childStackTopBound) {
+                // We're past the child top bound, so must be in the parent stack.
+                return _cloneState.parentTlsIdx;
+            } else if (_cloneState.parentStackTopBound < _cloneState.childStackTopBound) {
+                return _cloneState.parentTlsIdx;
+            } else {
+                return _cloneState.childTlsIdx;
+            }
+        }
+        _cloneState.recursedInChild = true;
+        if (!idxInitd) {
+            idx = _cloneState.childTlsIdx;
+            idxInitd = true;
+        }
+        _cloneState.recursedInChild = false;
+    }
+    if (!idxInitd) {
+        idx = shimtls_takeNextIdx();
+        idxInitd = true;
+    }
+    return idx;
+}
+
+// Initialize storage and return whether it had already been initialized.
+void* shimtlsvar_ptr(ShimTlsVar* v, size_t sz) {
+    if (!v->_initd) {
+        v->_offset = _nextByteOffset;
+        _nextByteOffset += sz;
+
+        // Always leave aligned at 16 for simplicity.
+        // 16 is a safe alignment for any C primitive.
+        size_t overhang = _nextByteOffset % 16;
+        _nextByteOffset += (16 - overhang);
+
+        assert(_nextByteOffset < sizeof(ShimThreadLocalStorage));
+        v->_initd = true;
+    }
+    return &_tlss[shimtls_getCurrentIdx()]._bytes[v->_offset];
+}

--- a/src/lib/shim/shim_tls.h
+++ b/src/lib/shim/shim_tls.h
@@ -3,10 +3,19 @@
 
 // Bare bones implementation of thread-local-storage. Never makes syscalls.
 //
-// This is useful for some core functionality of the shim, such as tracking the
-// per-thread IPC block, whether interposition is enabled, etc. Using native
-// thread-local-storage for these can be problematic because the implementation
-// can make syscalls, leading to infinite recursion.
+// The shim relies on thread-local-storage to track data such as the per-thread
+// IPC block, whether interposition is enabled, etc. However, many of the
+// implementation details of "native" thread local storage are unspecified. e.g.
+// in CentOS 7, the first access to thread-local-storage in a child thread
+// lazily set up the TLS, which makes syscalls, resulting in an infinite loop.
+//
+// While the current implementation of this library just uses native thread
+// local storage (__thread), using this library within the shim instead of
+// directly using __thread gives us the option to avoid depending on the
+// implementation details of __thread, or even permit `clone` calls that don't
+// set up native thread local storage at all. For example, we could inspect the
+// current stack pointer or (if necessary) make a gettid syscall to determine
+// which thread we're running in.
 
 #include <inttypes.h>
 #include <stdbool.h>
@@ -32,10 +41,5 @@ typedef struct ShimTlsVar {
 // always align(16), and the data at that pointer is zero-initialized for each
 // thread.
 void* shimtlsvar_ptr(ShimTlsVar* v, size_t sz);
-
-void shimtls_prepareClone(const void *childStackTopBound, const void *parentStackTopBound);
-void shimtls_cloneDone();
-
-#define GET_CURRENT_RSP(rsp) __asm__ ("movq %%rsp, %[RSP]" : [RSP] "=rm"(rsp))
 
 #endif

--- a/src/lib/shim/shim_tls.h
+++ b/src/lib/shim/shim_tls.h
@@ -1,0 +1,41 @@
+#ifndef SHIM_TLS_H_
+#define SHIM_TLS_H_
+
+// Bare bones implementation of thread-local-storage. Never makes syscalls.
+//
+// This is useful for some core functionality of the shim, such as tracking the
+// per-thread IPC block, whether interposition is enabled, etc. Using native
+// thread-local-storage for these can be problematic because the implementation
+// can make syscalls, leading to infinite recursion.
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+// A thread-local variable.
+//
+// Instances should have static storage type, and be zero-initialized. e.g.:
+//
+//     static ShimTlsVar v = {0};
+//
+// To get a pointer to the current thread's instance of the variable, use
+// `shimtlsvar_ptr`:
+//
+//     MyType* t = shimtlsvar_ptr(&v, sizeof(*t));
+//
+typedef struct ShimTlsVar {
+    size_t _offset;
+    bool _initd;
+} ShimTlsVar;
+
+// Return pointer to this thread's instance of the given var. The pointer is
+// always align(16), and the data at that pointer is zero-initialized for each
+// thread.
+void* shimtlsvar_ptr(ShimTlsVar* v, size_t sz);
+
+void shimtls_prepareClone(const void *childStackTopBound, const void *parentStackTopBound);
+void shimtls_cloneDone();
+
+#define GET_CURRENT_RSP(rsp) __asm__ ("movq %%rsp, %[RSP]" : [RSP] "=rm"(rsp))
+
+#endif

--- a/src/test/clone/CMakeLists.txt
+++ b/src/test/clone/CMakeLists.txt
@@ -10,5 +10,6 @@ add_shadow_tests(BASENAME clone METHODS hybrid ptrace)
 # the memory manager (really the MemoryMapper) enabled.
 add_shadow_tests(BASENAME clone-nomm METHODS hybrid ptrace ARGS --use-memory-manager=false)
 
-# Preload mode doesn't support threads. https://github.com/shadow/shadow/issues/1454
+# Preload mode doesn't support basic, raw clone. In particular it needs
+# working thread-local-storage, which this test doesn't implement.
 #add_shadow_tests(BASENAME clone METHODS preload)

--- a/src/test/determinism/CMakeLists.txt
+++ b/src/test/determinism/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(test-determinism test_determinism.c)
 target_link_libraries(test-determinism ${CMAKE_THREAD_LIBS_INIT})
 
 # preload doesn't support threads.
-foreach(METHOD ptrace hybrid)
+foreach(METHOD ptrace hybrid preload)
     ## We need to run twice to make sure the 'random' output is the same both times
     add_shadow_tests(
         BASENAME determinism1a
@@ -41,7 +41,7 @@ endforeach()
 ## done
 
 ## now let's run a phold test and compare the order of packet events
-foreach(METHOD ptrace hybrid)
+foreach(METHOD ptrace hybrid preload)
     add_shadow_tests(
         BASENAME determinism2a
         METHODS ${METHOD}

--- a/src/test/determinism/test_determinism.c
+++ b/src/test/determinism/test_determinism.c
@@ -238,5 +238,10 @@ int main(int argc, char* argv[]) {
     fprintf(stdout, "_test_nameAddress() passed\n");
 
     fprintf(stdout, "########## determinism test passed! ##########\n");
+
+    // Work around https://github.com/shadow/shadow/issues/1476.
+    // FIXME: Shouldn't have to flush explicitly.
+    fflush(stdout);
+
     return EXIT_SUCCESS;
 }

--- a/src/test/socket/sendto_recvfrom/CMakeLists.txt
+++ b/src/test/socket/sendto_recvfrom/CMakeLists.txt
@@ -8,8 +8,6 @@ add_shadow_tests(BASENAME sendto-recvfrom METHODS hybrid ptrace preload)
 # on a laptop with SSD. Due to shadow's small `SYSCALL_IO_BUFSIZE` size of
 # 16 KiB, the 'test_nonblocking_tcp' test needs to make a lot of
 # sendto()/recvfrom() calls before an EAGAIN is returned.
-#
-# TODO: Revisit whether we need this since dropping support for Centos 7.
 set_property(TEST 
                 sendto-recvfrom-shadow-hybrid 
                 sendto-recvfrom-shadow-ptrace 

--- a/src/test/threads/CMakeLists.txt
+++ b/src/test/threads/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_linux_tests(BASENAME pthreads COMMAND sh -c "../target/debug/test_pthreads --libc-passing")
-add_shadow_tests(BASENAME pthreads METHODS hybrid ptrace)
+add_shadow_tests(BASENAME pthreads METHODS hybrid ptrace preload)
 
 add_linux_tests(BASENAME threads-noexit COMMAND sh -c "../target/debug/test_threads_noexit")
 add_shadow_tests(BASENAME threads-noexit METHODS hybrid ptrace CHECK_RETVAL FALSE)


### PR DESCRIPTION
thread_preload now implements `ThreadMethods`::clone. This is implemented by sending a message to the shim to set aside an ipc block for the thread, and then having the shim implement the clone syscall.

In the shim, when executing the clone syscall, the child thread *jumps* back to where the managed program made the original syscall. This is implemented by saving the instruction pointer (RIP) in the SIGSYS syscall handler.

This also adds a wrapper for thread local storage in the shim. In CentOS 7 this was needed to work around some of the implementation details of the native thread local storage. This indirection is no longer necessary at the moment now that we've dropped CentOS 7 support and all supported platforms have compatible thread local storage implementations. However in the future if we need to decouple ourselves form the native thread local storage we can now just change *our* thread local storage implementation to not rely on the native thread local storage, without having to (again) change all the individual variables using thread local storage.

Fixes #1454