### PR TITLE
Remove (broken) support for old signal APIs

### DIFF
--- a/src/main/host/syscall/signal.h
+++ b/src/main/host/syscall/signal.h
@@ -11,10 +11,7 @@
 SYSCALL_HANDLER(kill);
 SYSCALL_HANDLER(tgkill);
 SYSCALL_HANDLER(tkill);
-SYSCALL_HANDLER(sigaction);
 SYSCALL_HANDLER(rt_sigaction);
-SYSCALL_HANDLER(signal);
-SYSCALL_HANDLER(sigprocmask);
 SYSCALL_HANDLER(rt_sigprocmask);
 
 #endif


### PR DESCRIPTION
The older signal APIs took different structs than the new ones (e.g.
`sigaction` vs `rt_sigaction`). These syscall are all obsolete since
Linux 2.2 so it's probably not worth trying to maintain them.