### PR TITLE
Unref partial packet during tcp free

### DIFF
--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -2490,6 +2490,12 @@ static void _tcp_free(LegacyDescriptor* descriptor) {
     g_hash_table_destroy(tcp->retransmit.queue);
     priorityqueue_free(tcp->retransmit.scheduledTimerExpirations);
 
+    if (tcp->partialUserDataPacket != NULL) {
+        packet_unref(tcp->partialUserDataPacket);
+        tcp->partialUserDataPacket = NULL;
+        tcp->partialOffset = 0;
+    }
+
     if(tcp->child) {
         MAGIC_ASSERT(tcp->child);
         MAGIC_ASSERT(tcp->child->parent);


### PR DESCRIPTION
Closes #1413.

This bug is unrelated to the issue that prevents newer versions of tor from running properly in Shadow.

After running a 1% network for 60 simulated minutes, there were no packets leaked.