### PR TITLE
Disassociate sockets from interface when stopping process

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -328,6 +328,10 @@ struct DescriptorTable *descriptortable_new(void);
 // Free the table.
 void descriptortable_free(struct DescriptorTable *table);
 
+void descriptortable_iter(struct DescriptorTable *table,
+                          void (*f)(struct CompatDescriptor*, void*),
+                          void *data);
+
 // Store a descriptor object for later reference at the next available index
 // in the table. The chosen table index is stored in the descriptor object and
 // returned. The descriptor is guaranteed to be stored successfully.

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -22,6 +22,10 @@ name = "test_bind"
 path = "socket/bind/test_bind.rs"
 
 [[bin]]
+name = "test_bind_in_new_process"
+path = "socket/bind/test_bind_in_new_process.rs"
+
+[[bin]]
 name = "test_listen"
 path = "socket/listen/test_listen.rs"
 

--- a/src/test/socket/bind/CMakeLists.txt
+++ b/src/test/socket/bind/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_linux_tests(BASENAME bind COMMAND sh -c "../../target/debug/test_bind --libc-passing")
 add_shadow_tests(BASENAME bind METHODS hybrid ptrace preload)
+
+add_shadow_tests(BASENAME bind_in_new_process METHODS hybrid ptrace preload)

--- a/src/test/socket/bind/bind_in_new_process.yaml
+++ b/src/test/socket/bind/bind_in_new_process.yaml
@@ -1,0 +1,28 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  # test when shadow has to stop the process (when it reaches its stop_time)
+  test-shadow-stop:
+    processes:
+    - path: ../../target/debug/test_bind_in_new_process
+      args: '10000000'
+      start_time: 1
+      stop_time: 2
+    # start the process a second time, which tries to bind to the same port
+    - path: ../../target/debug/test_bind_in_new_process
+      args: '10000000'
+      start_time: 3
+  # test when the process stops by itself (before it reaches its stop_time)
+  test-self-stop:
+    processes:
+    - path: ../../target/debug/test_bind_in_new_process
+      args: '0'
+      start_time: 1
+      stop_time: 2
+    # start the process a second time, which tries to bind to the same port
+    - path: ../../target/debug/test_bind_in_new_process
+      args: '0'
+      start_time: 3

--- a/src/test/socket/bind/test_bind_in_new_process.rs
+++ b/src/test/socket/bind/test_bind_in_new_process.rs
@@ -1,0 +1,30 @@
+fn main() {
+    // use libc rather than nix so that we don't accidentally close the socket due to a
+    // Drop impl or something
+
+    // first and only arg is the number of seconds to sleep for
+    let sleep_time: u32 = std::env::args().nth(1).unwrap().parse().unwrap();
+
+    let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
+
+    let addr = libc::sockaddr_in {
+        sin_family: libc::AF_INET as u16,
+        sin_port: 11111u16.to_be(),
+        sin_addr: libc::in_addr {
+            s_addr: libc::INADDR_ANY.to_be(),
+        },
+        sin_zero: [0; 8],
+    };
+
+    let rv = unsafe {
+        libc::bind(
+            fd,
+            &addr as *const _ as *const libc::sockaddr,
+            std::mem::size_of_val(&addr) as u32,
+        )
+    };
+
+    assert_eq!(rv, 0);
+
+    unsafe { libc::sleep(sleep_time) };
+}


### PR DESCRIPTION
Previously the socket table would be freed, but the sockets would remain bound/associated in the network interface. Now we disassociate them when the process is stopped.

Closes #1490.