### PR TITLE
Fixed socket disassociation when a process ends without 'stop_time'

### DIFF
--- a/src/test/socket/bind/bind_in_new_process.yaml
+++ b/src/test/socket/bind/bind_in_new_process.yaml
@@ -21,7 +21,6 @@ hosts:
     - path: ../../target/debug/test_bind_in_new_process
       args: '0'
       start_time: 1
-      stop_time: 2
     # start the process a second time, which tries to bind to the same port
     - path: ../../target/debug/test_bind_in_new_process
       args: '0'


### PR DESCRIPTION
The previous code did not correctly handle when a process ends on its own and doesn't use the `stop_time` option. The test was also updated to test this scenario.