### PR TITLE
Openssl drbg

### DIFF
--- a/docs/getting_started_tor.md
+++ b/docs/getting_started_tor.md
@@ -34,3 +34,25 @@ You can use the [tornettools
 toolkit](https://github.com/shadow/tornettools) to run larger, more
 complex Tor networks that are meant to more accurately resemble the
 characteristics and state of the public Tor network.
+
+## Determinism
+
+Shadow isn't able to natively intercept all sources entropy that tor uses via
+openssl, which results in non-deterministic results. If you'd like better
+determinism for your simulation, you can use the provided auxiliary library,
+libshadow_openssl_rng, whichoverride's some of openssl's RNG routines.
+
+To do so, add the full path to the library to the `LD_PRELOAD` in each tor
+process's `environment`.  If you've installed Shadow to the default location,
+the path should be `home/<username>/.local/lib/libshadow_openssl_rng.so`.
+
+```
+...
+hosts:
+  torclient:
+    processes:
+      - path: ~/.local/bin/tor
+        # Must provide absolute path. See #1523.
+        environment: 'LD_PRELOAD=/home/<username>/.local/lib/libshadow_openssl_rng.so'
+...
+```

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(logger)
+add_subdirectory(openssl_preload)
 add_subdirectory(tsc)
 add_subdirectory(shim)

--- a/src/lib/openssl_preload/CMakeLists.txt
+++ b/src/lib/openssl_preload/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(shadow_openssl_rng SHARED shadow_openssl_rng.c)
+target_compile_options(shadow_openssl_rng PRIVATE -D_GNU_SOURCE -fPIC)
+install(TARGETS shadow_openssl_rng DESTINATION lib)

--- a/src/lib/openssl_preload/shadow_openssl_rng.c
+++ b/src/lib/openssl_preload/shadow_openssl_rng.c
@@ -1,0 +1,106 @@
+/*
+ * The Shadow Simulator
+ * Copyright (c) 2010-2011, Rob Jansen
+ * See LICENSE for licensing information
+ */
+
+/* Implements an LD_PRELOAD library intended for use with Shadow. libcrypto
+ * otherwise internally uses some entropy sources that Shadow is unable to trap
+ * and emulate (such as the RDRAND instruction), making Shadow simulations of
+ * software using libcrypto non-deterministic.
+ *
+ * To use this library, set LD_PRELOAD in the target program's `environment`
+ * attribute in the Shadow simulation config file. e.g.:
+ *
+ * hosts:
+ *   torclient:
+ *     processes:
+ *       - path: ~/.local/bin/tor
+ *         # Must provide absolute path. See #1523.
+ *         environment: 'LD_PRELOAD=/home/<username>/.local/lib/libshadow_openssl_rng.so'
+ */
+
+#include <stddef.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static int _getRandomBytes(unsigned char* buf, int numBytes) {
+    // shadow interposes this and will fill the buffer for us
+    // return 1 on success, 0 otherwise
+    return (numBytes == syscall(SYS_getrandom, buf, (size_t)numBytes, 0)) ? 1 : 0;
+}
+
+int RAND_DRBG_generate(void *drbg,
+                        unsigned char *out, size_t outlen,
+                        int prediction_resistance,
+                        const unsigned char *adin, size_t adinlen) {
+    return _getRandomBytes(out, outlen);
+}
+
+int RAND_DRBG_bytes(void *drbg,
+                     unsigned char *out, size_t outlen) {
+    return _getRandomBytes(out, outlen);
+}
+
+int RAND_bytes(unsigned char *buf, int num) {
+    return _getRandomBytes(buf, num);
+}
+
+int RAND_pseudo_bytes(unsigned char *buf, int num) {
+    return _getRandomBytes(buf, num);
+}
+
+void RAND_seed(const void *buf, int num) {
+    return;
+}
+
+void RAND_add(const void *buf, int num, double entropy) {
+    return;
+}
+
+int RAND_poll() {
+    return 1;
+}
+
+void RAND_cleanup(void) {
+    return;
+}
+
+int RAND_status(void) {
+    return 1;
+}
+
+// Callback return type changed from void to int in OpenSSL_1_1_0-pre1.
+// However, since x86-64 uses rax for return values, and rax is a caller-saved
+// register, it's safe to return an int even if the caller is expecting void.
+static int nop_seed(const void* buf, int num) { return 1; }
+
+// Callback return type changed from void to int, and entropy from int to to
+// double in OpenSSL_1_1_0-pre1.
+//
+// However, since x86-64 uses rax for return values, and rax is a caller-saved
+// register, it's safe to return an int even if the caller is expecting void.
+// Similarly, since we don't actually use either parameter, it doesn't matter if
+// the types match.
+static int nop_add(const void* buf, int num, double entropy) { return 1; }
+
+typedef struct {
+    int (*seed)(const void* buf, int num);
+    int (*bytes)(unsigned char* buf, int num);
+    void (*cleanup)(void);
+    int (*add)(const void* buf, int num, double entropy);
+    int (*pseudorand)(unsigned char* buf, int num);
+    int (*status)(void);
+} RAND_METHOD;
+
+const RAND_METHOD* RAND_get_rand_method() {
+    static const RAND_METHOD method = {
+        .seed = nop_seed,
+        .bytes = RAND_bytes,
+        .cleanup = RAND_cleanup,
+        .add = nop_add,
+        .pseudorand = RAND_pseudo_bytes,
+        .status = RAND_status,
+    };
+    return &method;
+}

--- a/src/test/tor/minimal/tor-minimal.yaml
+++ b/src/test/tor/minimal/tor-minimal.yaml
@@ -33,6 +33,7 @@ hosts:
       args: ../../../conf/tgen.hiddenserver.graphml.xml
       start_time: 1
     - path: ~/.local/bin/tor
+      environment: 'LD_PRELOAD=../../../../../../lib/openssl_preload/libshadow_openssl_rng.so'
       args: --Address hiddenserver --Nickname hiddenserver
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
@@ -41,30 +42,35 @@ hosts:
       ip_address_hint: 100.0.0.1
     processes:
     - path: ~/.local/bin/tor
+      environment: 'LD_PRELOAD=../../../../../../lib/openssl_preload/libshadow_openssl_rng.so'
       args: --Address 4uthority --Nickname 4uthority
             --defaults-torrc torrc-defaults -f torrc
       start_time: 1
   exit1:
     processes:
     - path: ~/.local/bin/tor
+      environment: 'LD_PRELOAD=../../../../../../lib/openssl_preload/libshadow_openssl_rng.so'
       args: --Address exit1 --Nickname exit1
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
   exit2:
     processes:
     - path: ~/.local/bin/tor
+      environment: 'LD_PRELOAD=../../../../../../lib/openssl_preload/libshadow_openssl_rng.so'
       args: --Address exit2 --Nickname exit2
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
   relay1:
     processes:
     - path: ~/.local/bin/tor
+      environment: 'LD_PRELOAD=../../../../../../lib/openssl_preload/libshadow_openssl_rng.so'
       args: --Address relay1 --Nickname relay1
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
   relay2:
     processes:
     - path: ~/.local/bin/tor
+      environment: 'LD_PRELOAD=../../../../../../lib/openssl_preload/libshadow_openssl_rng.so'
       args: --Address relay2 --Nickname relay2
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
@@ -76,6 +82,7 @@ hosts:
   torclient:
     processes:
     - path: ~/.local/bin/tor
+      environment: 'LD_PRELOAD=../../../../../../lib/openssl_preload/libshadow_openssl_rng.so'
       args: --Address torclient --Nickname torclient
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
@@ -85,6 +92,7 @@ hosts:
   torbridgeclient:
     processes:
     - path: ~/.local/bin/tor
+      environment: 'LD_PRELOAD=../../../../../../lib/openssl_preload/libshadow_openssl_rng.so'
       args: --Address torbridgeclient --Nickname torbridgeclient
             --UseBridges 1 --Bridge 100.0.0.1:9111
             --defaults-torrc torrc-defaults -f torrc
@@ -95,6 +103,7 @@ hosts:
   torhiddenclient:
     processes:
     - path: ~/.local/bin/tor
+      environment: 'LD_PRELOAD=../../../../../../lib/openssl_preload/libshadow_openssl_rng.so'
       args: --Address torhiddenclient --Nickname torhiddenclient
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900


### PR DESCRIPTION
Adapted from shadow-plugin-tor. I only took the RNG overrides, since those seemed generic enough to plausibly work with other programs besides tor.

Not sure whether we'll want the "nop crypto" overrides as well, but if so it should probably be able to be used independently of the RNG overrides; e.g. by putting them in a separate library.

Progress on #666 

Before this PR, the heartbeat data diverges at around 8 sim minutes. (Only showing the first few lines of the diff for brevity)

```
$ (cd build/src/test/tor/minimal/ && for i in 1 2; do rm -rf data-$i && /home/jnewsome/projects/shadow/dev/build/src/main/shadow          --data-directory=data-$i          --interpose-method=preload          --log-level=info          --use-cpu-pinning true --parallelism 2 --template-directory shadow.data.template          /home/jnewsome/projects/shadow/dev/src/test/tor/minimal/tor-minimal.yaml  > $i.log && cat $i.log | cut -d' ' -f 2- | grep heartbeat | grep -v "process resource usage" | sort -s > $i.log.norm ; done ; diff [12].log.norm | head -n 30)
** Starting Shadow v2.0.0-pre.2-36-g7150c559 2021-07-16--13:45:11 with GLib v2.64.6 and IGraph v0.7.1
** Stopping Shadow, returning code 0 (success)
** Starting Shadow v2.0.0-pre.2-36-g7150c559 2021-07-16--13:45:11 with GLib v2.64.6 and IGraph v0.7.1
** Stopping Shadow, returning code 0 (success)
485,487c485,487
< [worker-0] 00:08:03.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,330,616,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;4,330,3,198,0,0,1,66,66,0,0,0;5,616,4,264,0,0,1,66,286,0,0,0
< [worker-0] 00:08:04.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,330,616,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;4,330,3,198,0,0,1,66,66,0,0,0;5,616,4,264,0,0,1,66,286,0,0,0
< [worker-0] 00:08:05.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,0,0,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0
---
> [worker-0] 00:08:03.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,0,0,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0
> [worker-0] 00:08:04.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,0,0,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0
> [worker-0] 00:08:05.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,330,616,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;4,330,3,198,0,0,1,66,66,0,0,0;5,616,4,264,0,0,1,66,286,0,0,0
491c491
< [worker-0] 00:08:09.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,330,616,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;4,330,3,198,0,0,1,66,66,0,0,0;5,616,4,264,0,0,1,66,286,0,0,0
---
> [worker-0] 00:08:09.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,0,0,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0
493c493
< [worker-0] 00:08:11.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,3142,3274,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;7,3142,2,132,0,0,5,330,2680,0,0,0;9,3274,4,264,0,0,5,330,2680,0,0,0
---
> [worker-0] 00:08:11.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,3472,3890,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;11,3472,5,330,0,0,6,396,2746,0,0,0;14,3890,8,528,0,0,6,396,2966,0,0,0
496c496
< [worker-0] 00:08:14.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,0,0,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0
---
> [worker-0] 00:08:14.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,330,616,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;4,330,3,198,0,0,1,66,66,0,0,0;5,616,4,264,0,0,1,66,286,0,0,0
498c498
< [worker-0] 00:08:16.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,668,668,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;2,668,1,66,0,0,1,66,536,0,0,0;2,668,1,66,0,0,1,66,536,0,0,0
---
> [worker-0] 00:08:16.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,998,1284,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;6,998,4,264,0,0,2,132,602,0,0,0;7,1284,5,330,0,0,2,132,822,0,0,0
503c503
< [worker-0] 00:08:21.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,0,0,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0
---
> [worker-0] 00:08:21.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,330,616,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;4,330,3,198,0,0,1,66,66,0,0,0;5,616,4,264,0,0,1,66,286,0,0,0
505c505
< [worker-0] 00:08:23.000000000 [INFO] [relay1:11.0.0.6] [tracker.c:456] [_tracker_logNode] [shadow-heartbeat] [node] 1,0,0,0.000000,0,0.000000;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0;0,0,0,0,0,0,0,0,0,0,0,0
```

With this PR the heartbeats match up completely:

```
$ (cd build/src/test/tor/minimal/ && for i in 1 2; do rm -rf data-$i && /home/jnewsome/projects/shadow/dev/build/src/main/shadow          --data-directory=data-$i          --interpose-method=preload          --log-level=info          --use-cpu-pinning true --parallelism 2 --template-directory shadow.data.template          /home/jnewsome/projects/shadow/dev/src/test/tor/minimal/tor-minimal.yaml  > $i.log && cat $i.log | cut -d' ' -f 2- | grep heartbeat | grep -v "process resource usage" | sort -s > $i.log.norm ; done ; diff [12].log.norm | head -n 30)
** Starting Shadow v2.0.0-pre.2-40-gaacf276f 2021-07-16--14:07:08 with GLib v2.64.6 and IGraph v0.7.1
** Stopping Shadow, returning code 0 (success)
** Starting Shadow v2.0.0-pre.2-40-gaacf276f 2021-07-16--14:07:08 with GLib v2.64.6 and IGraph v0.7.1
** Stopping Shadow, returning code 0 (success)
```