### PR TITLE
Tsc tweaks

### DIFF
--- a/src/lib/logger/logger.c
+++ b/src/lib/logger/logger.c
@@ -152,11 +152,11 @@ void logger_setLevel(Logger* logger, LogLevel level) {
 }
 
 bool logger_isEnabled(Logger* logger, LogLevel level) {
-    if (!logger) {
-        return level > LOGLEVEL_WARNING;
-    } else {
-        return logger->isEnabled(logger, level);
-    }
+    // Most logging frameworks log little/nothing unless explicitly enabled.
+    // That probably makes sense for a framework used across independent
+    // libraries and apps, but in our case verbose is a useful default,
+    // particularly in test programs.
+    return true;
 }
 
 void logger_flush(Logger* logger) {

--- a/src/lib/tsc/tsc.c
+++ b/src/lib/tsc/tsc.c
@@ -68,7 +68,9 @@ static uint64_t _frequency_via_cpuid0x15() {
         // what's meant by "CPUID signature 06_5CH".
         //
         // Fail and fall back to alternate method for now.
-        debug("cpuid 0x15 didn't give core frequency");
+        debug("cpuid 0x15 didn't give core frequency. Frequency should be either %lu or %lu",
+              (uint64_t)24000000 * numerator / denominator,
+              (uint64_t)19200000 * numerator / denominator);
         return 0;
     }
 


### PR DESCRIPTION
The default logger filter's logic was backwards, s.t. it'd only log *less* severe messages. Changed it not to filter at all, since outside of tests we always override the default anyway.

Tried to make the tsc test a bit more robust, and added some extra logging; trying to debug #1519 .