### PR TITLE
Improvements for preloading libraries

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -59,6 +59,7 @@ hosts:
 - [`experimental.use_memory_manager`](#experimentaluse_memory_manager)
 - [`experimental.use_o_n_waitpid_workarounds`](#experimentaluse_o_n_waitpid_workarounds)
 - [`experimental.use_object_counters`](#experimentaluse_object_counters)
+- [`experimental.use_openssl_rng_preload`](#experimentaluse_openssl_rng_preload)
 - [`experimental.use_sched_fifo`](#experimentaluse_sched_fifo)
 - [`experimental.use_shim_syscall_handler`](#experimentaluse_shim_syscall_handler)
 - [`experimental.use_seccomp`](#experimentaluse_seccomp)
@@ -360,6 +361,14 @@ Type: Bool
 
 Count object allocations and deallocations. If disabled, we will not be able to
 detect object memory leaks.
+
+#### `experimental.use_openssl_rng_preload`
+
+Default: true  
+Type: Bool
+
+Preload our OpenSSL RNG library for all managed processes to mitigate
+non-deterministic use of OpenSSL.
 
 #### `experimental.use_sched_fifo`
 

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -15,8 +15,9 @@ endif()
 
 include_directories(${RT_INCLUDES} ${DL_INCLUDES} ${M_INCLUDES} ${IGRAPH_INCLUDES} ${GLIB_INCLUDES})
 
-## link to the shim (rpath will not contain this path when shadow is installed)
+## link to preload libs (rpath will not contain these paths when shadow is installed)
 link_directories(${CMAKE_BINARY_DIR}/src/lib/shim)
+link_directories(${CMAKE_BINARY_DIR}/src/lib/openssl_preload)
 
 ## compile defs and flags
 #add_definitions(-D_SVID_SOURCE -D_XOPEN_SOURCE=600 -D_ISOC11_SOURCE) #-D_GNU_SOURCE
@@ -196,6 +197,7 @@ set(RUSTFLAGS "${RUSTFLAGS} -lstdc++")
 set(RUSTFLAGS "${RUSTFLAGS} -L${CMAKE_CURRENT_BINARY_DIR}")
 set(RUSTFLAGS "${RUSTFLAGS} -L${CMAKE_BINARY_DIR}/src/lib/logger")
 set(RUSTFLAGS "${RUSTFLAGS} -L${CMAKE_BINARY_DIR}/src/lib/shim")
+set(RUSTFLAGS "${RUSTFLAGS} -L${CMAKE_BINARY_DIR}/src/lib/openssl_preload")
 set(RUSTFLAGS "${RUSTFLAGS} -L${CMAKE_BINARY_DIR}/src/lib/tsc")
 set(CARGO_ENV_VARS "${CARGO_ENV_VARS} RUSTFLAGS=\"${RUSTFLAGS}\"")
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -193,6 +193,8 @@ bool config_getUseSyscallCounters(const struct ConfigOptions *config);
 
 bool config_getUseObjectCounters(const struct ConfigOptions *config);
 
+bool config_getUseOpensslRNGPreload(const struct ConfigOptions *config);
+
 bool config_getUseMemoryManager(const struct ConfigOptions *config);
 
 bool config_getUseShimSyscallHandler(const struct ConfigOptions *config);

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -19,6 +19,7 @@
 #include "main/core/manager.h"
 #include "main/core/scheduler/scheduler.h"
 #include "main/core/scheduler/scheduler_policy.h"
+#include "main/core/support/config_handlers.h"
 #include "main/core/support/definitions.h"
 #include "main/host/host.h"
 #include "main/host/network_interface.h"
@@ -30,6 +31,10 @@
 
 #define PRELOAD_SHIM_LIB_STR "libshadow-shim.so"
 #define PRELOAD_OPENSSL_RNG_LIB_STR "libshadow_openssl_rng.so"
+
+// Allow turning off openssl rng lib preloading at run-time.
+static bool _use_openssl_rng_preload = true;
+ADD_CONFIG_HANDLER(config_getUseOpensslRNGPreload, _use_openssl_rng_preload)
 
 struct _Manager {
     Controller* controller;
@@ -414,7 +419,9 @@ static gchar** _manager_generateEnvv(Manager* manager, InterposeMethod interpose
         g_ptr_array_add(ldPreloadArray, g_strdup(manager->preloadShimPath));
     }
 
-    if (manager->preloadOpensslRngPath != NULL) {
+    if (!_use_openssl_rng_preload) {
+        debug("openssl rng preloading is disabled");
+    } else if (manager->preloadOpensslRngPath != NULL) {
         debug("adding Shadow preload lib path %s", manager->preloadOpensslRngPath);
         g_ptr_array_add(ldPreloadArray, g_strdup(manager->preloadOpensslRngPath));
     }

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -460,9 +460,9 @@ static gchar** _manager_generateEnvv(Manager* manager, InterposeMethod interpose
                     for (int i = 0; paths != NULL && paths[i] != NULL; i++) {
                         GString* pathBuf = g_string_new(NULL);
 
-                        if (!g_ascii_strncasecmp(paths[i], "~/", 2)) {
+                        if (g_str_has_prefix(paths[i], "~/")) {
                             g_string_printf(pathBuf, "%s%s", g_get_home_dir(), &paths[i][1]);
-                        } else if (!g_ascii_strncasecmp(paths[i], "~", 1)) {
+                        } else if (g_str_has_prefix(paths[i], "~")) {
                             g_string_printf(pathBuf, "/home/%s", &paths[i][1]);
                         } else {
                             g_string_printf(pathBuf, "%s", paths[i]);

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -260,6 +260,11 @@ pub struct ExperimentalOptions {
     #[clap(about = EXP_HELP.get("use_object_counters").unwrap())]
     use_object_counters: Option<bool>,
 
+    /// Preload our OpenSSL RNG library for all managed processes to mitigate non-deterministic use of OpenSSL.
+    #[clap(long, value_name = "bool")]
+    #[clap(about = EXP_HELP.get("use_openssl_rng_preload").unwrap())]
+    use_openssl_rng_preload: Option<bool>,
+
     /// Max number of iterations to busy-wait on IPC semaphore before blocking
     #[clap(long, value_name = "iterations")]
     #[clap(about = EXP_HELP.get("preload_spin_max").unwrap())]
@@ -357,6 +362,7 @@ impl Default for ExperimentalOptions {
             use_seccomp: None,
             use_syscall_counters: Some(false),
             use_object_counters: Some(true),
+            use_openssl_rng_preload: Some(true),
             preload_spin_max: Some(0),
             use_memory_manager: Some(true),
             use_shim_syscall_handler: Some(true),
@@ -1149,6 +1155,13 @@ mod export {
         assert!(!config.is_null());
         let config = unsafe { &*config };
         config.experimental.use_object_counters.unwrap()
+    }
+
+    #[no_mangle]
+    pub extern "C" fn config_getUseOpensslRNGPreload(config: *const ConfigOptions) -> bool {
+        assert!(!config.is_null());
+        let config = unsafe { &*config };
+        config.experimental.use_openssl_rng_preload.unwrap()
     }
 
     #[no_mangle]


### PR DESCRIPTION
Changes:
- Adds a new `use_openssl_rng_preload` config option that defaults to true and allows control over our preloading of the openssl rng preload lib.
- The path to the openssl rng preload lib is found automatically by searching the rpath, as we do for the preload shim lib.
- For every entry given in the `LD_PRELOAD` key in the `environment` option for processes, we now expand the `~` if one appears as the first character in an entry. This allows users to avoid adding an absolute path to the config file.

I tested this locally in an ad-hoc manner and all features work as intended. It's a bit tricky to add tests to our framework because of the home dir absolute paths. (Unit tests would be ideal here, but the changes are mostly in C code.)

Closes #1523