### PR TITLE
Disable circuit build timeout learning in tor-minimal test

### DIFF
--- a/src/test/tor/minimal/conf/tor.common.torrc
+++ b/src/test/tor/minimal/conf/tor.common.torrc
@@ -23,3 +23,4 @@ DoSConnectionEnabled 0
 DoSRefuseSingleHopClientRendezvous 0
 CircuitPriorityHalflife 30
 ControlPort 9051
+LearnCircuitBuildTimeout 0


### PR DESCRIPTION
Closes #1503. We've decided to disable circuit build timeout learning since it's already disabled in tornettools for clients (using `UseEntryGuards 0`), and since our minimal test case uses a network where the latency between every host is exactly 50 ms. When all the latencies are the same, the circuit build time distribution is not a pareto distribution and the circuit timeout learning does not work correctly. It also causes us to run into the issue https://gitlab.torproject.org/tpo/core/tor/-/issues/40434.