### PR TITLE
ChildPidWatcher: remove dependence on pidfd_open

### DIFF
--- a/src/main/utility/childpid_watcher.rs
+++ b/src/main/utility/childpid_watcher.rs
@@ -394,10 +394,10 @@ mod tests {
         }
 
         // Child should be ready to be reaped.
-        assert_eq!(
-            waitpid(child, Some(WaitPidFlag::WNOHANG)).unwrap(),
-            WaitStatus::Exited(child, 42)
-        );
+        // TODO: use WNOHANG here if we go back to a pidfd-based implementation.
+        // With the current fd-based implementation we may be notified before kernel
+        // marks the child reapable.
+        assert_eq!(waitpid(child, None).unwrap(), WaitStatus::Exited(child, 42));
     }
 
     #[test]
@@ -445,10 +445,10 @@ mod tests {
         }
 
         // Child should be ready to be reaped.
-        assert_eq!(
-            waitpid(child, Some(WaitPidFlag::WNOHANG)).unwrap(),
-            WaitStatus::Exited(child, 42)
-        );
+        // TODO: use WNOHANG here if we go back to a pidfd-based implementation.
+        // With the current fd-based implementation we may be notified before kernel
+        // marks the child reapable.
+        assert_eq!(waitpid(child, None).unwrap(), WaitStatus::Exited(child, 42));
     }
 
     #[test]
@@ -484,10 +484,10 @@ mod tests {
         }
 
         // Child should be ready to be reaped.
-        assert_eq!(
-            waitpid(child, Some(WaitPidFlag::WNOHANG)).unwrap(),
-            WaitStatus::Exited(child, 42)
-        );
+        // TODO: use WNOHANG here if we go back to a pidfd-based implementation.
+        // With the current fd-based implementation we may be notified before kernel
+        // marks the child reapable.
+        assert_eq!(waitpid(child, None).unwrap(), WaitStatus::Exited(child, 42));
     }
 
     #[test]
@@ -539,10 +539,10 @@ mod tests {
         assert!(!*cb1_ran.0.lock().unwrap());
 
         // Child should be ready to be reaped.
-        assert_eq!(
-            waitpid(child, Some(WaitPidFlag::WNOHANG)).unwrap(),
-            WaitStatus::Exited(child, 42)
-        );
+        // TODO: use WNOHANG here if we go back to a pidfd-based implementation.
+        // With the current fd-based implementation we may be notified before kernel
+        // marks the child reapable.
+        assert_eq!(waitpid(child, None).unwrap(), WaitStatus::Exited(child, 42));
     }
 }
 

--- a/src/main/utility/childpid_watcher.rs
+++ b/src/main/utility/childpid_watcher.rs
@@ -1,12 +1,14 @@
 use nix::errno::Errno;
+use nix::fcntl::{FcntlArg, FdFlag, OFlag};
 use nix::sys::epoll::{
     epoll_create1, epoll_ctl, epoll_wait, EpollCreateFlags, EpollEvent, EpollFlags, EpollOp,
 };
-use nix::unistd::close;
 use nix::unistd::Pid;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
+use std::fs::File;
 use std::os::unix::io::RawFd;
+use std::os::unix::prelude::{AsRawFd, FromRawFd};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
@@ -26,15 +28,23 @@ enum Command {
     Finish,
 }
 
+struct PidData {
+    // Registered callbacks.
+    callbacks: HashMap<WatchHandle, Box<dyn Send + FnOnce(Pid)>>,
+    // After the pid has exited, this fd is closed and set to None.
+    fd: Option<File>,
+    // Whether this pid has been unregistered. The whole struct is removed after
+    // both the pid is unregistered, and `callbacks` is empty.
+    unregistered: bool,
+}
+
 struct Inner {
     // Next unique handle ID.
     next_handle: WatchHandle,
     // Pending commands for watcher thread.
     commands: Vec<Command>,
-    // For each monitored pid, the fd obtained via `pidfd_open`.
-    pidfds: HashMap<Pid, RawFd>,
-    // Registered callbacks.
-    callbacks: HashMap<Pid, HashMap<WatchHandle, Box<dyn Send + FnOnce(Pid)>>>,
+    // Data for each monitored pid.
+    pids: HashMap<Pid, PidData>,
     // event_fd used to notify watcher thread via epoll. Calling thread writes a
     // single byte, which the watcher thread reads to reset.
     command_notifier: RawFd,
@@ -48,28 +58,37 @@ impl Inner {
     }
 
     fn unwatch_pid(&mut self, epoll: RawFd, pid: Pid) {
-        self.callbacks.remove(&pid);
-        if let Some(pidfd) = self.pidfds.remove(&pid) {
-            epoll_ctl(epoll, EpollOp::EpollCtlDel, pidfd, None).unwrap();
-            close(pidfd).unwrap();
+        if let Some(fd) = self.pids.get_mut(&pid).unwrap().fd.take() {
+            epoll_ctl(epoll, EpollOp::EpollCtlDel, fd.as_raw_fd(), None).unwrap();
         }
     }
 
-    fn run_callbacks_for_fd(&mut self, epoll: RawFd, pid: Pid) {
-        if let Some(callback_map) = self.callbacks.remove(&pid) {
-            for (_handle, cb) in callback_map {
-                cb(pid)
-            }
-        }
+    fn pid_has_exited(&self, pid: Pid) -> bool {
+        self.pids.get(&pid).unwrap().fd.is_none()
+    }
+
+    fn remove_pid(&mut self, epoll: RawFd, pid: Pid) {
+        debug_assert!(self.should_remove_pid(pid));
         self.unwatch_pid(epoll, pid);
+        self.pids.remove(&pid);
     }
-}
 
-// Panics if pid doesn't exist at all.
-fn is_zombie(pid: Pid) -> bool {
-    let stat_name = format!("/proc/{}/stat", pid.as_raw());
-    let contents = std::fs::read_to_string(stat_name).unwrap();
-    contents.contains(") Z")
+    fn run_callbacks_for_pid(&mut self, pid: Pid) {
+        for (_handle, cb) in self.pids.get_mut(&pid).unwrap().callbacks.drain() {
+            cb(pid)
+        }
+    }
+
+    fn should_remove_pid(&mut self, pid: Pid) -> bool {
+        let pid_data = self.pids.get(&pid).unwrap();
+        pid_data.callbacks.is_empty() && pid_data.unregistered
+    }
+
+    fn maybe_remove_pid(&mut self, epoll: RawFd, pid: Pid) {
+        if self.should_remove_pid(pid) {
+            self.remove_pid(epoll, pid)
+        }
+    }
 }
 
 impl ChildPidWatcher {
@@ -90,8 +109,7 @@ impl ChildPidWatcher {
         let watcher = ChildPidWatcher {
             inner: Arc::new(Mutex::new(Inner {
                 next_handle: 1,
-                pidfds: HashMap::new(),
-                callbacks: HashMap::new(),
+                pids: HashMap::new(),
                 commands: Vec::new(),
                 command_notifier,
                 thread_handle: None,
@@ -133,7 +151,13 @@ impl ChildPidWatcher {
 
             for event in &events[0..nevents] {
                 let pid = Pid::from_raw(i32::try_from(event.data()).unwrap());
-                inner.run_callbacks_for_fd(epoll, pid);
+                // We get an event for pid=0 when there's a write to the command_notifier;
+                // Ignore that here and handle below.
+                if pid.as_raw() != 0 {
+                    inner.unwatch_pid(epoll, pid);
+                    inner.run_callbacks_for_pid(pid);
+                    inner.maybe_remove_pid(epoll, pid);
+                }
             }
             // Reading an eventfd always returns an 8 byte integer. Do so to ensure it's
             // no longer marked 'readable'.
@@ -150,7 +174,9 @@ impl ChildPidWatcher {
             for cmd in commands.drain(..) {
                 match cmd {
                     Command::RunCallbacks(pid) => {
-                        inner.run_callbacks_for_fd(epoll, pid);
+                        debug_assert!(inner.pid_has_exited(pid));
+                        inner.run_callbacks_for_pid(pid);
+                        inner.maybe_remove_pid(epoll, pid);
                     }
                     Command::Finish => {
                         done = true;
@@ -166,35 +192,120 @@ impl ChildPidWatcher {
         }
     }
 
-    /// Call `callback` exactly once from another thread after the child `pid`
+    unsafe fn fork_watchable_internal(
+        &self,
+        fork_syscall: i64,
+        child_fn: impl FnOnce(),
+    ) -> Result<Pid, nix::Error> {
+        let (read_fd, write_fd) = nix::unistd::pipe2(OFlag::O_CLOEXEC)?;
+
+        // TODO: Allow vfork when Rust supports it:
+        assert!(fork_syscall == libc::SYS_fork);
+        let raw_pid = unsafe { libc::syscall(fork_syscall) };
+        if raw_pid < 0 {
+            let rv = Err(Errno::last());
+            nix::unistd::close(read_fd).unwrap();
+            nix::unistd::close(write_fd).unwrap();
+            return rv;
+        }
+        if raw_pid == 0 {
+            // Keep the write-end of the pipe open.
+            nix::fcntl::fcntl(write_fd, FcntlArg::F_SETFD(FdFlag::empty())).unwrap();
+            child_fn();
+            panic!("child_fn shouldn't have returned");
+        }
+        // Parent doesn't need the write end.
+        nix::unistd::close(write_fd).unwrap();
+
+        let pid = Pid::from_raw(raw_pid.try_into().unwrap());
+        self.register_pid(pid, unsafe { File::from_raw_fd(read_fd) });
+
+        Ok(pid)
+    }
+
+    /// Fork a child and register it. Uses `fork` internally; it `vfork` is desired,
+    /// use `register_pid` instead.
+    ///
+    /// TODO: add a vfork version when Rust supports vfork:
+    /// https://github.com/rust-lang/rust/issues/58314
+    pub unsafe fn fork_watchable(&self, child_fn: impl FnOnce()) -> Result<Pid, nix::Error> {
+        unsafe { self.fork_watchable_internal(libc::SYS_fork, child_fn) }
+    }
+
+    /// Register interest in `pid`, and associate it with `read_fd`.
+    ///
+    /// `read_fd` should be the read end of a pipe, whose write end is owned
+    /// *solely* by `pid`, causing `read_fd` to become invalid when `pid` exits.
+    /// In a multi-threaded program care must be taken to prevent a concurrent
+    /// fork from leaking the write end of the pipe into other children. One way
+    /// to avoid this is to use O_CLOEXEC when creating the pipe, and then unset
+    /// O_CLOEXEC in the child before calling exec.
+    ///
+    /// Be sure to close the parent's write-end of the pipe.
+    ///
+    /// Takes ownership of `read_fd`, and will close it when appropriate.
+    pub fn register_pid(&self, pid: Pid, read_fd: File) {
+        let mut inner = self.inner.lock().unwrap();
+        let raw_read_fd = read_fd.as_raw_fd();
+        let prev = inner.pids.insert(
+            pid,
+            PidData {
+                callbacks: HashMap::new(),
+                fd: Some(read_fd),
+                unregistered: false,
+            },
+        );
+        assert!(prev.is_none());
+        let mut event = EpollEvent::new(EpollFlags::empty(), pid.as_raw().try_into().unwrap());
+        epoll_ctl(
+            self.epoll,
+            EpollOp::EpollCtlAdd,
+            raw_read_fd,
+            Some(&mut event),
+        )
+        .unwrap();
+    }
+
+    // TODO: Re-enable when Rust supports vfork: https://github.com/rust-lang/rust/issues/58314
+    // pub unsafe fn vfork_watchable(&self, child_fn: impl FnOnce()) -> Result<Pid, nix::Error> {
+    //     unsafe { self.fork_watchable_internal(libc::SYS_vfork, child_fn) }
+    // }
+
+    /// Unregister the pid. After unregistration, no more callbacks may be
+    /// registered for the given pid. Already-registered callbacks will still be
+    /// called if and when the pid exits unless individually unregistered.
+    ///
+    /// Safe to call multiple times.
+    pub fn unregister_pid(&self, pid: Pid) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(pid_data) = inner.pids.get_mut(&pid) {
+            pid_data.unregistered = true;
+            inner.maybe_remove_pid(self.epoll, pid);
+        }
+    }
+
+    /// Call `callback` from another thread after the child `pid`
     /// has exited, including if it has already exited. Does *not* reap the
     /// child itself.
     ///
     /// The returned handle is guaranteed to be non-zero.
     ///
-    /// Panics if `pid` doesn't exist.
-    pub fn watch(&self, pid: Pid, callback: impl Send + FnOnce(Pid) + 'static) -> WatchHandle {
+    /// Panics if `pid` isn't registered.
+    pub fn register_callback(
+        &self,
+        pid: Pid,
+        callback: impl Send + FnOnce(Pid) + 'static,
+    ) -> WatchHandle {
         let mut inner = self.inner.lock().unwrap();
-        if !inner.pidfds.contains_key(&pid) {
-            let pidfd: RawFd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid.as_raw(), 0) }
-                .try_into()
-                .unwrap();
-            if pidfd < 0 {
-                panic!("pidfd_open: {:?}", nix::errno::Errno::last());
-            }
-            inner.pidfds.insert(pid, pidfd);
-            let mut event = EpollEvent::new(EpollFlags::EPOLLIN, pid.as_raw().try_into().unwrap());
-            epoll_ctl(self.epoll, EpollOp::EpollCtlAdd, pidfd, Some(&mut event)).unwrap();
-            if is_zombie(pid) {
-                // Child is dead. If it died before adding it to the epoll,
-                // we'll never get an event. Notify via the command notifier.
-                inner.send_command(Command::RunCallbacks(pid));
-            }
-        };
         let handle = inner.next_handle;
         inner.next_handle += 1;
-        let callbacks = inner.callbacks.entry(pid).or_default();
-        callbacks.insert(handle, Box::new(callback));
+        let pid_data = inner.pids.get_mut(&pid).unwrap();
+        assert!(!pid_data.unregistered);
+        pid_data.callbacks.insert(handle, Box::new(callback));
+        if pid_data.fd.is_none() {
+            // pid is already dead. Run the callback we just registered.
+            inner.send_command(Command::RunCallbacks(pid));
+        }
         handle
     }
 
@@ -202,15 +313,12 @@ impl ChildPidWatcher {
     /// guaranteed either to have already run, or to never run. i.e. it's safe to
     /// free data that the callback might otherwise access.
     ///
-    /// Calling with pids or handles that no longer exist is safe.
-    pub fn unwatch(&self, pid: Pid, handle: WatchHandle) {
+    /// Panics if `pid` was never registered.
+    pub fn unregister_callback(&self, pid: Pid, handle: WatchHandle) {
         let mut inner = self.inner.lock().unwrap();
-        if let Some(callbacks) = inner.callbacks.get_mut(&pid) {
-            callbacks.remove(&handle);
-            if callbacks.is_empty() {
-                inner.unwatch_pid(self.epoll, pid);
-            }
-        }
+        let pid_data = inner.pids.get_mut(&pid).unwrap();
+        pid_data.callbacks.remove(&handle);
+        inner.maybe_remove_pid(self.epoll, pid);
     }
 }
 
@@ -222,10 +330,6 @@ impl Drop for ChildPidWatcher {
             inner.thread_handle.take().unwrap()
         };
         handle.join().unwrap();
-        let inner = self.inner.lock().unwrap();
-        for (_pid, fd) in inner.pidfds.iter() {
-            nix::unistd::close(*fd).unwrap();
-        }
         nix::unistd::close(self.epoll).unwrap();
     }
 }
@@ -235,29 +339,33 @@ mod tests {
     use super::*;
     use nix::sys::wait::WaitStatus;
     use nix::sys::wait::{waitpid, WaitPidFlag};
-    use nix::unistd::{fork, ForkResult};
     use std::sync::{Arc, Condvar};
+
+    fn is_zombie(pid: Pid) -> bool {
+        let stat_name = format!("/proc/{}/stat", pid.as_raw());
+        let contents = std::fs::read_to_string(stat_name).unwrap();
+        contents.contains(") Z")
+    }
 
     #[test]
     fn register_before_exit() {
-        // Pipe used to synchronize the child process.
-        let (read_fd, write_fd) = nix::unistd::pipe().unwrap();
-
-        let child = match unsafe { fork() }.unwrap() {
-            ForkResult::Parent { child } => child,
-            ForkResult::Child => {
-                let mut buf = [0u8];
-                // Wait for parent to register its callback.
-                nix::unistd::read(read_fd, &mut buf).unwrap();
-                unsafe { libc::_exit(42) }
-            }
-        };
+        let notifier = nix::sys::eventfd::eventfd(0, nix::sys::eventfd::EfdFlags::empty()).unwrap();
 
         let watcher = ChildPidWatcher::new();
+        let child = unsafe {
+            watcher.fork_watchable(|| {
+                let mut buf = [0; 8];
+                // Wait for parent to register its callback.
+                nix::unistd::read(notifier, &mut buf).unwrap();
+                libc::_exit(42);
+            })
+        }
+        .unwrap();
+
         let callback_ran = Arc::new((Mutex::new(false), Condvar::new()));
         {
             let callback_ran = callback_ran.clone();
-            watcher.watch(
+            watcher.register_callback(
                 child,
                 Box::new(move |pid| {
                     assert_eq!(pid, child);
@@ -277,7 +385,7 @@ mod tests {
         assert!(!*callback_ran.0.lock().unwrap());
 
         // Let the child exit.
-        nix::unistd::write(write_fd, &[0u8]).unwrap();
+        nix::unistd::write(notifier, &1u64.to_ne_bytes()).unwrap();
 
         // Wait for our callback to run.
         let mut callback_ran_lock = callback_ran.0.lock().unwrap();
@@ -294,9 +402,16 @@ mod tests {
 
     #[test]
     fn register_after_exit() {
-        let child = match unsafe { fork() }.unwrap() {
-            ForkResult::Parent { child } => child,
-            ForkResult::Child => unsafe { libc::_exit(42) },
+        let (read_fd, write_fd) = nix::unistd::pipe().unwrap();
+        let child = match unsafe { nix::unistd::fork() }.unwrap() {
+            nix::unistd::ForkResult::Parent { child } => {
+                nix::unistd::close(write_fd).unwrap();
+                child
+            }
+            nix::unistd::ForkResult::Child => {
+                nix::unistd::close(read_fd).unwrap();
+                unsafe { libc::_exit(42) };
+            }
         };
 
         // Wait until child is dead, but don't reap it yet.
@@ -307,12 +422,13 @@ mod tests {
         }
 
         let watcher = ChildPidWatcher::new();
+        watcher.register_pid(child, unsafe { File::from_raw_fd(read_fd) });
 
         // Used to wait until after the ChildPidWatcher has ran our callback
         let callback_ran = Arc::new((Mutex::new(false), Condvar::new()));
         {
             let callback_ran = callback_ran.clone();
-            watcher.watch(
+            watcher.register_callback(
                 child,
                 Box::new(move |pid| {
                     assert_eq!(pid, child);
@@ -340,16 +456,17 @@ mod tests {
         let cb1_ran = Arc::new((Mutex::new(false), Condvar::new()));
         let cb2_ran = Arc::new((Mutex::new(false), Condvar::new()));
 
-        let child = match unsafe { fork() }.unwrap() {
-            ForkResult::Parent { child } => child,
-            ForkResult::Child => unsafe { libc::_exit(42) },
-        };
-
         let watcher = ChildPidWatcher::new();
+        let child = unsafe {
+            watcher.fork_watchable(|| {
+                libc::_exit(42);
+            })
+        }
+        .unwrap();
 
         for cb_ran in vec![cb1_ran.clone(), cb2_ran.clone()].drain(..) {
             let cb_ran = cb_ran.clone();
-            watcher.watch(
+            watcher.register_callback(
                 child,
                 Box::new(move |pid| {
                     assert_eq!(pid, child);
@@ -378,27 +495,25 @@ mod tests {
         let cb1_ran = Arc::new((Mutex::new(false), Condvar::new()));
         let cb2_ran = Arc::new((Mutex::new(false), Condvar::new()));
 
-        // Pipe used to synchronize the child process.
-        let (read_fd, write_fd) = nix::unistd::pipe().unwrap();
-
-        let child = match unsafe { fork() }.unwrap() {
-            ForkResult::Parent { child } => child,
-            ForkResult::Child => {
-                let mut buf = [0u8];
-                // Wait for parent to register its callback.
-                nix::unistd::read(read_fd, &mut buf).unwrap();
-                unsafe { libc::_exit(42) }
-            }
-        };
+        let notifier = nix::sys::eventfd::eventfd(0, nix::sys::eventfd::EfdFlags::empty()).unwrap();
 
         let watcher = ChildPidWatcher::new();
+        let child = unsafe {
+            watcher.fork_watchable(|| {
+                let mut buf = [0; 8];
+                // Wait for parent to register its callback.
+                nix::unistd::read(notifier, &mut buf).unwrap();
+                libc::_exit(42);
+            })
+        }
+        .unwrap();
 
         let handles: Vec<WatchHandle> = [&cb1_ran, &cb2_ran]
             .iter()
             .cloned()
             .map(|cb_ran| {
                 let cb_ran = cb_ran.clone();
-                watcher.watch(
+                watcher.register_callback(
                     child,
                     Box::new(move |pid| {
                         assert_eq!(pid, child);
@@ -409,10 +524,10 @@ mod tests {
             })
             .collect();
 
-        watcher.unwatch(child, handles[0]);
+        watcher.unregister_callback(child, handles[0]);
 
         // Let the child exit.
-        nix::unistd::write(write_fd, &[0u8]).unwrap();
+        nix::unistd::write(notifier, &1u64.to_ne_bytes()).unwrap();
 
         // Wait for the still-registered callback to run.
         let mut cb_ran_lock = cb2_ran.0.lock().unwrap();
@@ -446,6 +561,56 @@ mod export {
         unsafe { Box::from_raw(notnull_mut(watcher)) };
     }
 
+    #[no_mangle]
+    pub unsafe extern "C" fn childpidwatcher_forkWatchable(
+        watcher: *const ChildPidWatcher,
+        child_fn: extern "C" fn(*mut libc::c_void),
+        child_fn_data: *mut libc::c_void,
+    ) -> i32 {
+        match unsafe {
+            watcher
+                .as_ref()
+                .unwrap()
+                .fork_watchable(|| child_fn(child_fn_data))
+        } {
+            Ok(pid) => pid.as_raw(),
+            Err(e) => -(e as i32),
+        }
+    }
+
+    /// Register interest in `pid`, and associate it with `read_fd`.
+    ///
+    /// `read_fd` should be the read end of a pipe, whose write end is owned
+    /// *solely* by `pid`, causing `read_fd` to become invalid when `pid` exits.
+    /// In a multi-threaded program care must be taken to prevent a concurrent
+    /// fork from leaking the write end of the pipe into other children. One way
+    /// to avoid this is to use O_CLOEXEC when creating the pipe, and then unset
+    /// O_CLOEXEC in the child before calling exec.
+    ///
+    /// Be sure to close the parent's write-end of the pipe.
+    ///
+    /// Takes ownership of `read_fd`, and will close it when appropriate.
+    #[no_mangle]
+    pub unsafe extern "C" fn childpidwatcher_registerPid(
+        watcher: *const ChildPidWatcher,
+        pid: i32,
+        read_fd: i32,
+    ) {
+        unsafe { watcher.as_ref() }
+            .unwrap()
+            .register_pid(Pid::from_raw(pid), unsafe { File::from_raw_fd(read_fd) });
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn childpidwatcher_unregisterPid(
+        watcher: *const ChildPidWatcher,
+        pid: i32,
+    ) {
+        unsafe { watcher.as_ref() }
+            .unwrap()
+            .unregister_pid(Pid::from_raw(pid));
+    }
+
     /// Call `callback` exactly once from another thread after the child `pid`
     /// has exited, including if it has already exited. Does *not* reap the
     /// child itself.
@@ -463,7 +628,7 @@ mod export {
         let data = SyncSendPointer(data);
         unsafe { watcher.as_ref() }
             .unwrap()
-            .watch(Pid::from_raw(pid), move |pid| {
+            .register_callback(Pid::from_raw(pid), move |pid| {
                 callback(pid.into(), data.ptr())
             })
     }
@@ -481,6 +646,6 @@ mod export {
     ) {
         unsafe { watcher.as_ref() }
             .unwrap()
-            .unwatch(Pid::from_raw(pid), handle);
+            .unregister_callback(Pid::from_raw(pid), handle);
     }
 }


### PR DESCRIPTION
pidfd_open was only added in Linux 5.3. There are still some platforms
supported by Shadow that may not have a new enough kernel to use it.

Fixes https://github.com/shadow/shadow/issues/1532