### PR TITLE
Support 'epoll_pwait' syscall when given a NULL sigmask

### DIFF
--- a/src/main/host/syscall/epoll.c
+++ b/src/main/host/syscall/epoll.c
@@ -216,3 +216,15 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
     /* Return the number of events that are ready. */
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = nEvents};
 }
+
+SysCallReturn syscallhandler_epoll_pwait(SysCallHandler* sys, const SysCallArgs* args) {
+    PluginPtr sigmask = args->args[4].as_ptr;
+
+    if (sigmask.val != 0) {
+        error("epoll_pwait called with non-null sigmask, which is not yet supported by shadow; "
+              "returning ENOSYS");
+        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+    }
+
+    return syscallhandler_epoll_wait(sys, args);
+}

--- a/src/main/host/syscall/epoll.h
+++ b/src/main/host/syscall/epoll.h
@@ -11,6 +11,7 @@
 SYSCALL_HANDLER(epoll_create);
 SYSCALL_HANDLER(epoll_create1);
 SYSCALL_HANDLER(epoll_ctl);
+SYSCALL_HANDLER(epoll_pwait);
 SYSCALL_HANDLER(epoll_wait);
 
 #endif /* SRC_MAIN_HOST_SYSCALL_EPOLL_H_ */

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -281,6 +281,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         HANDLE(epoll_create);
         HANDLE(epoll_create1);
         HANDLE(epoll_ctl);
+        HANDLE(epoll_pwait);
         HANDLE(epoll_wait);
         HANDLE(eventfd);
         HANDLE(eventfd2);


### PR DESCRIPTION
The `epoll_pwait` syscall with a NULL signal mask is equivalent to calling `epoll_wait`. Golang uses `epoll_pwait` rather than `epoll_wait` in its runtime scheduler.