### PR TITLE
Improve TSC emulation

### DIFF
--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -514,7 +514,7 @@ static void _handle_sigsegv(int sig, siginfo_t* info, void* voidUcontext) {
     static Tsc tsc;
     if (!tsc_initd) {
         trace("Initializing tsc");
-        tsc = Tsc_create();
+        tsc = Tsc_create(Tsc_nativeCyclesPerSecond());
         tsc_initd = true;
     }
 

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -514,7 +514,12 @@ static void _handle_sigsegv(int sig, siginfo_t* info, void* voidUcontext) {
     static Tsc tsc;
     if (!tsc_initd) {
         trace("Initializing tsc");
-        tsc = Tsc_create(Tsc_nativeCyclesPerSecond());
+        uint64_t hz;
+        int rc = sscanf(getenv("SHADOW_TSC_HZ"), "%" PRIu64, &hz);
+        if (rc != 1) {
+            panic("Couldn't parse SHADOW_TSC_HZ %s", getenv("SHADOW_TSC_HZ"));
+        }
+        tsc = Tsc_create(hz);
         tsc_initd = true;
     }
 

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -514,7 +514,7 @@ static void _handle_sigsegv(int sig, siginfo_t* info, void* voidUcontext) {
     static Tsc tsc;
     if (!tsc_initd) {
         trace("Initializing tsc");
-        tsc = Tsc_init();
+        tsc = Tsc_create();
         tsc_initd = true;
     }
 

--- a/src/lib/tsc/tsc.c
+++ b/src/lib/tsc/tsc.c
@@ -53,13 +53,16 @@ static uint64_t _frequency_via_cpuid0x15() {
     unsigned int core = c;
     if (!core) {
         // From "cpuid": "If ECX is 0, the nominal core crystal clock frequency
-        // is not enumerated". Gee, thanks.
+        // is not enumerated".
         //
-        // "Intel® 64 and IA-32 ArchitecturesSoftware Developer’s Manual
-        // Volume 3B: System Programming Guide, Part 2", "18.18 COUNTING CLOCKS",
-        // gives a 2 row table for this case:
+        // The June 2021 revision of "Intel® 64 and IA-32 Architectures Software
+        // Developer’s Manual Combined Volumes: 1, 2A, 2B, 2C, 2D, 3A, 3B, 3C,
+        // 3D and 4", section "18.7.3" has a 3 row table for this case:
         //
-        //   6th and 7th generation Intel® Core™ processors -> 24 MHz
+        //   Intel® Xeon® Processor Scalable Family with CPUID signature 06_55H
+        //   -> 25 MHz.
+        //
+        //   6th and 7th generation Intel® Core™ processors -> 24 MHz.
         //
         //   Next Generation Intel® Atom™ processors based on Goldmont
         //   Microarchitecture with CPUID signature 06_5CH -> 19.2 MHz.
@@ -84,11 +87,14 @@ static uint64_t _frequency_via_cpuid0x15() {
         unsigned int model = (a >> 4) & 0xf;
         trace("rax %u -> family_id:0x%x extended_model_id:0x%x model:0x%x", a, family_id,
               extended_model_id, model);
-        if (family_id == 0x6 && extended_model_id == 0x5 && model == 0xc) {
+        if (family_id == 0x6 && extended_model_id == 0x5 && model == 0x5) {
+            trace("xeon; using 25 MHz crystal frequency");
+            core = 25000000;
+        } else if (family_id == 0x6 && extended_model_id == 0x5 && model == 0xc) {
             trace("goldmont; using 19.2 MHz crystal frequency");
             core = 19200000;
         } else {
-            trace("non-goldmont; using 24 MHz crystal frequency");
+            trace("non-goldmont, non-xeon; using 24 MHz crystal frequency");
             core = 24000000;
         }
     }

--- a/src/lib/tsc/tsc.c
+++ b/src/lib/tsc/tsc.c
@@ -164,7 +164,7 @@ static uint64_t _frequency_via_brand_string() {
     return frequency;
 }
 
-Tsc Tsc_create() {
+uint64_t Tsc_nativeCyclesPerSecond() {
     // Since we don't have an efficient way of trapping and emulating cpuid
     // to just dictate the perceived clock frequency to the managed program,
     // we need to use cpuid ourselves to figure out the clock frequency, so that
@@ -182,7 +182,12 @@ Tsc Tsc_create() {
         panic("Couldn't get CPU frequency");
     }
 
-    return (Tsc){.cyclesPerSecond = f};
+    return f;
+}
+
+Tsc Tsc_create(uint64_t cyclesPerSecond) {
+    assert(cyclesPerSecond);
+    return (Tsc) { .cyclesPerSecond = cyclesPerSecond};
 }
 
 static void _Tsc_setRdtscCycles(const Tsc* tsc, uint64_t* rax, uint64_t* rdx, uint64_t nanos) {

--- a/src/lib/tsc/tsc.c
+++ b/src/lib/tsc/tsc.c
@@ -164,7 +164,7 @@ static uint64_t _frequency_via_brand_string() {
     return frequency;
 }
 
-Tsc Tsc_init() {
+Tsc Tsc_create() {
     // Since we don't have an efficient way of trapping and emulating cpuid
     // to just dictate the perceived clock frequency to the managed program,
     // we need to use cpuid ourselves to figure out the clock frequency, so that

--- a/src/lib/tsc/tsc.h
+++ b/src/lib/tsc/tsc.h
@@ -14,8 +14,16 @@ typedef struct _Tsc {
     uint64_t cyclesPerSecond;
 } Tsc;
 
-// Instantiate a TSC with the same frequency as the host system TSC.
-Tsc Tsc_create();
+// Returns the host system's native TSC rate, or 0 if it couldn't be found.
+//
+// WARNING: this is known to fail completely on some supported CPUs
+// (particularly AMD), and can return the wrong value for others. i.e. this
+// needs more work if we need to dependably get the host's TSC rate.
+// e.g. see https://github.com/shadow/shadow/issues/1519.
+uint64_t Tsc_nativeCyclesPerSecond();
+
+// Instantiate a TSC with the given clock rate.
+Tsc Tsc_create(uint64_t cyclesPerSecond);
 
 // Updates `regs` to reflect the result of executing an rdtsc instruction at
 // time `nanos`.

--- a/src/lib/tsc/tsc.h
+++ b/src/lib/tsc/tsc.h
@@ -15,7 +15,7 @@ typedef struct _Tsc {
 } Tsc;
 
 // Instantiate a TSC with the same frequency as the host system TSC.
-Tsc Tsc_init();
+Tsc Tsc_create();
 
 // Updates `regs` to reflect the result of executing an rdtsc instruction at
 // time `nanos`.

--- a/src/lib/tsc/tsc_test.c
+++ b/src/lib/tsc/tsc_test.c
@@ -15,7 +15,7 @@
 static uint64_t _getEmulatedCycles(void (*emulate_fn)(const Tsc* tsc, uint64_t* rax, uint64_t* rdx,
                                                       uint64_t* rip, uint64_t nanos),
                                    uint64_t cyclesPerSecond, int64_t nanos) {
-    Tsc tsc = {.cyclesPerSecond = cyclesPerSecond};
+    Tsc tsc = Tsc_create(cyclesPerSecond);
     uint64_t rax = 0, rdx = 0, rip = 0;
     emulate_fn(&tsc, &rax, &rdx, &rip, nanos);
     return (rdx << 32) | rax;
@@ -65,7 +65,7 @@ void closeToNativeRdtsc(void* unusedFixture, gconstpointer user_data) {
     void (*emulate_fn)(
         const Tsc* tsc, uint64_t* rax, uint64_t* rdx, uint64_t* rip, uint64_t nanos) = user_data;
 
-    Tsc tsc = Tsc_create();
+    Tsc tsc = Tsc_create(Tsc_nativeCyclesPerSecond());
 
     // Use the monotonic timer.
     clockid_t clk_id = CLOCK_MONOTONIC;

--- a/src/lib/tsc/tsc_test.c
+++ b/src/lib/tsc/tsc_test.c
@@ -65,7 +65,7 @@ void closeToNativeRdtsc(void* unusedFixture, gconstpointer user_data) {
     void (*emulate_fn)(
         const Tsc* tsc, uint64_t* rax, uint64_t* rdx, uint64_t* rip, uint64_t nanos) = user_data;
 
-    Tsc tsc = Tsc_init();
+    Tsc tsc = Tsc_create();
 
     // Use the monotonic timer.
     clockid_t clk_id = CLOCK_MONOTONIC;

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -139,6 +139,35 @@ extern "C" {
 pub type SysCallHandler = _SysCallHandler;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct _Tsc {
+    pub cyclesPerSecond: u64,
+}
+#[test]
+fn bindgen_test_layout__Tsc() {
+    assert_eq!(
+        ::std::mem::size_of::<_Tsc>(),
+        8usize,
+        concat!("Size of: ", stringify!(_Tsc))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_Tsc>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_Tsc))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<_Tsc>())).cyclesPerSecond as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_Tsc),
+            "::",
+            stringify!(cyclesPerSecond)
+        )
+    );
+}
+pub type Tsc = _Tsc;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct _CPU {
     _unused: [u8; 0],
 }
@@ -1248,6 +1277,9 @@ extern "C" {
 }
 extern "C" {
     pub fn host_getCPU(host: *mut Host) -> *mut CPU;
+}
+extern "C" {
+    pub fn host_getTsc(host: *mut Host) -> *mut Tsc;
 }
 extern "C" {
     pub fn host_getName(host: *mut Host) -> *mut gchar;

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -16,6 +16,7 @@
 #include <sys/socket.h>
 
 #include "lib/logger/log_level.h"
+#include "lib/tsc/tsc.h"
 #include "main/core/support/definitions.h"
 #include "main/host/cpu.h"
 #include "main/host/descriptor/compat_socket.h"
@@ -63,6 +64,7 @@ gint host_compare(gconstpointer a, gconstpointer b, gpointer user_data);
 GQuark host_getID(Host* host);
 gboolean host_isEqual(Host* a, Host* b);
 CPU* host_getCPU(Host* host);
+Tsc* host_getTsc(Host* host);
 gchar* host_getName(Host* host);
 Address* host_getDefaultAddress(Host* host);
 in_addr_t host_getDefaultIP(Host* host);

--- a/src/main/host/thread_ptrace.c
+++ b/src/main/host/thread_ptrace.c
@@ -1368,7 +1368,7 @@ Thread* threadptraceonly_new(Host* host, Process* process, int threadID) {
                                   .getShMBlock = _threadptrace_getShMBlock,
                               }),
         // FIXME: This should the emulated CPU's frequency
-        .tsc = {.cyclesPerSecond = 2000000000UL},
+        .tsc = Tsc_create(2000000000UL),
         .childState = THREAD_PTRACE_CHILD_STATE_NONE,
     };
     thread->base.sys = syscallhandler_new(host, process, _threadPtraceToThread(thread));


### PR DESCRIPTION
* Add case handling Xeon processors with base clock frequency of 25 MHz (fixing #1519 ).
* Don't try to use clock rate from brand string as TSC rate, since it isn't guaranteed to be the same rate.
* Consolidate setting TSC rate in host initialization, along-side initialization of emulated CPU.
* Fall back to emulated CPU clock rate if we can't determine TSC rate, with a warning that using TSC to measure wallclock time will be inaccurate within the simulation.
* Clean up some related environment variable parsing in the shim.