### PR TITLE
Shim logger bug fixes

### DIFF
--- a/src/lib/logger/logger.c
+++ b/src/lib/logger/logger.c
@@ -8,17 +8,6 @@
 #include <sys/param.h>
 #include <sys/time.h>
 
-static Logger* defaultLogger = NULL;
-
-void logger_setDefault(Logger* logger) {
-    if (defaultLogger != NULL) {
-        defaultLogger->destroy(defaultLogger);
-    }
-    defaultLogger = logger;
-}
-
-Logger* logger_getDefault() { return defaultLogger; }
-
 // Process start time, initialized explicitly or on first use.
 static pthread_once_t _start_time_once = PTHREAD_ONCE_INIT;
 static bool _start_time_initd = false;
@@ -85,12 +74,18 @@ const char* logger_base_name(const char* filename) {
     return rv;
 }
 
-void _logger_default_flush() {
+typedef struct {
+    Logger base;
+    LogLevel level;
+} StderrLogger;
+
+static void _stderrlogger_flush() {
     fflush(stderr);
 }
 
-static void _logger_default_log(LogLevel level, const char* fileName, const char* functionName,
-                                const int lineNumber, const char* format, va_list vargs) {
+static void _stderrlogger_log(Logger* logger, LogLevel level, const char* fileName,
+                         const char* functionName, const int lineNumber, const char* format,
+                         va_list vargs) {
     static __thread bool in_logger = false;
     if (in_logger) {
         // Avoid recursing. We do this here rather than in logger_log so that
@@ -98,7 +93,7 @@ static void _logger_default_log(LogLevel level, const char* fileName, const char
         // dropping the message.
         return;
     }
-    if (!logger_isEnabled(NULL, level)) {
+    if (!logger_isEnabled(logger, level)) {
         return;
     }
     in_logger = true;
@@ -118,25 +113,57 @@ static void _logger_default_log(LogLevel level, const char* fileName, const char
     offset += vsnprintf(&buf[offset], sizeof(buf) - offset, format, vargs);
     offset = MIN(offset, sizeof(buf));
 
-    offset += fprintf(stderr, "%s\n", buf);
-    offset = MIN(offset, sizeof(buf));
+    fprintf(stderr, "%s\n", buf);
 
-        _logger_default_flush();
     in_logger = false;
 }
+
+static void _stderrlogger_destroy(Logger* logger) {
+    // Do nothing; Default logger is statically allocated.
+}
+
+static void _stderrlogger_setLevel(Logger* baseLogger, LogLevel level) {
+    StderrLogger* logger = (StderrLogger*)baseLogger;
+    logger->level = level;
+}
+
+static bool _stderrlogger_isEnabled(Logger* baseLogger, LogLevel level) {
+    StderrLogger* logger = (StderrLogger*)baseLogger;
+    return level <= logger->level;
+}
+
+static StderrLogger stderrLogger = {
+    .base = {
+        .destroy = _stderrlogger_destroy,
+        .flush = _stderrlogger_flush,
+        .isEnabled = _stderrlogger_isEnabled,
+        .log = _stderrlogger_log,
+        .setLevel = _stderrlogger_setLevel,
+    },
+    .level = LOGLEVEL_TRACE,
+};
+
+static Logger* defaultLogger = &stderrLogger.base;
+
+void logger_setDefault(Logger* logger) {
+    if (defaultLogger != NULL) {
+        defaultLogger->destroy(defaultLogger);
+    }
+    defaultLogger = logger;
+}
+
+Logger* logger_getDefault() { return defaultLogger; }
 
 void logger_log(Logger* logger, LogLevel level, const gchar* fileName,
                 const gchar* functionName, const gint lineNumber,
                 const gchar* format, ...) {
+    if (!logger) {
+        return;
+    }
     va_list vargs;
     va_start(vargs, format);
-    if (!logger) {
-        _logger_default_log(level, fileName, functionName, lineNumber, format,
-                            vargs);
-    } else {
-        logger->log(logger, level, fileName, functionName, lineNumber, format,
-                    vargs);
-    }
+    logger->log(logger, level, fileName, functionName, lineNumber, format,
+                vargs);
     va_end(vargs);
     if (level == LOGLEVEL_ERROR) {
         logger_flush(logger);
@@ -145,28 +172,22 @@ void logger_log(Logger* logger, LogLevel level, const gchar* fileName,
 
 void logger_setLevel(Logger* logger, LogLevel level) {
     if (!logger) {
-        // Not implemented for default logger.
-    } else {
-        logger->setLevel(logger, level);
+        return;
     }
+    logger->setLevel(logger, level);
 }
 
 bool logger_isEnabled(Logger* logger, LogLevel level) {
     if (!logger) {
-        // Most logging frameworks log little/nothing unless explicitly enabled.
-        // That probably makes sense for a framework used across independent
-        // libraries and apps, but in our case verbose is a useful default,
-        // particularly in test programs.
-        return true;
-    } else {
-        return logger->isEnabled(logger, level);
+        return false;
     }
+
+    return logger->isEnabled(logger, level);
 }
 
 void logger_flush(Logger* logger) {
     if (!logger) {
-        _logger_default_flush();
-    } else {
-        logger->flush(logger);
+        return;
     }
+    logger->flush(logger);
 }

--- a/src/lib/logger/logger.h
+++ b/src/lib/logger/logger.h
@@ -54,7 +54,8 @@ struct _Logger {
 void logger_setDefault(Logger* logger);
 
 // Until overridden by logger_setDefault, returns a default logger that logs to
-// stderr, and is initially configured to log at LOGLEVEL_TRACE.
+// stderr, is initially configured to log at LOGLEVEL_TRACE, and is thread-safe
+// and signal-safe.
 //
 // May return NULL.
 Logger* logger_getDefault();

--- a/src/lib/logger/logger.h
+++ b/src/lib/logger/logger.h
@@ -50,14 +50,16 @@ struct _Logger {
 };
 
 // Not thread safe. The previously set logger, if any, will be destroyed.
-// `logger` may be NULL.
+// `logger` may be NULL, which will effectively disable logging.
 void logger_setDefault(Logger* logger);
 
+// Until overridden by logger_setDefault, returns a default logger that logs to
+// stderr, and is initially configured to log at LOGLEVEL_TRACE.
+//
 // May return NULL.
 Logger* logger_getDefault();
 
-// Thread safe. `logger` may be NULL, in which a hard coded default logger will be used, which
-// writes to stdout.
+// Thread safe. `logger` may be NULL, in which case nothing will be logged.
 //
 // Doesn't do dynamic memory allocation.
 //
@@ -69,8 +71,10 @@ __attribute__((__format__(__printf__, 6, 7))) void
 logger_log(Logger* logger, LogLevel level, const char* fileName, const char* functionName,
            const int lineNumber, const char* format, ...);
 
+// logger may be NULL.
 void logger_setLevel(Logger* logger, LogLevel level);
 
+// logger may be NULL, in which case `false` is returned.
 bool logger_isEnabled(Logger* logger, LogLevel level);
 
 // Returns an agreed-upon start time for logging purposes, as returned by
@@ -109,6 +113,6 @@ void logger_set_global_start_time_micros(int64_t);
 // /foo/bar/ -> bar/
 const char* logger_base_name(const char* filename);
 
-// Flush all logged output.
+// Flush all logged output. `logger` may be NULL.
 void logger_flush(Logger* logger);
 #endif

--- a/src/lib/shim/preload_syscall.c
+++ b/src/lib/shim/preload_syscall.c
@@ -233,7 +233,7 @@ long shadow_vraw_syscall(long n, va_list args) {
 
     long rv;
 
-    if (shim_use_syscall_handler() && shim_syscall(n, &rv, args)) {
+    if (shim_interpositionEnabled() && shim_use_syscall_handler() && shim_syscall(n, &rv, args)) {
         // No inter-process syscall needed, we handled it on the shim side! :)
         trace("Handled syscall %ld from the shim; we avoided inter-process overhead.", n);
         // rv was already set

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -185,7 +185,9 @@ static void _shim_parent_init_logging() {
     // Set logger start time from environment variable.
     {
         const char* logger_start_time_string = getenv("SHADOW_LOG_START_TIME");
-        assert(logger_start_time_string);
+        if (!logger_start_time_string) {
+            panic("Missing SHADOW_LOG_START_TIME");
+        }
         int64_t logger_start_time;
         if (sscanf(logger_start_time_string, "%" PRId64, &logger_start_time) != 1) {
             panic("Couldn't parse logger start time string %s", logger_start_time_string);
@@ -198,10 +200,22 @@ static void _shim_parent_init_logging() {
         const char* name = getenv("SHADOW_LOG_FILE");
         FILE* log_file = fopen(name, "w");
         if (log_file == NULL) {
-            perror("fopen");
-            abort();
+            panic("fopen: %s", strerror(errno));
         }
         logger_setDefault(shimlogger_new(log_file));
+    }
+
+    // Set log level
+    {
+        const char* level_string = getenv("SHADOW_LOG_LEVEL");
+        if (!level_string) {
+            panic("Missing SHADOW_LOG_LEVEL");
+        }
+        int level;
+        if (sscanf(level_string, "%d", &level) != 1) {
+            panic("Couldn't parse log level %s", level_string);
+        };
+        logger_setLevel(logger_getDefault(), level);
     }
 }
 

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -601,7 +601,12 @@ __attribute__((constructor)) void _shim_load() {
     static bool did_global_pre_init = false;
     if (!did_global_pre_init) {
         // Early init; must not make any syscalls.
+
         did_global_pre_init = true;
+
+        // Avoid logging until we've set up the shim logger.
+        logger_setLevel(logger_getDefault(), LOGLEVEL_WARNING);
+
         _set_interpose_type();
         _set_use_shim_syscall_handler();
     }

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -25,11 +25,6 @@ void shim_syscall_set_simtime_nanos(uint64_t simulation_nanos) {
     _cached_simulation_time.tv_nsec = simulation_nanos % SIMTIME_ONE_SECOND;
 }
 
-uint64_t shim_syscall_get_simtime_nanos() {
-    return (uint64_t)(_cached_simulation_time.tv_sec * SIMTIME_ONE_SECOND) +
-           _cached_simulation_time.tv_nsec;
-}
-
 static struct timespec* _shim_syscall_get_time() {
     // First try to get time from shared mem.
     struct timespec* simtime_ts = shim_get_shared_time_location();
@@ -53,6 +48,15 @@ static struct timespec* _shim_syscall_get_time() {
 #endif
 
     return simtime_ts;
+}
+
+uint64_t shim_syscall_get_simtime_nanos() {
+    struct timespec* ts = _shim_syscall_get_time();
+    if (!ts) {
+        return 0;
+    }
+
+    return (uint64_t)(ts->tv_sec * SIMTIME_ONE_SECOND) + ts->tv_nsec;
 }
 
 bool shim_syscall(long syscall_num, long* rv, va_list args) {

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -398,6 +398,12 @@ static gchar** _manager_generateEnvv(Manager* manager, InterposeMethod interpose
         g_free(timestring);
     }
 
+    {
+        char* level_string = g_strdup_printf("%d", config_getLogLevel(manager->config));
+        envv = g_environ_setenv(envv, "SHADOW_LOG_LEVEL", level_string, TRUE);
+        g_free(level_string);
+    }
+
     switch (interposeMethod) {
         case INTERPOSE_METHOD_PTRACE:
             envv = g_environ_setenv(envv, "SHADOW_INTERPOSE_METHOD", "PTRACE", 0);


### PR DESCRIPTION
* Log at level WARNING until shim logger is set up, fixing #1070.
* Propagate configured log level to shim logger, fixing #890.
* Fix bug where shim logger was getting sim time instead of real time.
* Fix bug where shim logger was always getting 0 for sim time in ptrace mode.
* Make default logger thread safe and signal safe