### PR TITLE
fixed error for undefined IGRAPH_VERSION

### DIFF
--- a/src/main/routing/topology.c
+++ b/src/main/routing/topology.c
@@ -326,12 +326,14 @@ static gboolean _topology_findEdgeAttributeDouble(Topology* top, igraph_integer_
 static gboolean _topology_loadGraph(Topology* top, const gchar* graphPath) {
     MAGIC_ASSERT(top);
     /* initialize the built-in C attribute handler */
+#ifndef IGRAPH_VERSION
 #if defined(IGRAPH_VERSION_MAJOR_GUESS) && defined(IGRAPH_VERSION_MINOR_GUESS) &&                  \
     ((IGRAPH_VERSION_MAJOR_GUESS == 0 && IGRAPH_VERSION_MINOR_GUESS >= 9) ||                       \
      IGRAPH_VERSION_MAJOR_GUESS > 0)
     igraph_attribute_table_t* oldHandler = igraph_set_attribute_table(&igraph_cattribute_table);
 #else
     igraph_attribute_table_t* oldHandler = igraph_i_set_attribute_table(&igraph_cattribute_table);
+#endif
 #endif
 
     /* get the file */


### PR DESCRIPTION
I'm using arch linux and I coun't get TGen and Shadow to work together without installing an older version of igraph. This caused a failed compilation of shadow with the older igraph version, so I came across this error that could be fixed just with a #ifndef.