### PR TITLE
During debug mode tests, log at debug level rather than trace level

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -46,7 +46,8 @@ macro(add_shadow_tests)
 
    if(NOT DEFINED SHADOW_TEST_LOGLEVEL)
       if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-         set(SHADOW_TEST_LOGLEVEL "trace")
+         # trace log level causes us to generate a very large ctest log file
+         set(SHADOW_TEST_LOGLEVEL "debug")
       else()
          set(SHADOW_TEST_LOGLEVEL "info")
       endif()


### PR DESCRIPTION
When we log at trace level in debug mode, we generate a 556 MiB log file. If we log at debug level instead, it's only 22 MiB. I don't think we need to log at trace level by default, so I think it's worth having a significantly smaller log file.