### PR TITLE
Simplify syscall condition and timeouts

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -21,7 +21,48 @@ pub type __uint32_t = ::std::os::raw::c_uint;
 pub type __int64_t = ::std::os::raw::c_long;
 pub type __uint64_t = ::std::os::raw::c_ulong;
 pub type __pid_t = ::std::os::raw::c_int;
+pub type __time_t = ::std::os::raw::c_long;
 pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+#[test]
+fn bindgen_test_layout_timespec() {
+    assert_eq!(
+        ::std::mem::size_of::<timespec>(),
+        16usize,
+        concat!("Size of: ", stringify!(timespec))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<timespec>(),
+        8usize,
+        concat!("Alignment of ", stringify!(timespec))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<timespec>())).tv_sec as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(timespec),
+            "::",
+            stringify!(tv_sec)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<timespec>())).tv_nsec as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(timespec),
+            "::",
+            stringify!(tv_nsec)
+        )
+    );
+}
 pub type pid_t = __pid_t;
 pub type gchar = ::std::os::raw::c_char;
 pub type gint = ::std::os::raw::c_int;
@@ -168,12 +209,6 @@ pub struct _CPU {
     _unused: [u8; 0],
 }
 pub type CPU = _CPU;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _Timer {
-    _unused: [u8; 0],
-}
-pub type Timer = _Timer;
 pub type PluginVirtualPtr = _PluginVirtualPtr;
 pub type PluginPtr = _PluginVirtualPtr;
 pub type PluginPhysicalPtr = _PluginPhysicalPtr;
@@ -516,6 +551,9 @@ extern "C" {
     pub fn thread_getSysCallHandler(thread: *mut Thread) -> *mut SysCallHandler;
 }
 extern "C" {
+    pub fn thread_getSysCallCondition(thread: *mut Thread) -> *mut SysCallCondition;
+}
+extern "C" {
     pub fn process_new(
         host: *mut Host,
         processID: guint,
@@ -641,6 +679,13 @@ extern "C" {
         src: PluginVirtualPtr,
         n: size_t,
     ) -> ssize_t;
+}
+extern "C" {
+    pub fn process_readTimespec(
+        proc_: *mut Process,
+        ts: *mut timespec,
+        src: PluginVirtualPtr,
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn process_writePtr(
@@ -1479,7 +1524,6 @@ pub struct _SysCallHandler {
     pub host: *mut Host,
     pub process: *mut Process,
     pub thread: *mut Thread,
-    pub timer: *mut Timer,
     pub epoll: *mut Epoll,
     pub blockedSyscallNR: ::std::os::raw::c_long,
     pub perfTimer: *mut GTimer,
@@ -1494,7 +1538,7 @@ pub struct _SysCallHandler {
 fn bindgen_test_layout__SysCallHandler() {
     assert_eq!(
         ::std::mem::size_of::<_SysCallHandler>(),
-        96usize,
+        88usize,
         concat!("Size of: ", stringify!(_SysCallHandler))
     );
     assert_eq!(
@@ -1533,18 +1577,8 @@ fn bindgen_test_layout__SysCallHandler() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).timer as *const _ as usize },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_SysCallHandler),
-            "::",
-            stringify!(timer)
-        )
-    );
-    assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).epoll as *const _ as usize },
-        32usize,
+        24usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1556,7 +1590,7 @@ fn bindgen_test_layout__SysCallHandler() {
         unsafe {
             &(*(::std::ptr::null::<_SysCallHandler>())).blockedSyscallNR as *const _ as usize
         },
-        40usize,
+        32usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1566,7 +1600,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).perfTimer as *const _ as usize },
-        48usize,
+        40usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1578,7 +1612,7 @@ fn bindgen_test_layout__SysCallHandler() {
         unsafe {
             &(*(::std::ptr::null::<_SysCallHandler>())).perfSecondsCurrent as *const _ as usize
         },
-        56usize,
+        48usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1590,7 +1624,7 @@ fn bindgen_test_layout__SysCallHandler() {
         unsafe {
             &(*(::std::ptr::null::<_SysCallHandler>())).perfSecondsTotal as *const _ as usize
         },
-        64usize,
+        56usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1600,7 +1634,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).numSyscalls as *const _ as usize },
-        72usize,
+        64usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1610,7 +1644,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).syscall_counter as *const _ as usize },
-        80usize,
+        72usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1620,7 +1654,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).referenceCount as *const _ as usize },
-        88usize,
+        80usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1630,7 +1664,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).magic as *const _ as usize },
-        92usize,
+        84usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1831,7 +1865,7 @@ fn bindgen_test_layout__Trigger() {
     );
 }
 extern "C" {
-    pub fn syscallcondition_new(trigger: Trigger, timeout: *mut Timer) -> *mut SysCallCondition;
+    pub fn syscallcondition_new(trigger: Trigger) -> *mut SysCallCondition;
 }
 extern "C" {
     pub fn syscallcondition_unref(cond: *mut SysCallCondition);

--- a/src/main/host/descriptor/timer.c
+++ b/src/main/host/descriptor/timer.c
@@ -83,7 +83,7 @@ Timer* timer_new() {
     return timer;
 }
 
-static void _timer_getCurrentTime(Timer* timer, struct timespec* out) {
+static void _timer_getCurrentTime(const Timer* timer, struct timespec* out) {
     MAGIC_ASSERT(timer);
     utility_assert(out);
 
@@ -103,7 +103,7 @@ static void _timer_getCurrentTime(Timer* timer, struct timespec* out) {
     }
 }
 
-static void _timer_getCurrentInterval(Timer* timer, struct timespec* out) {
+static void _timer_getCurrentInterval(const Timer* timer, struct timespec* out) {
     MAGIC_ASSERT(timer);
     utility_assert(out);
 
@@ -117,7 +117,7 @@ static void _timer_getCurrentInterval(Timer* timer, struct timespec* out) {
     }
 }
 
-gint timer_getTime(Timer* timer, struct itimerspec *curr_value) {
+gint timer_getTime(const Timer* timer, struct itimerspec* curr_value) {
     MAGIC_ASSERT(timer);
 
     if(!curr_value) {
@@ -366,7 +366,7 @@ ssize_t timer_read(Timer* timer, void *buf, size_t count) {
     }
 }
 
-guint64 timer_getExpirationCount(Timer* timer) {
+guint64 timer_getExpirationCount(const Timer* timer) {
     MAGIC_ASSERT(timer);
     return timer->expireCountSinceLastSet;
 }

--- a/src/main/host/descriptor/timer.h
+++ b/src/main/host/descriptor/timer.h
@@ -17,12 +17,11 @@ typedef struct _Timer Timer;
 Timer* timer_new();
 gint timer_setTime(Timer* timer, Host* host, gint flags, const struct itimerspec* new_value,
                    struct itimerspec* old_value);
-gint timer_getTime(Timer* timer, struct itimerspec *curr_value);
+gint timer_getTime(const Timer* timer, struct itimerspec* curr_value);
 ssize_t timer_read(Timer* timer, void *buf, size_t count);
-gint timer_close(Timer* timer);
 
 /* Returns the number of timer expirations that have occurred
  * since the last time the timer was set. */
-guint64 timer_getExpirationCount(Timer* timer);
+guint64 timer_getExpirationCount(const Timer* timer);
 
 #endif /* SHD_TIMER_H_ */

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -131,6 +131,14 @@ int process_getReadableString(Process* process, PluginPtr plugin_src, size_t n, 
 // -EFAULT if the string extends beyond the accessible address space.
 ssize_t process_readString(Process* proc, char* str, PluginVirtualPtr src, size_t n);
 
+// Convenience function to read and validate a timespec.
+//
+// Returns:
+// 0 on success.
+// -EFAULT if `src` couldn't be read.
+// -EINVAL if `src` didn't contain a valid timespec.
+int process_readTimespec(Process* proc, struct timespec* ts, PluginVirtualPtr src);
+
 // Copy `n` bytes from `src` to `dst`. Returns 0 on success or EFAULT if any of
 // the specified range couldn't be accessed. The write is flushed immediately.
 int process_writePtr(Process* proc, PluginVirtualPtr dst, const void* src, size_t n);

--- a/src/main/host/syscall/epoll.c
+++ b/src/main/host/syscall/epoll.c
@@ -188,7 +188,7 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
             Trigger trigger = (Trigger){.type = TRIGGER_DESCRIPTOR,
                                         .object = (LegacyDescriptor*)epoll,
                                         .status = STATUS_DESCRIPTOR_READABLE};
-            SysCallCondition* cond = syscallcondition_new(trigger, NULL);
+            SysCallCondition* cond = syscallcondition_new(trigger);
 
             /* Set timeout, if provided. */
             if (timeout_ms > 0) {

--- a/src/main/host/syscall/epoll.c
+++ b/src/main/host/syscall/epoll.c
@@ -183,21 +183,21 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
         } else {
             trace("No events are ready on epoll %i and we need to block", epfd);
 
-            /* We need to block, either for timeout_ms time if it's positive,
-             * or indefinitely if it's negative. */
-            if (timeout_ms > 0) {
-                _syscallhandler_setListenTimeoutMillis(sys, timeout_ms);
-            }
-
             /* Block on epoll status. An epoll descriptor is readable when it
-             * has events. We either use our timer as a timeout, or no timeout. */
+             * has events. */
             Trigger trigger = (Trigger){.type = TRIGGER_DESCRIPTOR,
                                         .object = (LegacyDescriptor*)epoll,
                                         .status = STATUS_DESCRIPTOR_READABLE};
+            SysCallCondition* cond = syscallcondition_new(trigger, NULL);
 
-            return (SysCallReturn){
-                .state = SYSCALL_BLOCK,
-                .cond = syscallcondition_new(trigger, (timeout_ms > 0) ? sys->timer : NULL)};
+            /* Set timeout, if provided. */
+            if (timeout_ms > 0) {
+                syscallcondition_setTimeout(
+                    cond, sys->host,
+                    worker_getEmulatedTime() + timeout_ms * SIMTIME_ONE_MILLISECOND);
+            }
+
+            return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = cond};
         }
     }
 

--- a/src/main/host/syscall/futex.c
+++ b/src/main/host/syscall/futex.c
@@ -96,12 +96,13 @@ static SysCallReturn _syscallhandler_futexWaitHelper(SysCallHandler* sys, Plugin
     trace("Futex blocking for wakeup %s timeout", timeoutVPtr.val ? "with" : "without");
     Trigger trigger =
         (Trigger){.type = TRIGGER_FUTEX, .object = futex, .status = STATUS_FUTEX_WAKEUP};
+    SysCallCondition* cond = syscallcondition_new(trigger, NULL);
     if (timeoutVPtr.val) {
-        _syscallhandler_setListenTimeout(sys, &timeout, type);
+        syscallcondition_setTimeout(cond, sys->host,
+                                    worker_getEmulatedTime() + timeout.tv_sec * SIMTIME_ONE_SECOND +
+                                        timeout.tv_nsec * SIMTIME_ONE_NANOSECOND);
     }
-    return (SysCallReturn){
-        .state = SYSCALL_BLOCK,
-        .cond = syscallcondition_new(trigger, timeoutVPtr.val ? sys->timer : NULL)};
+    return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = cond};
 }
 
 static SysCallReturn _syscallhandler_futexWakeHelper(SysCallHandler* sys, PluginPtr futexVPtr,

--- a/src/main/host/syscall/futex.c
+++ b/src/main/host/syscall/futex.c
@@ -96,7 +96,7 @@ static SysCallReturn _syscallhandler_futexWaitHelper(SysCallHandler* sys, Plugin
     trace("Futex blocking for wakeup %s timeout", timeoutVPtr.val ? "with" : "without");
     Trigger trigger =
         (Trigger){.type = TRIGGER_FUTEX, .object = futex, .status = STATUS_FUTEX_WAKEUP};
-    SysCallCondition* cond = syscallcondition_new(trigger, NULL);
+    SysCallCondition* cond = syscallcondition_new(trigger);
     if (timeoutVPtr.val) {
         syscallcondition_setTimeout(cond, sys->host,
                                     worker_getEmulatedTime() + timeout.tv_sec * SIMTIME_ONE_SECOND +

--- a/src/main/host/syscall/poll.c
+++ b/src/main/host/syscall/poll.c
@@ -147,7 +147,7 @@ static SysCallReturn _syscallhandler_pollHelper(SysCallHandler* sys, PluginPtr f
             Trigger trigger = (Trigger){.type = TRIGGER_DESCRIPTOR,
                                         .object = (LegacyDescriptor*)sys->epoll,
                                         .status = STATUS_DESCRIPTOR_READABLE};
-            SysCallCondition* cond = syscallcondition_new(trigger, NULL);
+            SysCallCondition* cond = syscallcondition_new(trigger);
             if (timeout && (timeout->tv_sec > 0 || timeout->tv_nsec > 0)) {
                 syscallcondition_setTimeout(cond, sys->host,
                                             worker_getEmulatedTime() +

--- a/src/main/host/syscall/protected.c
+++ b/src/main/host/syscall/protected.c
@@ -19,34 +19,6 @@
 #include "main/host/syscall_condition.h"
 #include "main/host/thread.h"
 
-void _syscallhandler_setListenTimeout(SysCallHandler* sys, const struct timespec* timeout,
-                                      TimeoutType type) {
-    MAGIC_ASSERT(sys);
-
-    /* Set a non-repeating (one-shot) timer to the given timeout.
-     * A NULL timeout indicates we should turn off the timer. */
-    struct itimerspec value = {
-        .it_value = timeout ? *timeout : (struct timespec){0},
-    };
-
-    /* This causes us to lose the previous state of the timer. */
-    gint result = timer_setTime(
-        sys->timer, sys->host, type == TIMEOUT_ABSOLUTE ? TFD_TIMER_ABSTIME : 0, &value, NULL);
-
-    if (result != 0) {
-        utility_panic("syscallhandler failed to set timeout to %lu.%09lu seconds",
-                      (long unsigned int)value.it_value.tv_sec,
-                      (long unsigned int)value.it_value.tv_nsec);
-        utility_assert(result == 0);
-    }
-}
-
-void _syscallhandler_setListenTimeoutMillis(SysCallHandler* sys,
-                                            gint timeout_ms) {
-    struct timespec timeout = utility_timespecFromMillis((int64_t)timeout_ms);
-    _syscallhandler_setListenTimeout(sys, &timeout, TIMEOUT_RELATIVE);
-}
-
 static const Timer* _syscallhandler_timeout(const SysCallHandler* sys) {
     MAGIC_ASSERT(sys);
 

--- a/src/main/host/syscall/protected.c
+++ b/src/main/host/syscall/protected.c
@@ -19,7 +19,7 @@
 #include "main/host/syscall_condition.h"
 #include "main/host/thread.h"
 
-static const Timer* _syscallhandler_timeout(const SysCallHandler* sys) {
+static const Timer* _syscallhandler_getTimeout(const SysCallHandler* sys) {
     MAGIC_ASSERT(sys);
 
     SysCallCondition* cond = thread_getSysCallCondition(sys->thread);
@@ -27,13 +27,13 @@ static const Timer* _syscallhandler_timeout(const SysCallHandler* sys) {
         return NULL;
     }
 
-    return syscallcondition_timeout(cond);
+    return syscallcondition_getTimeout(cond);
 }
 
 bool _syscallhandler_isListenTimeoutPending(SysCallHandler* sys) {
     MAGIC_ASSERT(sys);
 
-    const Timer* timeout = _syscallhandler_timeout(sys);
+    const Timer* timeout = _syscallhandler_getTimeout(sys);
     if (!timeout) {
         return false;
     }
@@ -49,7 +49,7 @@ bool _syscallhandler_isListenTimeoutPending(SysCallHandler* sys) {
 bool _syscallhandler_didListenTimeoutExpire(const SysCallHandler* sys) {
     MAGIC_ASSERT(sys);
 
-    const Timer* timeout = _syscallhandler_timeout(sys);
+    const Timer* timeout = _syscallhandler_getTimeout(sys);
     if (!timeout) {
         return false;
     }

--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -13,6 +13,8 @@
  * handlers.
  */
 
+#include <stdbool.h>
+
 #include "main/host/descriptor/epoll.h"
 #include "main/host/descriptor/timer.h"
 #include "main/host/host.h"
@@ -91,9 +93,9 @@ void _syscallhandler_setListenTimeout(SysCallHandler* sys, const struct timespec
 void _syscallhandler_setListenTimeoutMillis(SysCallHandler* sys,
                                             gint timeout_ms);
 void _syscallhandler_setListenTimeoutNanos(SysCallHandler* sys, gint timeout_ns);
-int _syscallhandler_isListenTimeoutPending(SysCallHandler* sys);
-int _syscallhandler_didListenTimeoutExpire(const SysCallHandler* sys);
-int _syscallhandler_wasBlocked(const SysCallHandler* sys);
+bool _syscallhandler_isListenTimeoutPending(SysCallHandler* sys);
+bool _syscallhandler_didListenTimeoutExpire(const SysCallHandler* sys);
+bool _syscallhandler_wasBlocked(const SysCallHandler* sys);
 int _syscallhandler_validateDescriptor(LegacyDescriptor* descriptor,
                                        LegacyDescriptorType expectedType);
 

--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -35,10 +35,9 @@ struct _SysCallHandler {
     Process* process;
     Thread* thread;
 
-    /* Timers are used to support the timerfd syscalls (man timerfd_create);
-     * they are types of descriptors on which we can listen for events.
-     * Here we use it to help us handling blocking syscalls that include a
-     * timeout after which we should stop blocking. */
+    /*
+     * Timer for when the current blocking syscall (if any) should unblock.
+     */
     Timer* timer;
     /* We use this epoll to service syscalls that need to block on the status
      * of multiple descriptors, like poll. */

--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -37,10 +37,6 @@ struct _SysCallHandler {
     Process* process;
     Thread* thread;
 
-    /*
-     * Timer for when the current blocking syscall (if any) should unblock.
-     */
-    Timer* timer;
     /* We use this epoll to service syscalls that need to block on the status
      * of multiple descriptors, like poll. */
     Epoll* epoll;
@@ -88,11 +84,6 @@ struct _SysCallHandler {
     SysCallReturn syscallhandler_##s(                                          \
         SysCallHandler* sys, const SysCallArgs* args);
 
-void _syscallhandler_setListenTimeout(SysCallHandler* sys, const struct timespec* timeout,
-                                      TimeoutType type);
-void _syscallhandler_setListenTimeoutMillis(SysCallHandler* sys,
-                                            gint timeout_ms);
-void _syscallhandler_setListenTimeoutNanos(SysCallHandler* sys, gint timeout_ns);
 bool _syscallhandler_isListenTimeoutPending(SysCallHandler* sys);
 bool _syscallhandler_didListenTimeoutExpire(const SysCallHandler* sys);
 bool _syscallhandler_wasBlocked(const SysCallHandler* sys);

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -204,7 +204,7 @@ static SysCallReturn _syscallhandler_acceptHelper(SysCallHandler* sys,
         trace("Listening socket %i waiting for acceptable connection.", sockfd);
         Trigger trigger = (Trigger){
             .type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_DESCRIPTOR_READABLE};
-        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger, NULL)};
+        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger)};
     } else if (errcode < 0) {
         trace("TCP error when accepting connection on socket %i", sockfd);
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
@@ -502,7 +502,7 @@ SysCallReturn _syscallhandler_recvfromHelper(SysCallHandler* sys, int sockfd,
         /* We need to block until the descriptor is ready to read. */
         Trigger trigger = (Trigger){
             .type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_DESCRIPTOR_READABLE};
-        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger, NULL)};
+        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger)};
     }
 
     /* check if they wanted to know where we got the data from */
@@ -659,7 +659,7 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
             /* We need to block until the descriptor is ready to write. */
             Trigger trigger = (Trigger){
                 .type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_DESCRIPTOR_WRITABLE};
-            return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger, NULL)};
+            return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger)};
         } else {
             /* We attempted to write 0 bytes, so no need to block or return EWOULDBLOCK. */
             retval = 0;
@@ -848,7 +848,7 @@ SysCallReturn syscallhandler_connect(SysCallHandler* sys,
                           .object = desc,
                           .status = STATUS_DESCRIPTOR_ACTIVE | STATUS_DESCRIPTOR_WRITABLE};
             return (SysCallReturn){
-                .state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger, NULL)};
+                .state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger)};
         } else if (_syscallhandler_wasBlocked(sys) && errcode == -EISCONN) {
             /* It was EINPROGRESS, but is now a successful blocking connect. */
             errcode = 0;

--- a/src/main/host/syscall/time.c
+++ b/src/main/host/syscall/time.c
@@ -45,7 +45,7 @@ SysCallReturn syscallhandler_nanosleep(SysCallHandler* sys,
     int wasBlocked = _syscallhandler_wasBlocked(sys);
 
     if (requestToBlock && !wasBlocked) {
-        SysCallCondition* cond = syscallcondition_new((Trigger){.type = TRIGGER_NONE}, NULL);
+        SysCallCondition* cond = syscallcondition_new((Trigger){.type = TRIGGER_NONE});
         syscallcondition_setTimeout(cond, sys->host,
                                     worker_getEmulatedTime() + req.tv_sec * SIMTIME_ONE_SECOND +
                                         req.tv_nsec * SIMTIME_ONE_NANOSECOND);

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -193,7 +193,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
         /* We need to block until the descriptor is ready to write. */
         Trigger trigger = (Trigger){
             .type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_DESCRIPTOR_READABLE};
-        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger, NULL)};
+        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger)};
     }
 
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
@@ -309,7 +309,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
         /* We need to block until the descriptor is ready to write. */
         Trigger trigger = (Trigger){
             .type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_DESCRIPTOR_WRITABLE};
-        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger, NULL)};
+        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger)};
     }
 
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -168,7 +168,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd,
         /* We need to block until the descriptor is ready to read. */
         Trigger trigger = (Trigger){
             .type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_DESCRIPTOR_READABLE};
-        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger, NULL)};
+        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger)};
     }
 
     return (SysCallReturn){
@@ -261,7 +261,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd,
         /* We need to block until the descriptor is ready to write. */
         Trigger trigger = (Trigger){
             .type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_DESCRIPTOR_WRITABLE};
-        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger, NULL)};
+        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = syscallcondition_new(trigger)};
     }
 
     return (SysCallReturn){

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -10,6 +10,7 @@
 #include <sys/timerfd.h>
 
 #include "lib/logger/logger.h"
+#include "main/core/support/definitions.h"
 #include "main/core/worker.h"
 #include "main/host/descriptor/descriptor.h"
 #include "main/host/descriptor/descriptor_types.h"
@@ -458,3 +459,5 @@ void syscallcondition_cancel(SysCallCondition* cond) {
     _syscallcondition_cleanupListeners(cond);
     _syscallcondition_cleanupProc(cond);
 }
+
+Timer* syscallcondition_timeout(SysCallCondition* cond) { return cond->timeout; }

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -40,11 +40,11 @@ struct _SysCallCondition {
     MAGIC_DECLARE;
 };
 
-SysCallCondition* syscallcondition_new(Trigger trigger, Timer* timeout) {
+SysCallCondition* syscallcondition_new(Trigger trigger) {
     SysCallCondition* cond = malloc(sizeof(*cond));
 
     *cond = (SysCallCondition){
-        .timeout = timeout, .trigger = trigger, .referenceCount = 1, MAGIC_INITIALIZER};
+        .timeout = NULL, .trigger = trigger, .referenceCount = 1, MAGIC_INITIALIZER};
 
     /* We now hold refs to these objects. */
     if (cond->timeout) {

--- a/src/main/host/syscall_condition.h
+++ b/src/main/host/syscall_condition.h
@@ -67,4 +67,7 @@ void syscallcondition_waitNonblock(SysCallCondition* cond, Process* proc,
  * clearing any references to the process an thread given in wait(). */
 void syscallcondition_cancel(SysCallCondition* cond);
 
+/* Get the timer for the condition, or NULL if there isn't one. */
+Timer* syscallcondition_timeout(SysCallCondition* cond);
+
 #endif /* SRC_MAIN_HOST_SYSCALL_CONDITION_H_ */

--- a/src/main/host/syscall_condition.h
+++ b/src/main/host/syscall_condition.h
@@ -47,7 +47,8 @@ struct _Trigger {
  * The condition starts with a reference count of 1. */
 SysCallCondition* syscallcondition_new(Trigger trigger);
 
-/* Add a timeout to the condition. `t` is absolute emulated time, as returned by
+/* Add a timeout to the condition. At time `t`, the conditition will be triggered
+ * if it hasn't already. `t` is absolute emulated time, as returned by
  * `worker_getEmulatedTime`. */
 void syscallcondition_setTimeout(SysCallCondition* cond, Host* host, EmulatedTime t);
 
@@ -70,6 +71,6 @@ void syscallcondition_waitNonblock(SysCallCondition* cond, Process* proc,
 void syscallcondition_cancel(SysCallCondition* cond);
 
 /* Get the timer for the condition, or NULL if there isn't one. */
-Timer* syscallcondition_timeout(SysCallCondition* cond);
+Timer* syscallcondition_getTimeout(SysCallCondition* cond);
 
 #endif /* SRC_MAIN_HOST_SYSCALL_CONDITION_H_ */

--- a/src/main/host/syscall_condition.h
+++ b/src/main/host/syscall_condition.h
@@ -43,10 +43,12 @@ struct _Trigger {
 
 /* Create a new object that will cause a signal to be delivered to
  * a waiting process and thread, conditional upon the given trigger object
- * reaching the given status or the given timeout expiring.
+ * reaching the given status.
  * The condition starts with a reference count of 1. */
-SysCallCondition* syscallcondition_new(Trigger trigger, Timer* timeout);
+SysCallCondition* syscallcondition_new(Trigger trigger);
 
+/* Add a timeout to the condition. `t` is absolute emulated time, as returned by
+ * `worker_getEmulatedTime`. */
 void syscallcondition_setTimeout(SysCallCondition* cond, Host* host, EmulatedTime t);
 
 /* Increment the reference count on the given condition. */

--- a/src/main/host/syscall_condition.h
+++ b/src/main/host/syscall_condition.h
@@ -47,6 +47,8 @@ struct _Trigger {
  * The condition starts with a reference count of 1. */
 SysCallCondition* syscallcondition_new(Trigger trigger, Timer* timeout);
 
+void syscallcondition_setTimeout(SysCallCondition* cond, Host* host, EmulatedTime t);
+
 /* Increment the reference count on the given condition. */
 void syscallcondition_ref(SysCallCondition* cond);
 

--- a/src/main/host/syscall_condition.rs
+++ b/src/main/host/syscall_condition.rs
@@ -21,7 +21,7 @@ impl SysCallCondition {
     // implementation or wrapper.
     pub fn new(trigger: Trigger) -> Self {
         SysCallCondition {
-            c_ptr: unsafe { cshadow::syscallcondition_new(trigger.into(), std::ptr::null_mut()) },
+            c_ptr: unsafe { cshadow::syscallcondition_new(trigger.into()) },
         }
     }
 

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -77,5 +77,6 @@ Process* thread_getProcess(Thread* thread);
 Host* thread_getHost(Thread* thread);
 // Get the syscallhandler for this thread.
 SysCallHandler* thread_getSysCallHandler(Thread* thread);
+SysCallCondition* thread_getSysCallCondition(Thread* thread);
 
 #endif /* SRC_MAIN_HOST_SHD_THREAD_H_ */


### PR DESCRIPTION
This is primarily to make timeout handling easier to expose in Rust.

* Remove SyscallHandler::timer, since in practice it was redundant with SyscallCondition::timeout.
* Deduplicate code to read and validate a timespec