### PR TITLE
Set a few tests to log at debug level instead of trace

### DIFF
--- a/src/test/determinism/CMakeLists.txt
+++ b/src/test/determinism/CMakeLists.txt
@@ -10,12 +10,14 @@ foreach(METHOD ptrace preload)
     add_shadow_tests(
         BASENAME determinism1a
         METHODS ${METHOD}
+        LOGLEVEL debug
         SHADOW_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/determinism1.test.shadow.config.yaml
         ARGS --use-cpu-pinning true --parallelism 2
         PROPERTIES RUN_SERIAL TRUE)
     add_shadow_tests(
         BASENAME determinism1b
         METHODS ${METHOD}
+        LOGLEVEL debug
         SHADOW_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/determinism1.test.shadow.config.yaml
         ARGS --use-cpu-pinning true --parallelism 2
         PROPERTIES RUN_SERIAL TRUE)
@@ -45,12 +47,14 @@ foreach(METHOD ptrace preload)
     add_shadow_tests(
         BASENAME determinism2a
         METHODS ${METHOD}
+        LOGLEVEL debug
         SHADOW_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/determinism2.test.shadow.config.yaml
         ARGS --use-cpu-pinning true --parallelism 2
         PROPERTIES RUN_SERIAL TRUE)
     add_shadow_tests(
         BASENAME determinism2b
         METHODS ${METHOD}
+        LOGLEVEL debug
         SHADOW_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/determinism2.test.shadow.config.yaml
         ARGS --use-cpu-pinning true --parallelism 2
         PROPERTIES RUN_SERIAL TRUE)

--- a/src/test/epoll/CMakeLists.txt
+++ b/src/test/epoll/CMakeLists.txt
@@ -6,4 +6,4 @@ add_linux_tests(BASENAME epoll COMMAND test-epoll)
 add_shadow_tests(BASENAME epoll)
 
 add_executable(test-epoll-writeable test_epoll_writeable.c)
-add_shadow_tests(BASENAME epoll-writeable)
+add_shadow_tests(BASENAME epoll-writeable LOGLEVEL debug)

--- a/src/test/sockbuf/CMakeLists.txt
+++ b/src/test/sockbuf/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(test-sockbuf test_sockbuf.c ../test_common.c)
 add_linux_tests(BASENAME sockbuf COMMAND test-sockbuf)
-add_shadow_tests(BASENAME sockbuf)
+add_shadow_tests(BASENAME sockbuf LOGLEVEL debug)

--- a/src/test/socket/accept/CMakeLists.txt
+++ b/src/test/socket/accept/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_linux_tests(BASENAME accept COMMAND sh -c "../../target/debug/test_accept --libc-passing")
-add_shadow_tests(BASENAME accept)
+add_shadow_tests(BASENAME accept LOGLEVEL debug)

--- a/src/test/socket/sendto_recvfrom/CMakeLists.txt
+++ b/src/test/socket/sendto_recvfrom/CMakeLists.txt
@@ -1,14 +1,2 @@
 add_linux_tests(BASENAME sendto-recvfrom COMMAND sh -c "../../target/debug/test_sendto_recvfrom --libc-passing")
-add_shadow_tests(BASENAME sendto-recvfrom)
-
-# This test fails in shadow (debug mode) on centos 7 in the GitHub CI. The
-# cause of failure seems to be that centos 7 is about twice as slow as the
-# other distros, and debug mode causes so many debug log messages that it
-# exceeds the default timeout of 30 seconds. The test takes about 3 seconds
-# on a laptop with SSD. Due to shadow's small `SYSCALL_IO_BUFSIZE` size of
-# 16 KiB, the 'test_nonblocking_tcp' test needs to make a lot of
-# sendto()/recvfrom() calls before an EAGAIN is returned.
-set_property(TEST 
-                sendto-recvfrom-shadow-ptrace 
-                sendto-recvfrom-shadow-preload 
-            PROPERTY TIMEOUT 60)
+add_shadow_tests(BASENAME sendto-recvfrom LOGLEVEL debug)

--- a/src/test/socket/shutdown/CMakeLists.txt
+++ b/src/test/socket/shutdown/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_linux_tests(BASENAME shutdown COMMAND sh -c "../../target/debug/test_shutdown --libc-passing")
-add_shadow_tests(BASENAME shutdown)
+add_shadow_tests(BASENAME shutdown LOGLEVEL debug)


### PR DESCRIPTION
This reduces the size of `build/Testing/Temporary/LastTest.log` from 556 MiB to 203 MiB when shadow is built in debug mode, and should fix #1572. These tests generated the most log lines (> 50,000) in `LastTest.log`.