### PR TITLE
Re-enable shim-side syscalls in ptrace

### DIFF
--- a/src/lib/shim/preload_syscall.c
+++ b/src/lib/shim/preload_syscall.c
@@ -237,7 +237,7 @@ long shadow_vraw_syscall(long n, va_list args) {
         // No inter-process syscall needed, we handled it on the shim side! :)
         trace("Handled syscall %ld from the shim; we avoided inter-process overhead.", n);
         // rv was already set
-    } else if (shim_interpositionEnabled()) {
+    } else if (shim_interpositionEnabled() && shim_thisThreadEventIPC()) {
         // The syscall is made using the shmem IPC channel.
         trace("Making syscall %ld indirectly; we ask shadow to handle it using the shmem IPC "
               "channel.",

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -141,7 +141,7 @@ void shim_enableInterposition() {
 }
 
 bool shim_interpositionEnabled() {
-    return _using_interpose_preload && !*_shim_disable_interposition();
+    return !*_shim_disable_interposition();
 }
 
 bool shim_use_syscall_handler() { return _using_shim_syscall_handler; }


### PR DESCRIPTION
These were inadvertently disabled in 6bc81dbcaa, leading to a
performance regression in syscalls that can be serviced without a real
syscall (currently `clock_gettime`, `time`, and `gettimeofday`).