### PR TITLE
Use result of g_test_run

### DIFF
--- a/src/test/bindc/test_bind.c
+++ b/src/test/bindc/test_bind.c
@@ -254,6 +254,5 @@ int main(int argc, char* argv[]) {
     g_test_add_data_func("/bind/implicit_bind_stream_nonblock",
                          GUINT_TO_POINTER(SOCK_STREAM | SOCK_NONBLOCK),
                          &_test_implicit_bind);
-    g_test_run();
-    return EXIT_SUCCESS;
+    return g_test_run();
 }

--- a/src/test/epoll/test_epoll.c
+++ b/src/test/epoll/test_epoll.c
@@ -232,7 +232,5 @@ int main(int argc, char* argv[]) {
     g_test_add_func("/epoll/epoll_pipe_edgetrigger", _test_pipe_edgetrigger);
     // TODO: expand testing epoll on files, sockets, timerfd?
     // Note that the timerfd test already uses epoll extensively.
-    g_test_run();
-
-    return 0;
+    return g_test_run();
 }

--- a/src/test/file/test_file.c
+++ b/src/test/file/test_file.c
@@ -597,7 +597,5 @@ int main(int argc, char* argv[]) {
     //    TODO: debug and fix iov test
     //    g_test_add_func("/file/iov", _test_iov);
 
-    g_test_run();
-
-    return 0;
+    return g_test_run();
 }

--- a/src/test/futex/test_futex.c
+++ b/src/test/futex/test_futex.c
@@ -385,5 +385,5 @@ int main(int argc, char** argv) {
         g_test_add_func("/futex/wait_bitset", _futex_wait_bitset_test);
     }
 
-    g_test_run();
+    return g_test_run();
 }

--- a/src/test/timerfd/test_timerfd.c
+++ b/src/test/timerfd/test_timerfd.c
@@ -162,6 +162,5 @@ int main(int argc, char* argv[]) {
     g_test_add_func("/timerfd/expired_pause", _test_expired_timer_pause);
     g_test_add_func("/timerfd/disarm", _test_disarm_timer);
 
-    g_test_run();
-    return 0;
+    return g_test_run();
 }

--- a/src/test/udp/test_udp.c
+++ b/src/test/udp/test_udp.c
@@ -218,7 +218,7 @@ int main(int argc, char* argv[]) {
     };
 
     g_test_add_data_func("/udp/sendto_one_byte", &test_params, test_sendto_one_byte);
-    g_test_run();
+    int rv = g_test_run();
     g_strfreev(addr_parts);
-    return EXIT_SUCCESS;
+    return rv;
 }

--- a/src/test/udp/test_udp_uniprocess.c
+++ b/src/test/udp/test_udp_uniprocess.c
@@ -145,6 +145,5 @@ int main(int argc, char* argv[]) {
     g_test_add_func("/udp_uniprocess/getaddrinfo", test_getaddrinfo);
     g_test_add_func("/udp_uniprocess/sendto_one_byte", test_sendto_one_byte);
     g_test_add_func("/udp_uniprocess/echo", test_echo);
-    g_test_run();
-    return EXIT_SUCCESS;
+    return g_test_run();
 }


### PR DESCRIPTION
Many tests were ignoring the result of g_test_run. This means if a test
was marked as failing through a gunit macro (vs just crashing), the
process would still return 0 and the ctest would still pass.