### PR TITLE
Partially support sys_clock_nanosleep

### DIFF
--- a/src/main/host/syscall/time.c
+++ b/src/main/host/syscall/time.c
@@ -77,6 +77,11 @@ SysCallReturn syscallhandler_clock_gettime(SysCallHandler* sys,
     trace("syscallhandler_clock_gettime with %d %p", clk_id,
           GUINT_TO_POINTER(args->args[1].as_ptr.val));
 
+    if (clk_id == CLOCK_PROCESS_CPUTIME_ID || clk_id == CLOCK_THREAD_CPUTIME_ID) {
+        warning("Unsupported clock ID %d during gettime", clk_id);
+        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+    }
+
     /* Make sure they didn't pass a NULL pointer. */
     if (!args->args[1].as_ptr.val) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};

--- a/src/main/host/syscall/time.h
+++ b/src/main/host/syscall/time.h
@@ -9,6 +9,7 @@
 #include "main/host/syscall/protected.h"
 
 SYSCALL_HANDLER(clock_gettime);
+SYSCALL_HANDLER(clock_nanosleep);
 SYSCALL_HANDLER(gettimeofday);
 SYSCALL_HANDLER(nanosleep);
 SYSCALL_HANDLER(time);

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -265,6 +265,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         HANDLE(bind);
         HANDLE(brk);
         HANDLE(clock_gettime);
+        HANDLE(clock_nanosleep);
         HANDLE(clone);
         HANDLE_RUST(close);
         HANDLE(connect);

--- a/src/test/sleep/test_sleep.rs
+++ b/src/test/sleep/test_sleep.rs
@@ -9,10 +9,11 @@ type SleepFn<'a> = (fn(u32), &'a str);
 type TimeFn<'a> = (fn() -> std::time::Duration, &'a str);
 
 fn main() {
-    let sleep_fns: [SleepFn; 3] = [
+    let sleep_fns: [SleepFn; 4] = [
         (sleep, "sleep"),
         (usleep, "usleep"),
         (nanosleep, "nanosleep"),
+        (clock_nanosleep, "clock_nanosleep"),
     ];
     let time_fns: [TimeFn; 2] = [
         (call_clock_gettime, "call_clock_gettime"),
@@ -73,6 +74,18 @@ fn nanosleep(seconds: u32) {
     let rv;
     unsafe {
         rv = libc::nanosleep(&stop, std::ptr::null_mut());
+    }
+    assert_eq!(rv, 0);
+}
+
+fn clock_nanosleep(seconds: u32) {
+    let stop = libc::timespec {
+        tv_sec: seconds as i64,
+        tv_nsec: 0,
+    };
+    let rv;
+    unsafe {
+        rv = libc::clock_nanosleep(libc::CLOCK_MONOTONIC, 0, &stop, std::ptr::null_mut());
     }
     assert_eq!(rv, 0);
 }


### PR DESCRIPTION
Support `sys_clock_nanosleep` when there are no flags and when using only the realtime or monotonic clocks.