### PR TITLE
Make the pcap directory relative to the host directory

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -485,7 +485,10 @@ Type: String OR null
 Where to save the pcap files (relative to the host directory).
 
 Logs all network input and output for this host in PCAP format (for viewing in
-e.g. wireshark).
+e.g. wireshark). The directory must already exist and be relative to the host
+directory, although absolute paths are also allowed. Example:
+`pcap_directory: '.'` will generate pcap files such as
+`shadow.data/hosts/myhost/myhost-11.0.0.1.pcap`.
 
 #### `hosts`
 

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -186,13 +186,24 @@ void host_setup(Host* host, DNS* dns, guint rawCPUFreq, const gchar* hostRootPat
     guint64 bwDownKiBps = host->params.requestedBwDownBits / (8 * 1024);
     guint64 bwUpKiBps = host->params.requestedBwUpBits / (8 * 1024);
 
+    char* pcapDir = NULL;
+    if (host->params.pcapDir != NULL) {
+        if (g_path_is_absolute(host->params.pcapDir)) {
+            pcapDir = g_strdup(host->params.pcapDir);
+        } else {
+            pcapDir = g_build_path("/", host_getDataPath(host), host->params.pcapDir, NULL);
+        }
+    }
+
     /* virtual addresses and interfaces for managing network I/O */
     NetworkInterface* loopback =
-        networkinterface_new(host, loopbackAddress, G_MAXUINT32, G_MAXUINT32, host->params.pcapDir,
+        networkinterface_new(host, loopbackAddress, G_MAXUINT32, G_MAXUINT32, pcapDir,
                              host->params.qdisc, host->params.interfaceBufSize);
     NetworkInterface* ethernet =
-        networkinterface_new(host, ethernetAddress, bwDownKiBps, bwUpKiBps, host->params.pcapDir,
+        networkinterface_new(host, ethernetAddress, bwDownKiBps, bwUpKiBps, pcapDir,
                              host->params.qdisc, host->params.interfaceBufSize);
+
+    g_free(pcapDir);
 
     g_hash_table_replace(
         host->interfaces, GUINT_TO_POINTER((guint)address_toNetworkIP(ethernetAddress)), ethernet);


### PR DESCRIPTION
The documentation previously stated that the pcap directory was relative to the host directory, but this wasn't true. This PR fixes the code to follow the documentation. We could remove this directory option and make it an on/off option with a fixed path, but I don't think it hurts to leave the directory as an option if someone wants to use it.