### PR TITLE
Make preload the default interposition mechanism

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -293,7 +293,7 @@ The queueing discipline to use at the network interface.
 
 #### `experimental.interpose_method`
 
-Default: "ptrace"  
+Default: "preload"  
 Type: "ptrace" OR "preload"
 
 Which interposition method to use.

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -375,7 +375,7 @@ impl Default for ExperimentalOptions {
             use_memory_manager: Some(true),
             use_shim_syscall_handler: Some(true),
             use_cpu_pinning: Some(true),
-            interpose_method: Some(InterposeMethod::Ptrace),
+            interpose_method: Some(InterposeMethod::Preload),
             runahead: None,
             scheduler_policy: Some(SchedulerPolicy::Host),
             socket_send_buffer: Some(units::Bytes::new(131_072, units::SiPrefixUpper::Base)),


### PR DESCRIPTION
Preload-based interposition is now fairly stable, and is significantly
faster than ptrace. It is now the most sensible default.

Closes #1647