### PR TITLE
Improve the descriptor close process

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -458,6 +458,9 @@ void descriptortable_set(struct DescriptorTable *table,
 // TODO: remove this once the TCP layer is better designed.
 void descriptortable_shutdownHelper(struct DescriptorTable *table);
 
+// Close all descriptors. The `host` option is a legacy option for legacy descriptors.
+void descriptortable_removeAndCloseAll(struct DescriptorTable *table, Host *host);
+
 // The new compat descriptor takes ownership of the reference to the legacy descriptor and
 // does not increment its ref count, but will decrement the ref count when this compat
 // descriptor is freed/dropped.

--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -31,6 +31,7 @@ add_custom_command(OUTPUT wrapper.rs
 
         --whitelist-function "affinity_.*"
         --whitelist-function "thread_.*"
+        --whitelist-function "descriptor_close"
         --whitelist-function "descriptor_unref"
         --whitelist-function "descriptor_setHandle"
         --whitelist-function "descriptor_shutdownHelper"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1056,6 +1056,9 @@ extern "C" {
     pub fn descriptor_unref(data: gpointer);
 }
 extern "C" {
+    pub fn descriptor_close(descriptor: *mut LegacyDescriptor, host: *mut Host);
+}
+extern "C" {
     pub fn descriptor_setHandle(descriptor: *mut LegacyDescriptor, handle: gint);
 }
 extern "C" {

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -488,9 +488,8 @@ extern "C" {
     pub fn return_code_for_signal(signal: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 pub type LegacyDescriptor = [u64; 7usize];
-pub type DescriptorCloseFunc = ::std::option::Option<
-    unsafe extern "C" fn(descriptor: *mut LegacyDescriptor, host: *mut Host) -> gboolean,
->;
+pub type DescriptorCloseFunc =
+    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor, host: *mut Host)>;
 pub type DescriptorCleanupFunc =
     ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor)>;
 pub type DescriptorFreeFunc =

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -491,6 +491,8 @@ pub type LegacyDescriptor = [u64; 7usize];
 pub type DescriptorCloseFunc = ::std::option::Option<
     unsafe extern "C" fn(descriptor: *mut LegacyDescriptor, host: *mut Host) -> gboolean,
 >;
+pub type DescriptorCleanupFunc =
+    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor)>;
 pub type DescriptorFreeFunc =
     ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor)>;
 pub type SysCallHandler = _SysCallHandler;
@@ -1086,6 +1088,7 @@ pub type TransportReceiveFunc = ::std::option::Option<
 #[derive(Debug, Copy, Clone)]
 pub struct _TransportFunctionTable {
     pub close: DescriptorCloseFunc,
+    pub cleanup: DescriptorCleanupFunc,
     pub free: DescriptorFreeFunc,
     pub send: TransportSendFunc,
     pub receive: TransportReceiveFunc,
@@ -1095,7 +1098,7 @@ pub struct _TransportFunctionTable {
 fn bindgen_test_layout__TransportFunctionTable() {
     assert_eq!(
         ::std::mem::size_of::<_TransportFunctionTable>(),
-        40usize,
+        48usize,
         concat!("Size of: ", stringify!(_TransportFunctionTable))
     );
     assert_eq!(
@@ -1114,8 +1117,18 @@ fn bindgen_test_layout__TransportFunctionTable() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<_TransportFunctionTable>())).free as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<_TransportFunctionTable>())).cleanup as *const _ as usize },
         8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_TransportFunctionTable),
+            "::",
+            stringify!(cleanup)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<_TransportFunctionTable>())).free as *const _ as usize },
+        16usize,
         concat!(
             "Offset of field: ",
             stringify!(_TransportFunctionTable),
@@ -1125,7 +1138,7 @@ fn bindgen_test_layout__TransportFunctionTable() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_TransportFunctionTable>())).send as *const _ as usize },
-        16usize,
+        24usize,
         concat!(
             "Offset of field: ",
             stringify!(_TransportFunctionTable),
@@ -1135,7 +1148,7 @@ fn bindgen_test_layout__TransportFunctionTable() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_TransportFunctionTable>())).receive as *const _ as usize },
-        24usize,
+        32usize,
         concat!(
             "Offset of field: ",
             stringify!(_TransportFunctionTable),
@@ -1145,7 +1158,7 @@ fn bindgen_test_layout__TransportFunctionTable() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_TransportFunctionTable>())).magic as *const _ as usize },
-        32usize,
+        40usize,
         concat!(
             "Offset of field: ",
             stringify!(_TransportFunctionTable),

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -111,7 +111,7 @@ static void _scheduler_finishTaskFn(void* voidScheduler) {
     if(scheduler->policy->getAssignedHosts) {
         myHosts = scheduler->policy->getAssignedHosts(scheduler->policy);
     }
-    worker_finish(myHosts);
+    worker_finish(myHosts, scheduler->endTime);
 }
 
 Scheduler* scheduler_new(Manager* manager, SchedulerPolicyType policyType,

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -472,7 +472,9 @@ void worker_runEvent(Event* event) {
     worker_setCurrentTime(SIMTIME_INVALID);
 }
 
-void worker_finish(GQueue* hosts) {
+void worker_finish(GQueue* hosts, SimulationTime time) {
+    worker_setCurrentTime(time);
+
     if (hosts) {
         guint nHosts = g_queue_get_length(hosts);
         info("starting to shut down %u hosts", nHosts);
@@ -480,6 +482,9 @@ void worker_finish(GQueue* hosts) {
         g_queue_foreach(hosts, (GFunc)_worker_shutdownHost, NULL);
         info("%u hosts are shut down", nHosts);
     }
+
+    _worker_setLastEventTime(worker_getCurrentTime());
+    worker_setCurrentTime(SIMTIME_INVALID);
 
     /* cleanup is all done, send counters to manager */
     WorkerPool* pool = _worker_pool();

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -34,7 +34,7 @@ typedef void (*WorkerPoolTaskFn)(void*);
 // To be called by scheduler. Consumes `event`
 void worker_runEvent(Event* event);
 // To be called by worker thread
-void worker_finish(GQueue* hosts);
+void worker_finish(GQueue* hosts, SimulationTime time);
 
 // Create a workerpool with `nThreads` threads, allowing up to `nConcurrent` to
 // run at a time.

--- a/src/main/host/descriptor/channel.c
+++ b/src/main/host/descriptor/channel.c
@@ -38,7 +38,7 @@ static Channel* _channel_fromLegacyDescriptor(LegacyDescriptor* descriptor) {
     return (Channel*)descriptor;
 }
 
-static gboolean channel_close(LegacyDescriptor* descriptor, Host* host) {
+static void channel_close(LegacyDescriptor* descriptor, Host* host) {
     Channel* channel = _channel_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(channel);
     /* tell our link that we are done */
@@ -52,9 +52,6 @@ static gboolean channel_close(LegacyDescriptor* descriptor, Host* host) {
         descriptor_unref(&channel->linkedChannel->super.super);
         channel->linkedChannel = NULL;
     }
-
-    /* host can stop monitoring us for changes */
-    return TRUE;
 }
 
 static void channel_free(LegacyDescriptor* descriptor) {

--- a/src/main/host/descriptor/channel.c
+++ b/src/main/host/descriptor/channel.c
@@ -187,8 +187,7 @@ static gssize channel_receiveUserData(Transport* transport, Thread* thread, Plug
 }
 
 TransportFunctionTable channel_functions = {
-    channel_close, channel_free, channel_sendUserData, channel_receiveUserData,
-    MAGIC_VALUE};
+    channel_close, NULL, channel_free, channel_sendUserData, channel_receiveUserData, MAGIC_VALUE};
 
 Channel* channel_new(ChannelType type, LegacyDescriptorType dtype) {
     Channel* channel = g_new0(Channel, 1);

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -286,11 +286,7 @@ void descriptor_removeFlags(LegacyDescriptor* descriptor, gint flags) {
 void descriptor_shutdownHelper(LegacyDescriptor* legacyDesc) {
     MAGIC_ASSERT(legacyDesc);
 
-    if (legacyDesc->type == DT_TCPSOCKET) {
-        /* tcp servers and their children holds refs to each other. make
-         * sure they all get freed by removing the refs in one direction */
-        tcp_clearAllChildrenIfServer((TCP*)legacyDesc);
-    } else if (legacyDesc->type == DT_UNIXSOCKET || legacyDesc->type == DT_PIPE) {
+    if (legacyDesc->type == DT_UNIXSOCKET || legacyDesc->type == DT_PIPE) {
         /* we need to correctly update the linked channel refs */
         channel_setLinkedChannel((Channel*)legacyDesc, NULL);
     } else if (legacyDesc->type == DT_EPOLL) {

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -120,7 +120,9 @@ void descriptor_close(LegacyDescriptor* descriptor, Host* host) {
     MAGIC_ASSERT(descriptor->funcTable);
     trace("Descriptor %i calling vtable close now", descriptor->handle);
     descriptor_adjustStatus(descriptor, STATUS_DESCRIPTOR_CLOSED, TRUE);
-    if (descriptor->funcTable->close(descriptor, host) && descriptor->ownerProcess) {
+
+    descriptor->funcTable->close(descriptor, host);
+    if (descriptor->ownerProcess) {
         process_deregisterLegacyDescriptor(descriptor->ownerProcess, descriptor);
     }
 }

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -122,9 +122,6 @@ void descriptor_close(LegacyDescriptor* descriptor, Host* host) {
     descriptor_adjustStatus(descriptor, STATUS_DESCRIPTOR_CLOSED, TRUE);
 
     descriptor->funcTable->close(descriptor, host);
-    if (descriptor->ownerProcess) {
-        process_deregisterLegacyDescriptor(descriptor->ownerProcess, descriptor);
-    }
 }
 
 gint descriptor_compare(const LegacyDescriptor* foo, const LegacyDescriptor* bar, gpointer user_data) {

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -23,6 +23,8 @@ void descriptor_clear(LegacyDescriptor* descriptor);
 
 void descriptor_ref(gpointer data);
 void descriptor_unref(gpointer data);
+void descriptor_refWeak(gpointer data);
+void descriptor_unrefWeak(gpointer data);
 void descriptor_close(LegacyDescriptor* descriptor, Host* host);
 gint descriptor_compare(const LegacyDescriptor* foo, const LegacyDescriptor* bar, gpointer user_data);
 

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -131,10 +131,22 @@ impl DescriptorTable {
             };
         }
     }
+
+    /// Remove and return all descriptors.
+    pub fn remove_all<'a>(&mut self) -> impl Iterator<Item = CompatDescriptor> {
+        // reset the descriptor table
+        let mut old_self = std::mem::replace(self, Self::new());
+        // return the old descriptors
+        for desc in old_self.descriptors.values_mut() {
+            desc.set_handle(None);
+        }
+        old_self.descriptors.into_values()
+    }
 }
 
 mod export {
     use super::*;
+    use crate::host::descriptor::EventQueue;
     use libc::c_int;
 
     /// Create an object that can be used to store all descriptors created by a
@@ -193,7 +205,6 @@ mod export {
         let table = unsafe { table.as_mut().unwrap() };
         match table.remove(index.try_into().unwrap()) {
             Some(d) => CompatDescriptor::into_raw(Box::new(d)),
-
             None => std::ptr::null_mut(),
         }
     }
@@ -244,5 +255,20 @@ mod export {
     pub unsafe extern "C" fn descriptortable_shutdownHelper(table: *mut DescriptorTable) {
         let table = unsafe { table.as_mut().unwrap() };
         table.shutdown_helper();
+    }
+
+    /// Close all descriptors. The `host` option is a legacy option for legacy descriptors.
+    #[no_mangle]
+    pub unsafe extern "C" fn descriptortable_removeAndCloseAll(
+        table: *mut DescriptorTable,
+        host: *mut cshadow::Host,
+    ) {
+        let table = unsafe { table.as_mut().unwrap() };
+
+        EventQueue::queue_and_run(|event_queue| {
+            for desc in table.remove_all() {
+                desc.close(host, event_queue);
+            }
+        });
     }
 }

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -49,7 +49,7 @@ impl DescriptorTable {
             idx
         };
 
-        descriptor.set_handle(idx);
+        descriptor.set_handle(Some(idx));
         let prev = self.descriptors.insert(idx, descriptor);
         debug_assert!(prev.is_none(), "Already a descriptor at {}", idx);
 
@@ -81,7 +81,7 @@ impl DescriptorTable {
         self.available_indices.insert(idx);
         self.trim_tail();
         if let Some(descriptor) = &mut maybe_descriptor {
-            descriptor.set_handle(0);
+            descriptor.set_handle(None);
         }
         maybe_descriptor
     }
@@ -98,7 +98,7 @@ impl DescriptorTable {
         index: u32,
         mut descriptor: CompatDescriptor,
     ) -> Option<CompatDescriptor> {
-        descriptor.set_handle(index);
+        descriptor.set_handle(Some(index));
 
         // We ensure the index is no longer in `self.available_indices`. We *don't* ensure
         // `self.next_index` is > `index`, since that'd require adding the indices in between to
@@ -108,7 +108,7 @@ impl DescriptorTable {
 
         if let Some(mut prev) = self.descriptors.insert(index, descriptor) {
             trace!("Overwriting index {}", index);
-            prev.set_handle(0);
+            prev.set_handle(None);
             Some(prev)
         } else {
             trace!("Setting to unused index {}", index);

--- a/src/main/host/descriptor/descriptor_types.h
+++ b/src/main/host/descriptor/descriptor_types.h
@@ -28,11 +28,7 @@ typedef struct _LegacyDescriptor LegacyDescriptor;
 typedef struct _DescriptorFunctionTable DescriptorFunctionTable;
 
 /* required functions */
-
-/* Returns TRUE if the descriptor should be deregistered from the owning
- * process upon return from the function, FALSE if the child will handle
- * deregistration on its own. */
-typedef gboolean (*DescriptorCloseFunc)(LegacyDescriptor* descriptor, Host* host);
+typedef void (*DescriptorCloseFunc)(LegacyDescriptor* descriptor, Host* host);
 typedef void (*DescriptorCleanupFunc)(LegacyDescriptor* descriptor);
 typedef void (*DescriptorFreeFunc)(LegacyDescriptor* descriptor);
 

--- a/src/main/host/descriptor/descriptor_types.h
+++ b/src/main/host/descriptor/descriptor_types.h
@@ -33,6 +33,7 @@ typedef struct _DescriptorFunctionTable DescriptorFunctionTable;
  * process upon return from the function, FALSE if the child will handle
  * deregistration on its own. */
 typedef gboolean (*DescriptorCloseFunc)(LegacyDescriptor* descriptor, Host* host);
+typedef void (*DescriptorCleanupFunc)(LegacyDescriptor* descriptor);
 typedef void (*DescriptorFreeFunc)(LegacyDescriptor* descriptor);
 
 /*
@@ -41,6 +42,7 @@ typedef void (*DescriptorFreeFunc)(LegacyDescriptor* descriptor);
  */
 struct _DescriptorFunctionTable {
     DescriptorCloseFunc close;
+    DescriptorCleanupFunc cleanup;
     DescriptorFreeFunc free;
     MAGIC_DECLARE;
 };
@@ -52,7 +54,8 @@ struct _LegacyDescriptor {
     LegacyDescriptorType type;
     Status status;
     GHashTable* listeners;
-    gint referenceCount;
+    gint refCountStrong;
+    gint refCountWeak;
     gint flags;
     // Since this structure is shared with Rust, we should always include the magic struct
     // member so that the struct is always the same size regardless of compile-time options.

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -310,11 +310,10 @@ void epoll_reset(Epoll* epoll) {
     g_hash_table_remove_all(epoll->watching);
 }
 
-static gboolean _epoll_close(LegacyDescriptor* descriptor, Host* host) {
+static void _epoll_close(LegacyDescriptor* descriptor, Host* host) {
     Epoll* epoll = _epoll_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(epoll);
     epoll_clearWatchListeners(epoll);
-    return TRUE;
 }
 
 DescriptorFunctionTable epollFunctions = {

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -217,13 +217,15 @@ static EpollWatch* _epollwatch_new(Epoll* epoll, int fd, EpollWatchTypes type,
 static void _epollwatch_free(EpollWatch* watch) {
     MAGIC_ASSERT(watch);
 
-    statuslistener_unref(watch->listener);
-
     if (watch->watchType == EWT_LEGACY_DESCRIPTOR) {
+        descriptor_removeListener(watch->watchObject.as_descriptor, watch->listener);
         descriptor_unref(watch->watchObject.as_descriptor);
     } else if (watch->watchType == EWT_POSIX_FILE) {
+        posixfile_removeListener(watch->watchObject.as_file, watch->listener);
         posixfile_drop(watch->watchObject.as_file);
     }
+
+    statuslistener_unref(watch->listener);
 
     MAGIC_CLEAR(watch);
     g_free(watch);

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -318,7 +318,7 @@ static gboolean _epoll_close(LegacyDescriptor* descriptor, Host* host) {
 }
 
 DescriptorFunctionTable epollFunctions = {
-    _epoll_close, _epoll_free, MAGIC_VALUE};
+    _epoll_close, NULL, _epoll_free, MAGIC_VALUE};
 
 Epoll* epoll_new() {
     Epoll* epoll = g_new0(Epoll, 1);

--- a/src/main/host/descriptor/eventd.c
+++ b/src/main/host/descriptor/eventd.c
@@ -57,7 +57,7 @@ static void _eventd_free(LegacyDescriptor* descriptor) {
     worker_count_deallocation(EventD);
 }
 
-static DescriptorFunctionTable _eventdFunctions = {_eventd_close, _eventd_free, MAGIC_VALUE};
+static DescriptorFunctionTable _eventdFunctions = {_eventd_close, NULL, _eventd_free, MAGIC_VALUE};
 
 static void _eventd_updateStatus(EventD* eventd) {
     // Set the descriptor as readable if we have a non-zero counter.

--- a/src/main/host/descriptor/eventd.c
+++ b/src/main/host/descriptor/eventd.c
@@ -30,7 +30,7 @@ static EventD* _eventfd_fromLegacyDescriptor(LegacyDescriptor* descriptor) {
     return (EventD*)descriptor;
 }
 
-static gboolean _eventd_close(LegacyDescriptor* descriptor, Host* host) {
+static void _eventd_close(LegacyDescriptor* descriptor, Host* host) {
     EventD* eventd = _eventfd_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(eventd);
 
@@ -38,12 +38,6 @@ static gboolean _eventd_close(LegacyDescriptor* descriptor, Host* host) {
 
     eventd->is_closed = true;
     descriptor_adjustStatus(&(eventd->super), STATUS_DESCRIPTOR_ACTIVE, FALSE);
-
-    if (eventd->super.handle > 0) {
-        return TRUE; // deregister from process
-    } else {
-        return FALSE; // we are not owned by a process
-    }
 }
 
 static void _eventd_free(LegacyDescriptor* descriptor) {

--- a/src/main/host/descriptor/file.c
+++ b/src/main/host/descriptor/file.c
@@ -98,7 +98,7 @@ static void _file_closeHelper(File* file) {
     }
 }
 
-static gboolean _file_close(LegacyDescriptor* desc, Host* host) {
+static void _file_close(LegacyDescriptor* desc, Host* host) {
     File* file = _file_descriptorToFile(desc);
 
     trace("Closing file %i with os-backed file %i", _file_getFD(file),
@@ -106,10 +106,6 @@ static gboolean _file_close(LegacyDescriptor* desc, Host* host) {
 
     /* Make sure we mimic the close on the OS-backed file now. */
     _file_closeHelper(file);
-
-    /* tell the host to stop tracking us, and unref the descriptor.
-     * this should trigger _file_free in most cases. */
-    return TRUE;
 }
 
 static void _file_free(LegacyDescriptor* desc) {

--- a/src/main/host/descriptor/file.c
+++ b/src/main/host/descriptor/file.c
@@ -133,6 +133,7 @@ static void _file_free(LegacyDescriptor* desc) {
 
 static DescriptorFunctionTable _fileFunctions = (DescriptorFunctionTable){
     .close = _file_close,
+    .cleanup = NULL,
     .free = _file_free,
 };
 

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -452,9 +452,13 @@ impl CompatDescriptor {
 
     /// Update the handle.
     /// This is a no-op for non-legacy descriptors.
-    pub fn set_handle(&mut self, handle: u32) {
+    pub fn set_handle(&mut self, handle: Option<u32>) {
         if let CompatDescriptor::Legacy(d) = self {
-            unsafe { c::descriptor_setHandle(d.ptr(), handle.try_into().unwrap()) }
+            let handle = match handle {
+                Some(x) => x.try_into().unwrap(),
+                None => -1,
+            };
+            unsafe { c::descriptor_setHandle(d.ptr(), handle) }
         }
         // new descriptor types don't store their file handle, so do nothing
     }

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -462,6 +462,17 @@ impl CompatDescriptor {
         }
         // new descriptor types don't store their file handle, so do nothing
     }
+
+    /// Close the descriptor. The `host` option is a legacy option for legacy descriptors.
+    pub fn close(self, host: *mut c::Host, event_queue: &mut EventQueue) -> Option<SyscallResult> {
+        match self {
+            Self::New(desc) => desc.close(event_queue),
+            Self::Legacy(desc) => {
+                unsafe { c::descriptor_close(desc.ptr(), host) };
+                Some(Ok(0.into()))
+            }
+        }
+    }
 }
 
 mod export {

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -77,7 +77,7 @@ static void _socket_free(LegacyDescriptor* descriptor) {
     socket->vtable->free((LegacyDescriptor*)socket);
 }
 
-static gboolean _socket_close(LegacyDescriptor* descriptor, Host* host) {
+static void _socket_close(LegacyDescriptor* descriptor, Host* host) {
     Socket* socket = _socket_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(socket);
     MAGIC_ASSERT(socket->vtable);
@@ -85,7 +85,7 @@ static gboolean _socket_close(LegacyDescriptor* descriptor, Host* host) {
     Tracker* tracker = host_getTracker(host);
     tracker_removeSocket(tracker, descriptor_getHandle(descriptor));
 
-    return socket->vtable->close((LegacyDescriptor*)socket, host);
+    socket->vtable->close((LegacyDescriptor*)socket, host);
 }
 
 static gssize _socket_sendUserData(Transport* transport, Thread* thread, PluginVirtualPtr buffer,

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -29,6 +29,16 @@ static Socket* _socket_fromLegacyDescriptor(LegacyDescriptor* descriptor) {
     return (Socket*)descriptor;
 }
 
+static void _socket_cleanup(LegacyDescriptor* descriptor) {
+    Socket* socket = _socket_fromLegacyDescriptor(descriptor);
+    MAGIC_ASSERT(socket);
+    MAGIC_ASSERT(socket->vtable);
+
+    if (socket->vtable->cleanup) {
+        socket->vtable->cleanup(descriptor);
+    }
+}
+
 static void _socket_free(LegacyDescriptor* descriptor) {
     Socket* socket = _socket_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(socket);
@@ -95,8 +105,8 @@ static gssize _socket_receiveUserData(Transport* transport, Thread* thread, Plug
 }
 
 TransportFunctionTable socket_functions = {
-    _socket_close, _socket_free, _socket_sendUserData, _socket_receiveUserData,
-    MAGIC_VALUE};
+    _socket_close,        _socket_cleanup,         _socket_free,
+    _socket_sendUserData, _socket_receiveUserData, MAGIC_VALUE};
 
 void socket_init(Socket* socket, Host* host, SocketFunctionTable* vtable, LegacyDescriptorType type,
                  guint receiveBufferSize, guint sendBufferSize) {

--- a/src/main/host/descriptor/socket.h
+++ b/src/main/host/descriptor/socket.h
@@ -28,6 +28,7 @@ typedef void (*SocketDropFunc)(Socket* socket, Host* host, Packet* packet);
 
 struct _SocketFunctionTable {
     DescriptorCloseFunc close;
+    DescriptorCleanupFunc cleanup;
     DescriptorFreeFunc free;
     TransportSendFunc send;
     TransportReceiveFunc receive;

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -670,6 +670,8 @@ static void _tcp_setState(TCP* tcp, Host* host, enum TCPState state) {
                     /* if i was the server's last child and its waiting to close, close it */
                     if((parent->state == TCPS_CLOSED) && (g_hash_table_size(parent->server->children) <= 0)) {
                         /* this will unbind from the network interface and free socket */
+                        CompatSocket compat_socket = compatsocket_fromLegacySocket(&parent->super);
+                        host_disassociateInterface(host, &compat_socket);
                         LegacyDescriptor* parentDesc = (LegacyDescriptor*)parent;
                         process_deregisterLegacyDescriptor(
                             descriptor_getOwnerProcess(parentDesc), parentDesc);
@@ -677,6 +679,8 @@ static void _tcp_setState(TCP* tcp, Host* host, enum TCPState state) {
                 }
 
                 /* this will unbind from the network interface and free socket */
+                CompatSocket compat_socket = compatsocket_fromLegacySocket(&tcp->super);
+                host_disassociateInterface(host, &compat_socket);
                 LegacyDescriptor* desc = (LegacyDescriptor*)tcp;
                 process_deregisterLegacyDescriptor(
                     descriptor_getOwnerProcess(desc), desc);

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -658,7 +658,8 @@ static void _tcp_setState(TCP* tcp, Host* host, enum TCPState state) {
              * servers have to wait for all children to close.
              * children need to notify their parents when closing.
              */
-            if(!tcp->server || g_hash_table_size(tcp->server->children) <= 0) {
+            if (!tcp->server || !tcp->server->children ||
+                g_hash_table_size(tcp->server->children) <= 0) {
                 if(tcp->child && tcp->child->parent) {
                     TCP* parent = tcp->child->parent;
                     utility_assert(parent->server);

--- a/src/main/host/descriptor/timer.c
+++ b/src/main/host/descriptor/timer.c
@@ -69,7 +69,7 @@ static void _timer_free(LegacyDescriptor* descriptor) {
 }
 
 static DescriptorFunctionTable _timerFunctions = {
-    _timer_close, _timer_free, MAGIC_VALUE};
+    _timer_close, NULL, _timer_free, MAGIC_VALUE};
 
 Timer* timer_new() {
     Timer* timer = g_new0(Timer, 1);

--- a/src/main/host/descriptor/timer.c
+++ b/src/main/host/descriptor/timer.c
@@ -46,17 +46,12 @@ static Timer* _timer_fromLegacyDescriptor(LegacyDescriptor* descriptor) {
     return (Timer*)descriptor;
 }
 
-static gboolean _timer_close(LegacyDescriptor* descriptor, Host* host) {
+static void _timer_close(LegacyDescriptor* descriptor, Host* host) {
     Timer* timer = _timer_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(timer);
     trace("timer fd %i closing now", timer->super.handle);
     timer->isClosed = TRUE;
     descriptor_adjustStatus(&(timer->super), STATUS_DESCRIPTOR_ACTIVE, FALSE);
-    if (timer->super.handle > 0) {
-        return TRUE; // deregister from process
-    } else {
-        return FALSE; // we are not owned by a process
-    }
 }
 
 static void _timer_free(LegacyDescriptor* descriptor) {

--- a/src/main/host/descriptor/transport.c
+++ b/src/main/host/descriptor/transport.c
@@ -43,11 +43,11 @@ static void _transport_free(LegacyDescriptor* descriptor) {
     transport->vtable->free(descriptor);
 }
 
-static gboolean _transport_close(LegacyDescriptor* descriptor, Host* host) {
+static void _transport_close(LegacyDescriptor* descriptor, Host* host) {
     Transport* transport = _transport_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(transport);
     MAGIC_ASSERT(transport->vtable);
-    return transport->vtable->close(descriptor, host);
+    transport->vtable->close(descriptor, host);
 }
 
 DescriptorFunctionTable transport_functions = {

--- a/src/main/host/descriptor/transport.c
+++ b/src/main/host/descriptor/transport.c
@@ -21,6 +21,16 @@ static Transport* _transport_fromLegacyDescriptor(LegacyDescriptor* descriptor) 
     return (Transport*)descriptor;
 }
 
+static void _transport_cleanup(LegacyDescriptor* descriptor) {
+    Transport* transport = _transport_fromLegacyDescriptor(descriptor);
+    MAGIC_ASSERT(transport);
+    MAGIC_ASSERT(transport->vtable);
+
+    if (transport->vtable->cleanup) {
+        transport->vtable->cleanup(descriptor);
+    }
+}
+
 static void _transport_free(LegacyDescriptor* descriptor) {
     Transport* transport = _transport_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(transport);
@@ -41,7 +51,7 @@ static gboolean _transport_close(LegacyDescriptor* descriptor, Host* host) {
 }
 
 DescriptorFunctionTable transport_functions = {
-    _transport_close, _transport_free, MAGIC_VALUE};
+    _transport_close, _transport_cleanup, _transport_free, MAGIC_VALUE};
 
 void transport_init(Transport* transport, TransportFunctionTable* vtable,
                     LegacyDescriptorType type) {

--- a/src/main/host/descriptor/transport.h
+++ b/src/main/host/descriptor/transport.h
@@ -27,6 +27,7 @@ typedef gssize (*TransportReceiveFunc)(Transport* transport, Thread* thread,
 
 struct _TransportFunctionTable {
     DescriptorCloseFunc close;
+    DescriptorCleanupFunc cleanup;
     DescriptorFreeFunc free;
     TransportSendFunc send;
     TransportReceiveFunc receive;

--- a/src/main/host/descriptor/udp.c
+++ b/src/main/host/descriptor/udp.c
@@ -247,10 +247,16 @@ gint udp_shutdown(UDP* udp, gint how) {
 }
 
 /* we implement the socket interface, this describes our function suite */
-SocketFunctionTable udp_functions = {
-    _udp_close,           _udp_free,          _udp_sendUserData,
-    _udp_receiveUserData, _udp_processPacket, _udp_isFamilySupported,
-    _udp_connectToPeer,   _udp_dropPacket,    MAGIC_VALUE};
+SocketFunctionTable udp_functions = {_udp_close,
+                                     NULL,
+                                     _udp_free,
+                                     _udp_sendUserData,
+                                     _udp_receiveUserData,
+                                     _udp_processPacket,
+                                     _udp_isFamilySupported,
+                                     _udp_connectToPeer,
+                                     _udp_dropPacket,
+                                     MAGIC_VALUE};
 
 UDP* udp_new(Host* host, guint receiveBufferSize, guint sendBufferSize) {
     UDP* udp = g_new0(UDP, 1);

--- a/src/main/host/descriptor/udp.c
+++ b/src/main/host/descriptor/udp.c
@@ -228,16 +228,13 @@ static void _udp_free(LegacyDescriptor* descriptor) {
     worker_count_deallocation(UDP);
 }
 
-static gboolean _udp_close(LegacyDescriptor* descriptor, Host* host) {
+static void _udp_close(LegacyDescriptor* descriptor, Host* host) {
     UDP* udp = _udp_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(udp);
-    /* Deregister us from the process upon return. */
     _udp_setState(udp, UDPS_CLOSED);
 
     CompatSocket compat_socket = compatsocket_fromLegacySocket(&udp->super);
     host_disassociateInterface(host, &compat_socket);
-
-    return TRUE;
 }
 
 gint udp_shutdown(UDP* udp, gint how) {

--- a/src/main/host/descriptor/udp.c
+++ b/src/main/host/descriptor/udp.c
@@ -233,6 +233,10 @@ static gboolean _udp_close(LegacyDescriptor* descriptor, Host* host) {
     MAGIC_ASSERT(udp);
     /* Deregister us from the process upon return. */
     _udp_setState(udp, UDPS_CLOSED);
+
+    CompatSocket compat_socket = compatsocket_fromLegacySocket(&udp->super);
+    host_disassociateInterface(host, &compat_socket);
+
     return TRUE;
 }
 

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -1112,8 +1112,23 @@ void process_deregisterLegacyDescriptor(Process* proc, LegacyDescriptor* desc) {
     MAGIC_ASSERT(proc);
 
     if (desc) {
-        CompatDescriptor* compatDesc =
-            process_deregisterCompatDescriptor(proc, descriptor_getHandle(desc));
+        int handle = descriptor_getHandle(desc);
+
+        if (handle < 0) {
+            warning("Attempted to deregister a descriptor with handle %d", handle);
+            return;
+        }
+
+        CompatDescriptor* compatDesc = process_deregisterCompatDescriptor(proc, handle);
+
+        if (!compatDesc) {
+            error("Could not deregister a descriptor with handle %d", handle);
+            return;
+        }
+
+        if (compatdescriptor_asLegacy(compatDesc) != desc) {
+            panic("Deregistered the wrong descriptor with handle %d", handle);
+        }
 
         descriptor_setOwnerProcess(desc, NULL);
         compatdescriptor_free(compatDesc);

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -431,6 +431,7 @@ static File* _process_openStdIOFileHelper(Process* proc, int fd, gchar* fileName
     utility_assert(fileName != NULL);
 
     File* stdfile = file_new();
+    descriptor_setOwnerProcess((LegacyDescriptor*)stdfile, proc);
 
     CompatDescriptor* compatDesc = compatdescriptor_fromLegacy((LegacyDescriptor*)stdfile);
     descriptortable_set(proc->descTable, fd, compatDesc);

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -817,10 +817,12 @@ static void _process_free(Process* proc) {
      * will release it's ref. We also need to release our proc ref. */
     if (proc->stderrFile) {
         descriptor_close((LegacyDescriptor*)proc->stderrFile, proc->host);
+        process_deregisterLegacyDescriptor(proc, (LegacyDescriptor*)proc->stderrFile);
         descriptor_unref((LegacyDescriptor*)proc->stderrFile);
     }
     if (proc->stdoutFile) {
         descriptor_close((LegacyDescriptor*)proc->stdoutFile, proc->host);
+        process_deregisterLegacyDescriptor(proc, (LegacyDescriptor*)proc->stdoutFile);
         descriptor_unref((LegacyDescriptor*)proc->stdoutFile);
     }
 

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -1119,7 +1119,6 @@ int process_registerCompatDescriptor(Process* proc, CompatDescriptor* compatDesc
 CompatDescriptor* process_deregisterCompatDescriptor(Process* proc, int handle) {
     MAGIC_ASSERT(proc);
     CompatDescriptor* compatDesc = descriptortable_remove(proc->descTable, handle);
-    _disassociateCompatDescriptor(compatDesc, proc->host);
     return compatDesc;
 }
 

--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -72,6 +72,7 @@ static SysCallReturn _syscallhandler_openHelper(SysCallHandler* sys,
     if (errcode < 0) {
         /* This will remove the descriptor entry and unref/free the File. */
         descriptor_close((LegacyDescriptor*)filed, sys->host);
+        process_deregisterLegacyDescriptor(sys->process, (LegacyDescriptor*)filed);
     } else {
         utility_assert(errcode == handle);
     }

--- a/src/main/host/syscall/fileat.c
+++ b/src/main/host/syscall/fileat.c
@@ -134,6 +134,7 @@ SysCallReturn syscallhandler_openat(SysCallHandler* sys,
     if (errcode < 0) {
         /* This will remove the descriptor entry and unref/free the File. */
         descriptor_close((LegacyDescriptor*)file_desc, sys->host);
+        process_deregisterLegacyDescriptor(sys->process, (LegacyDescriptor*)file_desc);
     } else {
         utility_assert(errcode == handle);
     }

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -246,6 +246,7 @@ SysCallReturn syscallhandler_close(SysCallHandler* sys,
     if (descriptor && !errorCode) {
         trace("Closing descriptor %i", descriptor_getHandle(descriptor));
         descriptor_close(descriptor, sys->host);
+        process_deregisterLegacyDescriptor(sys->process, descriptor);
         return (SysCallReturn){.state = SYSCALL_DONE};
     }
 


### PR DESCRIPTION
This PR makes some improvements to decouple the descriptor table and legacy descriptor objects. It should improve simulation accuracy and make it easier to write rust syscalls that need to work with legacy descriptors. It also closes all descriptors when the process ends, but doesn't disassociate them, so this appears to fix #1596.