### PR TITLE
Updated syscall handlers to use rust descriptor lookup

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1744,12 +1744,6 @@ extern "C" {
     ) -> SysCallReturn;
 }
 extern "C" {
-    pub fn syscallhandler_close(
-        sys: *mut SysCallHandler,
-        args: *const SysCallArgs,
-    ) -> SysCallReturn;
-}
-extern "C" {
     pub fn syscallhandler_dup(sys: *mut SysCallHandler, args: *const SysCallArgs) -> SysCallReturn;
 }
 extern "C" {

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -144,6 +144,13 @@ void descriptor_unrefWeak(gpointer data) {
 void descriptor_close(LegacyDescriptor* descriptor, Host* host) {
     MAGIC_ASSERT(descriptor);
     MAGIC_ASSERT(descriptor->funcTable);
+
+    // if it's already closed, exit early
+    if ((descriptor_getStatus(descriptor) & STATUS_DESCRIPTOR_CLOSED) != 0) {
+        warning("Attempting to close an already-closed descriptor");
+        return;
+    }
+
     trace("Descriptor %i calling vtable close now", descriptor->handle);
     descriptor_adjustStatus(descriptor, STATUS_DESCRIPTOR_CLOSED, TRUE);
 

--- a/src/main/host/syscall/fcntl.rs
+++ b/src/main/host/syscall/fcntl.rs
@@ -13,11 +13,9 @@ fn fcntl(ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
     let cmd: i32 = args.args[1].into();
 
     // get the descriptor, or return early if it doesn't exist
-    let desc = unsafe { &*syscall::get_descriptor(fd, ctx.process.raw_mut())? };
-
-    // if it's a legacy descriptor, use the C syscall handler instead
-    let desc = match desc {
+    let desc = match syscall::get_descriptor(ctx.process, fd)? {
         CompatDescriptor::New(d) => d,
+        // if it's a legacy descriptor, use the C syscall handler instead
         CompatDescriptor::Legacy(_) => {
             return unsafe {
                 cshadow::syscallhandler_fcntl(

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -227,32 +227,6 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd,
 // System Calls
 ///////////////////////////////////////////////////////////
 
-SysCallReturn syscallhandler_close(SysCallHandler* sys,
-                                   const SysCallArgs* args) {
-    gint fd = args->args[0].as_i64;
-    gint errorCode = 0;
-
-    trace("Trying to close fd %i", fd);
-
-    /* Check that fd is within bounds. */
-    if (fd < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EBADF};
-    }
-
-    /* Check if this is a virtual Shadow descriptor. */
-    LegacyDescriptor* descriptor = process_getRegisteredLegacyDescriptor(sys->process, fd);
-    errorCode = _syscallhandler_validateDescriptor(descriptor, DT_NONE);
-
-    if (descriptor && !errorCode) {
-        trace("Closing descriptor %i", descriptor_getHandle(descriptor));
-        descriptor_close(descriptor, sys->host);
-        process_deregisterLegacyDescriptor(sys->process, descriptor);
-        return (SysCallReturn){.state = SYSCALL_DONE};
-    }
-
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errorCode};
-}
-
 SysCallReturn syscallhandler_dup(SysCallHandler* sys,
                                  const SysCallArgs* args) {
     gint fd = args->args[0].as_i64;

--- a/src/main/host/syscall/unistd.h
+++ b/src/main/host/syscall/unistd.h
@@ -8,7 +8,6 @@
 
 #include "main/host/syscall/protected.h"
 
-SYSCALL_HANDLER(close);
 SYSCALL_HANDLER(dup);
 SYSCALL_HANDLER(exit_group);
 SYSCALL_HANDLER(getpid);


### PR DESCRIPTION
The C close() syscall handler is also now redundant, so it was removed.

The helper functions also must take a cloned `PosixFile` (an enum containing an `Arc`) instead of a `&Descriptor` since a `&Descriptor` holds an immutable reference to the `Process` for the lifetime of the `&Descriptor`, and cloning the `PosixFile` allows us to break that reference.