### PR TITLE
Improve error messages before logger is initialized

### DIFF
--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -243,14 +243,18 @@ mod export {
 
         if let Err(e) = result {
             // log the full error, its context, and its backtrace if enabled
-            for line in format!("{:?}", e).split("\n") {
-                log::error!("{}", line);
-            }
-            log::logger().flush();
+            if log::log_enabled!(log::Level::Error) {
+                for line in format!("{:?}", e).split("\n") {
+                    log::error!("{}", line);
+                }
+                log::logger().flush();
 
-            // print the short error
-            eprintln!("** Shadow did not complete successfully: {}", e);
-            eprintln!("** See the log for details");
+                // print the short error
+                eprintln!("** Shadow did not complete successfully: {}", e);
+                eprintln!("** See the log for details");
+            } else {
+                eprintln!("{:?}", e);
+            }
 
             return 1;
         }


### PR DESCRIPTION
Some errors such as parsing the configuration file occur before the logger is initialized.