### PR TITLE
Don't panic on non-unicode env vars

### DIFF
--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::ffi::{CStr, OsStr};
 use std::os::unix::ffi::OsStrExt;
 
@@ -216,14 +217,14 @@ fn log_environment<'a>(args: Vec<&'a OsStr>) {
         log::info!("arg: {}", arg.to_string_lossy());
     }
 
-    for (key, value) in std::env::vars() {
-        let level = match key.as_str() {
+    for (key, value) in std::env::vars_os() {
+        let level = match key.to_string_lossy().borrow() {
             "LD_PRELOAD" | "SHADOW_SPAWNED" | "LD_STATIC_TLS_EXTRA" | "G_DEBUG" | "G_SLICE" => {
                 log::Level::Info
             }
             _ => log::Level::Trace,
         };
-        log::log!(level, "env: {}={}", key, value);
+        log::log!(level, "env: {:?}={:?}", key, value);
     }
 }
 


### PR DESCRIPTION
In particular this avoids a panic when using the HEAPPROFILE env
variable to enable gperftools heap profiling
https://gperftools.github.io/gperftools/heapprofile.html.

I suspect it has something to do with "Due to a hack we make to work
around a possible gcc bug, your profiles may end up named strangely if
the first character of your HEAPPROFILE variable has ascii value greater
than 127". It looks like the referenced hack is mangling the env var in
memory to something non-unicode.