### PR TITLE
Return replaced descriptor from 'descriptortable_set()'

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -420,13 +420,12 @@ struct DescriptorTable *descriptortable_new(void);
 // Free the table.
 void descriptortable_free(struct DescriptorTable *table);
 
-// Store the given descriptor at given index. Any previous descriptor that was
-// stored there will be removed and its table index will be cleared. This
-// unrefs any existing descriptor stored at index as in remove(), and consumes
-// a ref to the existing descriptor as in add().
-void descriptortable_set(struct DescriptorTable *table,
-                         int index,
-                         struct CompatDescriptor *descriptor);
+// Store the given descriptor at the given index. Any previous descriptor that was
+// stored there will be returned. This consumes a ref to the given descriptor as in
+// add(), and any returned descriptor must be freed manually.
+struct CompatDescriptor *descriptortable_set(struct DescriptorTable *table,
+                                             int index,
+                                             struct CompatDescriptor *descriptor);
 
 // This is a helper function that handles some corner cases where some
 // descriptors are linked to each other and we must remove that link in

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -430,7 +430,10 @@ static File* _process_openStdIOFileHelper(Process* proc, int fd, gchar* fileName
     descriptor_setOwnerProcess((LegacyDescriptor*)stdfile, proc);
 
     CompatDescriptor* compatDesc = compatdescriptor_fromLegacy((LegacyDescriptor*)stdfile);
-    descriptortable_set(proc->descTable, fd, compatDesc);
+    CompatDescriptor* replacedDesc = descriptortable_set(proc->descTable, fd, compatDesc);
+
+    // assume the fd was not previously in use
+    utility_assert(replacedDesc == NULL);
 
     char* cwd = getcwd(NULL, 0);
     if (!cwd) {


### PR DESCRIPTION
In general, the calling function would want to close the descriptor after it's removed rather than immediately dropping/freeing it, so returning the descriptor allows the calling function to do that. But right now, we know that 'descriptortable_set()' is only called for fds 0, 1, and 2, and that they won't have previously been used, so we can assume that one isn't returned.