### PR TITLE
Renamed 'FileStatus' to 'FileState' and 'FileFlags' to 'FileStatus'

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -466,7 +466,7 @@ const struct PosixFile *compatdescriptor_newRefPosixFile(const struct CompatDesc
 // calling this function.
 void posixfile_drop(const struct PosixFile *file);
 
-// Get the status of the posix file object.
+// Get the state of the posix file object.
 Status posixfile_getStatus(const struct PosixFile *file);
 
 // Add a status listener to the posix file object. This will increment the status

--- a/src/main/host/syscall/fcntl.rs
+++ b/src/main/host/syscall/fcntl.rs
@@ -1,6 +1,6 @@
 use crate::cshadow;
 use crate::host::context::{ThreadContext, ThreadContextObjs};
-use crate::host::descriptor::{CompatDescriptor, FileFlags};
+use crate::host::descriptor::{CompatDescriptor, FileStatus};
 use crate::host::syscall;
 use crate::host::syscall_types::SyscallResult;
 use crate::host::syscall_types::{SysCallArgs, SysCallReg};
@@ -29,12 +29,12 @@ fn fcntl(ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
 
     Ok(match cmd {
         libc::F_GETFL => {
-            let flags = desc.get_file().borrow().get_flags();
-            SysCallReg::from(flags.bits())
+            let status = desc.get_file().borrow().get_status();
+            SysCallReg::from(status.bits())
         }
         libc::F_SETFL => {
-            let flags = FileFlags::from_bits(i32::from(args.args[2])).ok_or(Errno::EINVAL)?;
-            desc.get_file().borrow_mut().set_flags(flags);
+            let status = FileStatus::from_bits(i32::from(args.args[2])).ok_or(Errno::EINVAL)?;
+            desc.get_file().borrow_mut().set_status(status);
             SysCallReg::from(0)
         }
         _ => Err(Errno::EINVAL)?,

--- a/src/main/host/syscall/mod.rs
+++ b/src/main/host/syscall/mod.rs
@@ -1,5 +1,5 @@
 use crate::cshadow as c;
-use crate::host::descriptor::{CompatDescriptor, FileStatus, PosixFile};
+use crate::host::descriptor::{CompatDescriptor, FileState, PosixFile};
 use crate::host::process::Process;
 
 use std::convert::TryInto;
@@ -22,7 +22,7 @@ impl From<Trigger> for c::Trigger {
 }
 
 impl Trigger {
-    pub fn from_posix_file(file: &PosixFile, status: FileStatus) -> Self {
+    pub fn from_posix_file(file: &PosixFile, status: FileState) -> Self {
         let file_ptr = Box::into_raw(Box::new(file.clone()));
 
         Self(c::Trigger {


### PR DESCRIPTION
The `FileFlags` are called 'status flags' in Linux so it was renamed to `FileStatus`. We needed to rename the existing `FileStatus` flags which represent the readable/writable/closed/etc status of the file, so it is now `FileState`. Other related names such as `StatusEventSource` have also been renamed to match.