### PR TITLE
Downgrade clap version to fix mismatched heading bug

### DIFF
--- a/src/main/Cargo.lock
+++ b/src/main/Cargo.lock
@@ -123,9 +123,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd70aa5597dbc42f7217a543f9ef2768b2ef823ba29036072d30e1d88e98406"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/clap-rs/clap?rev=8f2ba607aa629176c84ee6d0076a989e44ab7e7f#8f2ba607aa629176c84ee6d0076a989e44ab7e7f"
 dependencies = [
  "atty",
  "bitflags",
@@ -142,9 +141,8 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5bb0d655624a0b8770d1c178fb8ffcb1f91cc722cb08f451e3dc72465421ac"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/clap-rs/clap?rev=8f2ba607aa629176c84ee6d0076a989e44ab7e7f#8f2ba607aa629176c84ee6d0076a989e44ab7e7f"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -12,7 +12,8 @@ crate-type = ["staticlib"]
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 atomic_refcell = "0.1"
 bitflags = "1.3"
-clap = { version = "3.0.0-beta.4", features = ["wrap_help"] }
+# holding clap version until there is a fix for https://github.com/clap-rs/clap/issues/2785
+clap = { git = "https://github.com/clap-rs/clap", rev = "8f2ba607aa629176c84ee6d0076a989e44ab7e7f", features = ["wrap_help"] }
 crossbeam = "0.8.1"
 gml-parser = { path = "../lib/gml-parser" }
 libc = "0.2"


### PR DESCRIPTION
Closes #1663. A proposed fix is to set the help heading on each argument, but we have a lot of arguments so we'll leave that as a last resort if we need to update to a newer clap in the future.