### PR TITLE
Experimental option for dynamically updating the minimum time jump

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -78,6 +78,7 @@ hosts:
 - [`experimental.socket_send_autotune`](#experimentalsocket_send_autotune)
 - [`experimental.socket_send_buffer`](#experimentalsocket_send_buffer)
 - [`experimental.use_cpu_pinning`](#experimentaluse_cpu_pinning)
+- [`experimental.use_dynamic_min_jump_time`](#experimentaluse_dynamic_min_jump_time)
 - [`experimental.use_explicit_block_message`](#experimentaluse_explicit_block_message)
 - [`experimental.use_legacy_working_dir`](#experimentaluse_legacy_working_dir)
 - [`experimental.use_libc_preload`](#experimentaluse_libc_preload)
@@ -384,6 +385,13 @@ Type: Bool
 
 Pin each thread and any processes it executes to the same logical CPU Core to
 improve cache affinity.
+
+#### `experimental.use_dynamic_min_jump_time`
+
+Default: false  
+Type: Bool
+
+Update the minimum jump time dynamically throughout the simulation.
 
 #### `experimental.use_explicit_block_message`
 

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -78,7 +78,7 @@ hosts:
 - [`experimental.socket_send_autotune`](#experimentalsocket_send_autotune)
 - [`experimental.socket_send_buffer`](#experimentalsocket_send_buffer)
 - [`experimental.use_cpu_pinning`](#experimentaluse_cpu_pinning)
-- [`experimental.use_dynamic_min_jump_time`](#experimentaluse_dynamic_min_jump_time)
+- [`experimental.use_dynamic_runahead`](#experimentaluse_dynamic_runahead)
 - [`experimental.use_explicit_block_message`](#experimentaluse_explicit_block_message)
 - [`experimental.use_legacy_working_dir`](#experimentaluse_legacy_working_dir)
 - [`experimental.use_libc_preload`](#experimentaluse_libc_preload)
@@ -386,12 +386,12 @@ Type: Bool
 Pin each thread and any processes it executes to the same logical CPU Core to
 improve cache affinity.
 
-#### `experimental.use_dynamic_min_jump_time`
+#### `experimental.use_dynamic_runahead`
 
 Default: false  
 Type: Bool
 
-Update the minimum jump time dynamically throughout the simulation.
+Update the minimum runahead dynamically throughout the simulation.
 
 #### `experimental.use_explicit_block_message`
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -253,7 +253,7 @@ SimulationTime config_getHeartbeatInterval(const struct ConfigOptions *config);
 
 SimulationTime config_getRunahead(const struct ConfigOptions *config);
 
-bool config_getUseDynamicMinJumpTime(const struct ConfigOptions *config);
+bool config_getUseDynamicRunahead(const struct ConfigOptions *config);
 
 bool config_getUseCpuPinning(const struct ConfigOptions *config);
 
@@ -408,7 +408,7 @@ void worker_setCurrentTime(SimulationTime t);
 
 SimulationTime worker_getCurrentTime(void);
 
-void worker_updateMinTimeJump(SimulationTime t);
+void worker_updateMinRunahead(SimulationTime t);
 
 void _worker_setLastEventTime(SimulationTime t);
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -253,6 +253,8 @@ SimulationTime config_getHeartbeatInterval(const struct ConfigOptions *config);
 
 SimulationTime config_getRunahead(const struct ConfigOptions *config);
 
+bool config_getUseDynamicMinJumpTime(const struct ConfigOptions *config);
+
 bool config_getUseCpuPinning(const struct ConfigOptions *config);
 
 enum InterposeMethod config_getInterposeMethod(const struct ConfigOptions *config);
@@ -405,6 +407,8 @@ SimulationTime _worker_getRoundEndTime(void);
 void worker_setCurrentTime(SimulationTime t);
 
 SimulationTime worker_getCurrentTime(void);
+
+void worker_updateMinTimeJump(SimulationTime t);
 
 void _worker_setLastEventTime(SimulationTime t);
 

--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -48,6 +48,8 @@ add_custom_command(OUTPUT wrapper.rs
         --whitelist-function "runConfigHandlers"
         --whitelist-function "rustlogger_new"
 
+        --whitelist-function "workerpool_updateMinTimeJump"
+
         --whitelist-function "process_.*"
         --whitelist-function "shadow_logger_getDefault"
         --whitelist-function "shadow_logger_shouldFilter"

--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -48,7 +48,7 @@ add_custom_command(OUTPUT wrapper.rs
         --whitelist-function "runConfigHandlers"
         --whitelist-function "rustlogger_new"
 
-        --whitelist-function "workerpool_updateMinTimeJump"
+        --whitelist-function "workerpool_updateMinRunahead"
 
         --whitelist-function "process_.*"
         --whitelist-function "shadow_logger_getDefault"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1433,13 +1433,16 @@ extern "C" {
     pub fn worker_getNodeBandwidthDown(nodeID: GQuark, ip: in_addr_t) -> guint32;
 }
 extern "C" {
+    pub fn workerpool_updateMinTimeJump(pool: *mut WorkerPool, time: SimulationTime);
+}
+extern "C" {
     pub fn worker_getLatencyForAddresses(
         sourceAddress: *mut Address,
         destinationAddress: *mut Address,
-    ) -> gdouble;
+    ) -> SimulationTime;
 }
 extern "C" {
-    pub fn worker_getLatency(sourceHostID: GQuark, destinationHostID: GQuark) -> gdouble;
+    pub fn worker_getLatency(sourceHostID: GQuark, destinationHostID: GQuark) -> SimulationTime;
 }
 extern "C" {
     pub fn worker_getReliabilityForAddresses(
@@ -1502,6 +1505,9 @@ extern "C" {
 }
 extern "C" {
     pub fn worker_setActiveThread(thread: *mut Thread);
+}
+extern "C" {
+    pub fn worker_updateMinTimeJump(t: SimulationTime);
 }
 extern "C" {
     pub fn process_registerCompatDescriptor(

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1433,7 +1433,7 @@ extern "C" {
     pub fn worker_getNodeBandwidthDown(nodeID: GQuark, ip: in_addr_t) -> guint32;
 }
 extern "C" {
-    pub fn workerpool_updateMinTimeJump(pool: *mut WorkerPool, time: SimulationTime);
+    pub fn workerpool_updateMinRunahead(pool: *mut WorkerPool, time: SimulationTime);
 }
 extern "C" {
     pub fn worker_getLatencyForAddresses(
@@ -1507,7 +1507,7 @@ extern "C" {
     pub fn worker_setActiveThread(thread: *mut Thread);
 }
 extern "C" {
-    pub fn worker_updateMinTimeJump(t: SimulationTime);
+    pub fn worker_updateMinRunahead(t: SimulationTime);
 }
 extern "C" {
     pub fn process_registerCompatDescriptor(

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -93,6 +93,9 @@ Controller* controller_new(const ConfigOptions* config) {
 
     controller->minJumpTimeConfig = config_getRunahead(config);
 
+    controller->endTime = config_getStopTime(config);
+    controller->bootstrapEndTime = config_getBootstrapEndTime(config);
+
     /* these are only avail in glib >= 2.30
      * setup signal handlers for gracefully handling shutdowns */
     //  TODO
@@ -187,14 +190,9 @@ static gboolean _controller_loadNetworkGraph(Controller* controller) {
 static void _controller_initializeTimeWindows(Controller* controller) {
     MAGIC_ASSERT(controller);
 
-    /* set simulation end time */
-    controller->endTime = config_getStopTime(controller->config);
-
     controller->executeWindowStart = 0;
     SimulationTime jump = _controller_getMinTimeJump(controller);
     controller->executeWindowEnd = jump;
-
-    controller->bootstrapEndTime = config_getBootstrapEndTime(controller->config);
 }
 
 static void _controller_registerArgCallback(const char* arg, void* _argArray) {

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -152,7 +152,7 @@ static SimulationTime _controller_getMinTimeJump(Controller* controller) {
     return minJumpTime;
 }
 
-void controller_updateMinTimeJumpNs(Controller* controller, uint64_t minPathLatencyNs) {
+static void _controller_updateMinTimeJumpNs(Controller* controller, uint64_t minPathLatencyNs) {
     MAGIC_ASSERT(controller);
     SimulationTime minPathLatencySimTime = minPathLatencyNs * SIMTIME_ONE_NANOSECOND;
 
@@ -472,7 +472,7 @@ gint controller_run(Controller* controller) {
         return 1;
     }
 
-    controller_updateMinTimeJumpNs(
+    _controller_updateMinTimeJumpNs(
         controller, routinginfo_smallestLatencyNs(controller->routingInfo));
 
     /* we don't need the network graph anymore, so free it to save memory */

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -158,10 +158,11 @@ void controller_updateMinTimeJumpNs(Controller* controller, uint64_t minPathLate
 
     if (controller->nextMinJumpTime == 0 || minPathLatencySimTime < controller->nextMinJumpTime) {
         utility_assert(minPathLatencySimTime > 0);
-        SimulationTime oldJumpNs = controller->nextMinJumpTime;
+        SimulationTime oldJumpNs =
+            controller->nextMinJumpTime > 0 ? controller->nextMinJumpTime : controller->minJumpTime;
         controller->nextMinJumpTime = minPathLatencySimTime;
-        info("updated topology minimum time jump from %" G_GUINT64_FORMAT " to %" G_GUINT64_FORMAT
-             " nanoseconds; the minimum config override is %s (%" G_GUINT64_FORMAT " nanoseconds)",
+        info("minimum time jump for next scheduling round updated from %" G_GUINT64_FORMAT " to %"
+             G_GUINT64_FORMAT " ns; the minimum config override is %s (%" G_GUINT64_FORMAT " ns)",
              oldJumpNs, controller->nextMinJumpTime,
              controller->minJumpTimeConfig > 0 ? "set" : "not set", controller->minJumpTimeConfig);
     }

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -160,11 +160,10 @@ void controller_updateMinTimeJumpNs(Controller* controller, uint64_t minPathLate
         utility_assert(minPathLatencySimTime > 0);
         SimulationTime oldJumpNs = controller->nextMinJumpTime;
         controller->nextMinJumpTime = minPathLatencySimTime;
-        debug("updated topology minimum time jump from %" G_GUINT64_FORMAT " to %" G_GUINT64_FORMAT
-              " nanoseconds; "
-              "the minimum config override is %s (%" G_GUINT64_FORMAT " nanoseconds)",
-              oldJumpNs, controller->nextMinJumpTime,
-              controller->minJumpTimeConfig > 0 ? "set" : "not set", controller->minJumpTimeConfig);
+        info("updated topology minimum time jump from %" G_GUINT64_FORMAT " to %" G_GUINT64_FORMAT
+             " nanoseconds; the minimum config override is %s (%" G_GUINT64_FORMAT " nanoseconds)",
+             oldJumpNs, controller->nextMinJumpTime,
+             controller->minJumpTimeConfig > 0 ? "set" : "not set", controller->minJumpTimeConfig);
     }
 }
 

--- a/src/main/core/controller.h
+++ b/src/main/core/controller.h
@@ -24,7 +24,9 @@ gdouble controller_getRunTimeElapsed(Controller*);
 
 gboolean controller_managerFinishedCurrentRound(Controller*, SimulationTime, SimulationTime*,
                                                 SimulationTime*);
-gdouble controller_getLatency(Controller* controller, Address* srcAddress, Address* dstAddress);
+void controller_updateMinTimeJump(Controller* controller, SimulationTime minPathLatency);
+SimulationTime controller_getLatency(Controller* controller, Address* srcAddress,
+                                     Address* dstAddress);
 gfloat controller_getReliability(Controller* controller, Address* srcAddress, Address* dstAddress);
 bool controller_isRoutable(Controller* controller, Address* srcAddress, Address* dstAddress);
 void controller_incrementPacketCount(Controller* controller, Address* srcAddress,

--- a/src/main/core/controller.h
+++ b/src/main/core/controller.h
@@ -24,7 +24,7 @@ gdouble controller_getRunTimeElapsed(Controller*);
 
 gboolean controller_managerFinishedCurrentRound(Controller*, SimulationTime, SimulationTime*,
                                                 SimulationTime*);
-void controller_updateMinTimeJump(Controller* controller, SimulationTime minPathLatency);
+void controller_updateMinRunahead(Controller* controller, SimulationTime minPathLatency);
 SimulationTime controller_getLatency(Controller* controller, Address* srcAddress,
                                      Address* dstAddress);
 gfloat controller_getReliability(Controller* controller, Address* srcAddress, Address* dstAddress);

--- a/src/main/core/controller.h
+++ b/src/main/core/controller.h
@@ -20,7 +20,6 @@ Controller* controller_new(const ConfigOptions*);
 void controller_free(Controller*);
 gint controller_run(Controller*);
 
-void controller_updateMinTimeJumpNs(Controller*, uint64_t);
 gdouble controller_getRunTimeElapsed(Controller*);
 
 gboolean controller_managerFinishedCurrentRound(Controller*, SimulationTime, SimulationTime*,

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -615,9 +615,9 @@ guint32 manager_getNodeBandwidthDown(Manager* manager, GQuark nodeID, in_addr_t 
     return networkinterface_getSpeedDownKiBps(interface);
 }
 
-void manager_updateMinTimeJump(Manager* manager, SimulationTime time) {
+void manager_updateMinRunahead(Manager* manager, SimulationTime time) {
     MAGIC_ASSERT(manager);
-    return controller_updateMinTimeJump(manager->controller, time);
+    return controller_updateMinRunahead(manager->controller, time);
 }
 
 SimulationTime manager_getLatencyForAddresses(Manager* manager, Address* sourceAddress,

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -615,13 +615,18 @@ guint32 manager_getNodeBandwidthDown(Manager* manager, GQuark nodeID, in_addr_t 
     return networkinterface_getSpeedDownKiBps(interface);
 }
 
-gdouble manager_getLatencyForAddresses(Manager* manager, Address* sourceAddress,
-                                       Address* destinationAddress) {
+void manager_updateMinTimeJump(Manager* manager, SimulationTime time) {
+    MAGIC_ASSERT(manager);
+    return controller_updateMinTimeJump(manager->controller, time);
+}
+
+SimulationTime manager_getLatencyForAddresses(Manager* manager, Address* sourceAddress,
+                                              Address* destinationAddress) {
     MAGIC_ASSERT(manager);
     return controller_getLatency(manager->controller, sourceAddress, destinationAddress);
 }
 
-gdouble manager_getLatency(Manager* manager, GQuark sourceHostID, GQuark destinationHostID) {
+SimulationTime manager_getLatency(Manager* manager, GQuark sourceHostID, GQuark destinationHostID) {
     Host* sourceHost = _manager_getHost(manager, sourceHostID);
     Host* destinationHost = _manager_getHost(manager, destinationHostID);
     Address* sourceAddress = host_getDefaultAddress(sourceHost);

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -43,7 +43,7 @@ guint manager_getRawCPUFrequency(Manager* manager);
 DNS* manager_getDNS(Manager* manager);
 guint32 manager_getNodeBandwidthUp(Manager* manager, GQuark nodeID, in_addr_t ip);
 guint32 manager_getNodeBandwidthDown(Manager* manager, GQuark nodeID, in_addr_t ip);
-void manager_updateMinTimeJump(Manager* manager, SimulationTime time);
+void manager_updateMinRunahead(Manager* manager, SimulationTime time);
 SimulationTime manager_getLatencyForAddresses(Manager* manager, Address* sourceAddress,
                                               Address* destinationAddress);
 SimulationTime manager_getLatency(Manager* manager, GQuark sourceHostID, GQuark destinationHostID);

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -43,9 +43,10 @@ guint manager_getRawCPUFrequency(Manager* manager);
 DNS* manager_getDNS(Manager* manager);
 guint32 manager_getNodeBandwidthUp(Manager* manager, GQuark nodeID, in_addr_t ip);
 guint32 manager_getNodeBandwidthDown(Manager* manager, GQuark nodeID, in_addr_t ip);
-gdouble manager_getLatencyForAddresses(Manager* manager, Address* sourceAddress,
-                                       Address* destinationAddress);
-gdouble manager_getLatency(Manager* manager, GQuark sourceHostID, GQuark destinationHostID);
+void manager_updateMinTimeJump(Manager* manager, SimulationTime time);
+SimulationTime manager_getLatencyForAddresses(Manager* manager, Address* sourceAddress,
+                                              Address* destinationAddress);
+SimulationTime manager_getLatency(Manager* manager, GQuark sourceHostID, GQuark destinationHostID);
 gfloat manager_getReliabilityForAddresses(Manager* manager, Address* sourceAddress,
                                           Address* destinationAddress);
 gfloat manager_getReliability(Manager* manager, GQuark sourceHostID, GQuark destinationHostID);

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -305,6 +305,11 @@ pub struct ExperimentalOptions {
     #[clap(about = EXP_HELP.get("runahead").unwrap())]
     pub runahead: Option<units::Time<units::TimePrefix>>,
 
+    /// Update the minimum jump time dynamically throughout the simulation.
+    #[clap(long, value_name = "bool")]
+    #[clap(about = EXP_HELP.get("use_dynamic_min_jump_time").unwrap())]
+    pub use_dynamic_min_jump_time: Option<bool>,
+
     /// The event scheduler's policy for thread synchronization
     #[clap(long, value_name = "policy")]
     #[clap(about = EXP_HELP.get("scheduler_policy").unwrap())]
@@ -400,6 +405,7 @@ impl Default for ExperimentalOptions {
             use_cpu_pinning: Some(true),
             interpose_method: Some(InterposeMethod::Preload),
             runahead: None,
+            use_dynamic_min_jump_time: Some(false),
             scheduler_policy: Some(SchedulerPolicy::Host),
             socket_send_buffer: Some(units::Bytes::new(131_072, units::SiPrefixUpper::Base)),
             socket_send_autotune: Some(true),
@@ -1018,6 +1024,13 @@ mod export {
             // shadow uses a value of 0 as "not set" instead of SIMTIME_INVALID
             None => 0,
         }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn config_getUseDynamicMinJumpTime(config: *const ConfigOptions) -> bool {
+        assert!(!config.is_null());
+        let config = unsafe { &*config };
+        config.experimental.use_dynamic_min_jump_time.unwrap()
     }
 
     #[no_mangle]

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -305,10 +305,10 @@ pub struct ExperimentalOptions {
     #[clap(about = EXP_HELP.get("runahead").unwrap())]
     pub runahead: Option<units::Time<units::TimePrefix>>,
 
-    /// Update the minimum jump time dynamically throughout the simulation.
+    /// Update the minimum runahead dynamically throughout the simulation.
     #[clap(long, value_name = "bool")]
-    #[clap(about = EXP_HELP.get("use_dynamic_min_jump_time").unwrap())]
-    pub use_dynamic_min_jump_time: Option<bool>,
+    #[clap(about = EXP_HELP.get("use_dynamic_runahead").unwrap())]
+    pub use_dynamic_runahead: Option<bool>,
 
     /// The event scheduler's policy for thread synchronization
     #[clap(long, value_name = "policy")]
@@ -405,7 +405,7 @@ impl Default for ExperimentalOptions {
             use_cpu_pinning: Some(true),
             interpose_method: Some(InterposeMethod::Preload),
             runahead: None,
-            use_dynamic_min_jump_time: Some(false),
+            use_dynamic_runahead: Some(false),
             scheduler_policy: Some(SchedulerPolicy::Host),
             socket_send_buffer: Some(units::Bytes::new(131_072, units::SiPrefixUpper::Base)),
             socket_send_autotune: Some(true),
@@ -1027,10 +1027,10 @@ mod export {
     }
 
     #[no_mangle]
-    pub extern "C" fn config_getUseDynamicMinJumpTime(config: *const ConfigOptions) -> bool {
+    pub extern "C" fn config_getUseDynamicRunahead(config: *const ConfigOptions) -> bool {
         assert!(!config.is_null());
         let config = unsafe { &*config };
-        config.experimental.use_dynamic_min_jump_time.unwrap()
+        config.experimental.use_dynamic_runahead.unwrap()
     }
 
     #[no_mangle]

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -551,8 +551,8 @@ void worker_sendPacket(Host* srcHost, Packet* packet) {
      * control has problems responding to packet loss */
     if (bootstrapping || chance <= reliability || packet_getPayloadLength(packet) == 0) {
         /* the sender's packet will make it through, find latency */
-        gfloat latency = worker_getLatencyForAddresses(srcAddress, dstAddress);
-        SimulationTime delay = (SimulationTime)ceil(latency * SIMTIME_ONE_MILLISECOND);
+        SimulationTime delay = worker_getLatencyForAddresses(srcAddress, dstAddress);
+        worker_updateMinTimeJump(delay);
         SimulationTime deliverTime = worker_getCurrentTime() + delay;
 
         worker_incrementPacketCount(srcAddress, dstAddress);
@@ -624,11 +624,16 @@ guint32 worker_getNodeBandwidthDown(GQuark nodeID, in_addr_t ip) {
     return manager_getNodeBandwidthDown(_worker_pool()->manager, nodeID, ip);
 }
 
-gdouble worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress) {
-    return manager_getLatencyForAddresses(_worker_pool()->manager, sourceAddress, destinationAddress);
+void workerpool_updateMinTimeJump(WorkerPool* pool, SimulationTime time) {
+    manager_updateMinTimeJump(pool->manager, time);
 }
 
-gdouble worker_getLatency(GQuark sourceHostID, GQuark destinationHostID) {
+SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress) {
+    return manager_getLatencyForAddresses(
+        _worker_pool()->manager, sourceAddress, destinationAddress);
+}
+
+SimulationTime worker_getLatency(GQuark sourceHostID, GQuark destinationHostID) {
     return manager_getLatency(_worker_pool()->manager, sourceHostID, destinationHostID);
 }
 

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -552,7 +552,7 @@ void worker_sendPacket(Host* srcHost, Packet* packet) {
     if (bootstrapping || chance <= reliability || packet_getPayloadLength(packet) == 0) {
         /* the sender's packet will make it through, find latency */
         SimulationTime delay = worker_getLatencyForAddresses(srcAddress, dstAddress);
-        worker_updateMinTimeJump(delay);
+        worker_updateMinRunahead(delay);
         SimulationTime deliverTime = worker_getCurrentTime() + delay;
 
         worker_incrementPacketCount(srcAddress, dstAddress);
@@ -624,8 +624,8 @@ guint32 worker_getNodeBandwidthDown(GQuark nodeID, in_addr_t ip) {
     return manager_getNodeBandwidthDown(_worker_pool()->manager, nodeID, ip);
 }
 
-void workerpool_updateMinTimeJump(WorkerPool* pool, SimulationTime time) {
-    manager_updateMinTimeJump(pool->manager, time);
+void workerpool_updateMinRunahead(WorkerPool* pool, SimulationTime time) {
+    manager_updateMinRunahead(pool->manager, time);
 }
 
 SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress) {

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -84,7 +84,7 @@ bool worker_isBootstrapActive(void);
 guint32 worker_getNodeBandwidthUp(GQuark nodeID, in_addr_t ip);
 guint32 worker_getNodeBandwidthDown(GQuark nodeID, in_addr_t ip);
 
-void workerpool_updateMinTimeJump(WorkerPool* pool, SimulationTime time);
+void workerpool_updateMinRunahead(WorkerPool* pool, SimulationTime time);
 SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress);
 SimulationTime worker_getLatency(GQuark sourceHostID, GQuark destinationHostID);
 gdouble worker_getReliabilityForAddresses(Address* sourceAddress, Address* destinationAddress);

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -84,8 +84,9 @@ bool worker_isBootstrapActive(void);
 guint32 worker_getNodeBandwidthUp(GQuark nodeID, in_addr_t ip);
 guint32 worker_getNodeBandwidthDown(GQuark nodeID, in_addr_t ip);
 
-gdouble worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress);
-gdouble worker_getLatency(GQuark sourceHostID, GQuark destinationHostID);
+void workerpool_updateMinTimeJump(WorkerPool* pool, SimulationTime time);
+SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress);
+SimulationTime worker_getLatency(GQuark sourceHostID, GQuark destinationHostID);
 gdouble worker_getReliabilityForAddresses(Address* sourceAddress, Address* destinationAddress);
 gdouble worker_getReliability(GQuark sourceHostID, GQuark destinationHostID);
 bool worker_isRoutable(Address* sourceAddress, Address* destinationAddress);

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -211,7 +211,7 @@ impl Worker {
         Worker::with_mut(|w| w.clock.last.replace(t)).unwrap();
     }
 
-    pub fn update_min_time_jump(t: Duration) {
+    pub fn update_min_runahead(t: Duration) {
         assert!(!t.is_zero());
 
         let updated = Worker::with_mut(|w| {
@@ -226,7 +226,7 @@ impl Worker {
         if updated {
             Worker::with(|w| {
                 unsafe {
-                    cshadow::workerpool_updateMinTimeJump(
+                    cshadow::workerpool_updateMinRunahead(
                         w.worker_pool,
                         SimulationTime::to_c_simtime(Some(t.into())),
                     )
@@ -367,8 +367,8 @@ mod export {
     }
 
     #[no_mangle]
-    pub extern "C" fn worker_updateMinTimeJump(t: cshadow::SimulationTime) {
-        Worker::update_min_time_jump(*SimulationTime::from_c_simtime(t).unwrap());
+    pub extern "C" fn worker_updateMinRunahead(t: cshadow::SimulationTime) {
+        Worker::update_min_runahead(*SimulationTime::from_c_simtime(t).unwrap());
     }
 
     #[no_mangle]

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -200,7 +200,7 @@ impl Worker {
     }
 
     fn clear_current_time() {
-        Worker::with_mut(|w| w.clock.now.take());
+        Worker::with_mut(|w| w.clock.now.take()).unwrap();
     }
 
     pub fn current_time() -> Option<EmulatedTime> {
@@ -238,6 +238,7 @@ impl Worker {
 
     // Runs `f` with a shared reference to the current thread's Worker. Returns
     // None if this thread has no Worker object.
+    #[must_use]
     fn with<F, O>(f: F) -> Option<O>
     where
         F: FnOnce(&Worker) -> O,
@@ -250,6 +251,7 @@ impl Worker {
 
     // Runs `f` with a mutable reference to the current thread's Worker. Returns
     // None if this thread has no Worker object.
+    #[must_use]
     fn with_mut<F, O>(f: F) -> Option<O>
     where
         F: FnOnce(&mut Worker) -> O,

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -396,12 +396,13 @@ static guint _tcp_calculateRTT(TCP* tcp, Host* host) {
         GQuark sourceID = (GQuark)address_getID(srcAddress);
         GQuark destinationID = (GQuark)address_getID(dstAddress);
 
-        /* get latency in milliseconds */
-        gdouble srcLatency = worker_getLatency(sourceID, destinationID);
-        gdouble dstLatency = worker_getLatency(destinationID, sourceID);
+        /* these sim time values are a duration and not an absolute time */
+        SimulationTime srcLatency = worker_getLatency(sourceID, destinationID);
+        SimulationTime dstLatency = worker_getLatency(destinationID, sourceID);
 
-        guint sendLatency = (guint) ceil(srcLatency);
-        guint receiveLatency = (guint) ceil(dstLatency);
+        /* find latency in milliseconds */
+        guint sendLatency = (guint)ceil((gdouble)srcLatency / SIMTIME_ONE_MILLISECOND);
+        guint receiveLatency = (guint)ceil((gdouble)dstLatency / SIMTIME_ONE_MILLISECOND);
 
         if(sendLatency == 0 || receiveLatency == 0) {
             utility_panic("need nonzero latency to set buffer sizes, "


### PR DESCRIPTION
Added an experimental option to dynamically update the minimum time jump as packets are sent on new edges between graph nodes. This should model the behaviour of Shadow before the graph code was moved to rust (one difference is that the initial time jump is now the min network latency rather than 10 ms). If the first packet between two nodes has a latency less than the current time jump, that packet will arrive late.