### PR TITLE
Set default min runahead to 1ms

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -337,7 +337,7 @@ Show the simulation progress at the bottom of the terminal.
 
 #### `experimental.runahead`
 
-Default: null  
+Default: "1 ms"  
 Type: String OR null
 
 If set, overrides the automatically calculated minimum time workers may run

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -404,7 +404,7 @@ impl Default for ExperimentalOptions {
             use_shim_syscall_handler: Some(true),
             use_cpu_pinning: Some(true),
             interpose_method: Some(InterposeMethod::Preload),
-            runahead: None,
+            runahead: Some(units::Time::new(1, units::TimePrefix::Milli)),
             use_dynamic_runahead: Some(false),
             scheduler_policy: Some(SchedulerPolicy::Host),
             socket_send_buffer: Some(units::Bytes::new(131_072, units::SiPrefixUpper::Base)),


### PR DESCRIPTION
Larger values for the `--runahead` option improves our ability to parallelize work across workers, leading to faster run-times. 1 millisecond was the lowest possible minimum in Shadow 1.x, and I think a reasonable default since most latencies for our target networks are in terms of milliseconds.

refs #1699