### PR TITLE
Upgrade clap to 3.0 beta 5

### DIFF
--- a/src/main/Cargo.lock
+++ b/src/main/Cargo.lock
@@ -123,8 +123,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.2"
-source = "git+https://github.com/clap-rs/clap?rev=8f2ba607aa629176c84ee6d0076a989e44ab7e7f#8f2ba607aa629176c84ee6d0076a989e44ab7e7f"
+version = "3.0.0-beta.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feff3878564edb93745d58cf63e17b63f24142506e7a20c87a5521ed7bfb1d63"
 dependencies = [
  "atty",
  "bitflags",
@@ -136,13 +137,14 @@ dependencies = [
  "termcolor",
  "terminal_size",
  "textwrap",
- "vec_map",
+ "unicase",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.2"
-source = "git+https://github.com/clap-rs/clap?rev=8f2ba607aa629176c84ee6d0076a989e44ab7e7f#8f2ba607aa629176c84ee6d0076a989e44ab7e7f"
+version = "3.0.0-beta.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b15c6b4f786ffb6192ffe65a36855bc1fc2444bcd0945ae16748dcd6ed7d0d3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -425,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -485,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.2.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
 dependencies = [
  "bitvec",
  "funty",
@@ -529,9 +531,12 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "os_str_bytes"
-version = "3.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
+checksum = "addaa943333a514159c80c97ff4a93306530d965d27e139188283cd13e06a799"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "petgraph"
@@ -893,6 +898,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,12 +923,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = { version = "1.0.44", features = ["backtrace"] }
 atomic_refcell = "0.1"
 bitflags = "1.3"
 # holding clap version until there is a fix for https://github.com/clap-rs/clap/issues/2785
-clap = { git = "https://github.com/clap-rs/clap", rev = "8f2ba607aa629176c84ee6d0076a989e44ab7e7f", features = ["wrap_help"] }
+clap = { version = "3.0.0-beta.5", features = ["wrap_help"] }
 crossbeam = "0.8.1"
 gml-parser = { path = "../lib/gml-parser" }
 libc = "0.2"

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -3,7 +3,7 @@ use std::ffi::{CStr, OsStr};
 use std::os::unix::ffi::OsStrExt;
 
 use anyhow::{self, Context};
-use clap::Clap;
+use clap::Parser;
 use nix::sys::{personality, resource, signal};
 
 use crate::core::logger::log_wrapper::c_to_rust_log_level;

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -4,7 +4,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::MetadataExt;
 
 use clap::ArgEnum;
-use clap::Clap;
+use clap::Parser;
 use merge::Merge;
 use once_cell::sync::Lazy;
 use schemars::{schema_for, JsonSchema};
@@ -23,7 +23,7 @@ const END_HELP_TEXT: &str = "\
     case-sensitive.";
 
 /// Run real applications over simulated networks.
-#[derive(Debug, Clone, Clap)]
+#[derive(Debug, Clone, Parser)]
 #[clap(name = "Shadow", after_help = END_HELP_TEXT)]
 #[clap(version = std::option_env!("SHADOW_VERSION").unwrap_or(std::env!("CARGO_PKG_VERSION")))]
 pub struct CliOptions {
@@ -127,7 +127,7 @@ static GENERAL_HELP: Lazy<std::collections::HashMap<String, String>> =
 
 // these must all be Option types since they aren't required by the CLI, even if they're
 // required in the configuration file
-#[derive(Debug, Clone, Clap, Serialize, Deserialize, Merge, JsonSchema)]
+#[derive(Debug, Clone, Parser, Serialize, Deserialize, Merge, JsonSchema)]
 #[clap(help_heading = "GENERAL (Override configuration file options)")]
 #[serde(deny_unknown_fields)]
 pub struct GeneralOptions {
@@ -197,7 +197,7 @@ static NETWORK_HELP: Lazy<std::collections::HashMap<String, String>> =
 
 // these must all be Option types since they aren't required by the CLI, even if they're
 // required in the configuration file
-#[derive(Debug, Clone, Clap, Serialize, Deserialize, Merge, JsonSchema)]
+#[derive(Debug, Clone, Parser, Serialize, Deserialize, Merge, JsonSchema)]
 #[clap(help_heading = "NETWORK (Override network options)")]
 #[serde(deny_unknown_fields)]
 pub struct NetworkOptions {
@@ -226,7 +226,7 @@ impl NetworkOptions {
 static EXP_HELP: Lazy<std::collections::HashMap<String, String>> =
     Lazy::new(|| generate_help_strs(schema_for!(ExperimentalOptions)));
 
-#[derive(Debug, Clone, Clap, Serialize, Deserialize, Merge, JsonSchema)]
+#[derive(Debug, Clone, Parser, Serialize, Deserialize, Merge, JsonSchema)]
 #[clap(
     help_heading = "EXPERIMENTAL (Unstable and may change or be removed at any time, regardless of Shadow version)"
 )]
@@ -428,7 +428,7 @@ impl Default for ExperimentalOptions {
 static HOST_HELP: Lazy<std::collections::HashMap<String, String>> =
     Lazy::new(|| generate_help_strs(schema_for!(HostDefaultOptions)));
 
-#[derive(Debug, Clone, Clap, Serialize, Deserialize, Merge, JsonSchema)]
+#[derive(Debug, Clone, Parser, Serialize, Deserialize, Merge, JsonSchema)]
 #[clap(help_heading = "HOST DEFAULTS (Default options for hosts)")]
 #[serde(default, deny_unknown_fields)]
 pub struct HostDefaultOptions {


### PR DESCRIPTION
This version contains a fix for the help header bug (https://github.com/clap-rs/clap/issues/2785).