### PR TITLE
Update fedora 34 to 35

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,7 +34,7 @@ jobs:
           - 'ubuntu:20.04'
           - 'debian:10-slim'
           - 'debian:11-slim'
-          - 'fedora:34'
+          - 'fedora:35'
           - 'quay.io/centos/centos:stream8'
         cc: ['gcc', 'clang']
         buildtype: ['debug', 'release']

--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -15,6 +15,7 @@ APT_PACKAGES="
   python3
   python3-pip
   xz-utils
+  util-linux
   "
 
 # packages that are only required for our CI environment
@@ -37,6 +38,7 @@ RPM_PACKAGES="
   yum-utils
   diffutils
   libarchive
+  util-linux
   "
 
 # packages that are only required for our CI environment

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -11,7 +11,7 @@ CONTAINERS=(
     ubuntu:20.04
     debian:10-slim
     debian:11-slim
-    fedora:34
+    fedora:35
     quay.io/centos/centos:stream8
     )
 
@@ -53,9 +53,9 @@ Run all default configurations, but restrict C compilers to gcc:
   $0 -C gcc
 
 Run all default configurations, but restrict C compilers to gcc,
-and containers to ubuntu:18.04 and fedora:34:
+and containers to ubuntu:18.04 and fedora:35:
 
-  $0 -C gcc -c "ubuntu:18.04 fedora:34"
+  $0 -C gcc -c "ubuntu:18.04 fedora:35"
 
 Set "extra" configurations to ubuntu:18.04;clang;coverage
 and debian:11-slim;gcc;coverage

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -35,7 +35,7 @@ you'll want to only run some smaller set of configurations locally.
 To run only the configurations you specify, use the `-o` flag:
 
 ```{.bash}
-sudo ci/run.sh -i -o "ubuntu:18.04;clang;debug fedora:34;gcc;release"
+sudo ci/run.sh -i -o "ubuntu:18.04;clang;debug fedora:35;gcc;release"
 ```
 
 For additional options, run `ci/run.sh -h`.

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -8,6 +8,7 @@
   + make
   + xz-utils
   + procps
+  + lscpu
   + cargo, rustc (version \~ latest)
 
 ### Recommended Python Modules (for helper/analysis scripts):
@@ -31,6 +32,7 @@ sudo apt-get install -y \
     python3 \
     python3-pip \
     xz-utils \
+    util-linux \
     gcc \
     g++
 
@@ -78,6 +80,7 @@ sudo dnf install -y \
     xz-devel \
     yum-utils \
     diffutils \
+    util-linux \
     gcc \
     gcc-c++
 

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -4,7 +4,7 @@
 
   + Ubuntu 18.04 and 20.04
   + Debian 10 and 11
-  + Fedora 34
+  + Fedora 35
   + CentOS Stream 8
 
 If you are installing Shadow within a Docker container, you must increase the

--- a/src/test/file/test_file.c
+++ b/src/test/file/test_file.c
@@ -477,14 +477,24 @@ __attribute__((unused)) static void _test_iov() {
     int filed;
     assert_nonneg_errno(filed = fileno(file));
 
-    struct iovec iov[UIO_MAXIOV];
+    struct iovec iov[UIO_MAXIOV+1];
 
     int rv = 0;
     int expected_errno = 0;
     int expected_rv = 0;
 
+#pragma GCC diagnostic push
+#if defined(__GNUC__) && __GNUC__ >= 11
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+#if defined(__has_warning)
+#if __has_warning("-Wstringop-overflow")
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+#endif
     g_assert_cmpint(readv(filed, iov, -1), ==, -1);
     assert_errno_is(EINVAL);
+#pragma GCC diagnostic pop
 
     g_assert_cmpint(readv(filed, iov, UIO_MAXIOV+1), ==, -1);
     assert_errno_is(EINVAL);


### PR DESCRIPTION
I don't think Fedora 35 is technically released yet, but should be sometime this week and the docker image is already available.

Also fixes some gcc 11 warnings in tests.