### PR TITLE
Add lscpu to dependencies

### DIFF
--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -15,6 +15,7 @@ APT_PACKAGES="
   python3
   python3-pip
   xz-utils
+  util-linux
   "
 
 # packages that are only required for our CI environment
@@ -37,6 +38,7 @@ RPM_PACKAGES="
   yum-utils
   diffutils
   libarchive
+  util-linux
   "
 
 # packages that are only required for our CI environment

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -8,6 +8,7 @@
   + make
   + xz-utils
   + procps
+  + lscpu
   + cargo, rustc (version \~ latest)
 
 ### Recommended Python Modules (for helper/analysis scripts):
@@ -31,6 +32,7 @@ sudo apt-get install -y \
     python3 \
     python3-pip \
     xz-utils \
+    util-linux \
     gcc \
     g++
 
@@ -78,6 +80,7 @@ sudo dnf install -y \
     xz-devel \
     yum-utils \
     diffutils \
+    util-linux \
     gcc \
     gcc-c++
 


### PR DESCRIPTION
Required for CPU pinning.

I noticed this since the Fedora 35 docker image doesn't include `util-linux` by default.