### PR TITLE
Remove old comment from 'Cargo.toml'

### DIFF
--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -16,7 +16,6 @@ bitflags = "1.3"
 # issue: https://github.com/tokio-rs/bytes/issues/287
 # pr: https://github.com/tokio-rs/bytes/pull/513
 bytes = { git = "https://github.com/stevenengler/bytes", rev = "871c7a18482186c91dbe2a2d9be20cc2c636fb02" }
-# holding clap version until there is a fix for https://github.com/clap-rs/clap/issues/2785
 clap = { version = "3.0.0-beta.5", features = ["wrap_help"] }
 crossbeam = "0.8.1"
 gml-parser = { path = "../lib/gml-parser" }


### PR DESCRIPTION
Should have removed this comment when we upgraded to '3.0.0-beta.5' as it fixes the bug.