### PR TITLE
Prevent type inference on 'TypedPluginPtr'

### DIFF
--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -152,7 +152,7 @@ impl ShmFile {
         memory_manager
             .copy_from_ptr(
                 dst,
-                TypedPluginPtr::new(PluginPtr::from(interval.start), interval.len()),
+                TypedPluginPtr::new::<u8>(PluginPtr::from(interval.start), interval.len()),
             )
             .unwrap()
     }
@@ -357,7 +357,7 @@ impl MemoryMapper {
         let shm_path = format!("/proc/{}/fd/{}\0", process::id(), shm_file.as_raw_fd());
 
         let shm_plugin_fd = {
-            let path_buf_plugin_ptr = TypedPluginPtr::new(
+            let path_buf_plugin_ptr = TypedPluginPtr::new::<u8>(
                 thread.malloc_plugin_ptr(shm_path.len()).unwrap(),
                 shm_path.len(),
             );

--- a/src/main/host/syscall/unistd.rs
+++ b/src/main/host/syscall/unistd.rs
@@ -202,7 +202,7 @@ fn read_helper(
         // call the file's read(), and run any resulting events
         EventQueue::queue_and_run(|event_queue| {
             posix_file.borrow_mut().read(
-                ctx.process.memory_mut().writer(TypedPluginPtr::new(buf_ptr, buf_size)),
+                ctx.process.memory_mut().writer(TypedPluginPtr::new::<u8>(buf_ptr, buf_size)),
                 offset,
                 event_queue,
             )
@@ -272,7 +272,7 @@ fn write_helper(
         // call the file's write(), and run any resulting events
         EventQueue::queue_and_run(|event_queue| {
             posix_file.borrow_mut().write(
-                ctx.process.memory().reader(TypedPluginPtr::<u8>::new(buf_ptr, buf_size)),
+                ctx.process.memory().reader(TypedPluginPtr::new::<u8>(buf_ptr, buf_size)),
                 offset,
                 event_queue,
             )
@@ -377,7 +377,7 @@ fn pipe_helper(ctx: &mut ThreadContext, fd_ptr: PluginPtr, flags: i32) -> Syscal
     let write_res = ctx
         .process
         .memory_mut()
-        .copy_to_ptr(TypedPluginPtr::new(fd_ptr.into(), 2), &fds);
+        .copy_to_ptr(TypedPluginPtr::new::<libc::c_int>(fd_ptr.into(), 2), &fds);
 
     // Clean up in case of error
     match write_res {


### PR DESCRIPTION
This code/trait is a little weird, but it seems to work.

Letting rust infer the type of the plugin pointer is dangerous since the size of the type might change unexpectedly, leading to accessing memory that we shouldn't. For example:

```rust
let x = [1i32, 2, 3, 4];
...
mem_manager.copy_to_ptr(TypedPluginPtr::new(ptr_to_c_ints, 4), &x);
```

If `x` were to change from a slice of `i32` to `i64`, the type of the plugin pointer would also change and we would write out of bounds of the plugin pointer.

This change forces you to specify the type for the `PluginPtr`.