### PR TITLE
Upgrade codecov uploader to v2

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -74,10 +74,10 @@ jobs:
           grcov ./build -s src/ -t lcov --llvm --branch --ignore-not-existing -o ./grcov.lcov.txt
 
       - name: Upload coverage report to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           name: coverage
-          file: grcov.lcov.txt
+          files: grcov.lcov.txt
           flags: tests
           fail_ci_if_error: false
 


### PR DESCRIPTION
https://github.com/codecov/codecov-action

> On February 1, 2022, [v1] will be fully sunset and no longer function
>
> Due to the deprecation of the underlying bash uploader, the Codecov GitHub Action has released v2 which will use the new uploader. You can learn more about our deprecation plan and the new uploader on our blog.