### PR TITLE
Switch descriptors/files from static dispatch to dynamic dispatch

### DIFF
--- a/src/main/host/syscall/unistd.rs
+++ b/src/main/host/syscall/unistd.rs
@@ -202,7 +202,7 @@ fn read_helper(
         // call the file's read(), and run any resulting events
         EventQueue::queue_and_run(|event_queue| {
             posix_file.borrow_mut().read(
-                ctx.process.memory_mut().writer(TypedPluginPtr::new::<u8>(buf_ptr, buf_size)),
+                &mut ctx.process.memory_mut().writer(TypedPluginPtr::new::<u8>(buf_ptr, buf_size)),
                 offset,
                 event_queue,
             )
@@ -272,7 +272,7 @@ fn write_helper(
         // call the file's write(), and run any resulting events
         EventQueue::queue_and_run(|event_queue| {
             posix_file.borrow_mut().write(
-                ctx.process.memory().reader(TypedPluginPtr::new::<u8>(buf_ptr, buf_size)),
+                &mut ctx.process.memory().reader(TypedPluginPtr::new::<u8>(buf_ptr, buf_size)),
                 offset,
                 event_queue,
             )
@@ -352,8 +352,8 @@ fn pipe_helper(ctx: &mut ThreadContext, fd_ptr: PluginPtr, flags: i32) -> Syscal
     });
 
     // file descriptors for the read and write file objects
-    let mut reader_desc = Descriptor::new(PosixFile::Pipe(reader));
-    let mut writer_desc = Descriptor::new(PosixFile::Pipe(writer));
+    let mut reader_desc = Descriptor::new(reader);
+    let mut writer_desc = Descriptor::new(writer);
 
     // set the file descriptor flags
     reader_desc.set_flags(descriptor_flags);

--- a/src/main/utility/enum_passthrough.rs
+++ b/src/main/utility/enum_passthrough.rs
@@ -40,6 +40,7 @@ enum_passthrough_generic!(self, (bytes, offset, event_queue), Pipe, Socket;
 );
 ```
 **/
+#[allow(unused_macros)]
 macro_rules! enum_passthrough_generic {
     ($self:ident, $args2:tt, $($variant:ident),+; $v:vis fn $name:ident <$($generics:ident),+> $args:tt $(-> $($rv:tt)+)?) => {
         $v fn $name <$($generics)+> $args $(-> $($rv)+)? {

--- a/src/main/utility/stream_len.rs
+++ b/src/main/utility/stream_len.rs
@@ -7,7 +7,7 @@ pub trait StreamLen {
 
 impl<T> StreamLen for T
 where
-    T: Seek,
+    T: Seek + ?Sized,
 {
     fn stream_len_bp(&mut self) -> std::io::Result<u64> {
         let current = self.seek(SeekFrom::Current(0))?;


### PR DESCRIPTION
A proof of concept for changing the descriptor/file implementation to use dynamic dispatch (using trait objects) instead of static dispatch (using generics and enums).