### PR TITLE
Fix eventfd syscall wrapper

### DIFF
--- a/src/lib/libc_preload/syscall_wrappers.c
+++ b/src/lib/libc_preload/syscall_wrappers.c
@@ -138,11 +138,9 @@ INTERPOSE(epoll_pwait2);
 INTERPOSE(epoll_wait);
 #endif
 #ifdef SYS_eventfd // kernel entry: num=284 func=sys_eventfd
-INTERPOSE(eventfd);
+INTERPOSE_REMAP(eventfd, eventfd2);
 #endif
-#ifdef SYS_eventfd2 // kernel entry: num=290 func=sys_eventfd2
-INTERPOSE(eventfd2);
-#endif
+// Skipping SYS_eventfd2
 #ifdef SYS_execve // kernel entry: num=59 func=sys_execve
 INTERPOSE(execve);
 #endif

--- a/src/main/host/syscall/eventfd.c
+++ b/src/main/host/syscall/eventfd.c
@@ -85,7 +85,7 @@ static SysCallReturn _syscallhandler_eventfdHelper(SysCallHandler* sys, unsigned
 ///////////////////////////////////////////////////////////
 
 SysCallReturn syscallhandler_eventfd(SysCallHandler* sys, const SysCallArgs* args) {
-    return _syscallhandler_eventfdHelper(sys, args->args[0].as_u64, args->args[1].as_i64);
+    return _syscallhandler_eventfdHelper(sys, args->args[0].as_u64, 0);
 }
 
 SysCallReturn syscallhandler_eventfd2(SysCallHandler* sys, const SysCallArgs* args) {


### PR DESCRIPTION
The libc preload library was creating a C function `eventfd()` which called the `SYS_eventfd` syscall, but `eventfd()` should be calling `SYS_eventfd2`.