### PR TITLE
Remove unnecessary 'Random' initialization

### DIFF
--- a/src/main/utility/random.rs
+++ b/src/main/utility/random.rs
@@ -13,21 +13,9 @@ mod export {
 
     #[no_mangle]
     pub unsafe extern "C" fn random_new(seed: u64) -> *mut Random {
-        let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
-
-        // From https://docs.rs/rand/0.8.4/rand/rngs/struct.SmallRng.html:
-        //
-        // > SmallRng is not a good choice when: [...] Seeds with many zeros are provided. In such
-        // > cases, it takes SmallRng about 10 samples to produce 0 and 1 bits with equal
-        // > probability.
-        //
-        // SmallRng on x86_64 uses Xoshiro256PlusPlus as of version 0.8, so this should apply to us.
-        //
-        // Since shadow usually uses small seeds, we should throw away 10 samples.
-        for _ in 0..10 {
-            rng.next_u64();
-        }
-
+        // Xoshiro256PlusPlus is not ideal when a seed with many zeros is used, but
+        // 'seed_from_u64()' uses SplitMix64 to derive the actual seed, so we are okay here.
+        let rng = Xoshiro256PlusPlus::seed_from_u64(seed);
         Box::into_raw(Box::new(Random(rng)))
     }
 


### PR DESCRIPTION
This extra sampling is unneeded when using `seed_from_u64()`:

https://docs.rs/rand_xoshiro/latest/rand_xoshiro/struct.Xoshiro256PlusPlus.html?search=#impl-SeedableRng

> pub fn seed_from_u64(seed: u64) -> Xoshiro256PlusPlus
>   Seed a `Xoshiro256PlusPlus` from a `u64` using `SplitMix64`.

From a small test, it seems to be working as expected:

```rust
let mut rng = Xoshiro256PlusPlus::seed_from_u64(0);
for x in 0..5 {
    println!("{:b}", rng.next_u64());
}
```

```text
101001100010111010111010110000101001001000010110010001111011111
110000111011010011011110011110111000011100000001101010100000111
101110000001111110111111001000111101100100110100111101111111100
1011101110101111111000110000111011101111100101111000011010
111111011001010000001001110101110101111010010100101111011101010
```