### PR TITLE
Fix test regexes which caused incorrect tests to pass

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -125,14 +125,16 @@ macro(add_shadow_tests)
          )
       endif()
 
+      # check that we didn't leak any reference-counted objects
+      set(FAIL_REGEX "Memory leak detected")
+
       # need to check the test's return code, not just shadow's (see shadow/shadow#902)
       if(SHADOW_TEST_CHECK_RETVAL)
-         set_property(TEST ${SHADOW_TEST_NAME} PROPERTY FAIL_REGULAR_EXPRESSION "main error code '.*' for process")
+         list(APPEND FAIL_REGEX "main error code '.*' for process")
       endif()
       set_property(TEST ${SHADOW_TEST_NAME} PROPERTY ENVIRONMENT "RUST_BACKTRACE=1;G_DEBUG=fatal-criticals")
 
-      # check that we didn't leak any reference-counted objects
-      set_property(TEST ${SHADOW_TEST_NAME} PROPERTY FAIL_REGULAR_EXPRESSION "Memory leak detected")
+      set_property(TEST ${SHADOW_TEST_NAME} PROPERTY FAIL_REGULAR_EXPRESSION ${FAIL_REGEX})
 
       if(DEFINED SHADOW_TEST_PROPERTIES)
          set_tests_properties(${SHADOW_TEST_NAME} PROPERTIES ${SHADOW_TEST_PROPERTIES})

--- a/src/test/exit/CMakeLists.txt
+++ b/src/test/exit/CMakeLists.txt
@@ -3,8 +3,8 @@ add_shadow_tests(BASENAME exit)
 
 add_executable(test_exit_sigsegv test_exit_sigsegv.c)
 # Expect the managed process to exit with with 139 (128 + SIGSEGV).
-add_shadow_tests(BASENAME exit_sigsegv EXPECT_ERROR true POST_CMD "test `cat hosts/*/*.exitcode` -eq 139")
+add_shadow_tests(BASENAME exit_sigsegv EXPECT_ERROR true CHECK_RETVAL false POST_CMD "test `cat hosts/*/*.exitcode` -eq 139")
 
 add_executable(test_exit_abort test_exit_abort.c)
 # Expect the managed process to exit with with 134 (128 + SIGABRT)
-add_shadow_tests(BASENAME exit_abort EXPECT_ERROR true POST_CMD "test `cat hosts/*/*.exitcode` -eq 134")
+add_shadow_tests(BASENAME exit_abort EXPECT_ERROR true CHECK_RETVAL false POST_CMD "test `cat hosts/*/*.exitcode` -eq 134")

--- a/src/test/socket/bind/CMakeLists.txt
+++ b/src/test/socket/bind/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_linux_tests(BASENAME bind COMMAND sh -c "../../target/debug/test_bind --libc-passing")
 add_shadow_tests(BASENAME bind LOGLEVEL debug)
 
-add_shadow_tests(BASENAME bind_in_new_process)
+add_shadow_tests(BASENAME bind_in_new_process CHECK_RETVAL false)

--- a/src/test/socket/sendto_recvfrom/test_sendto_recvfrom.rs
+++ b/src/test/socket/sendto_recvfrom/test_sendto_recvfrom.rs
@@ -286,7 +286,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                     tests.extend(vec![test_utils::ShadowTest::new(
                         &append_args("test_null_addr_not_connected"),
                         move || test_null_addr_not_connected(method, sock_type, flag),
-                        set![TestEnv::Libc, TestEnv::Shadow],
+                        passing.clone(),
                     )]);
                 }
             }

--- a/src/test/tor/minimal/CMakeLists.txt
+++ b/src/test/tor/minimal/CMakeLists.txt
@@ -22,6 +22,9 @@ add_custom_target(tor-minimal-shadow-data-template ALL
 
 add_shadow_tests(BASENAME tor-minimal
                  LOGLEVEL info
+                 # don't check tor's return value since it will be killed by shadow at the end of
+                 # the sim
+                 CHECK_RETVAL false
                  ARGS
                    --use-cpu-pinning true
                    --parallelism 2


### PR DESCRIPTION
We need to ignore the return values of managed processes in some tests, and one of the sendto/recvfrom tests was passing when it shouldn't have been.