### PR TITLE
Show build-time error if using clang 13.0.0, and exclude centos stream 8 + clang from the CI tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -38,6 +38,10 @@ jobs:
           - 'quay.io/centos/centos:stream8'
         cc: ['gcc', 'clang']
         buildtype: ['debug', 'release']
+        exclude:
+          # https://github.com/shadow/shadow/issues/1741
+          - container: 'quay.io/centos/centos:stream8'
+            cc: clang
     env:
       CC: ${{ matrix.cc }}
       CONTAINER: ${{ matrix.container }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,11 @@ if(((CMAKE_C_COMPILER MATCHES "[/^]gcc") AND (NOT (CMAKE_CXX_COMPILER MATCHES "[
     message(FATAL_ERROR "Mismatched C and C++ compiler ${CMAKE_C_COMPILER} and ${CMAKE_CXX_COMPILER}")
 endif()
 
+## https://github.com/shadow/shadow/issues/1741
+if((CMAKE_C_COMPILER MATCHES "[/^]clang") AND (CMAKE_C_COMPILER_VERSION VERSION_EQUAL 13.0.0))
+	message(FATAL_ERROR "Clang 13.0.0 is not supported (see https://github.com/shadow/shadow/issues/1741)")
+endif()
+
 ## additional user-defined library directories
 foreach(library ${CMAKE_EXTRA_LIBRARIES})
     link_directories(${library})


### PR DESCRIPTION
Workaround for #1741 until clang 13.0.1 is available on supported distributions.