### PR TITLE
Add note to docs about cURL spinloop

### DIFF
--- a/docs/getting_started_basic.md
+++ b/docs/getting_started_basic.md
@@ -5,6 +5,11 @@ server with 3 clients, each running on different virtual hosts. If you do not
 have Python or cURL installed, you can download them through your distribution's
 package manager.
 
+**Notice:** Older versions of cURL use a spinloop that is incompatible with
+Shadow and will cause Shadow to deadlock. Newer versions of cURL, such as the
+version provided in Ubuntu 20.04, don't have this issue. See [issue
+\#1794](https://github.com/shadow/shadow/issues/1794) for details.
+
 ## Configuring the Simulation
 
 Each client uses cURL to make an HTTP request to a basic Python HTTP server.


### PR DESCRIPTION
Adds a note to the docs about #1794. We should maybe consider removing this example, but I think we should have this in the docs in the meantime.