### PR TITLE
Allows TCPS_LISTEN to be a valid listening state

### DIFF
--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -1431,7 +1431,7 @@ gboolean tcp_isValidListener(TCP* tcp) {
  */
 gboolean tcp_isListeningAllowed(TCP* tcp) {
     MAGIC_ASSERT(tcp);
-    if(tcp->state == TCPCS_NONE && tcp->flags == TCPF_NONE) {
+    if ((tcp->state == TCPS_CLOSED || tcp->state == TCPS_LISTEN) && tcp->flags == TCPF_NONE) {
         return TRUE;
     } else {
         return FALSE;

--- a/src/test/socket/listen/test_listen.rs
+++ b/src/test/socket/listen/test_listen.rs
@@ -108,7 +108,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                     test_utils::ShadowTest::new(
                         &append_args("test_listen_twice"),
                         move || test_listen_twice(sock_type, flag, bind),
-                        set![TestEnv::Libc],
+                        set![TestEnv::Libc, TestEnv::Shadow],
                     ),
                     test_utils::ShadowTest::new(
                         &append_args("test_after_close"),


### PR DESCRIPTION
Allows TCPS_LISTEN to be a valid listening state; enables socket double-listen test in Shadow.