### PR TITLE
Prefer `IntoIterator::into_iter` instead of deprecated `IntoIter::new`

### DIFF
--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -417,7 +417,7 @@ impl Default for ExperimentalOptions {
             use_legacy_working_dir: Some(false),
             progress: Some(false),
             host_heartbeat_log_level: Some(LogLevel::Info),
-            host_heartbeat_log_info: Some(std::array::IntoIter::new([LogInfoFlag::Node]).collect()),
+            host_heartbeat_log_info: Some(IntoIterator::into_iter([LogInfoFlag::Node]).collect()),
             host_heartbeat_interval: None,
         }
     }


### PR DESCRIPTION
Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
