### PR TITLE
Disable 'rebase-strategy' dependabot option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     schedule:
       interval: 'daily'
     target-branch: 'main'
+    # don't auto-rebase, otherwise dependabot will rebase several PRs at once
+    # and create many hours of unnecessary workflow runs
+    rebase-strategy: 'disabled'
     milestone: 24 # "Code health and maintenance"
     labels:
       - 'Component: Build'
@@ -17,6 +20,9 @@ updates:
     schedule:
       interval: 'daily'
     target-branch: 'main'
+    # don't auto-rebase, otherwise dependabot will rebase several PRs at once
+    # and create many hours of unnecessary workflow runs
+    rebase-strategy: 'disabled'
     milestone: 24 # "Code health and maintenance"
     labels:
       - 'Component: Build'
@@ -26,6 +32,9 @@ updates:
     schedule:
       interval: 'daily'
     target-branch: 'main'
+    # don't auto-rebase, otherwise dependabot will rebase several PRs at once
+    # and create many hours of unnecessary workflow runs
+    rebase-strategy: 'disabled'
     milestone: 24 # "Code health and maintenance"
     labels:
       - 'Component: Build'


### PR DESCRIPTION
Dependabot can open up to 5 PRs at once. When the main branch changes, it will rebase all 5 dependabot PRs, which causes hours worth of workflow runs in the CI. This is painful when you try to merge these dependabot PRs since every merged PR causes workflow runs for all remaining dependabot PRs, even though you can only merge one at a time.

This PR disable's dependabot's auto-rebase. Instead dependabot will need to be told manually to rebase PRs.