### PR TITLE
Use an alternate stack for signal handling

### DIFF
--- a/src/lib/shim/shim.h
+++ b/src/lib/shim/shim.h
@@ -1,6 +1,7 @@
 #ifndef SHD_SHIM_SHIM_H_
 #define SHD_SHIM_SHIM_H_
 
+#include <signal.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>

--- a/src/lib/shim/shim_rdtsc.c
+++ b/src/lib/shim/shim_rdtsc.c
@@ -108,7 +108,9 @@ void shim_rdtsc_init() {
                       // handler.
                       // SA_SIGINFO: Required because we're specifying
                       // sa_sigaction.
-                      .sa_flags = SA_SIGINFO | SA_NODEFER,
+                      // SA_ONSTACK: Use the alternate signal handling stack, to avoid interfering
+                      // with userspace thread stacks.
+                      .sa_flags = SA_SIGINFO | SA_NODEFER | SA_ONSTACK,
                   },
                   NULL) < 0) {
         panic("sigaction: %s", strerror(errno));

--- a/src/lib/shim/shim_seccomp.c
+++ b/src/lib/shim/shim_seccomp.c
@@ -80,7 +80,9 @@ void shim_seccomp_init() {
                       // to properly handle the case that we end up logging from the syscall
                       // handler, and the IO syscalls themselves are trapped.
                       // SA_SIGINFO: Required because we're specifying sa_sigaction.
-                      .sa_flags = SA_NODEFER | SA_SIGINFO,
+                      // SA_ONSTACK: Use the alternate signal handling stack, to avoid interfering
+                      // with userspace thread stacks.
+                      .sa_flags = SA_NODEFER | SA_SIGINFO | SA_ONSTACK,
                   },
                   &old_action) < 0) {
         panic("sigaction: %s", strerror(errno));

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -196,6 +196,9 @@ long shim_emulated_syscallv(long n, va_list args) {
      * back.
      */
 
+    // TODO: Do this once instead of on every syscall.
+    // https://github.com/shadow/shadow/issues/1846
+
     // Needs to be big enough to run signal handlers in case Shadow delivers a
     // non-fatal signal. No need to be stingy with the size here, since pages
     // that are never used should never get allocated by the OS.

--- a/src/lib/shim/shim_tls.c
+++ b/src/lib/shim/shim_tls.c
@@ -6,12 +6,16 @@
 #include <assert.h>
 #include <stdalign.h>
 
-// Size of the thread-local stack in _shim_emulated_syscallv (4096*10) + an extra
-// kilobyte for the handful of other thread locals we use.  If the former
-// becomes a permanent fixture, we should make it a shared constant, but it
-// should eventually go away. In the meantime we catch at runtime if we try to
-// use more TLS than we've pre-reserved.
-#define BYTES_PER_THREAD (4096*10 + 1024)
+// This needs to be big enough to store all thread-local variables for a single
+// thread. We fail at runtime if this limit is exceeded.
+//
+// Right now the biggest contributors are special thread-local stacks in
+// _shim_emulated_syscallv and in _shim_init_signal_stack. Each of those is
+// 4096*10 bytes.
+//
+// Fixing https://github.com/shadow/shadow/issues/1846 will likely remove one
+// of those, in which case we can reduce this allocation.
+#define BYTES_PER_THREAD (2 * 4096 * 10 + 1024)
 #define MAX_THREADS 100
 
 // Stores the TLS for a single thread.

--- a/src/main/host/syscall/signal.h
+++ b/src/main/host/syscall/signal.h
@@ -13,5 +13,6 @@ SYSCALL_HANDLER(tgkill);
 SYSCALL_HANDLER(tkill);
 SYSCALL_HANDLER(rt_sigaction);
 SYSCALL_HANDLER(rt_sigprocmask);
+SYSCALL_HANDLER(sigaltstack);
 
 #endif

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -367,6 +367,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         UNSUPPORTED(sigaction);
 #endif
         HANDLE(rt_sigaction);
+        HANDLE(sigaltstack);
 #ifdef SYS_signal
         // Superseded by sigaction in glibc 2.0
         UNSUPPORTED(signal);
@@ -479,7 +480,6 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         NATIVE(stat64);
 #endif
         NATIVE(statfs);
-        NATIVE(sigaltstack);
         NATIVE(symlink);
         NATIVE(truncate);
         NATIVE(unlink);


### PR DESCRIPTION
Configure the shim's signal handlers (which are only used in preload mode) to use an alternate stack via `sigaltstack`. Experimentally this appears to fix the stack corruption observed in https://github.com/shadow/shadow/issues/1549.

In preload mode, also prevent managed calls to `sigaltstack` from overwriting our configuration. Eventually this should be implemented more faithfully, but this should be good enough at least until we're to the point of being able to invoke signal handlers configured by the managed process.

This is "milestone 1" of https://github.com/shadow/shadow/discussions/1851