### PR TITLE
Show the progress when stderr is not a tty

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -333,7 +333,7 @@ Max number of iterations to busy-wait on IPC semaphore before blocking.
 Default: false  
 Type: Bool
 
-Show the simulation progress at the bottom of the terminal.
+Show the simulation progress.
 
 #### `experimental.runahead`
 

--- a/src/main/bindings/c/bindings-opaque.h
+++ b/src/main/bindings/c/bindings-opaque.h
@@ -106,6 +106,6 @@ typedef struct Random Random;
 // Routing information for paths between nodes.
 typedef struct RoutingInfo_u32 RoutingInfo_u32;
 
-typedef struct StatusBar_ShadowStatusBarState StatusBar_ShadowStatusBarState;
+typedef struct StatusLogger_ShadowStatusBarState StatusLogger_ShadowStatusBarState;
 
 #endif /* main_opaque_bindings_h */

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -107,7 +107,7 @@ typedef struct Random Random;
 // Routing information for paths between nodes.
 typedef struct RoutingInfo_u32 RoutingInfo_u32;
 
-typedef struct StatusBar_ShadowStatusBarState StatusBar_ShadowStatusBarState;
+typedef struct StatusLogger_ShadowStatusBarState StatusLogger_ShadowStatusBarState;
 
 typedef uint64_t WatchHandle;
 
@@ -207,11 +207,14 @@ uint32_t random_nextU32(struct Random *rng);
 // Fills the buffer with pseudo-random bytes.
 void random_nextNBytes(struct Random *rng, uint8_t *buf, uintptr_t len);
 
-struct StatusBar_ShadowStatusBarState *statusBar_new(uint64_t end);
+struct StatusLogger_ShadowStatusBarState *statusBar_new(uint64_t end);
 
-void statusBar_free(struct StatusBar_ShadowStatusBarState *status_bar);
+struct StatusLogger_ShadowStatusBarState *statusPrinter_new(uint64_t end);
 
-void statusBar_update(const struct StatusBar_ShadowStatusBarState *status_bar, uint64_t current);
+void statusLogger_free(struct StatusLogger_ShadowStatusBarState *status_logger);
+
+void statusLogger_update(const struct StatusLogger_ShadowStatusBarState *status_logger,
+                         uint64_t current);
 
 // Flush Rust's log::logger().
 void rustlogger_flush(void);

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -88,7 +88,7 @@ struct _Manager {
     // Path to the openssl rng lib that we preload for managed processes.
     gchar* preloadOpensslRngPath;
 
-    StatusBar_ShadowStatusBarState* statusBar;
+    StatusLogger_ShadowStatusBarState* statusLogger;
 
     time_t timeOfLastUsageCheck;
     bool checkFdUsage;
@@ -315,9 +315,9 @@ Manager* manager_new(Controller* controller, const ConfigOptions* config, Simula
 
     if (config_getProgress(config)) {
         if (isatty(STDERR_FILENO) == 1) {
-            manager->statusBar = statusBar_new(endTime);
+            manager->statusLogger = statusBar_new(endTime);
         } else {
-            warning("Status/progress bar will not be enabled since stderr is not a tty");
+            manager->statusLogger = statusPrinter_new(endTime);
         }
     }
 
@@ -402,8 +402,8 @@ gint manager_free(Manager* manager) {
         g_free(manager->preloadOpensslRngPath);
     }
 
-    if (manager->statusBar) {
-        statusBar_free(manager->statusBar);
+    if (manager->statusLogger) {
+        statusLogger_free(manager->statusLogger);
     }
 
     MAGIC_CLEAR(manager);
@@ -776,8 +776,8 @@ void manager_run(Manager* manager) {
          */
         minNextEventTime = scheduler_awaitNextRound(manager->scheduler);
 
-        if (manager->statusBar != NULL) {
-            statusBar_update(manager->statusBar, windowEnd);
+        if (manager->statusLogger != NULL) {
+            statusLogger_update(manager->statusLogger, windowEnd);
         }
 
         /* we are in control now, the workers are waiting for the next round */

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -361,7 +361,7 @@ pub struct ExperimentalOptions {
     #[clap(help = EXP_HELP.get("use_legacy_working_dir").unwrap().as_str())]
     pub use_legacy_working_dir: Option<bool>,
 
-    /// Show the simulation progress at the bottom of the terminal
+    /// Show the simulation progress
     #[clap(long, value_name = "bool")]
     #[clap(help = EXP_HELP.get("progress").unwrap().as_str())]
     pub progress: Option<bool>,

--- a/src/main/utility/status_bar.rs
+++ b/src/main/utility/status_bar.rs
@@ -6,6 +6,7 @@ use std::io::Write;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::time::Duration;
 
 const SAVE_CURSOR: &str = "\u{1B}[s";
 const RESTORE_CURSOR: &str = "\u{1B}[u";
@@ -26,7 +27,7 @@ pub struct StatusBar<T: StatusBarState> {
 
 impl<T: 'static + StatusBarState> StatusBar<T> {
     /// Create and start drawing the status bar.
-    pub fn new(state: T, redraw_interval: std::time::Duration) -> Self {
+    pub fn new(state: T, redraw_interval: Duration) -> Self {
         let state = Arc::new(RwLock::new(state));
         let stop_flag = Arc::new(AtomicBool::new(false));
 
@@ -39,11 +40,7 @@ impl<T: 'static + StatusBarState> StatusBar<T> {
         }
     }
 
-    fn redraw_loop(
-        state: Arc<RwLock<T>>,
-        stop_flag: Arc<AtomicBool>,
-        redraw_interval: std::time::Duration,
-    ) {
+    fn redraw_loop(state: Arc<RwLock<T>>, stop_flag: Arc<AtomicBool>, redraw_interval: Duration) {
         // we re-draw the status bar every interval, even if the state hasn't changed, since the
         // terminal might have been resized and the scroll region might have been reset
         while !stop_flag.load(std::sync::atomic::Ordering::Acquire) {
@@ -178,7 +175,7 @@ mod export {
         let end = EmulatedTime::from_abs_simtime(end);
         let state = ShadowStatusBarState::new(end);
 
-        let redraw_interval = std::time::Duration::from_millis(1000);
+        let redraw_interval = Duration::from_millis(1000);
         Box::into_raw(Box::new(StatusBar::new(state, redraw_interval)))
     }
 


### PR DESCRIPTION
Previously if stderr was not a tty, Shadow would ignore the "progress" option. Now Shadow will periodically print the progress to stderr.