### PR TITLE
shim_enableInterposition + shim_disableInterposition -> shim_swapAllowNativeSyscalls

### DIFF
--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -59,9 +59,9 @@ static ShimSharedMem* _shim_shared_mem() {
 }
 
 // We disable syscall interposition when this is > 0.
-static int* _shim_disable_interposition() {
+static int* _shim_allowNativeSyscallsFlag() {
     static ShimTlsVar v = {0};
-    return shimtlsvar_ptr(&v, sizeof(int));
+    return shimtlsvar_ptr(&v, sizeof(bool));
 }
 
 static void _shim_set_allow_native_syscalls(bool is_allowed) {
@@ -121,27 +121,17 @@ void shim_newThreadFinish() {
     }
 }
 
-void shim_disableInterposition() {
-    if (++*_shim_disable_interposition() == 1) {
-        if (_using_interpose_ptrace) {
-            // We can't prevent there being a ptrace-stop on a syscall, but we
-            // can signal Shadow to allow syscalls to execute natively.
-            _shim_set_allow_native_syscalls(true);
-        }
+bool shim_swapAllowNativeSyscalls(bool new) {
+    bool old = *_shim_allowNativeSyscallsFlag();
+    *_shim_allowNativeSyscallsFlag() = new;
+    if (_using_interpose_ptrace && new != old) {
+        _shim_set_allow_native_syscalls(new);
     }
-}
-
-void shim_enableInterposition() {
-    assert(_shim_disable_interposition > 0);
-    if (--*_shim_disable_interposition() == 0) {
-        if (_using_interpose_ptrace) {
-            _shim_set_allow_native_syscalls(false);
-        }
-    }
+    return old;
 }
 
 bool shim_interpositionEnabled() {
-    return !*_shim_disable_interposition();
+    return !*_shim_allowNativeSyscallsFlag();
 }
 
 bool shim_use_syscall_handler() { return _using_shim_syscall_handler; }
@@ -339,12 +329,12 @@ static void _shim_ipc_wait_for_start_event() {
 }
 
 static void _shim_parent_init_ptrace() {
-    shim_disableInterposition();
+    bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
 
     _shim_parent_init_logging();
     _shim_parent_init_shm();
 
-    shim_enableInterposition();
+    shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
 }
 
 static void _shim_parent_init_seccomp() {
@@ -356,7 +346,7 @@ static void _shim_parent_init_rdtsc_emu() {
 }
 
 static void _shim_parent_init_preload() {
-    shim_disableInterposition();
+    bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
 
     // The shim logger internally disables interposition while logging, so we open the log
     // file with interposition disabled too to get a native file descriptor.
@@ -369,24 +359,24 @@ static void _shim_parent_init_preload() {
         _shim_parent_init_seccomp();
     }
 
-    shim_enableInterposition();
+    shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
 }
 
 static void _shim_child_init_ptrace() {
-    shim_disableInterposition();
+    bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
 
     _shim_child_init_shm();
 
-    shim_enableInterposition();
+    shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
 }
 
 static void _shim_child_init_preload() {
-    shim_disableInterposition();
+    bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
 
     _shim_preload_only_child_init_ipc();
     _shim_preload_only_child_ipc_wait_for_start_event();
 
-    shim_enableInterposition();
+    shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
 }
 
 // This function should be called before any wrapped syscall. We also use the

--- a/src/lib/shim/shim.h
+++ b/src/lib/shim/shim.h
@@ -15,13 +15,10 @@
 // Should be called by all syscall wrappers to ensure the shim is initialized.
 void shim_ensure_init();
 
-// Disables syscall interposition for the current thread if it's enabled.
-// Every call to this function should be matched with a call to shim_enableInterposition().
-void shim_disableInterposition();
-
-// Re-enabled syscall interposition for the current thread if it's disabled.
-// Every call to this function should be matched with a call to shim_disableInterposition().
-void shim_enableInterposition();
+// Sets the flag determining whether syscalls are passed through natively, and
+// returns the old value. Typical usage is to set this to the desired value at
+// the beginning of an operation, and restore the old value afterwards.
+bool shim_swapAllowNativeSyscalls(bool new);
 
 // Whether syscall interposition is currently enabled.
 bool shim_interpositionEnabled();

--- a/src/lib/shim/shim_logger.c
+++ b/src/lib/shim/shim_logger.c
@@ -49,7 +49,7 @@ void shimlogger_log(Logger* base, LogLevel level, const char* fileName, const ch
         return;
     }
     *in_logger = true;
-    shim_disableInterposition();
+    bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
 
     ShimLogger* logger = (ShimLogger*)base;
 
@@ -84,7 +84,7 @@ void shimlogger_log(Logger* base, LogLevel level, const char* fileName, const ch
         abort();
     }
 
-    shim_enableInterposition();
+    shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
     *in_logger = false;
 }
 
@@ -94,9 +94,9 @@ void shimlogger_destroy(Logger* logger) {
 
 void shimlogger_flush(Logger* base) {
     ShimLogger* logger = (ShimLogger*)base;
-    shim_disableInterposition();
+    bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
     fflush_unlocked(logger->file);
-    shim_enableInterposition();
+    shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
 }
 
 bool shimlogger_isEnabled(Logger* base, LogLevel level) {

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -178,7 +178,8 @@ _shim_emulated_syscall_event(const ShimEvent* syscall_event) {
 }
 
 long shim_emulated_syscallv(long n, va_list args) {
-    shim_disableInterposition();
+    bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
+
     ShimEvent e = {
         .event_id = SHD_SHIM_EVENT_SYSCALL,
         .event_data.syscall.syscall_args.number = n,
@@ -225,7 +226,7 @@ long shim_emulated_syscallv(long n, va_list args) {
                  /* All caller-saved registers not already used above */
                  "rax", "rdi", "rdx", "rcx", "rsi", "r8", "r9", "r10", "r11");
 
-    shim_enableInterposition();
+    shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
 
     return retval.as_i64;
 }


### PR DESCRIPTION
The old API assumed a "stack" of disabling interposition, where we
want to ensure interposition is disabled while beginning some operation,
and then restore the current state afterwards. It doesn't support the
inverse - ensuring interposition is *enabled* for some operation.

The new api allows pushing and popping the current state in a more
general way. In particular this will allow us to re-enable interposition
when invoking a managed process's signal handler.

It'll also allow us to ensure interposition is enabled when making
"shadow syscalls" in preload mode, from a context where interposition
was disabled higher in the stack.