### PR TITLE
Add guard page to signal stack

### DIFF
--- a/src/lib/shim/shim.h
+++ b/src/lib/shim/shim.h
@@ -45,4 +45,15 @@ void shim_newThreadFinish();
 // the parent thread that it is now initialized.
 void shim_newThreadChildInitd();
 
+// Signal stack size parameters defined here because this is a significant
+// portion of the memory that needs to be statically allocated in shim_tls.c.
+//
+// We use a page for a stack guard, and up to another page to page-align the
+// stack guard. We assume 4k pages here but detect at runtime if this is too small.
+#define SHIM_SIGNAL_STACK_GUARD_OVERHEAD ((size_t)4096 * 2)
+// Found experimentally. 4k seems to be enough for most platforms, but fails on Ubuntu 18.04.
+#define SHIM_SIGNAL_STACK_MIN_USABLE_SIZE ((size_t)1024 * 12)
+#define SHIM_SIGNAL_STACK_SIZE                                                                     \
+    (SHIM_SIGNAL_STACK_GUARD_OVERHEAD + SHIM_SIGNAL_STACK_MIN_USABLE_SIZE)
+
 #endif // SHD_SHIM_SHIM_H_

--- a/src/lib/shim/shim_tls.c
+++ b/src/lib/shim/shim_tls.c
@@ -8,13 +8,7 @@
 
 // This needs to be big enough to store all thread-local variables for a single
 // thread. We fail at runtime if this limit is exceeded.
-//
-// Right now the biggest contributors is the special thread-local stacks in
-// in _shim_init_signal_stack, which is 4096*10 bytes.
-//
-// Fixing https://github.com/shadow/shadow/issues/1846 will likely remove one
-// of those, in which case we can reduce this allocation.
-#define BYTES_PER_THREAD (4096 * 10 + 1024)
+#define BYTES_PER_THREAD (SHIM_SIGNAL_STACK_SIZE + 1024)
 #define MAX_THREADS 100
 
 // Stores the TLS for a single thread.


### PR DESCRIPTION
This ensures we'll fail in a more consistent and debuggable way if the
allocated stack is too small.

This lets us be less conservative with the allocated stack size, so we
reduce it from 40KiB to 20KiB.