### PR TITLE
Add per-process shared memory and clean up

### DIFF
--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -85,7 +85,7 @@ static int* _shim_allowNativeSyscallsFlag() {
     return shimtlsvar_ptr(&v, sizeof(bool));
 }
 
-static void _shim_set_allow_native_syscalls(bool is_allowed) {
+static void _shim_ptrace_set_allow_native_syscalls(bool is_allowed) {
     if (_shim_thread_shared_mem()) {
         _shim_thread_shared_mem()->ptrace_allow_native_syscalls = is_allowed;
         trace("%s native-syscalls via shmem %p", is_allowed ? "allowing" : "disallowing",
@@ -146,7 +146,7 @@ bool shim_swapAllowNativeSyscalls(bool new) {
     bool old = *_shim_allowNativeSyscallsFlag();
     *_shim_allowNativeSyscallsFlag() = new;
     if (_using_interpose_ptrace && (new != old)) {
-        _shim_set_allow_native_syscalls(new);
+        _shim_ptrace_set_allow_native_syscalls(new);
     }
     return old;
 }

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -60,7 +60,7 @@ static ShMemBlock* _shim_shared_mem_blk() {
     static ShimTlsVar v = {0};
     return shimtlsvar_ptr(&v, sizeof(ShMemBlock));
 }
-static ShimSharedMem* _shim_shared_mem() {
+static ShimThreadSharedMem* _shim_shared_mem() {
     if (_shim_shared_mem_blk() == NULL) {
         return NULL;
     }

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -444,7 +444,6 @@ static void _shim_preload_only_child_ipc_wait_for_start_event() {
 
     shimevent_recvEventFromShadow(ipc, &event, /* spin= */ true);
     assert(event.event_id == SHD_SHIM_EVENT_START);
-    shim_sys_set_simtime_nanos(event.event_data.start.simulation_nanos);
 }
 
 static void _shim_ipc_wait_for_start_event() {
@@ -455,7 +454,6 @@ static void _shim_ipc_wait_for_start_event() {
     trace("waiting for start event on %p", shim_thisThreadEventIPC);
     shimevent_recvEventFromShadow(shim_thisThreadEventIPC(), &event, /* spin= */ true);
     assert(event.event_id == SHD_SHIM_EVENT_START);
-    shim_sys_set_simtime_nanos(event.event_data.start.simulation_nanos);
 }
 
 static void _shim_parent_init_ptrace() {

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -566,9 +566,9 @@ __attribute__((constructor)) void _shim_load() {
 void shim_ensure_init() { _shim_load(); }
 
 struct timespec* shim_get_shared_time_location() {
-    if (_shim_thread_shared_mem() == NULL) {
+    if (_shim_process_shared_mem() == NULL) {
         return NULL;
     } else {
-        return &_shim_thread_shared_mem()->sim_time;
+        return &_shim_process_shared_mem()->sim_time;
     }
 }

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -25,6 +25,7 @@
 #include "lib/shim/shim_logger.h"
 #include "lib/shim/shim_rdtsc.h"
 #include "lib/shim/shim_seccomp.h"
+#include "lib/shim/shim_shmem.h"
 #include "lib/shim/shim_sys.h"
 #include "lib/shim/shim_syscall.h"
 #include "lib/shim/shim_tls.h"
@@ -563,7 +564,7 @@ __attribute__((constructor)) void _shim_load() {
 
 void shim_ensure_init() { _shim_load(); }
 
-struct timespec* shim_get_shared_time_location() {
+_Atomic EmulatedTime* shim_get_shared_time_location() {
     if (_shim_process_shared_mem() == NULL) {
         return NULL;
     } else {

--- a/src/lib/shim/shim.h
+++ b/src/lib/shim/shim.h
@@ -1,16 +1,10 @@
 #ifndef SHD_SHIM_SHIM_H_
 #define SHD_SHIM_SHIM_H_
 
-#include <signal.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <time.h>
-
-#include <arpa/inet.h>
-#include <sys/socket.h>
+#include <stdatomic.h>
 #include <sys/types.h>
 
+#include "main/core/support/definitions.h"
 #include "main/shmem/shmem_allocator.h"
 
 // Should be called by all syscall wrappers to ensure the shim is initialized.
@@ -31,7 +25,7 @@ bool shim_use_syscall_handler();
 struct IPCData* shim_thisThreadEventIPC();
 
 // Return the location of the time object in shared memory, or NULL if unavailable.
-struct timespec* shim_get_shared_time_location();
+_Atomic EmulatedTime* shim_get_shared_time_location();
 
 // To be called in parent thread before making the `clone` syscall.
 // It sets up data for the new thread.

--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -2,6 +2,7 @@
  * The Shadow Simulator
  * See LICENSE for licensing information
  */
+#include <arpa/inet.h>
 #include <assert.h>
 #include <dlfcn.h>
 #include <errno.h>
@@ -9,6 +10,7 @@
 #include <glib.h>
 #include <netdb.h>
 #include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>

--- a/src/lib/shim/shim_event.c
+++ b/src/lib/shim/shim_event.c
@@ -1,3 +1,6 @@
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "lib/shim/shim_event.h"

--- a/src/lib/shim/shim_event.h
+++ b/src/lib/shim/shim_event.h
@@ -21,6 +21,14 @@ typedef struct _ShimThreadSharedMem {
     struct timespec sim_time;
 } ShimThreadSharedMem;
 
+// Shared state between Shadow and a plugin-process. The shim-side code can modify
+// directly; synchronization is achieved via the Shadow/Plugin IPC mechanisms
+// (ptrace-stops and the shim IPC locking).
+typedef struct _ShimProcessSharedMem {
+    // Temporary; Shared mem allocator fails on size 0 struct.
+    int _dummy;
+} ShimProcessSharedMem;
+
 typedef enum {
     // Next val: 13
     SHD_SHIM_EVENT_NULL = 0,

--- a/src/lib/shim/shim_event.h
+++ b/src/lib/shim/shim_event.h
@@ -14,12 +14,12 @@
 // Shared state between Shadow and a plugin-thread. The shim-side code can modify
 // directly; synchronization is achieved via the Shadow/Plugin IPC mechanisms
 // (ptrace-stops and the shim IPC locking).
-typedef struct _ShimSharedMem {
+typedef struct _ShimThreadSharedMem {
     // While true, Shadow allows syscalls to be executed natively.
     bool ptrace_allow_native_syscalls;
     // Store the latest simulation time to avoid inter-process time syscalls.
     struct timespec sim_time;
-} ShimSharedMem;
+} ShimThreadSharedMem;
 
 typedef enum {
     // Next val: 13

--- a/src/lib/shim/shim_event.h
+++ b/src/lib/shim/shim_event.h
@@ -17,16 +17,14 @@
 typedef struct _ShimThreadSharedMem {
     // While true, Shadow allows syscalls to be executed natively.
     bool ptrace_allow_native_syscalls;
-    // Store the latest simulation time to avoid inter-process time syscalls.
-    struct timespec sim_time;
 } ShimThreadSharedMem;
 
 // Shared state between Shadow and a plugin-process. The shim-side code can modify
 // directly; synchronization is achieved via the Shadow/Plugin IPC mechanisms
 // (ptrace-stops and the shim IPC locking).
 typedef struct _ShimProcessSharedMem {
-    // Temporary; Shared mem allocator fails on size 0 struct.
-    int _dummy;
+    // Current simulation time.
+    struct timespec sim_time;
 } ShimProcessSharedMem;
 
 typedef enum {

--- a/src/lib/shim/shim_event.h
+++ b/src/lib/shim/shim_event.h
@@ -49,17 +49,6 @@ typedef struct _ShimEvent {
 
     union {
         struct {
-            // Update shim-side simulation clock
-            uint64_t simulation_nanos;
-        } start;
-
-        struct {
-            struct timespec ts;
-        } data_nano_sleep;
-
-        int rv; // TODO (rwails) hack, remove me
-
-        struct {
             // We wrap this in the surrounding struct in case there's anything
             // else we end up needing in the message besides the literal struct
             // we're going to pass to the syscall handler.
@@ -68,8 +57,6 @@ typedef struct _ShimEvent {
 
         struct {
             SysCallReg retval;
-            // Update shim-side simulation clock
-            uint64_t simulation_nanos;
         } syscall_complete;
 
         struct {

--- a/src/lib/shim/shim_event.h
+++ b/src/lib/shim/shim_event.h
@@ -4,28 +4,8 @@
 // Communication between Shadow and the shim. This is a header-only library
 // used in both places.
 
-#include <arpa/inet.h>
-#include <stdint.h>
-#include <time.h>
-
 #include "main/host/syscall_types.h"
 #include "main/shmem/shmem_allocator.h"
-
-// Shared state between Shadow and a plugin-thread. The shim-side code can modify
-// directly; synchronization is achieved via the Shadow/Plugin IPC mechanisms
-// (ptrace-stops and the shim IPC locking).
-typedef struct _ShimThreadSharedMem {
-    // While true, Shadow allows syscalls to be executed natively.
-    bool ptrace_allow_native_syscalls;
-} ShimThreadSharedMem;
-
-// Shared state between Shadow and a plugin-process. The shim-side code can modify
-// directly; synchronization is achieved via the Shadow/Plugin IPC mechanisms
-// (ptrace-stops and the shim IPC locking).
-typedef struct _ShimProcessSharedMem {
-    // Current simulation time.
-    struct timespec sim_time;
-} ShimProcessSharedMem;
 
 typedef enum {
     // Next val: 13

--- a/src/lib/shim/shim_shmem.h
+++ b/src/lib/shim/shim_shmem.h
@@ -1,8 +1,40 @@
 #ifndef SHD_SHIM_SHMEM_H_
 #define SHD_SHIM_SHMEM_H_
 
+#include <stdatomic.h>
+#include <stdint.h>
+#include <time.h>
+
 #include "ipc.h"
+#include "main/core/support/definitions.h"
 #include "shim_event.h"
+
+// Shared state between Shadow and a plugin-thread.
+//
+// While synchronized via Shadow/Plugin IPC and/or ptrace-stops, there could be
+// potential parallel access e.g. in preload mode's spin lock.  Therefore we
+// ensure members are Sync (in Rust parlance) via atomics, and maybe in the
+// future mutexes etc.
+//
+// Atomic members can mostly be dereferenced as normal, though the value should
+// be copied locally to ensure a consistent view if accessed multiple times.
+// * The compiler will use appropriate atomic-access-instructions when
+//   dereferencing.
+// * We generally only care about seeing the freshest value when transferring
+//   control between Shadow and the Shim, which already includes memory barriers.
+//
+typedef struct _ShimThreadSharedMem {
+    // While true, Shadow allows syscalls to be executed natively.
+    atomic_bool ptrace_allow_native_syscalls;
+} ShimThreadSharedMem;
+
+// Shared state between Shadow and a plugin-process.
+//
+// Safety is as for ShimThreadSharedMem, above.
+typedef struct _ShimProcessSharedMem {
+    // Current simulation time.
+    _Atomic EmulatedTime sim_time;
+} ShimProcessSharedMem;
 
 // Handle SHD_SHIM_EVENT_CLONE_REQ
 void shim_shmemHandleClone(const ShimEvent* ev);

--- a/src/lib/shim/shim_sys.h
+++ b/src/lib/shim/shim_sys.h
@@ -3,15 +3,11 @@
 
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 /// This module allows us to short-circuit syscalls that can be handled directly
 /// in the shim without needing to perform a more expensive inter-pocess syscall
 /// operation with shadow.
-
-// Caches the current simulation time to avoid invoking syscalls to get it.
-// Not thread safe, but doesn't matter since Shadow only permits
-// one thread at a time to run anyway.
-void shim_sys_set_simtime_nanos(uint64_t simulation_nanos);
 
 // Returns the current cached simulation time, or 0 if it has not yet been set.
 uint64_t shim_sys_get_simtime_nanos();

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -124,7 +124,6 @@ _shim_emulated_syscall_event(const ShimEvent* syscall_event) {
             case SHD_SHIM_EVENT_SYSCALL_COMPLETE: {
                 // Use provided result.
                 SysCallReg rv = res.event_data.syscall_complete.retval;
-                shim_sys_set_simtime_nanos(res.event_data.syscall_complete.simulation_nanos);
                 return rv;
             }
             case SHD_SHIM_EVENT_SYSCALL_DO_NATIVE: {

--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -29,6 +29,13 @@ add_custom_command(OUTPUT wrapper.rs
         # Needs Socket
         --blacklist-type "_?CompatSocket.*"
 
+        # Uses atomics, which bindgen doesn't translate correctly.
+        # https://github.com/rust-lang/rust-bindgen/issues/2151
+        --blacklist-type "atomic_bool"
+        --blacklist-type "_?ShimThreadSharedMem"
+        --blacklist-type "_?ShimProcessSharedMem"
+        --blacklist-function "thread_sharedMem"
+
         --whitelist-function "affinity_.*"
         --whitelist-function "thread_.*"
         --whitelist-function "descriptor_close"

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -21,6 +21,7 @@
 #include <pthread.h>
 #include <signal.h>
 #include <stdarg.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <sys/file.h>
@@ -161,9 +162,7 @@ ShimProcessSharedMem* process_sharedMem(Process* proc) {
 }
 
 static void _process_setSharedTime(Process* proc) {
-    EmulatedTime now = worker_getEmulatedTime();
-    process_sharedMem(proc)->sim_time.tv_sec = now / SIMTIME_ONE_SECOND;
-    process_sharedMem(proc)->sim_time.tv_nsec = now % SIMTIME_ONE_SECOND;
+    process_sharedMem(proc)->sim_time = worker_getEmulatedTime();
 }
 
 const gchar* process_getName(Process* proc) {

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -515,7 +515,7 @@ static void _process_start(Process* proc) {
         shmemblockserialized_toString(&sharedMemBlockSerial, sharedMemBlockBuf);
 
         /* append to the env */
-        proc->envv = g_environ_setenv(proc->envv, "SHADOW_SHM_BLK", sharedMemBlockBuf, TRUE);
+        proc->envv = g_environ_setenv(proc->envv, "SHADOW_SHM_THREAD_BLK", sharedMemBlockBuf, TRUE);
     }
 
     proc->plugin.isExecuting = TRUE;

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -869,6 +869,8 @@ static void _process_free(Process* proc) {
         host_unref(proc->host);
     }
 
+    shmemallocator_globalFree(&proc->shimSharedMemBlock);
+
     worker_count_deallocation(Process);
 
     MAGIC_CLEAR(proc);

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -506,6 +506,18 @@ static void _process_start(Process* proc) {
     g_timer_start(proc->cpuDelayTimer);
 #endif
 
+    /* Add shared mem block of first thread to env */
+    {
+        ShMemBlockSerialized sharedMemBlockSerial =
+            shmemallocator_globalBlockSerialize(thread_getShMBlock(mainThread));
+
+        char sharedMemBlockBuf[SHD_SHMEM_BLOCK_SERIALIZED_MAX_STRLEN] = {0};
+        shmemblockserialized_toString(&sharedMemBlockSerial, sharedMemBlockBuf);
+
+        /* append to the env */
+        proc->envv = g_environ_setenv(proc->envv, "SHADOW_SHM_BLK", sharedMemBlockBuf, TRUE);
+    }
+
     proc->plugin.isExecuting = TRUE;
     /* exec the process */
     thread_run(mainThread, proc->argv, proc->envv, proc->workingDir);

--- a/src/main/host/syscall/shadow.c
+++ b/src/main/host/syscall/shadow.c
@@ -92,7 +92,7 @@ SysCallReturn syscallhandler_shadow_set_ptrace_allow_native_syscalls(SysCallHand
         bool is_allowed = args->args[0].as_i64;
         trace("shadow_set_ptrace_allow_native_syscalls is_allowed=%d", is_allowed);
 
-        threadptrace_setAllowNativeSyscalls(sys->thread, is_allowed);
+        thread_sharedMem(sys->thread)->ptrace_allow_native_syscalls = is_allowed;
 
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
     } else {

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -81,6 +81,7 @@ void thread_unref(Thread* thread) {
         if (thread->host) {
             host_unref(thread->host);
         }
+        shmemallocator_globalFree(&thread->shimSharedMemBlock);
         MAGIC_CLEAR(thread);
         g_free(thread);
     }

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -32,9 +32,9 @@ Thread thread_create(Host* host, Process* process, int threadID, int type_id,
                      .process = process,
                      .tid = threadID,
                      .affinity = AFFINITY_UNINIT,
-                     .shimSharedMemBlock = shmemallocator_globalAlloc(sizeof(ShimSharedMem)),
+                     .shimSharedMemBlock = shmemallocator_globalAlloc(sizeof(ShimThreadSharedMem)),
                      MAGIC_INITIALIZER};
-    *thread_sharedMem(&thread) = (ShimSharedMem){
+    *thread_sharedMem(&thread) = (ShimThreadSharedMem){
         .ptrace_allow_native_syscalls = false,
     };
     host_ref(host);
@@ -159,7 +159,7 @@ ShMemBlock* thread_getShMBlock(Thread* thread) {
     return &thread->shimSharedMemBlock;
 }
 
-ShimSharedMem* thread_sharedMem(Thread* thread) {
+ShimThreadSharedMem* thread_sharedMem(Thread* thread) {
     MAGIC_ASSERT(thread);
     utility_assert(thread->shimSharedMemBlock.p);
     return thread->shimSharedMemBlock.p;

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -86,18 +86,11 @@ void thread_unref(Thread* thread) {
     }
 }
 
-static void _thread_setSharedTime(Thread* thread) {
-    EmulatedTime now = worker_getEmulatedTime();
-    thread_sharedMem(thread)->sim_time.tv_sec = now / SIMTIME_ONE_SECOND;
-    thread_sharedMem(thread)->sim_time.tv_nsec = now % SIMTIME_ONE_SECOND;
-}
-
 void thread_run(Thread* thread, gchar** argv, gchar** envv, const char* workingDir) {
     MAGIC_ASSERT(thread);
     utility_assert(thread->methods.run);
 
     _thread_syncAffinityWithWorker(thread);
-    _thread_setSharedTime(thread);
 
     thread->nativePid = thread->methods.run(thread, argv, envv, workingDir);
     // In Linux, the PID is equal to the TID of its first thread.
@@ -108,7 +101,6 @@ void thread_resume(Thread* thread) {
     MAGIC_ASSERT(thread);
     utility_assert(thread->methods.resume);
     _thread_syncAffinityWithWorker(thread);
-    _thread_setSharedTime(thread);
 
     // Ensure the condition isn't triggered again, but don't clear it yet.
     // Syscall handler can still access.

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -13,8 +13,9 @@
 
 typedef struct _Thread Thread;
 
-#include "main/host/syscall_handler.h"
+#include "lib/shim/shim_event.h"
 #include "main/host/process.h"
+#include "main/host/syscall_handler.h"
 #include "main/host/syscall_types.h"
 #include "main/shmem/shmem_allocator.h"
 
@@ -72,6 +73,10 @@ ShMemBlock* thread_getIPCBlock(Thread* thread);
 
 // Returns the block used for shared state, or NULL if no such block is is used.
 ShMemBlock* thread_getShMBlock(Thread* thread);
+
+// Returns a typed pointer to memory shared with the shim (which is backed by
+// the block returned by thread_getShMBlock).
+ShimSharedMem* thread_sharedMem(Thread* thread);
 
 Process* thread_getProcess(Thread* thread);
 Host* thread_getHost(Thread* thread);

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -13,7 +13,7 @@
 
 typedef struct _Thread Thread;
 
-#include "lib/shim/shim_event.h"
+#include "lib/shim/shim_shmem.h"
 #include "main/host/process.h"
 #include "main/host/syscall_handler.h"
 #include "main/host/syscall_types.h"

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -76,7 +76,7 @@ ShMemBlock* thread_getShMBlock(Thread* thread);
 
 // Returns a typed pointer to memory shared with the shim (which is backed by
 // the block returned by thread_getShMBlock).
-ShimSharedMem* thread_sharedMem(Thread* thread);
+ShimThreadSharedMem* thread_sharedMem(Thread* thread);
 
 Process* thread_getProcess(Thread* thread);
 Host* thread_getHost(Thread* thread);

--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -232,13 +232,6 @@ static ShMemBlock* _threadpreload_getIPCBlock(Thread* base) {
     return &thread->ipc_blk;
 }
 
-static ShMemBlock* _threadpreload_getShMBlock(Thread* base) {
-    // We currently communicate the simulation time to the shim by including it in every event
-    // we send over the IPC channel, and the shim caches it.
-    // TODO we could instead use a shmem segment like threadptrace does.
-    return NULL;
-}
-
 SysCallCondition* threadpreload_resume(Thread* base) {
     ThreadPreload* thread = _threadToThreadPreload(base);
 
@@ -472,7 +465,6 @@ Thread* threadpreload_new(Host* host, Process* process, gint threadID) {
                                   .nativeSyscall = threadpreload_nativeSyscall,
                                   .clone = _threadpreload_clone,
                                   .getIPCBlock = _threadpreload_getIPCBlock,
-                                  .getShMBlock = _threadpreload_getShMBlock,
                               }),
     };
     thread->base.sys = syscallhandler_new(host, process, _threadPreloadToThread(thread));

--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -249,7 +249,6 @@ SysCallCondition* threadpreload_resume(Thread* base) {
                 trace("sending start event code to %d on %p", thread->base.nativePid,
                       thread->ipc_data);
 
-                thread->currentEvent.event_data.start.simulation_nanos = worker_getEmulatedTime();
                 shimevent_sendEventToPlugin(thread->ipc_data, &thread->currentEvent);
                 break;
             }
@@ -306,14 +305,11 @@ SysCallCondition* threadpreload_resume(Thread* base) {
                 ShimEvent shim_result;
                 if (result.state == SYSCALL_DONE) {
                     // Now send the result of the syscall
-                    shim_result = (ShimEvent){
-                        .event_id = SHD_SHIM_EVENT_SYSCALL_COMPLETE,
-                        .event_data = {
-                            .syscall_complete = {.retval = result.retval,
-                                                 .simulation_nanos = worker_getEmulatedTime(),
-                                                 },
+                    shim_result = (ShimEvent){.event_id = SHD_SHIM_EVENT_SYSCALL_COMPLETE,
+                                              .event_data = {
+                                                  .syscall_complete = {.retval = result.retval},
 
-                        }};
+                                              }};
                 } else if (result.state == SYSCALL_NATIVE) {
                     // Tell the shim to make the syscall itself
                     shim_result = (ShimEvent){

--- a/src/main/host/thread_protected.h
+++ b/src/main/host/thread_protected.h
@@ -27,7 +27,6 @@ typedef struct _ThreadMethods {
     int (*clone)(Thread* thread, unsigned long flags, PluginPtr child_stack, PluginPtr ptid,
                  PluginPtr ctid, unsigned long newtls, Thread** child);
     ShMemBlock* (*getIPCBlock)(Thread* thread);
-    ShMemBlock* (*getShMBlock)(Thread* thread);
 } ThreadMethods;
 
 struct _Thread {
@@ -47,6 +46,8 @@ struct _Thread {
     int referenceCount;
 
     SysCallHandler* sys;
+
+    ShMemBlock shimSharedMemBlock;
 
     // Non-null if blocked by a syscall.
     SysCallCondition* cond;

--- a/src/main/host/thread_ptrace.c
+++ b/src/main/host/thread_ptrace.c
@@ -718,11 +718,7 @@ pid_t threadptrace_run(Thread* base, gchar** argv, gchar** envv, const char* wor
 
     if (thread->enableIpc) {
         // Send 'start' event.
-        ShimEvent startEvent = {
-            .event_id = SHD_SHIM_EVENT_START,
-            .event_data.start = {
-                .simulation_nanos = worker_getEmulatedTime(),
-            }};
+        ShimEvent startEvent = {.event_id = SHD_SHIM_EVENT_START};
         shimevent_sendEventToPlugin(_threadptrace_ipcData(thread), &startEvent);
     }
 
@@ -856,13 +852,10 @@ static SysCallCondition* _threadptrace_resumeIpcSyscall(ThreadPtrace* thread, bo
             return ret.cond;
         case SYSCALL_DONE: {
             trace("ipc_syscall done");
-            ShimEvent shim_result = {
-                .event_id = SHD_SHIM_EVENT_SYSCALL_COMPLETE,
-                .event_data = {
-                    .syscall_complete = {.retval = ret.retval,
-                                         .simulation_nanos = worker_getEmulatedTime()},
-
-                }};
+            ShimEvent shim_result = {.event_id = SHD_SHIM_EVENT_SYSCALL_COMPLETE,
+                                     .event_data = {
+                                         .syscall_complete = {.retval = ret.retval},
+                                     }};
             shimevent_sendEventToPlugin(_threadptrace_ipcData(thread), &shim_result);
             break;
         }
@@ -872,13 +865,10 @@ static SysCallCondition* _threadptrace_resumeIpcSyscall(ThreadPtrace* thread, bo
             long rv = thread_nativeSyscall(_threadPtraceToThread(thread), args->number,
                                            args->args[0], args->args[1], args->args[2],
                                            args->args[3], args->args[4], args->args[5]);
-            ShimEvent shim_result = {
-                .event_id = SHD_SHIM_EVENT_SYSCALL_COMPLETE,
-                .event_data = {
-                    .syscall_complete = {.retval = rv,
-                                         .simulation_nanos = worker_getEmulatedTime()},
-
-                }};
+            ShimEvent shim_result = {.event_id = SHD_SHIM_EVENT_SYSCALL_COMPLETE,
+                                     .event_data = {
+                                         .syscall_complete = {.retval = rv},
+                                     }};
             shimevent_sendEventToPlugin(_threadptrace_ipcData(thread), &shim_result);
         }
     }
@@ -1279,9 +1269,7 @@ int threadptrace_clone(Thread* base, unsigned long flags, PluginPtr child_stack,
         // Send 'start' event.
         ShimEvent startEvent = {
             .event_id = SHD_SHIM_EVENT_START,
-            .event_data.start = {
-                .simulation_nanos = worker_getEmulatedTime(),
-            }};
+        };
         shimevent_sendEventToPlugin(_threadptrace_ipcData(child), &startEvent);
     }
 

--- a/src/main/host/thread_ptrace.c
+++ b/src/main/host/thread_ptrace.c
@@ -225,9 +225,6 @@ typedef struct _ThreadPtrace {
     // Handle for IPC shared memory. Access via `_threadptrace_ipcData`.
     ShMemBlock ipcBlk;
 
-    // Handle for additional shared memory. Access via `_threadptrace_sharedMem`.
-    ShMemBlock shimSharedMemBlock;
-
     // Enable syscall handling via IPC.
     bool enableIpc;
 } ThreadPtrace;
@@ -236,12 +233,6 @@ static struct IPCData* _threadptrace_ipcData(ThreadPtrace* thread) {
     utility_assert(thread);
     utility_assert(thread->ipcBlk.p);
     return thread->ipcBlk.p;
-}
-
-static ShimSharedMem* _threadptrace_sharedMem(ThreadPtrace* thread) {
-    utility_assert(thread);
-    utility_assert(thread->shimSharedMemBlock.p);
-    return thread->shimSharedMemBlock.p;
 }
 
 // Forward declaration.
@@ -696,17 +687,6 @@ pid_t threadptrace_run(Thread* base, gchar** argv, gchar** envv, const char* wor
         myenvv = g_environ_setenv(myenvv, "SHADOW_IPC_BLK", ipcBlkBuf, TRUE);
     }
 
-    {
-        ShMemBlockSerialized sharedMemBlockSerial =
-            shmemallocator_globalBlockSerialize(&thread->shimSharedMemBlock);
-
-        char sharedMemBlockBuf[SHD_SHMEM_BLOCK_SERIALIZED_MAX_STRLEN] = {0};
-        shmemblockserialized_toString(&sharedMemBlockSerial, sharedMemBlockBuf);
-
-        /* append to the env */
-        myenvv = g_environ_setenv(myenvv, "SHADOW_SHM_BLK", sharedMemBlockBuf, TRUE);
-    }
-
     gchar* envStr = utility_strvToNewStr(myenvv);
     gchar* argStr = utility_strvToNewStr(argv);
     info("forking new thread with environment '%s', arguments '%s', and working directory '%s'",
@@ -761,11 +741,6 @@ _threadptrace_getSerializedBlock(ThreadPtrace* thread, PluginPtr shm_blk_pptr, S
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
 }
 
-void threadptrace_setAllowNativeSyscalls(Thread* base, bool is_allowed) {
-    ThreadPtrace* thread = _threadToThreadPtrace(base);
-    _threadptrace_sharedMem(thread)->ptrace_allow_native_syscalls = is_allowed;
-}
-
 static ShMemBlock* _threadptrace_getIPCBlock(Thread* base) {
     ThreadPtrace* thread = _threadToThreadPtrace(base);
     if (thread->enableIpc) {
@@ -775,17 +750,12 @@ static ShMemBlock* _threadptrace_getIPCBlock(Thread* base) {
     }
 }
 
-static ShMemBlock* _threadptrace_getShMBlock(Thread* base) {
-    ThreadPtrace* thread = _threadToThreadPtrace(base);
-    return &thread->shimSharedMemBlock;
-}
-
 static SysCallReturn _threadptrace_handleSyscall(ThreadPtrace* thread, SysCallArgs* args) {
     utility_assert(thread->childState == THREAD_PTRACE_CHILD_STATE_SYSCALL ||
                    thread->childState == THREAD_PTRACE_CHILD_STATE_IPC_SYSCALL);
 
     if (!syscall_num_is_shadow(args->number) &&
-        _threadptrace_sharedMem(thread)->ptrace_allow_native_syscalls) {
+        thread_sharedMem(&thread->base)->ptrace_allow_native_syscalls) {
         if (args->number == SYS_brk) {
             // brk should *always* be interposed so that the MemoryManager can track it.
             trace("Interposing brk even though native syscalls are enabled");
@@ -975,21 +945,12 @@ static SysCallCondition* _threadptrace_resumeSyscall(ThreadPtrace* thread, bool*
     return NULL;
 }
 
-static void _threadptrace_setSharedTime(ThreadPtrace* thread) {
-    EmulatedTime now = worker_getEmulatedTime();
-    _threadptrace_sharedMem(thread)->sim_time.tv_sec = now / SIMTIME_ONE_SECOND;
-    _threadptrace_sharedMem(thread)->sim_time.tv_nsec = now % SIMTIME_ONE_SECOND;
-}
-
 SysCallCondition* threadptrace_resume(Thread* base) {
     ThreadPtrace* thread = _threadToThreadPtrace(base);
 
     if (thread->needAttachment) {
         _threadptrace_doAttach(thread);
     }
-
-    // Make sure the shim has the latest time before we resume
-    _threadptrace_setSharedTime(thread);
 
     // Try to flush any buffers left from the previous thread. In particular if
     // the previous thread exited, we might not have been able to flush its
@@ -1353,16 +1314,10 @@ Thread* threadptraceonly_new(Host* host, Process* process, int threadID) {
                                   .nativeSyscall = threadptrace_nativeSyscall,
                                   .clone = threadptrace_clone,
                                   .getIPCBlock = _threadptrace_getIPCBlock,
-                                  .getShMBlock = _threadptrace_getShMBlock,
                               }),
         .childState = THREAD_PTRACE_CHILD_STATE_NONE,
     };
     thread->base.sys = syscallhandler_new(host, process, _threadPtraceToThread(thread));
-
-    // Set up a shared mem channel that we use even if not using IPC events
-    thread->shimSharedMemBlock = shmemallocator_globalAlloc(sizeof(ShimSharedMem));
-    *_threadptrace_sharedMem(thread) = (ShimSharedMem){.ptrace_allow_native_syscalls = false};
-    _threadptrace_setSharedTime(thread);
 
     worker_count_allocation(ThreadPtrace);
 

--- a/src/main/host/thread_ptrace.h
+++ b/src/main/host/thread_ptrace.h
@@ -10,7 +10,4 @@ Thread* threadptraceonly_new(Host* host, Process* process, gint threadID);
 
 void threadptrace_detach(Thread* base);
 
-// Set whether or not ptrace will allow the shim to perform native syscalls.
-void threadptrace_setAllowNativeSyscalls(Thread* base, bool is_allowed);
-
 #endif


### PR DESCRIPTION
* Adds per-process shared memory, which we need to hold per-process signal state.
* Moves per-thread shared memory from ThreadPtrace to Thread, since we will need it for per-thread signal state.
* Moves the simtime from per-thread state to per-process state.
* Migrates thread_preload to use the simtime in shared memory instead of explicitly sending it in IPC messages.