### PR TITLE
Implement basic signal emulation

### DIFF
--- a/src/lib/shim/CMakeLists.txt
+++ b/src/lib/shim/CMakeLists.txt
@@ -11,7 +11,6 @@ find_package(GLIB REQUIRED)
 find_package(RT REQUIRED)
 include_directories(${GLIB_INCLUDES})
 
-
 add_cflags(-fPIC)
 
 set(SHIM_HELPER_LIB shadow-shim-helper)
@@ -20,13 +19,15 @@ set(SHIM_HELPER_FILES
   ipc.cc
   shadow_sem.c
   shadow_spinlock.c
+  shadow_signals.c
   shim_event.c
+  shim_shmem.c
 )
 add_library(${SHIM_HELPER_LIB} STATIC ${SHIM_HELPER_FILES})
 # -D_GNU_SOURCE enables some additional features in libc, such at RTLD_NEXT.
 # -fPIC enables linking the static compile unit with a shared object library
 target_compile_options(${SHIM_HELPER_LIB} PRIVATE -D_GNU_SOURCE -fPIC)
-target_link_libraries(${SHIM_HELPER_LIB} INTERFACE shadow-shmem)
+target_link_libraries(${SHIM_HELPER_LIB} INTERFACE logger shadow-shmem)
 
 set(SHIM_LIB shadow-shim)
 set(SHIM_FILES
@@ -37,7 +38,6 @@ set(SHIM_FILES
   shim_logger.c
   shim_rdtsc.c
   shim_seccomp.c
-  shim_shmem.c
   shim_sys.c
   shim_syscall.c
   shim_tls.c

--- a/src/lib/shim/ipc.cc
+++ b/src/lib/shim/ipc.cc
@@ -2,7 +2,6 @@
 
 #include <assert.h>
 #include <errno.h>
-#include <signal.h>
 #include <string.h>
 
 #include <atomic>

--- a/src/lib/shim/shadow_signals.c
+++ b/src/lib/shim/shadow_signals.c
@@ -1,0 +1,103 @@
+#include "shadow_signals.h"
+
+ShdKernelDefaultAction shd_defaultAction(int signo) {
+    switch (signo) {
+        case SIGCONT: return SHD_DEFAULT_ACTION_CONT;
+        // aka SIGIOT
+        case SIGABRT:
+        case SIGBUS:
+        case SIGFPE:
+        case SIGILL:
+        case SIGQUIT:
+        case SIGSEGV:
+        case SIGSYS:
+        case SIGTRAP:
+        case SIGXCPU:
+        case SIGXFSZ: return SHD_DEFAULT_ACTION_CORE;
+        // aka SIGCLD
+        case SIGCHLD:
+        case SIGURG:
+        case SIGWINCH: return SHD_DEFAULT_ACTION_IGN;
+        case SIGSTOP:
+        case SIGTSTP:
+        case SIGTTIN:
+        case SIGTTOU: return SHD_DEFAULT_ACTION_STOP;
+        case SIGALRM:
+#ifdef SIGEMT
+        case SIGEMT:
+#endif
+        case SIGHUP:
+        case SIGINT:
+        // aka SIGPOLL
+        case SIGIO:
+        case SIGKILL:
+#ifdef SIGLOST
+        case SIGLOST:
+#endif
+        case SIGPIPE:
+        case SIGPROF:
+        case SIGPWR:
+        case SIGSTKFLT:
+        case SIGTERM:
+        case SIGUSR1:
+        case SIGUSR2:
+        case SIGVTALRM: return SHD_DEFAULT_ACTION_TERM;
+        default: error("Unrecognized signal %d", signo); return SHD_DEFAULT_ACTION_CORE;
+    }
+}
+
+shd_kernel_sigset_t shd_sigemptyset() { return (shd_kernel_sigset_t){0}; }
+
+shd_kernel_sigset_t shd_sigfullset() { return (shd_kernel_sigset_t){.val = ~UINT64_C(0)}; }
+
+void shd_sigaddset(shd_kernel_sigset_t* set, int signum) {
+    if (signum < 1 || signum > SHD_SIGRT_MAX) {
+        panic("Bad signum %d", signum);
+    }
+    set->val |= UINT64_C(1) << (signum - 1);
+}
+
+void shd_sigdelset(shd_kernel_sigset_t* set, int signum) {
+    if (signum < 1 || signum > SHD_SIGRT_MAX) {
+        panic("Bad signum %d", signum);
+    }
+    set->val &= ~(UINT64_C(1) << (signum - 1));
+}
+
+bool shd_sigismember(const shd_kernel_sigset_t* set, int signum) {
+    if (signum < 1 || signum > SHD_SIGRT_MAX) {
+        return false;
+    }
+    return set->val & (UINT64_C(1) << (signum - 1));
+}
+
+bool shd_sigisemptyset(const shd_kernel_sigset_t* set) { return set->val == 0; }
+
+shd_kernel_sigset_t shd_sigorset(const shd_kernel_sigset_t* left,
+                                 const shd_kernel_sigset_t* right) {
+    return (shd_kernel_sigset_t){.val = left->val | right->val};
+}
+
+shd_kernel_sigset_t shd_sigandset(const shd_kernel_sigset_t* left,
+                                  const shd_kernel_sigset_t* right) {
+    return (shd_kernel_sigset_t){.val = left->val & right->val};
+}
+
+shd_kernel_sigset_t shd_signotset(const shd_kernel_sigset_t* src) {
+    return (shd_kernel_sigset_t){.val = ~src->val};
+}
+
+// Return the smallest signal number that's set, or 0 if none are.
+int shd_siglowest(const shd_kernel_sigset_t* set) {
+    if (!set->val) {
+        return 0;
+    }
+    // Naive loop for now. There's probably some more clever bit manipulation we could do.
+    for (int i = 1; i <= SHD_SIGRT_MAX; ++i) {
+        if (shd_sigismember(set, i)) {
+            return i;
+        }
+    }
+    // Unreachable
+    panic("Unreachable");
+}

--- a/src/lib/shim/shadow_signals.h
+++ b/src/lib/shim/shadow_signals.h
@@ -1,0 +1,71 @@
+#ifndef LIB_SHIM_SHADOW_SIGNALS_H
+#define LIB_SHIM_SHADOW_SIGNALS_H
+
+#include <errno.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "lib/logger/logger.h"
+
+#define SHD_STANDARD_SIGNAL_MAX_NO 31
+
+// Lowest and highest valid realtime signal, according to signal(7).  We don't
+// use libc's SIGRTMIN and SIGRTMAX directly since those may omit some signal
+// numbers that libc reserves for its internal use. We still need to handle
+// those signal numbers in Shadow.
+#define SHD_SIGRT_MIN 32
+#define SHD_SIGRT_MAX 64
+
+// Compatible with the kernel's definition of sigset_t on x86_64. Exposing the
+// definition in the header so that it can be used as a value-type, but should
+// be manipulated with the helpers below.
+//
+// This is analagous to but typically smaller than libc's sigset_t.
+typedef struct {
+    uint64_t val;
+} shd_kernel_sigset_t;
+
+// Compatible with kernel's definition of `struct sigaction`. Different from libc's in that
+// `ksa_handler` and `ksa_sigaction` are explicitly in a union, and that `ksa_mask` is the
+// kernel's mask size (64 bits) vs libc's larger one (~1000 bits for glibc).
+//
+// We use the field prefix ksa_ to avoid conflicting with macros defined for the
+// corresponding field names in glibc.
+struct shd_kernel_sigaction {
+    union {
+        void (*ksa_handler)(int);
+        void (*ksa_sigaction)(int, siginfo_t*, void*);
+    };
+    int ksa_flags;
+    void (*ksa_restorer)(void);
+    shd_kernel_sigset_t ksa_mask;
+};
+
+// Corresponds to default actions documented in signal(7).
+typedef enum {
+    SHD_DEFAULT_ACTION_TERM,
+    SHD_DEFAULT_ACTION_IGN,
+    SHD_DEFAULT_ACTION_CORE,
+    SHD_DEFAULT_ACTION_STOP,
+    SHD_DEFAULT_ACTION_CONT,
+} ShdKernelDefaultAction;
+
+// Returns default action documented in signal(7) for the given signal.
+ShdKernelDefaultAction shd_defaultAction(int signo);
+
+shd_kernel_sigset_t shd_sigemptyset();
+shd_kernel_sigset_t shd_sigfullset();
+void shd_sigaddset(shd_kernel_sigset_t* set, int signum);
+void shd_sigdelset(shd_kernel_sigset_t* set, int signum);
+bool shd_sigismember(const shd_kernel_sigset_t* set, int signum);
+bool shd_sigisemptyset(const shd_kernel_sigset_t* set);
+shd_kernel_sigset_t shd_sigorset(const shd_kernel_sigset_t* left, const shd_kernel_sigset_t* right);
+shd_kernel_sigset_t shd_sigandset(const shd_kernel_sigset_t* left,
+                                  const shd_kernel_sigset_t* right);
+shd_kernel_sigset_t shd_signotset(const shd_kernel_sigset_t* src);
+
+// Return the smallest signal number that's set, or 0 if none are.
+int shd_siglowest(const shd_kernel_sigset_t* set);
+
+#endif

--- a/src/lib/shim/shim.h
+++ b/src/lib/shim/shim.h
@@ -4,6 +4,7 @@
 #include <stdatomic.h>
 #include <sys/types.h>
 
+#include "lib/shim/shim_shmem.h"
 #include "main/core/support/definitions.h"
 #include "main/shmem/shmem_allocator.h"
 
@@ -24,9 +25,6 @@ bool shim_use_syscall_handler();
 // Returns the shmem block used for IPC, which may be uninitialized.
 struct IPCData* shim_thisThreadEventIPC();
 
-// Return the location of the time object in shared memory, or NULL if unavailable.
-_Atomic EmulatedTime* shim_get_shared_time_location();
-
 // To be called in parent thread before making the `clone` syscall.
 // It sets up data for the new thread.
 void shim_newThreadStart(ShMemBlockSerialized* block);
@@ -45,9 +43,20 @@ void shim_newThreadChildInitd();
 // We use a page for a stack guard, and up to another page to page-align the
 // stack guard. We assume 4k pages here but detect at runtime if this is too small.
 #define SHIM_SIGNAL_STACK_GUARD_OVERHEAD ((size_t)4096 * 2)
-// Found experimentally. 4k seems to be enough for most platforms, but fails on Ubuntu 18.04.
-#define SHIM_SIGNAL_STACK_MIN_USABLE_SIZE ((size_t)1024 * 12)
+// Shouldn't need to make this very large, but needs to be big enough to run the
+// managed process's signal handlers as well - possibly recursively.
+//
+// Stack space that's *never* used shouldn't ever become resident, but an
+// occasional deep stack could force the pages to be resident ever after.  To
+// mitigate that, we could consider `madvise(MADV_DONTNEED)` after running
+// signal handlers, to let the OS reclaim the (now-popped) signal handler stack
+// frames.
+#define SHIM_SIGNAL_STACK_MIN_USABLE_SIZE ((size_t)1024 * 100)
 #define SHIM_SIGNAL_STACK_SIZE                                                                     \
     (SHIM_SIGNAL_STACK_GUARD_OVERHEAD + SHIM_SIGNAL_STACK_MIN_USABLE_SIZE)
+
+ShimShmemThread* shim_threadSharedMem();
+ShimShmemProcess* shim_processSharedMem();
+ShimShmemHost* shim_hostSharedMem();
 
 #endif // SHD_SHIM_SHIM_H_

--- a/src/lib/shim/shim_event.h
+++ b/src/lib/shim/shim_event.h
@@ -4,6 +4,7 @@
 // Communication between Shadow and the shim. This is a header-only library
 // used in both places.
 
+#include "main/host/syscall/kernel_types.h"
 #include "main/host/syscall_types.h"
 #include "main/shmem/shmem_allocator.h"
 

--- a/src/lib/shim/shim_shmem.c
+++ b/src/lib/shim/shim_shmem.c
@@ -5,9 +5,314 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "lib/logger/logger.h"
 #include "lib/shim/ipc.h"
 #include "lib/shim/shim_event.h"
+#include "main/host/host.h"
 #include "main/shmem/shmem_allocator.h"
+
+struct _ShimHostProtectedSharedMem {
+    GQuark host_id;
+};
+
+struct _ShimShmemHost {
+    GQuark host_id;
+
+    // The host lock. Guards _ShimShmemHost.protected,
+    // _ShimShmemProcess.protected, and _ShimShmemThread.protected.
+    pthread_mutex_t mutex;
+
+    // Guarded by `mutex`.
+    ShimShmemHostLock protected;
+};
+
+typedef struct _ShimProcessProtectedSharedMem ShimProcessProtectedSharedMem;
+struct _ShimProcessProtectedSharedMem {
+    GQuark host_id;
+
+    // Process-directed pending signals.
+    shd_kernel_sigset_t pending_signals;
+
+    // siginfo for each of the standard signals.
+    siginfo_t pending_standard_siginfos[SHD_STANDARD_SIGNAL_MAX_NO];
+
+    // actions for both standard and realtime signals.
+    // We currently support configuring handlers for realtime signals, but not
+    // actually delivering them. This is to handle the case where handlers are
+    // defensively installed, but not used in practice.
+    struct shd_kernel_sigaction signal_actions[SHD_SIGRT_MAX];
+};
+
+struct _ShimShmemProcess {
+    GQuark host_id;
+
+    // Current simulation time.
+    _Atomic EmulatedTime sim_time;
+
+    // Guarded by ShimShmemHost.mutex.
+    ShimProcessProtectedSharedMem protected;
+};
+
+typedef struct _ShimThreadProtectedSharedMem ShimThreadProtectedSharedMem;
+struct _ShimThreadProtectedSharedMem {
+    GQuark host_id;
+
+    // Thread-directed pending signals.
+    shd_kernel_sigset_t pending_signals;
+
+    // siginfo for each of the 32 standard signals.
+    siginfo_t pending_standard_siginfos[SHD_STANDARD_SIGNAL_MAX_NO];
+
+    // Signal mask, e.g. as set by `sigprocmask`.
+    // We don't use sigset_t since glibc uses a much larger bitfield than
+    // actually supported by the kernel.
+    shd_kernel_sigset_t blocked_signals;
+};
+
+struct _ShimShmemThread {
+    GQuark host_id;
+
+    // While true, Shadow allows syscalls to be executed natively.
+    atomic_bool ptrace_allow_native_syscalls;
+
+    // Guarded by ShimShmemHost.mutex.
+    ShimThreadProtectedSharedMem protected;
+};
+
+size_t shimshmemhost_size() { return sizeof(ShimShmemHost); }
+
+void shimshmemhost_init(ShimShmemHost* hostMem, Host* host) {
+    *hostMem = (ShimShmemHost){
+        .host_id = host_getID(host),
+        .mutex = PTHREAD_MUTEX_INITIALIZER,
+        .protected =
+            {
+                .host_id = host_getID(host),
+            },
+    };
+}
+
+shd_kernel_sigset_t shimshmem_getProcessPendingSignals(const ShimShmemHostLock* host,
+                                                       const ShimShmemProcess* process) {
+    assert(host);
+    assert(process);
+    assert(host->host_id == process->host_id);
+    return process->protected.pending_signals;
+}
+
+void shimshmem_setProcessPendingSignals(const ShimShmemHostLock* host, ShimShmemProcess* process,
+                                        shd_kernel_sigset_t set) {
+    assert(host);
+    assert(process);
+    assert(host->host_id == process->host_id);
+    process->protected.pending_signals = set;
+}
+
+siginfo_t shimshmem_getProcessSiginfo(const ShimShmemHostLock* host,
+                                      const ShimShmemProcess* process, int sig) {
+    assert(host);
+    assert(process);
+    assert(host->host_id == process->host_id);
+    assert(sig >= 1);
+    assert(sig <= SHD_STANDARD_SIGNAL_MAX_NO);
+    return process->protected.pending_standard_siginfos[sig - 1];
+}
+
+void shimshmem_setProcessSiginfo(const ShimShmemHostLock* host, ShimShmemProcess* process, int sig,
+                                 const siginfo_t* info) {
+    assert(host);
+    assert(process);
+    assert(host->host_id == process->host_id);
+    assert(sig >= 1);
+    assert(sig <= SHD_STANDARD_SIGNAL_MAX_NO);
+    process->protected.pending_standard_siginfos[sig - 1] = *info;
+}
+
+struct shd_kernel_sigaction shimshmem_getSignalAction(const ShimShmemHostLock* host,
+                                                      const ShimShmemProcess* process, int sig) {
+    assert(host);
+    assert(process);
+    assert(host->host_id == process->host_id);
+    assert(sig >= 1);
+    assert(sig <= SHD_SIGRT_MAX);
+    return process->protected.signal_actions[sig - 1];
+}
+
+void shimshmem_setSignalAction(const ShimShmemHostLock* host, ShimShmemProcess* process, int sig,
+                               const struct shd_kernel_sigaction* action) {
+    assert(host);
+    assert(process);
+    assert(host->host_id == process->host_id);
+    assert(sig >= 1);
+    assert(sig <= SHD_SIGRT_MAX);
+    process->protected.signal_actions[sig - 1] = *action;
+}
+
+size_t shimshmemprocess_size() { return sizeof(ShimShmemProcess); }
+
+void shimshmemprocess_init(ShimShmemProcess* processMem, Process* process) {
+    *processMem = (ShimShmemProcess){
+        .host_id = process_getHostId(process),
+        .protected =
+            {
+                .host_id = process_getHostId(process),
+            },
+    };
+}
+
+EmulatedTime shimshmem_getEmulatedTime(ShimShmemProcess* processMem) {
+    return atomic_load(&processMem->sim_time);
+}
+
+void shimshmem_setEmulatedTime(ShimShmemProcess* processMem, EmulatedTime t) {
+    atomic_store(&processMem->sim_time, t);
+}
+
+shd_kernel_sigset_t shimshmem_getThreadPendingSignals(const ShimShmemHostLock* host,
+                                                      const ShimShmemThread* thread) {
+    assert(host);
+    assert(thread);
+    assert(host->host_id == thread->host_id);
+    return thread->protected.pending_signals;
+}
+
+void shimshmem_setThreadPendingSignals(const ShimShmemHostLock* host, ShimShmemThread* thread,
+                                       shd_kernel_sigset_t sigset) {
+    assert(host);
+    assert(thread);
+    assert(host->host_id == thread->host_id);
+    thread->protected.pending_signals = sigset;
+}
+
+siginfo_t shimshmem_getThreadSiginfo(const ShimShmemHostLock* host, const ShimShmemThread* thread,
+                                     int sig) {
+    assert(host);
+    assert(thread);
+    assert(host->host_id == thread->host_id);
+    assert(sig >= 1);
+    assert(sig <= SHD_STANDARD_SIGNAL_MAX_NO);
+    return thread->protected.pending_standard_siginfos[sig - 1];
+}
+
+void shimshmem_setThreadSiginfo(const ShimShmemHostLock* host, ShimShmemThread* thread, int sig,
+                                const siginfo_t* info) {
+    assert(host);
+    assert(thread);
+    assert(host->host_id == thread->host_id);
+    assert(sig >= 1);
+    assert(sig <= SHD_STANDARD_SIGNAL_MAX_NO);
+    thread->protected.pending_standard_siginfos[sig - 1] = *info;
+}
+
+shd_kernel_sigset_t shimshmem_getBlockedSignals(const ShimShmemHostLock* host,
+                                                const ShimShmemThread* thread) {
+    assert(host);
+    assert(thread);
+    assert(host->host_id == thread->host_id);
+    return thread->protected.blocked_signals;
+}
+
+void shimshmem_setBlockedSignals(const ShimShmemHostLock* host, ShimShmemThread* thread,
+                                 shd_kernel_sigset_t sigset) {
+    assert(host);
+    assert(thread);
+    assert(host->host_id == thread->host_id);
+    thread->protected.blocked_signals = sigset;
+}
+
+size_t shimshmemthread_size() { return sizeof(ShimShmemThread); }
+
+void shimshmemthread_init(ShimShmemThread* threadMem, Thread* thread) {
+    *threadMem = (ShimShmemThread){
+        .host_id = thread_getHostId(thread),
+        .protected =
+            {
+                .host_id = thread_getHostId(thread),
+            },
+    };
+}
+
+bool shimshmem_getPtraceAllowNativeSyscalls(ShimShmemThread* thread) {
+    return atomic_load(&thread->ptrace_allow_native_syscalls);
+}
+
+void shimshmem_setPtraceAllowNativeSyscalls(ShimShmemThread* thread, bool allow) {
+    atomic_store(&thread->ptrace_allow_native_syscalls, allow);
+}
+
+ShimShmemHostLock* shimshmemhost_lock(ShimShmemHost* host) {
+    assert(host);
+    if (pthread_mutex_trylock(&host->mutex) != 0) {
+        // This is likely a deadlock.
+        panic("Lock is already held. This is probably a deadlock.");
+    }
+    return &host->protected;
+}
+void shimshmemhost_unlock(ShimShmemHost* host, ShimShmemHostLock** protected) {
+    assert(host);
+    assert(protected);
+    assert(*protected);
+    assert(host->host_id == (*protected)->host_id);
+
+    *protected = NULL;
+    int rv;
+    if ((rv = pthread_mutex_unlock(&host->mutex)) != 0) {
+        panic("pthread_mutex_unlock: %s", strerror(rv));
+    }
+}
+
+static int _shimshmem_takePendingUnblockedThreadSignal(const ShimShmemHostLock* lock,
+                                                       shd_kernel_sigset_t unblockedSignals,
+                                                       ShimShmemThread* thread, siginfo_t* info) {
+    shd_kernel_sigset_t thread_pending_signals = shimshmem_getThreadPendingSignals(lock, thread);
+    shd_kernel_sigset_t thread_pending_unblocked_signals =
+        shd_sigandset(&thread_pending_signals, &unblockedSignals);
+    if (!shd_sigisemptyset(&thread_pending_unblocked_signals)) {
+        int signo = shd_siglowest(&thread_pending_signals);
+        if (info) {
+            *info = shimshmem_getThreadSiginfo(lock, thread, signo);
+        }
+        shd_sigdelset(&thread_pending_signals, signo);
+        shimshmem_setThreadPendingSignals(lock, thread, thread_pending_signals);
+        return signo;
+    }
+    return 0;
+}
+
+static int _shimshmem_takePendingUnblockedProcessSignal(const ShimShmemHostLock* lock,
+                                                        shd_kernel_sigset_t unblockedSignals,
+                                                        ShimShmemProcess* process,
+                                                        siginfo_t* info) {
+    shd_kernel_sigset_t process_pending_signals = shimshmem_getProcessPendingSignals(lock, process);
+    shd_kernel_sigset_t process_pending_unblocked_signals =
+        shd_sigandset(&process_pending_signals, &unblockedSignals);
+    if (!shd_sigisemptyset(&process_pending_unblocked_signals)) {
+        int signo = shd_siglowest(&process_pending_signals);
+        if (info) {
+            *info = shimshmem_getProcessSiginfo(lock, process, signo);
+        }
+        shd_sigdelset(&process_pending_signals, signo);
+        shimshmem_setProcessPendingSignals(lock, process, process_pending_signals);
+        return signo;
+    }
+    return 0;
+}
+
+int shimshmem_takePendingUnblockedSignal(const ShimShmemHostLock* lock, ShimShmemProcess* process,
+                                         ShimShmemThread* thread, siginfo_t* info) {
+    shd_kernel_sigset_t unblocked_signals;
+    {
+        shd_kernel_sigset_t blocked_signals = shimshmem_getBlockedSignals(lock, thread);
+        unblocked_signals = shd_signotset(&blocked_signals);
+    }
+
+    int signo = _shimshmem_takePendingUnblockedThreadSignal(lock, unblocked_signals, thread, info);
+    if (signo != 0) {
+        return signo;
+    }
+
+    return _shimshmem_takePendingUnblockedProcessSignal(lock, unblocked_signals, process, info);
+}
 
 void shim_shmemHandleClone(const ShimEvent* ev) {
     assert(ev && ev->event_id == SHD_SHIM_EVENT_CLONE_REQ);

--- a/src/lib/shim/shim_shmem.h
+++ b/src/lib/shim/shim_shmem.h
@@ -5,36 +5,102 @@
 #include <stdint.h>
 #include <time.h>
 
+// Shared memory between the shim and Shadow for the host, process, and thread.
+typedef struct _ShimShmemHost ShimShmemHost;
+typedef struct _ShimShmemProcess ShimShmemProcess;
+typedef struct _ShimShmemThread ShimShmemThread;
+
+// Host-wide lock required for some operations.
+typedef struct _ShimHostProtectedSharedMem ShimShmemHostLock;
+
 #include "ipc.h"
+#include "lib/shim/shadow_signals.h"
 #include "main/core/support/definitions.h"
+#include "main/host/host.h"
+#include "main/host/process.h"
+#include "main/host/thread.h"
 #include "shim_event.h"
 
-// Shared state between Shadow and a plugin-thread.
+// Data structures kept in memory shared between Shadow and its managed processes.
 //
-// While synchronized via Shadow/Plugin IPC and/or ptrace-stops, there could be
-// potential parallel access e.g. in preload mode's spin lock.  Therefore we
-// ensure members are Sync (in Rust parlance) via atomics, and maybe in the
-// future mutexes etc.
+// Keeping state in these structures allows the shim to access it cheaply,
+// including implementing some syscalls on the shim-side without needing to
+// transfer control to Shadow.
 //
-// Atomic members can mostly be dereferenced as normal, though the value should
-// be copied locally to ensure a consistent view if accessed multiple times.
-// * The compiler will use appropriate atomic-access-instructions when
-//   dereferencing.
-// * We generally only care about seeing the freshest value when transferring
-//   control between Shadow and the Shim, which already includes memory barriers.
+// Most of the state is protected by a per-host lock, which shouldn't be held
+// when control may be transferred between Shadow and any managed thread in the
+// relevant Host. In the shim this means it shouldn't be held at any point where
+// a syscall could be made. Such errors will be caught at run time in debug builds.
 //
-typedef struct _ShimThreadSharedMem {
-    // While true, Shadow allows syscalls to be executed natively.
-    atomic_bool ptrace_allow_native_syscalls;
-} ShimThreadSharedMem;
+// Methods that require the host lock to be held take a ShimShmemHostLock
+// parameter to enforce that the lock is held. Methods that don't take a lock
+// parameter are still thread-safe, and internally use atomics.
 
-// Shared state between Shadow and a plugin-process.
+size_t shimshmemhost_size();
+void shimshmemhost_init(ShimShmemHost* hostMem, Host* host);
+
+ShimShmemHostLock* shimshmemhost_lock(ShimShmemHost* host);
+
+// Release and nullify `protected`.
+void shimshmemhost_unlock(ShimShmemHost* host, ShimShmemHostLock** protected);
+
+size_t shimshmemprocess_size();
+void shimshmemprocess_init(ShimShmemProcess* processMem, Process* process);
+
+// Get and set the emulated time. TODO: move up to Host?
+EmulatedTime shimshmem_getEmulatedTime(ShimShmemProcess* processMem);
+void shimshmem_setEmulatedTime(ShimShmemProcess* processMem, EmulatedTime t);
+
+// Get and set the process's pending signal set.
+shd_kernel_sigset_t shimshmem_getProcessPendingSignals(const ShimShmemHostLock* host,
+                                                       const ShimShmemProcess* process);
+void shimshmem_setProcessPendingSignals(const ShimShmemHostLock* host, ShimShmemProcess* process,
+                                        shd_kernel_sigset_t set);
+
+// Get and set the siginfo for the given signal number. Getting is only valid
+// when the signal is pending for the process.
+siginfo_t shimshmem_getProcessSiginfo(const ShimShmemHostLock* host,
+                                      const ShimShmemProcess* process, int sig);
+void shimshmem_setProcessSiginfo(const ShimShmemHostLock* host, ShimShmemProcess* process, int sig,
+                                 const siginfo_t* info);
+
+// Get and set the signal action for the specified signal.
+struct shd_kernel_sigaction shimshmem_getSignalAction(const ShimShmemHostLock* host,
+                                                      const ShimShmemProcess* process, int sig);
+void shimshmem_setSignalAction(const ShimShmemHostLock* host, ShimShmemProcess* m, int sig,
+                               const struct shd_kernel_sigaction* action);
+
+size_t shimshmemthread_size();
+void shimshmemthread_init(ShimShmemThread* threadMem, Thread* thread);
+
+bool shimshmem_getPtraceAllowNativeSyscalls(ShimShmemThread* thread);
+void shimshmem_setPtraceAllowNativeSyscalls(ShimShmemThread* thread, bool allow);
+
+// Get and set the thread's pending signal set.
+shd_kernel_sigset_t shimshmem_getThreadPendingSignals(const ShimShmemHostLock* host,
+                                                      const ShimShmemThread* thread);
+void shimshmem_setThreadPendingSignals(const ShimShmemHostLock* host, ShimShmemThread* thread,
+                                       shd_kernel_sigset_t sigset);
+
+// Get and set the siginfo for the given signal number. Getting is only valid
+// when the signal is pending for the thread.
+siginfo_t shimshmem_getThreadSiginfo(const ShimShmemHostLock* host, const ShimShmemThread* thread,
+                                     int sig);
+void shimshmem_setThreadSiginfo(const ShimShmemHostLock* host, ShimShmemThread* thread, int sig,
+                                const siginfo_t* info);
+
+// Get and set the set of blocked signals for the thread.
+shd_kernel_sigset_t shimshmem_getBlockedSignals(const ShimShmemHostLock* host,
+                                                const ShimShmemThread* m);
+void shimshmem_setBlockedSignals(const ShimShmemHostLock* host, ShimShmemThread* thread,
+                                 shd_kernel_sigset_t sigset);
+
+// Takes a pending unblocked signal (at the thread or process level) and marks it
+// no longer pending. Sets `info` if non-NULL.
 //
-// Safety is as for ShimThreadSharedMem, above.
-typedef struct _ShimProcessSharedMem {
-    // Current simulation time.
-    _Atomic EmulatedTime sim_time;
-} ShimProcessSharedMem;
+// Returns 0 if no unblocked signal is pending.
+int shimshmem_takePendingUnblockedSignal(const ShimShmemHostLock* lock, ShimShmemProcess* process,
+                                         ShimShmemThread* thread, siginfo_t* info);
 
 // Handle SHD_SHIM_EVENT_CLONE_REQ
 void shim_shmemHandleClone(const ShimEvent* ev);

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -77,6 +77,35 @@ pub type GQuark = guint32;
 pub type ssize_t = __ssize_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+#[test]
+fn bindgen_test_layout___sigset_t() {
+    assert_eq!(
+        ::std::mem::size_of::<__sigset_t>(),
+        128usize,
+        concat!("Size of: ", stringify!(__sigset_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<__sigset_t>(),
+        8usize,
+        concat!("Alignment of ", stringify!(__sigset_t))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__sigset_t>())).__val as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__sigset_t),
+            "::",
+            stringify!(__val)
+        )
+    );
+}
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct _GTimer {
     _unused: [u8; 0],
 }
@@ -449,58 +478,28 @@ pub struct _Event {
 pub type Event = _Event;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _Tsc {
-    pub cyclesPerSecond: u64,
-}
-#[test]
-fn bindgen_test_layout__Tsc() {
-    assert_eq!(
-        ::std::mem::size_of::<_Tsc>(),
-        8usize,
-        concat!("Size of: ", stringify!(_Tsc))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_Tsc>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_Tsc))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<_Tsc>())).cyclesPerSecond as *const _ as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_Tsc),
-            "::",
-            stringify!(cyclesPerSecond)
-        )
-    );
-}
-pub type Tsc = _Tsc;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _CPU {
+pub struct _ShimShmemHost {
     _unused: [u8; 0],
 }
-pub type CPU = _CPU;
-pub use self::_Status as Status;
-pub const _Status_STATUS_NONE: _Status = 0;
-pub const _Status_STATUS_DESCRIPTOR_ACTIVE: _Status = 1;
-pub const _Status_STATUS_DESCRIPTOR_READABLE: _Status = 2;
-pub const _Status_STATUS_DESCRIPTOR_WRITABLE: _Status = 4;
-pub const _Status_STATUS_DESCRIPTOR_CLOSED: _Status = 8;
-pub const _Status_STATUS_FUTEX_WAKEUP: _Status = 16;
-pub type _Status = i32;
-extern "C" {
-    pub fn return_code_for_signal(signal: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+pub type ShimShmemHost = _ShimShmemHost;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _ShimShmemProcess {
+    _unused: [u8; 0],
 }
-pub type LegacyDescriptor = [u64; 7usize];
-pub type DescriptorCloseFunc =
-    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor, host: *mut Host)>;
-pub type DescriptorCleanupFunc =
-    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor)>;
-pub type DescriptorFreeFunc =
-    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor)>;
-pub type SysCallHandler = _SysCallHandler;
+pub type ShimShmemProcess = _ShimShmemProcess;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _ShimShmemThread {
+    _unused: [u8; 0],
+}
+pub type ShimShmemThread = _ShimShmemThread;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _ShimHostProtectedSharedMem {
+    _unused: [u8; 0],
+}
+pub type ShimShmemHostLock = _ShimHostProtectedSharedMem;
 pub type PluginVirtualPtr = _PluginVirtualPtr;
 pub type PluginPtr = _PluginVirtualPtr;
 pub type PluginPhysicalPtr = _PluginPhysicalPtr;
@@ -714,12 +713,6 @@ fn bindgen_test_layout__SysCallReturn() {
 pub type SysCallReturn = _SysCallReturn;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _Thread {
-    _unused: [u8; 0],
-}
-pub type Thread = _Thread;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct _ShMemBlock {
     pub p: *mut ::std::os::raw::c_void,
     pub nbytes: size_t,
@@ -758,6 +751,31 @@ fn bindgen_test_layout__ShMemBlock() {
     );
 }
 pub type ShMemBlock = _ShMemBlock;
+pub use self::_Status as Status;
+pub const _Status_STATUS_NONE: _Status = 0;
+pub const _Status_STATUS_DESCRIPTOR_ACTIVE: _Status = 1;
+pub const _Status_STATUS_DESCRIPTOR_READABLE: _Status = 2;
+pub const _Status_STATUS_DESCRIPTOR_WRITABLE: _Status = 4;
+pub const _Status_STATUS_DESCRIPTOR_CLOSED: _Status = 8;
+pub const _Status_STATUS_FUTEX_WAKEUP: _Status = 16;
+pub type _Status = i32;
+extern "C" {
+    pub fn return_code_for_signal(signal: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+pub type LegacyDescriptor = [u64; 7usize];
+pub type DescriptorCloseFunc =
+    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor, host: *mut Host)>;
+pub type DescriptorCleanupFunc =
+    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor)>;
+pub type DescriptorFreeFunc =
+    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor)>;
+pub type SysCallHandler = _SysCallHandler;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _Thread {
+    _unused: [u8; 0],
+}
+pub type Thread = _Thread;
 extern "C" {
     pub fn thread_ref(thread: *mut Thread);
 }
@@ -845,6 +863,15 @@ extern "C" {
     pub fn thread_getSysCallCondition(thread: *mut Thread) -> *mut SysCallCondition;
 }
 extern "C" {
+    pub fn thread_getSignalSet(thread: *mut Thread) -> *mut sigset_t;
+}
+extern "C" {
+    pub fn thread_unblockedSignalPending(
+        thread: *mut Thread,
+        host_lock: *const ShimShmemHostLock,
+    ) -> bool;
+}
+extern "C" {
     pub fn process_new(
         host: *mut Host,
         processID: guint,
@@ -881,6 +908,9 @@ extern "C" {
 }
 extern "C" {
     pub fn process_addThread(proc_: *mut Process, thread: *mut Thread);
+}
+extern "C" {
+    pub fn process_getThread(proc_: *mut Process, virtualTID: pid_t) -> *mut Thread;
 }
 extern "C" {
     pub fn process_markAsExiting(proc_: *mut Process);
@@ -1012,6 +1042,51 @@ extern "C" {
         error: *mut ::std::os::raw::c_char,
     );
 }
+extern "C" {
+    pub fn process_getSharedMem(proc_: *mut Process) -> *mut ShimShmemProcess;
+}
+extern "C" {
+    pub fn process_interruptWithSignal(
+        process: *mut Process,
+        hostLock: *mut ShimShmemHostLock,
+        signo: ::std::os::raw::c_int,
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _Tsc {
+    pub cyclesPerSecond: u64,
+}
+#[test]
+fn bindgen_test_layout__Tsc() {
+    assert_eq!(
+        ::std::mem::size_of::<_Tsc>(),
+        8usize,
+        concat!("Size of: ", stringify!(_Tsc))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_Tsc>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_Tsc))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<_Tsc>())).cyclesPerSecond as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_Tsc),
+            "::",
+            stringify!(cyclesPerSecond)
+        )
+    );
+}
+pub type Tsc = _Tsc;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _CPU {
+    _unused: [u8; 0],
+}
+pub type CPU = _CPU;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _StatusListener {
@@ -1390,6 +1465,15 @@ extern "C" {
     pub fn host_getNativeTID(host: *mut Host, virtualPID: pid_t, virtualTID: pid_t) -> pid_t;
 }
 extern "C" {
+    pub fn host_getProcess(host: *mut Host, virtualPID: pid_t) -> *mut Process;
+}
+extern "C" {
+    pub fn host_getThread(host: *mut Host, virtualTID: pid_t) -> *mut Thread;
+}
+extern "C" {
+    pub fn host_getSharedMem(host: *mut Host) -> *mut ShimShmemHost;
+}
+extern "C" {
     pub fn worker_runEvent(event: *mut Event);
 }
 extern "C" {
@@ -1600,6 +1684,7 @@ pub struct _SysCallHandler {
     pub host: *mut Host,
     pub process: *mut Process,
     pub thread: *mut Thread,
+    pub shimShmemHostLock: *mut ShimShmemHostLock,
     pub epoll: *mut Epoll,
     pub blockedSyscallNR: ::std::os::raw::c_long,
     pub perfTimer: *mut GTimer,
@@ -1614,7 +1699,7 @@ pub struct _SysCallHandler {
 fn bindgen_test_layout__SysCallHandler() {
     assert_eq!(
         ::std::mem::size_of::<_SysCallHandler>(),
-        88usize,
+        96usize,
         concat!("Size of: ", stringify!(_SysCallHandler))
     );
     assert_eq!(
@@ -1653,8 +1738,20 @@ fn bindgen_test_layout__SysCallHandler() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).epoll as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<_SysCallHandler>())).shimShmemHostLock as *const _ as usize
+        },
         24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_SysCallHandler),
+            "::",
+            stringify!(shimShmemHostLock)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).epoll as *const _ as usize },
+        32usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1666,7 +1763,7 @@ fn bindgen_test_layout__SysCallHandler() {
         unsafe {
             &(*(::std::ptr::null::<_SysCallHandler>())).blockedSyscallNR as *const _ as usize
         },
-        32usize,
+        40usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1676,7 +1773,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).perfTimer as *const _ as usize },
-        40usize,
+        48usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1688,7 +1785,7 @@ fn bindgen_test_layout__SysCallHandler() {
         unsafe {
             &(*(::std::ptr::null::<_SysCallHandler>())).perfSecondsCurrent as *const _ as usize
         },
-        48usize,
+        56usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1700,7 +1797,7 @@ fn bindgen_test_layout__SysCallHandler() {
         unsafe {
             &(*(::std::ptr::null::<_SysCallHandler>())).perfSecondsTotal as *const _ as usize
         },
-        56usize,
+        64usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1710,7 +1807,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).numSyscalls as *const _ as usize },
-        64usize,
+        72usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1720,7 +1817,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).syscall_counter as *const _ as usize },
-        72usize,
+        80usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1730,7 +1827,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).referenceCount as *const _ as usize },
-        80usize,
+        88usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1740,7 +1837,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).magic as *const _ as usize },
-        84usize,
+        92usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),

--- a/src/main/core/scheduler/scheduler_policy.h
+++ b/src/main/core/scheduler/scheduler_policy.h
@@ -9,6 +9,7 @@
 #include "main/core/scheduler/scheduler_policy_type.h"
 #include "main/core/work/event.h"
 #include "main/host/host.h"
+#include "main/utility/utility.h"
 
 typedef struct _SchedulerPolicy SchedulerPolicy;
 

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -16,6 +16,7 @@
 #include <sys/socket.h>
 
 #include "lib/logger/log_level.h"
+#include "lib/shim/shim_shmem.h"
 #include "lib/tsc/tsc.h"
 #include "main/core/support/definitions.h"
 #include "main/host/cpu.h"
@@ -24,6 +25,7 @@
 #include "main/host/futex_table.h"
 #include "main/host/host_parameters.h"
 #include "main/host/network_interface.h"
+#include "main/host/thread.h"
 #include "main/host/tracker_types.h"
 #include "main/routing/address.h"
 #include "main/routing/dns.h"
@@ -99,5 +101,16 @@ FutexTable* host_getFutexTable(Host* host);
 
 // converts a virtual (shadow) tid into the native tid
 pid_t host_getNativeTID(Host* host, pid_t virtualPID, pid_t virtualTID);
+
+// Returns the specified process, or NULL if it doesn't exist.
+Process* host_getProcess(Host* host, pid_t virtualPID);
+
+// Returns the specified thread, or NULL if it doesn't exist.
+// If you already have the thread's Process*, `process_getThread` may be more
+// efficient.
+Thread* host_getThread(Host* host, pid_t virtualTID);
+
+// Returns host-specific state that's kept in memory shared with the shim(s).
+ShimShmemHost* host_getSharedMem(Host* host);
 
 #endif /* SHD_HOST_H_ */

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <wchar.h>
 
+#include "lib/shim/shim_shmem.h"
 #include "main/bindings/c/bindings.h"
 #include "main/core/support/definitions.h"
 #include "main/host/descriptor/descriptor_types.h"
@@ -53,6 +54,8 @@ const char* process_getWorkingDir(Process* proc);
 // Adds a new thread to the process and schedules it to run.
 // Intended for use by `clone`.
 void process_addThread(Process* proc, Thread* thread);
+
+Thread* process_getThread(Process* proc, pid_t virtualTID);
 
 // In some cases a running thread processes an action that will bring down the
 // entire process. Calling this tells the Process to clean up other threads
@@ -181,5 +184,13 @@ InterposeMethod process_getInterposeMethod(Process* proc);
 bool process_parseArgStr(const char* commandLine, int* argc, char*** argv, char** error);
 // Free all data allocated by `process_parseArgStr()`.
 void process_parseArgStrFree(char** argv, char* error);
+
+// Process state kept in memory shared with the managed process's shim.
+ShimShmemProcess* process_getSharedMem(Process* proc);
+
+// Wake up one thread that has `signo` unblocked. This is intended for syscall
+// handlers that generate process-directed signals (e.g. `kill`). The caller
+// should have already set the signal as pending via ShimShmemProcess.
+void process_interruptWithSignal(Process* process, ShimShmemHostLock* hostLock, int signo);
 
 #endif /* SHD_PROCESS_H_ */

--- a/src/main/host/syscall/kernel_types.h
+++ b/src/main/host/syscall/kernel_types.h
@@ -13,8 +13,12 @@
  */
 
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/src/main/host/syscall/protected.c
+++ b/src/main/host/syscall/protected.c
@@ -19,7 +19,7 @@
 #include "main/host/syscall_condition.h"
 #include "main/host/thread.h"
 
-static const Timer* _syscallhandler_getTimeout(const SysCallHandler* sys) {
+const Timer* _syscallhandler_getTimeout(const SysCallHandler* sys) {
     MAGIC_ASSERT(sys);
 
     SysCallCondition* cond = thread_getSysCallCondition(sys->thread);

--- a/src/main/host/syscall/shadow.c
+++ b/src/main/host/syscall/shadow.c
@@ -92,7 +92,7 @@ SysCallReturn syscallhandler_shadow_set_ptrace_allow_native_syscalls(SysCallHand
         bool is_allowed = args->args[0].as_i64;
         trace("shadow_set_ptrace_allow_native_syscalls is_allowed=%d", is_allowed);
 
-        thread_sharedMem(sys->thread)->ptrace_allow_native_syscalls = is_allowed;
+        shimshmem_setPtraceAllowNativeSyscalls(thread_sharedMem(sys->thread), is_allowed);
 
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
     } else {

--- a/src/main/host/syscall_condition.h
+++ b/src/main/host/syscall_condition.h
@@ -73,4 +73,11 @@ void syscallcondition_cancel(SysCallCondition* cond);
 /* Get the timer for the condition, or NULL if there isn't one. */
 Timer* syscallcondition_getTimeout(SysCallCondition* cond);
 
+/* If the condition's thread doesn't have `signo` blocked, schedule a wakeup.
+ *
+ * Returns whether a wakeup was scheduled.
+ */
+bool syscallcondition_wakeupForSignal(SysCallCondition* cond, ShimShmemHostLock* hostLock,
+                                      int signo);
+
 #endif /* SRC_MAIN_HOST_SYSCALL_CONDITION_H_ */

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -76,12 +76,18 @@ ShMemBlock* thread_getShMBlock(Thread* thread);
 
 // Returns a typed pointer to memory shared with the shim (which is backed by
 // the block returned by thread_getShMBlock).
-ShimThreadSharedMem* thread_sharedMem(Thread* thread);
+ShimShmemThread* thread_sharedMem(Thread* thread);
 
 Process* thread_getProcess(Thread* thread);
 Host* thread_getHost(Thread* thread);
 // Get the syscallhandler for this thread.
 SysCallHandler* thread_getSysCallHandler(Thread* thread);
 SysCallCondition* thread_getSysCallCondition(Thread* thread);
+
+sigset_t* thread_getSignalSet(Thread* thread);
+
+// Returns true iff there is an unblocked, unignored signal pending for this
+// thread (or its process).
+bool thread_unblockedSignalPending(Thread* thread, const ShimShmemHostLock* host_lock);
 
 #endif /* SRC_MAIN_HOST_SHD_THREAD_H_ */

--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -1,6 +1,5 @@
 #include "main/host/thread_preload.h"
 
-#include <signal.h>
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/src/main/host/thread_ptrace.c
+++ b/src/main/host/thread_ptrace.c
@@ -751,7 +751,7 @@ static SysCallReturn _threadptrace_handleSyscall(ThreadPtrace* thread, SysCallAr
                    thread->childState == THREAD_PTRACE_CHILD_STATE_IPC_SYSCALL);
 
     if (!syscall_num_is_shadow(args->number) &&
-        thread_sharedMem(&thread->base)->ptrace_allow_native_syscalls) {
+        shimshmem_getPtraceAllowNativeSyscalls(thread_sharedMem(&thread->base))) {
         if (args->number == SYS_brk) {
             // brk should *always* be interposed so that the MemoryManager can track it.
             trace("Interposing brk even though native syscalls are enabled");

--- a/src/test/Cargo.lock
+++ b/src/test/Cargo.lock
@@ -66,6 +66,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,7 +123,28 @@ version = "2.0.0"
 dependencies = [
  "libc",
  "nix",
+ "once_cell",
  "rand",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -129,7 +129,13 @@ path = "regression/test_exit_after_signal_sched.rs"
 name = "test_dup"
 path = "dup/test_dup.rs"
 
+[[bin]]
+name = "test_signals"
+path = "signal/test_signals.rs"
+
 [dependencies]
 libc = "0.2"
 nix = "0.23.1"
 rand = { version="0.8.0", features=["small_rng"] }
+signal-hook = "0.3.2"
+once_cell = "1.9.0"

--- a/src/test/determinism/CMakeLists.txt
+++ b/src/test/determinism/CMakeLists.txt
@@ -4,7 +4,6 @@
 add_executable(test-determinism test_determinism.c)
 target_link_libraries(test-determinism ${CMAKE_THREAD_LIBS_INIT})
 
-# preload doesn't support threads.
 foreach(METHOD ptrace preload)
     ## We need to run twice to make sure the 'random' output is the same both times
     add_shadow_tests(

--- a/src/test/signal/CMakeLists.txt
+++ b/src/test/signal/CMakeLists.txt
@@ -4,5 +4,8 @@ target_link_libraries(test-signal ${M_LIBRARIES} ${DL_LIBRARIES} ${RT_LIBRARIES}
 
 ## here we are testing 3 nodes to make sure they don't share signal handlers (in Shadow)
 add_linux_tests(BASENAME signal COMMAND shadow-test-launcher test-signal : test-signal : test-signal)
-# FIXME: Enable for preload. See https://github.com/shadow/shadow/issues/1455
-add_shadow_tests(BASENAME signal SKIP_METHODS preload)
+add_shadow_tests(BASENAME signal)
+
+## More complete signal functionality.
+add_linux_tests(BASENAME signals-extra COMMAND sh -c "../target/debug/test_signals --libc-passing")
+add_shadow_tests(BASENAME signals-extra SKIP_METHODS ptrace)

--- a/src/test/signal/signals-extra.yaml
+++ b/src/test/signal/signals-extra.yaml
@@ -1,0 +1,12 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  mytesthost:
+    network_node_id: 0
+    processes:
+    - path: ../target/debug/test_signals
+      args: --shadow-passing
+      start_time: 1

--- a/src/test/signal/test_signals.rs
+++ b/src/test/signal/test_signals.rs
@@ -1,0 +1,581 @@
+use nix::errno::Errno;
+use nix::sys::signal;
+use nix::sys::signal::Signal;
+use nix::unistd;
+use once_cell::sync::OnceCell;
+use signal_hook::low_level::channel::Channel as SignalSafeChannel;
+use std::convert::TryFrom;
+use std::error::Error;
+use std::iter::Iterator;
+use std::os::unix::io::RawFd;
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+use std::time::Duration;
+use test_utils::set;
+use test_utils::ShadowTest;
+use test_utils::TestEnvironment as TestEnv;
+
+// Record of having received a signal.
+#[derive(Debug, Eq, PartialEq)]
+struct Record {
+    signal: i32,
+    pid: unistd::Pid,
+    tid: unistd::Pid,
+    info: Option<libc::siginfo_t>,
+}
+
+// Global channel to be written from the signal handler.  We use
+// signal_hook::low_level::channel::Channel here, which is explicitly designed
+// to be async-signal-safe.
+fn signal_channel() -> &'static SignalSafeChannel<Record> {
+    static INSTANCE: OnceCell<SignalSafeChannel<Record>> = OnceCell::new();
+    INSTANCE.get_or_init(|| SignalSafeChannel::new())
+}
+
+// Signal handler used throughout. Tests read from `signal_channel` to validate
+// properties of the received signal.
+extern "C" fn signal_action(signal: i32, info: *mut libc::siginfo_t, _ctx: *mut std::ffi::c_void) {
+    // Try to use only async-signal-safe functions. See signal-safety(7).
+    //
+    // Following this strictly is *very* restrictive, since most apis don't
+    // bother to document/guarantee signal safety. Definitely avoid anything
+    // known to be non-reentrant, though, including heap allocation.
+
+    let pid = unistd::getpid();
+    let tid = unistd::gettid();
+    let info = unsafe { info.as_ref().cloned() };
+    let record = Record {
+        signal,
+        pid,
+        tid,
+        info,
+    };
+    signal_channel().send(record);
+}
+
+// Legacy/simple style handler.
+extern "C" fn signal_handler(sig: i32) {
+    signal_action(sig, std::ptr::null_mut(), std::ptr::null_mut());
+}
+
+fn catchable_signals() -> Box<dyn Iterator<Item = Signal>> {
+    Box::new(Signal::iterator().filter(|s| match s {
+        // Can't be caught, as per `sigaction(2)`.
+        Signal::SIGKILL | Signal::SIGSTOP => false,
+        _ => true,
+    }))
+}
+
+fn tkill(tid: unistd::Pid, signal: Signal) -> Result<(), Errno> {
+    Errno::result(unsafe { libc::syscall(libc::SYS_tkill, tid, signal) })?;
+    Ok(())
+}
+
+fn tgkill(pid: unistd::Pid, tid: unistd::Pid, signal: Signal) -> Result<(), Errno> {
+    Errno::result(unsafe { libc::syscall(libc::SYS_tgkill, pid, tid, signal) })?;
+    Ok(())
+}
+
+// Not exposed in Rust's libc crate.
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[allow(non_camel_case_types)]
+enum SignalCode {
+    SI_TKILL = -6,
+    SI_USER = 0,
+}
+
+// Tests basic signal delivery to self.
+fn test_raise(raise_fn: &dyn Fn(Signal), expected_code: SignalCode) -> Result<(), Box<dyn Error>> {
+    for handler in &[
+        signal::SigHandler::SigIgn,
+        signal::SigHandler::SigAction(signal_action),
+        signal::SigHandler::Handler(signal_handler),
+    ] {
+        for signal in catchable_signals() {
+            unsafe {
+                signal::sigaction(
+                    signal,
+                    &signal::SigAction::new(
+                        *handler,
+                        signal::SaFlags::empty(),
+                        signal::SigSet::empty(),
+                    ),
+                )
+                .unwrap()
+            };
+
+            raise_fn(signal);
+
+            match handler {
+                signal::SigHandler::SigIgn => {
+                    // Should be ignored.
+                    assert_eq!(signal_channel().recv(), None);
+                    continue;
+                }
+                _ => (),
+            };
+
+            // Exactly one signal should have been delivered, synchronously.
+            let record = signal_channel().recv().unwrap();
+            assert_eq!(signal_channel().recv(), None);
+
+            assert_eq!(record.pid, unistd::getpid());
+            assert_eq!(record.tid, unistd::gettid());
+            assert_eq!(Signal::try_from(record.signal).unwrap(), signal);
+
+            match handler {
+                signal::SigHandler::SigAction(_) => {
+                    let info = record.info.unwrap();
+                    assert_eq!(Signal::try_from(info.si_signo).unwrap(), signal);
+                    assert_eq!(info.si_code, expected_code as i32);
+                    assert_eq!(
+                        unistd::Pid::from_raw(unsafe { info.si_pid() }),
+                        unistd::getpid()
+                    );
+                }
+                signal::SigHandler::Handler(_) => {
+                    assert_eq!(record.info, None);
+                }
+                _ => unreachable!(),
+            };
+
+            unsafe {
+                signal::sigaction(
+                    signal,
+                    &signal::SigAction::new(
+                        signal::SigHandler::SigDfl,
+                        signal::SaFlags::empty(),
+                        signal::SigSet::empty(),
+                    ),
+                )
+                .unwrap()
+            };
+        }
+    }
+    Ok(())
+}
+
+// Test process-directed signals with multiple threads.
+fn test_process_pending_multithreaded() -> Result<(), Box<dyn Error>> {
+    let signal = Signal::SIGUSR1;
+
+    unsafe {
+        signal::sigaction(
+            signal,
+            &signal::SigAction::new(
+                signal::SigHandler::Handler(signal_handler),
+                signal::SaFlags::empty(),
+                signal::SigSet::empty(),
+            ),
+        )
+        .unwrap()
+    };
+
+    let run = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let mut threads = Vec::new();
+    for _ in 0..10 {
+        let run = run.clone();
+        threads.push(std::thread::spawn(move || {
+            while run.load(std::sync::atomic::Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }));
+    }
+
+    signal::kill(unistd::getpid(), signal).unwrap();
+
+    // Signal should be delivered exactly once, to one of the threads.  When
+    // there are other threads with the signal unblocked, POSIX.1 doesn't
+    // guarantee that the signal will be delivered to the current thread nor
+    // that it will delivered before `kill` returns.
+    let mut record = signal_channel().recv();
+    while record.is_none() {
+        std::thread::sleep(Duration::from_millis(1));
+        record = signal_channel().recv();
+    }
+    let record = record.unwrap();
+    assert_eq!(record.pid, unistd::getpid());
+    // TODO: check that tid is one of our threads?
+    // assert_ne!(record.tid, unistd::gettid());
+    assert_eq!(Signal::try_from(record.signal).unwrap(), signal);
+    assert_eq!(signal_channel().recv(), None);
+
+    // Shut down
+    run.store(false, std::sync::atomic::Ordering::Relaxed);
+    for thread in threads {
+        thread.join().unwrap();
+    }
+
+    unsafe {
+        signal::sigaction(
+            signal,
+            &signal::SigAction::new(
+                signal::SigHandler::SigDfl,
+                signal::SaFlags::empty(),
+                signal::SigSet::empty(),
+            ),
+        )
+        .unwrap()
+    };
+    Ok(())
+}
+
+fn test_sigprocmask() -> Result<(), Box<dyn Error>> {
+    for signal in catchable_signals() {
+        println!("{}", signal);
+        unsafe {
+            signal::sigaction(
+                signal,
+                &signal::SigAction::new(
+                    signal::SigHandler::Handler(signal_handler),
+                    signal::SaFlags::empty(),
+                    signal::SigSet::empty(),
+                ),
+            )
+            .unwrap()
+        };
+
+        // Block the signal
+        let mut sigset_to_block = signal::SigSet::empty();
+        sigset_to_block.add(signal);
+        signal::sigprocmask(signal::SigmaskHow::SIG_BLOCK, Some(&sigset_to_block), None).unwrap();
+
+        // Validate that the signal is in the returned mask.
+        let mut current_sigset = signal::SigSet::empty();
+        signal::sigprocmask(
+            signal::SigmaskHow::SIG_BLOCK,
+            None,
+            Some(&mut current_sigset),
+        )
+        .unwrap();
+        assert!(current_sigset.contains(signal));
+
+        // Raise multiple times; won't be delivered yet because it's masked,
+        // and subsequent signals aren't queued.
+        signal::raise(signal).unwrap();
+        signal::raise(signal).unwrap();
+        signal::raise(signal).unwrap();
+
+        // Should be nothing delivered yet, since the signal is unblocked.
+        assert_eq!(signal_channel().recv(), None);
+
+        // Unblock. The pending signal should be delivered synchronously.
+        signal::sigprocmask(
+            signal::SigmaskHow::SIG_UNBLOCK,
+            Some(&sigset_to_block),
+            None,
+        )
+        .unwrap();
+
+        // Exactly one signal should have been delivered, synchronously.
+        let record = signal_channel().recv().unwrap();
+        assert_eq!(record.pid, unistd::getpid());
+        assert_eq!(record.tid, unistd::gettid());
+        assert_eq!(Signal::try_from(record.signal).unwrap(), signal);
+        assert_eq!(signal_channel().recv(), None);
+
+        unsafe {
+            signal::sigaction(
+                signal,
+                &signal::SigAction::new(
+                    signal::SigHandler::SigDfl,
+                    signal::SaFlags::empty(),
+                    signal::SigSet::empty(),
+                ),
+            )
+            .unwrap()
+        };
+    }
+    Ok(())
+}
+
+fn test_send_to_thread_and_process() -> Result<(), Box<dyn Error>> {
+    let signal = Signal::SIGUSR1;
+    unsafe {
+        signal::sigaction(
+            signal,
+            &signal::SigAction::new(
+                signal::SigHandler::Handler(signal_handler),
+                signal::SaFlags::empty(),
+                signal::SigSet::empty(),
+            ),
+        )
+        .unwrap()
+    };
+
+    // Block the signal
+    let mut sigset_to_block = signal::SigSet::empty();
+    sigset_to_block.add(signal);
+    signal::sigprocmask(signal::SigmaskHow::SIG_BLOCK, Some(&sigset_to_block), None).unwrap();
+
+    // Raising should set it pending at the process level.
+    signal::kill(unistd::getpid(), signal).unwrap();
+
+    // tkill should *also* set it pending at the thread level.
+    tkill(unistd::gettid(), signal).unwrap();
+
+    // Should be nothing delivered yet, since the signal is unblocked.
+    assert_eq!(signal_channel().recv(), None);
+
+    // Unblock. The pending signal should be delivered synchronously.
+    signal::sigprocmask(
+        signal::SigmaskHow::SIG_UNBLOCK,
+        Some(&sigset_to_block),
+        None,
+    )
+    .unwrap();
+
+    // Should be delivered exactly twice.
+    signal_channel().recv().unwrap();
+    signal_channel().recv().unwrap();
+    assert_eq!(signal_channel().recv(), None);
+
+    unsafe {
+        signal::sigaction(
+            signal,
+            &signal::SigAction::new(
+                signal::SigHandler::SigDfl,
+                signal::SaFlags::empty(),
+                signal::SigSet::empty(),
+            ),
+        )
+        .unwrap()
+    };
+    Ok(())
+}
+
+struct BlockedThread {
+    handle: std::thread::JoinHandle<Result<usize, Errno>>,
+    write_fd: RawFd,
+    tid: unistd::Pid,
+}
+
+extern "C" fn nop_signal_handler(_sig: i32) {}
+
+impl BlockedThread {
+    pub fn new() -> Self {
+        let (read_fd, write_fd) = unistd::pipe().unwrap();
+        let (tid_sender, tid_receiver) = channel();
+        let handle = std::thread::spawn(move || {
+            tid_sender.send(unistd::gettid()).unwrap();
+            let mut buf = [0; 100];
+            unistd::read(read_fd, &mut buf)
+        });
+        let tid = tid_receiver.recv().unwrap();
+        // Wait until the thread is blocked in `read` (hopefully).  Ideally we'd
+        // use some syscall that atomically blocks the current thread and
+        // changes some observable state in other threads, so that we could wait
+        // until we knew the thread was blocked. I don't know of any such
+        // syscall that other threads can check without side effects.
+        std::thread::sleep(Duration::from_millis(10));
+        Self {
+            handle,
+            write_fd,
+            tid,
+        }
+    }
+}
+
+fn test_handled_tkill_interrupts_syscall() -> Result<(), Box<dyn Error>> {
+    let signal = Signal::SIGUSR1;
+    unsafe {
+        signal::sigaction(
+            signal,
+            &signal::SigAction::new(
+                signal::SigHandler::Handler(nop_signal_handler),
+                signal::SaFlags::empty(),
+                signal::SigSet::empty(),
+            ),
+        )
+        .unwrap()
+    };
+
+    let blocked_thread = BlockedThread::new();
+    tkill(blocked_thread.tid, signal).unwrap();
+    assert_eq!(blocked_thread.handle.join().unwrap(), Err(Errno::EINTR));
+
+    Ok(())
+}
+
+fn test_ignored_tkill_doesnt_interrupt_syscall() -> Result<(), Box<dyn Error>> {
+    let signal = Signal::SIGUSR1;
+    unsafe {
+        signal::sigaction(
+            signal,
+            &signal::SigAction::new(
+                signal::SigHandler::SigIgn,
+                signal::SaFlags::empty(),
+                signal::SigSet::empty(),
+            ),
+        )
+        .unwrap()
+    };
+
+    let blocked_thread = BlockedThread::new();
+    tkill(blocked_thread.tid, signal).unwrap();
+    // Give some time for the thread to (incorrectly) interrupt.
+    std::thread::sleep(Duration::from_millis(10));
+    // Write so that the thread can finish.
+    unistd::write(blocked_thread.write_fd, &[0]).unwrap();
+    assert_eq!(blocked_thread.handle.join().unwrap(), Ok(1));
+
+    Ok(())
+}
+
+fn test_default_ignored_tkill_doesnt_interrupt_syscall() -> Result<(), Box<dyn Error>> {
+    // Default action of this signal is to ignore.
+    let signal = Signal::SIGURG;
+
+    unsafe {
+        signal::sigaction(
+            signal,
+            &signal::SigAction::new(
+                // Explicity set to default action.
+                signal::SigHandler::SigDfl,
+                signal::SaFlags::empty(),
+                signal::SigSet::empty(),
+            ),
+        )
+        .unwrap()
+    };
+
+    let blocked_thread = BlockedThread::new();
+    tkill(blocked_thread.tid, signal).unwrap();
+    // Give some time for the thread to (incorrectly) interrupt.
+    std::thread::sleep(Duration::from_millis(10));
+    // Write so that the thread can finish.
+    unistd::write(blocked_thread.write_fd, &[0]).unwrap();
+    assert_eq!(blocked_thread.handle.join().unwrap(), Ok(1));
+
+    Ok(())
+}
+fn test_handled_kill_interrupts_syscall() -> Result<(), Box<dyn Error>> {
+    let signal = Signal::SIGUSR1;
+    unsafe {
+        signal::sigaction(
+            signal,
+            &signal::SigAction::new(
+                signal::SigHandler::Handler(nop_signal_handler),
+                signal::SaFlags::empty(),
+                signal::SigSet::empty(),
+            ),
+        )
+        .unwrap()
+    };
+
+    let blocked_thread = BlockedThread::new();
+
+    // Block the signal in the current thread, so that it'll interrupt the other.
+    let mut sigset_to_block = signal::SigSet::empty();
+    sigset_to_block.add(signal);
+    signal::sigprocmask(signal::SigmaskHow::SIG_BLOCK, Some(&sigset_to_block), None).unwrap();
+
+    // Send a *process* directed signal.
+    signal::kill(unistd::getpid(), signal).unwrap();
+    assert_eq!(blocked_thread.handle.join().unwrap(), Err(Errno::EINTR));
+
+    signal::sigprocmask(
+        signal::SigmaskHow::SIG_UNBLOCK,
+        Some(&sigset_to_block),
+        None,
+    )
+    .unwrap();
+
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // should we restrict the tests we run?
+    let filter_shadow_passing = std::env::args().any(|x| x == "--shadow-passing");
+    let filter_libc_passing = std::env::args().any(|x| x == "--libc-passing");
+    // should we summarize the results rather than exit on a failed test
+    let summarize = std::env::args().any(|x| x == "--summarize");
+
+    let all_envs = set![TestEnv::Libc, TestEnv::Shadow];
+    let mut tests: Vec<test_utils::ShadowTest<(), Box<dyn Error>>> = vec![
+        ShadowTest::new(
+            "raise",
+            &|| test_raise(&|s| signal::raise(s).unwrap(), SignalCode::SI_TKILL),
+            all_envs.clone(),
+        ),
+        ShadowTest::new(
+            "raise via kill",
+            &|| {
+                test_raise(
+                    &|s| signal::kill(unistd::getpid(), s).unwrap(),
+                    SignalCode::SI_USER,
+                )
+            },
+            all_envs.clone(),
+        ),
+        ShadowTest::new(
+            "raise via tkill",
+            &|| {
+                test_raise(
+                    &|s| tkill(unistd::gettid(), s).unwrap(),
+                    SignalCode::SI_TKILL,
+                )
+            },
+            all_envs.clone(),
+        ),
+        ShadowTest::new(
+            "raise via tgkill",
+            &|| {
+                test_raise(
+                    &|s| tgkill(unistd::getpid(), unistd::gettid(), s).unwrap(),
+                    SignalCode::SI_TKILL,
+                )
+            },
+            all_envs.clone(),
+        ),
+        ShadowTest::new("sigprocmask", test_sigprocmask, all_envs.clone()),
+        ShadowTest::new(
+            "send to thread and process",
+            test_send_to_thread_and_process,
+            all_envs.clone(),
+        ),
+        ShadowTest::new(
+            "raise process targeted signal multithreaded",
+            test_process_pending_multithreaded,
+            all_envs.clone(),
+        ),
+        ShadowTest::new(
+            "handled tkill interrupts syscall",
+            test_handled_tkill_interrupts_syscall,
+            all_envs.clone(),
+        ),
+        ShadowTest::new(
+            "ignored tkill doesn't interrupt syscall",
+            test_ignored_tkill_doesnt_interrupt_syscall,
+            all_envs.clone(),
+        ),
+        ShadowTest::new(
+            "default-ignored signal doesn't interrupt syscall",
+            test_default_ignored_tkill_doesnt_interrupt_syscall,
+            all_envs.clone(),
+        ),
+        ShadowTest::new(
+            "handled kill interrupts syscall",
+            test_handled_kill_interrupts_syscall,
+            all_envs.clone(),
+        ),
+    ];
+
+    if filter_shadow_passing {
+        tests = tests
+            .into_iter()
+            .filter(|x| x.passing(TestEnv::Shadow))
+            .collect()
+    }
+    if filter_libc_passing {
+        tests = tests
+            .into_iter()
+            .filter(|x| x.passing(TestEnv::Libc))
+            .collect()
+    }
+
+    test_utils::run_tests(&tests, summarize)?;
+
+    println!("Success.");
+    Ok(())
+}


### PR DESCRIPTION
Implements most of MS2 from https://github.com/shadow/shadow/discussions/1851.

* Adds an explicit locking mechanism to the shim-shared-memory structures. The "protected" bits of these structures are now protected by a host-wide lock. While we could have used atomics again here, there are many operations that touch multiple parts of this state; it's safer to use a lock to ensure such operations get a consistent view.
* Adds signal state to the thread and process  shim-shared-memory structures, including configured masks, pending signals, etc.
* Adds basic signal handling to preload mode including configuring signal handlers and masks, sending signals to threads and processes, and interrupting blocked syscalls with signals.
* Adds tests for the new signal functionality and enables both the old and new tests for preload mode. I left the old signal test in place to help ensure this doesn't introduce regressions in ptrace mode's signal handling. ptrace mode doesn't pass the new tests (in particular it doesn't support interrupting blocked syscalls).

Notable pieces still missing:
* SA_RESTART: automatically restart interrupted syscalls.
* SA_ONSTACK: run syscall handlers in stack previously provided in `sigaltstack`.

Neither of these are very difficult, but seemed worth leaving out of this already-large-PR, and maybe deferring to MS3.