### PR TITLE
_getaddrinfo_service: Make behavior on bad service name consistent

### DIFF
--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -56,6 +56,15 @@ static int _getaddrinfo_service(in_port_t* port, const char* service,
         //
         // getaddrinfo(3): "EAI_SYSTEM: Other system error, check errno for
         // details."
+        if (rv == EBADF) {
+            // In cases where libc wasn't able to connect to a local resolver
+            // (which is expected under Shadow), and the service wasn't found in
+            // /etc/services, some versions of libc return non-zero rv and
+            // errno=EBADF.
+            // https://github.com/shadow/shadow/issues/1869
+            warning("Converting EBADF to EAI_SERVICE to work around #1869");
+            return EAI_SERVICE;
+        }
         errno = rv;
         return EAI_SYSTEM;
     }

--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -43,7 +43,7 @@ static int _getaddrinfo_service(in_port_t* port, const char* service,
 
     // `buf` will be used for strings pointed to in `result`.
     // 1024 is the recommended size in getservbyname_r(3).
-    char* buf = malloc(1024);
+    char buf[1024];
     struct servent servent;
     struct servent* result;
     int rv = getservbyname_r(service, NULL, &servent, buf, 1024, &result);
@@ -71,7 +71,6 @@ static int _getaddrinfo_service(in_port_t* port, const char* service,
     // it will return UDP and RAW in addition to TCP, despite /etc/services
     // only containing a TCP entry for that protocol.
     *port = result->s_port;
-    free(buf);
     return rv;
 }
 

--- a/src/test/resolver/test_getaddrinfo.c
+++ b/src/test/resolver/test_getaddrinfo.c
@@ -1,6 +1,7 @@
 #include <glib.h>
 
 #include <arpa/inet.h>
+#include <errno.h>
 #include <netdb.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -154,17 +155,18 @@ bool addrinfo_equals(const struct addrinfo* lhs, const struct addrinfo* rhs) {
         g_test_fail();                                                         \
     }
 
-#define assert_getaddrinfo_rv_equals(got, expected)                            \
-    {                                                                          \
-        char buf1_##__LINE__[20];                                              \
-        char buf2_##__LINE__[20];                                              \
-        int rv##__LINE__ = got;                                                \
-        if (rv##__LINE__ != expected) {                                        \
-            printf("Expected: %s ; Got: %s\n",                                 \
-                   getaddrinfo_rv_string(buf1_##__LINE__, expected),           \
-                   getaddrinfo_rv_string(buf2_##__LINE__, rv##__LINE__));      \
-            g_test_fail();                                                     \
-        }                                                                      \
+#define assert_getaddrinfo_rv_equals(got, expected)                                                \
+    {                                                                                              \
+        char buf1_##__LINE__[20];                                                                  \
+        char buf2_##__LINE__[20];                                                                  \
+        int rv##__LINE__ = got;                                                                    \
+        if (rv##__LINE__ != expected) {                                                            \
+            printf("Expected: %s ; Got: %s ; errno: %s\n",                                         \
+                   getaddrinfo_rv_string(buf1_##__LINE__, expected),                               \
+                   getaddrinfo_rv_string(buf2_##__LINE__, rv##__LINE__),                           \
+                   (rv##__LINE__ == EAI_SERVICE) ? strerror(errno) : "N/A");                       \
+            g_test_fail();                                                                         \
+        }                                                                                          \
     }
 
 void test_service() {


### PR DESCRIPTION
Fixes https://github.com/shadow/shadow/issues/1869