### PR TITLE
Add Fedora 35 to supported releases and CI tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -40,6 +40,7 @@ jobs:
           - 'debian:10-slim'
           - 'debian:11-slim'
           - 'fedora:34'
+          - 'fedora:35'
           # EOL May 2024 https://www.centos.org/centos-stream/
           - 'quay.io/centos/centos:stream8'
         cc: ['gcc', 'clang']
@@ -50,6 +51,9 @@ jobs:
             cc: clang
           # https://github.com/shadow/shadow/issues/1741
           - container: 'ubuntu:21.10'
+            cc: clang
+          # https://github.com/shadow/shadow/issues/1741
+          - container: 'fedora:35'
             cc: clang
     env:
       CC: ${{ matrix.cc }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,11 +30,11 @@ jobs:
     strategy:
       matrix:
         container:
-          # EOL April 2028 https://wiki.ubuntu.com/Releases
+          # End of standard support: April 2023 https://wiki.ubuntu.com/Releases
           - 'ubuntu:18.04'
-          # EOL April 2030 https://wiki.ubuntu.com/Releases
+          # End of standard support: April 2025 https://wiki.ubuntu.com/Releases
           - 'ubuntu:20.04'
-          # EOL July 2022 https://wiki.ubuntu.com/Releases
+          # End of standard support: July 2022 https://wiki.ubuntu.com/Releases
           - 'ubuntu:21.10'
           # EOL ~August 2022 https://wiki.debian.org/DebianReleases
           - 'debian:10-slim'

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -13,6 +13,7 @@ CONTAINERS=(
     debian:10-slim
     debian:11-slim
     fedora:34
+    fedora:35
     quay.io/centos/centos:stream8
     )
 
@@ -54,9 +55,9 @@ Run all default configurations, but restrict C compilers to gcc:
   $0 -C gcc
 
 Run all default configurations, but restrict C compilers to gcc,
-and containers to ubuntu:18.04 and fedora:34:
+and containers to ubuntu:18.04 and fedora:35:
 
-  $0 -C gcc -c "ubuntu:18.04 fedora:34"
+  $0 -C gcc -c "ubuntu:18.04 fedora:35"
 
 Set "extra" configurations to ubuntu:18.04;clang;coverage
 and debian:11-slim;gcc;coverage

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -35,7 +35,7 @@ you'll want to only run some smaller set of configurations locally.
 To run only the configurations you specify, use the `-o` flag:
 
 ```{.bash}
-sudo ci/run.sh -i -o "ubuntu:18.04;clang;debug fedora:34;gcc;release"
+sudo ci/run.sh -i -o "ubuntu:18.04;clang;debug fedora:35;gcc;release"
 ```
 
 For additional options, run `ci/run.sh -h`.

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -4,7 +4,7 @@
 
   + Ubuntu 18.04 and 20.04
   + Debian 10 and 11
-  + Fedora 34
+  + Fedora 34 and 35
   + CentOS Stream 8
 
 If you are installing Shadow within a Docker container, you must increase the


### PR DESCRIPTION
Replaces #1734. Also update the EOL dates for Ubuntu to show the standard EOL dates rather than the enterprise / paid support EOL dates.