### PR TITLE
Log the thread id during strace logging

### DIFF
--- a/src/lib/syscall-logger/src/lib.rs
+++ b/src/lib/syscall-logger/src/lib.rs
@@ -95,6 +95,7 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
                     write_syscall(
                         file,
                         &Worker::current_time().unwrap(),
+                        ctx.thread.id(),
                         "{syscall_name}",
                         &syscall_args,
                         syscall_rv,

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -662,7 +662,11 @@ SysCallReturn rustsyscallhandler_fcntl(SysCallHandler *sys, const SysCallArgs *a
 
 SysCallReturn rustsyscallhandler_fcntl64(SysCallHandler *sys, const SysCallArgs *args);
 
-SysCallReturn log_syscall(Process *proc, const char *name, const char *args, SysCallReturn result);
+SysCallReturn log_syscall(Process *proc,
+                          pid_t tid,
+                          const char *name,
+                          const char *args,
+                          SysCallReturn result);
 
 SysCallReturn rustsyscallhandler_ioctl(SysCallHandler *sys, const SysCallArgs *args);
 

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -204,29 +204,29 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number,
 // Single public API function for calling Shadow syscalls
 ///////////////////////////////////////////////////////////
 
-#define HANDLE(s)                                                              \
-    case SYS_##s:                                                              \
-        _syscallhandler_pre_syscall(sys, args->number, #s);                    \
-        scr = syscallhandler_##s(sys, args);                                   \
-        if (process_straceLoggingEnabled(sys->process)) {                      \
-            scr = log_syscall(sys->process, #s, "...", scr);                   \
-        }                                                                      \
-        _syscallhandler_post_syscall(sys, args->number, #s, &scr);             \
+#define HANDLE(s)                                                                                  \
+    case SYS_##s:                                                                                  \
+        _syscallhandler_pre_syscall(sys, args->number, #s);                                        \
+        scr = syscallhandler_##s(sys, args);                                                       \
+        if (process_straceLoggingEnabled(sys->process)) {                                          \
+            scr = log_syscall(sys->process, thread_getID(sys->thread), #s, "...", scr);            \
+        }                                                                                          \
+        _syscallhandler_post_syscall(sys, args->number, #s, &scr);                                 \
         break
-#define NATIVE(s)                                                              \
-    case SYS_##s:                                                              \
-        trace("native syscall %ld " #s, args->number);                         \
-        scr = (SysCallReturn){.state = SYSCALL_NATIVE};                        \
-        if (process_straceLoggingEnabled(sys->process)) {                      \
-            scr = log_syscall(sys->process, #s, "...", scr);                   \
-        }                                                                      \
+#define NATIVE(s)                                                                                  \
+    case SYS_##s:                                                                                  \
+        trace("native syscall %ld " #s, args->number);                                             \
+        scr = (SysCallReturn){.state = SYSCALL_NATIVE};                                            \
+        if (process_straceLoggingEnabled(sys->process)) {                                          \
+            scr = log_syscall(sys->process, thread_getID(sys->thread), #s, "...", scr);            \
+        }                                                                                          \
         break
 #define UNSUPPORTED(s)                                                                             \
     case SYS_##s:                                                                                  \
         error("Returning error ENOSYS for explicitly unsupported syscall %ld " #s, args->number);  \
         scr = (SysCallReturn){.state = -ENOSYS};                                                   \
         if (process_straceLoggingEnabled(sys->process)) {                                          \
-            scr = log_syscall(sys->process, #s, "...", scr);                                       \
+            scr = log_syscall(sys->process, thread_getID(sys->thread), #s, "...", scr);            \
         }                                                                                          \
         break
 
@@ -502,7 +502,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
             if (process_straceLoggingEnabled(sys->process)) {
                 char arg_str[20] = {0};
                 snprintf(arg_str, sizeof(arg_str), "%ld, ...", args->number);
-                scr = log_syscall(sys->process, "syscall", arg_str, scr);
+                scr = log_syscall(sys->process, thread_getID(sys->thread), "syscall", arg_str, scr);
             }
 
             break;

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -5,9 +5,6 @@ use crate::cshadow as c;
 use crate::utility::syscall;
 use nix::unistd::Pid;
 
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub struct ThreadId(u32);
-
 pub trait Thread {
     /// Have the plugin thread natively execute the given syscall.
     fn native_syscall(&mut self, n: i64, args: &[SysCallReg]) -> nix::Result<SysCallReg>;
@@ -221,5 +218,22 @@ impl Drop for CThread {
         unsafe {
             c::thread_unref(self.cthread);
         }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub struct ThreadId(u32);
+
+impl TryFrom<libc::pid_t> for ThreadId {
+    type Error = <u32 as TryFrom<libc::pid_t>>::Error;
+
+    fn try_from(value: libc::pid_t) -> Result<Self, Self::Error> {
+        Ok(Self(u32::try_from(value)?))
+    }
+}
+
+impl std::fmt::Display for ThreadId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }


### PR DESCRIPTION
Example:

```
00:00:01.000 [tid 1000] write(1, "Testing test_make_detached...BBBBBBBBBBB"..., 29) = 29
00:00:01.000 [tid 1000] mmap(...) = 140737192390656
00:00:01.000 [tid 1000] mprotect(...) = 0
00:00:01.000 [tid 1000] clone(...) = 1001
00:00:01.000 [tid 1001] shadow_get_shm_blk(...) = 0
00:00:01.000 [tid 1001] set_robust_list(...) = -38 (ENOSYS: Function not implemented)
00:00:01.000 [tid 1001] madvise(...) = <native>
00:00:01.001 [tid 1000] nanosleep(...) = 0
```