### PR TITLE
Implement sigaltstack

### DIFF
--- a/src/lib/shim/shadow_signals.h
+++ b/src/lib/shim/shadow_signals.h
@@ -17,6 +17,13 @@
 #define SHD_SIGRT_MIN 32
 #define SHD_SIGRT_MAX 64
 
+// Definition is sometimes missing in the userspace headers. We could include
+// the kernel signal header, but it has definitions that conflict with the
+// userspace headers.
+#ifndef SS_AUTODISARM
+#define SS_AUTODISARM (1U << 31)
+#endif
+
 // Compatible with the kernel's definition of sigset_t on x86_64. Exposing the
 // definition in the header so that it can be used as a value-type, but should
 // be manipulated with the helpers below.

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -20,6 +20,7 @@
 #include "lib/logger/logger.h"
 #include "lib/shim/ipc.h"
 #include "lib/shim/shadow_sem.h"
+#include "lib/shim/shadow_signals.h"
 #include "lib/shim/shadow_spinlock.h"
 #include "lib/shim/shim_event.h"
 #include "lib/shim/shim_logger.h"
@@ -30,13 +31,6 @@
 #include "lib/shim/shim_syscall.h"
 #include "lib/shim/shim_tls.h"
 #include "main/host/syscall_numbers.h" // for SYS_shadow_* defs
-
-// Definition is sometimes missing in the userspace headers. We could include
-// the kernel signal header, but it has definitions that conflict with the
-// userspace headers.
-#ifndef SS_AUTODISARM
-#define SS_AUTODISARM (1U << 31)
-#endif
 
 // Whether Shadow is using preload-based interposition.
 static bool _using_interpose_preload = false;

--- a/src/lib/shim/shim_shmem.h
+++ b/src/lib/shim/shim_shmem.h
@@ -95,6 +95,11 @@ shd_kernel_sigset_t shimshmem_getBlockedSignals(const ShimShmemHostLock* host,
 void shimshmem_setBlockedSignals(const ShimShmemHostLock* host, ShimShmemThread* thread,
                                  shd_kernel_sigset_t sigset);
 
+// Get and set signal stack as set by `sigaltstack(2)`.
+stack_t shimshmem_getSigAltStack(const ShimShmemHostLock* host, const ShimShmemThread* thread);
+void shimshmem_setSigAltStack(const ShimShmemHostLock* host, ShimShmemThread* thread,
+                              stack_t stack);
+
 // Takes a pending unblocked signal (at the thread or process level) and marks it
 // no longer pending. Sets `info` if non-NULL.
 //


### PR DESCRIPTION
The golang runtime uses sigaltstack, and detects when its handlers aren't running on the configured stack.

Helps with some of the errors in #1549 .