### PR TITLE
If strace string logging pointer is invalid, print address

### DIFF
--- a/src/main/host/syscall/format.rs
+++ b/src/main/host/syscall/format.rs
@@ -180,35 +180,33 @@ simple_debug_impl!(nix::sys::socket::MsgFlags);
 
 impl SyscallPtrDisplay for SyscallPtr<*const i8> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, mem: &MemoryManager) -> std::fmt::Result {
-        if self.ptr.is_null() {
-            return write!(f, "{:p}", self.ptr);
-        }
         const DISPLAY_LEN: usize = 40;
 
         // read up to one extra character to check if it's a null byte
-        let mem_ref = mem.memory_ref_prefix(TypedPluginPtr::new::<u8>(self.ptr, DISPLAY_LEN + 1));
+        let mem_ref =
+            match mem.memory_ref_prefix(TypedPluginPtr::new::<u8>(self.ptr, DISPLAY_LEN + 1)) {
+                Ok(x) => x,
+                // the pointer didn't reference any valid memory
+                Err(_) => return write!(f, "{:p}", self.ptr),
+            };
 
         // to avoid printing too many escaped bytes, limit the number of non-graphic and non-ascii
         // characters
         let mut non_graphic_remaining = DISPLAY_LEN / 3;
 
-        let mut s: Vec<NonZeroU8> = match mem_ref {
-            // mem_ref will reference up to DISPLAY_LEN+1 bytes
-            Ok(mem_ref) => mem_ref
-                .iter()
-                // get bytes until a null byte
-                .map_while(|x| NonZeroU8::new(*x))
-                // stop after a certain number of non-graphic characters
-                .map_while(|x| {
-                    if !x.get().is_ascii_graphic() {
-                        non_graphic_remaining = non_graphic_remaining.saturating_sub(1);
-                    }
-                    (non_graphic_remaining > 0).then(|| x)
-                })
-                .collect(),
-            // the pointer didn't reference any valid memory
-            Err(_) => vec![],
-        };
+        // mem_ref will reference up to DISPLAY_LEN+1 bytes
+        let mut s: Vec<NonZeroU8> = mem_ref
+            .iter()
+            // get bytes until a null byte
+            .map_while(|x| NonZeroU8::new(*x))
+            // stop after a certain number of non-graphic characters
+            .map_while(|x| {
+                if !x.get().is_ascii_graphic() {
+                    non_graphic_remaining = non_graphic_remaining.saturating_sub(1);
+                }
+                (non_graphic_remaining > 0).then(|| x)
+            })
+            .collect();
 
         let len = s.len();
         s.truncate(DISPLAY_LEN);


### PR DESCRIPTION
When the buffer address is invalid, print the address rather than an empty string.

Old:
```
sendto(3, "", 0, (empty), 0x0, 0) = 0
```

New:
```
sendto(3, 0x1, 0, (empty), 0x0, 0) = 0
```