### PR TITLE
Remove centos stream 8 libarchive workaround

### DIFF
--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -35,7 +35,6 @@ RPM_PACKAGES="
   xz-devel
   yum-utils
   diffutils
-  libarchive
   util-linux
   "
 

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -59,9 +59,6 @@ sudo apt-get install -y \
 
 ## YUM (Fedora/CentOS):
 
-Before running these commands, please check any platform-specific
-requirements below.
-
 **Warning:** `dnf` often installs 32-bit (`i686`) versions of
 libraries. You may want to use the `--best` option to make sure you're
 installing the 64-bit (`x86_64`) versions, which are required by Shadow.
@@ -102,13 +99,4 @@ sudo dnf install -y \
     git \
     htop \
     tmux
-```
-
-### CentOS Stream 8
-
-Due to [a bug](https://bugs.centos.org/view.php?id=18212) in the CentOS 8 CMake
-package, you must install libarchive manually.
-
-```bash
-dnf install -y libarchive
 ```


### PR DESCRIPTION
This doesn't seem to be an issue anymore.