### PR TITLE
Docs bindings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ can fix it.
      * Application and Library-Specific Notes
        * [libopenblas](libopenblas.md)
    * Developer Guides
+     * [Coding](coding.md)
      * [Debugging and profiling](developer_guide.md)
      * [Continous integration tests](ci.md)
  * The Shadow project

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,13 +36,13 @@ can fix it.
        * [Parallel Simulations](parallel_sims.md)
      * Application and Library-Specific Notes
        * [libopenblas](libopenblas.md)
-   * Developer Guides
+   * Developer Guide
      * [Coding](coding.md)
      * [Debugging and profiling](developer_guide.md)
      * [Continous integration tests](ci.md)
+     * [Maintainer playbook](maintainer_playbook.md)
  * The Shadow project
    * [Contributing](contributing.md)
      * [Coding style](coding_style.md)
      * [Pull requests](pull_requests.md)
-   * [Maintainer playbook](maintainer_playbook.md)
    * [NSF Sponsorship](nsf_sponsorship.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -31,12 +31,15 @@
         - [Parallel Simulations](parallel_sims.md)
     - [Application and Library-Specific Notes]()
         - [libopenblas](libopenblas.md)
-- [Developer Guides]()
+- [Developer Guide]()
     - [Coding](coding.md)
     - [Debugging and profiling](developer_guide.md)
     - [Continous integration tests](ci.md)
+    - [Maintainer playbook](maintainer_playbook.md)
+
+# The Shadow Project
+
 - [Contributing](contributing.md)
     - [Coding style](coding_style.md)
     - [Pull requests](pull_requests.md)
-- [Maintainer playbook](maintainer_playbook.md)
 - [NSF Sponsorship](nsf_sponsorship.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -32,6 +32,7 @@
     - [Application and Library-Specific Notes]()
         - [libopenblas](libopenblas.md)
 - [Developer Guides]()
+    - [Coding](coding.md)
     - [Debugging and profiling](developer_guide.md)
     - [Continous integration tests](ci.md)
 - [Contributing](contributing.md)

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -1,0 +1,33 @@
+# Coding
+
+## Building the C-Rust bindings
+
+Shadow contains both C and Rust code, and we automatically generate bindings
+for both languages so that they can interoperate. Changing function or type
+definitions may require you to rebuild the bindings.
+
+When required, you can rebuild all of the C-Rust bindings by running:
+
+```bash
+cd build && cmake --target bindings .. && make bindings
+```
+
+To see the specific options/flags provided to bindgen and cbindgen, you can use
+`make VERBOSE=1 bindings`.
+
+Since the C bindings and Rust bindings rely on each other, you may sometimes
+need to build the bindings in a specific order. Instead of `make bindings`, you
+can be more specific using for example `make bindings_main_rust` to make the
+Rust bindings for `src/main`.
+
+You may need to install bindgen, cbindgen, and clang:
+
+```bash
+apt install -y clang
+cargo install --force --version 0.20.0 cbindgen
+cargo install --force --version 0.59.1 bindgen
+```
+
+The versions of bindgen and cbindgen you install should match the [versions
+installed in the
+CI](https://github.com/shadow/shadow/blob/main/.github/workflows/lint.yml).

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,33 +1,5 @@
 # Debugging and profiling
 
-## Building the C-Rust bindings
-
-When required, you can rebuild all of the C-Rust bindings by running:
-
-```bash
-cd build && cmake --target bindings .. && make bindings
-```
-
-To see the specific options/flags provided to bindgen and cbindgen, you can use
-`make VERBOSE=1 bindings`.
-
-Since the C bindings and Rust bindings rely on each other, you may sometimes
-need to build the bindings in a specific order. Instead of `make bindings`, you
-can be more specific using for example `make bindings_main_rust` to make the
-Rust bindings for `src/main`.
-
-You may need to install bindgen, cbindgen, and clang:
-
-```bash
-apt install -y clang
-cargo install --force --version 0.20.0 cbindgen
-cargo install --force --version 0.59.1 bindgen
-```
-
-The versions of bindgen and cbindgen you install should match the [versions
-installed in the
-CI](https://github.com/shadow/shadow/blob/main/.github/workflows/lint.yml).
-
 ## Extra tests
 
 Shadow includes tests that require additional dependencies, such as Tor, TGen,


### PR DESCRIPTION
- moved the "Building the C-Rust bindings" doc section from the "Debugging and profiling" page to a new "Coding" page
- moved the "Contributing" and "Maintainer playbook" pages into the "Developer Guide" section