### PR TITLE
Fix shm cleanup tests

### DIFF
--- a/src/main/Cargo.lock
+++ b/src/main/Cargo.lock
@@ -264,6 +264,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +343,15 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -626,6 +644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +668,15 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -797,6 +833,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "syscall-logger",
+ "tempfile",
  "vsprintf",
 ]
 
@@ -823,6 +860,20 @@ version = "0.1.0"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -39,6 +39,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.12.0"
 serde_yaml = "0.8"
 syscall-logger = { path = "../lib/syscall-logger" }
+tempfile = "3.3"
 # TODO: switch to upstream crate if/when they merge and release
 # https://github.com/dylanmckay/vsprintf/pull/2
 #

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -47,7 +47,7 @@ pub fn run_shadow<'a>(args: Vec<&'a OsStr>) -> anyhow::Result<()> {
 
     if options.shm_cleanup {
         // clean up any orphaned shared memory
-        cleanup::try_shm_cleanup().context("Cleaning shared memory files")?;
+        cleanup::shm_cleanup(cleanup::SHM_DIR_PATH).context("Cleaning shared memory files")?;
         std::process::exit(0);
     }
 
@@ -97,7 +97,7 @@ pub fn run_shadow<'a>(args: Vec<&'a OsStr>) -> anyhow::Result<()> {
     }
 
     // before we run the simulation, clean up any orphaned shared memory
-    if let Err(e) = cleanup::try_shm_cleanup() {
+    if let Err(e) = cleanup::shm_cleanup(cleanup::SHM_DIR_PATH) {
         log::warn!("Unable to clean up shared memory files: {:?}", e);
     }
 

--- a/src/main/shmem/cleanup.rs
+++ b/src/main/shmem/cleanup.rs
@@ -123,48 +123,48 @@ pub fn shm_cleanup(shm_dir: impl AsRef<Path>) -> anyhow::Result<u32> {
 mod tests {
     use super::*;
     use std::fs::OpenOptions;
+    use std::io;
     use std::process;
-    use std::{fs, io};
 
-    fn touch(path: &Path) -> io::Result<()> {
-        match OpenOptions::new().create(true).write(true).open(path) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e),
-        }
+    fn touch(path: impl AsRef<Path>) -> io::Result<()> {
+        OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(path.as_ref())?;
+        Ok(())
     }
 
     #[test]
     fn test_expired_shm_file_is_removed() {
-        let s = "/dev/shm/shadow_shmemfile_6379761.950298775-999999999";
-        let expired = Path::new(s);
+        let dir = tempfile::tempdir().unwrap();
+        let s = "shadow_shmemfile_6379761.950298775-999999999";
+        let expired: PathBuf = [dir.as_ref(), s.as_ref()].iter().collect();
 
         touch(&expired).unwrap();
-        assert_eq!(shm_cleanup(SHM_DIR_PATH).unwrap(), 1);
-        assert!(!expired.exists());
+        assert_eq!(shm_cleanup(&dir).unwrap(), 1);
+        assert!(!expired.exists(), "Exists: {}", expired.display());
     }
 
     #[test]
     fn test_valid_shm_file_is_not_removed() {
         let my_pid = process::id();
-        let s = format!("/dev/shm/shadow_shmemfile_6379761.950298775-{my_pid}");
-        let valid = Path::new(&s);
+        let dir = tempfile::tempdir().unwrap();
+        let s = format!("shadow_shmemfile_6379761.950298775-{my_pid}");
+        let valid: PathBuf = [dir.as_ref(), s.as_ref()].iter().collect();
 
         touch(&valid).unwrap();
-        assert_eq!(shm_cleanup(SHM_DIR_PATH).unwrap(), 0);
-        assert!(valid.exists());
-
-        fs::remove_file(valid).unwrap();
+        assert_eq!(shm_cleanup(&dir).unwrap(), 0);
+        assert!(valid.exists(), "Doesn't exist: {}", valid.display());
     }
 
     #[test]
     fn test_nonshadow_shm_file_is_not_removed() {
-        let s = "/dev/shm/shadow_unimportant_test_file";
-        let nonshadow = Path::new(s);
+        let dir = tempfile::tempdir().unwrap();
+        let s = "shadow_unimportant_test_file";
+        let nonshadow: PathBuf = [dir.as_ref(), s.as_ref()].iter().collect();
 
         touch(&nonshadow).unwrap();
-        assert_eq!(shm_cleanup(SHM_DIR_PATH).unwrap(), 0);
-        assert!(nonshadow.exists());
-
-        fs::remove_file(nonshadow).unwrap();
+        assert_eq!(shm_cleanup(&dir).unwrap(), 0);
+        assert!(nonshadow.exists(), "Doesn't exist: {}", nonshadow.display());
     }
 }


### PR DESCRIPTION
~Fixes a race condition by making the unit tests run single-threaded, and makes sure that there are no pre-existing shm files.~

Fixes a race condition by making the unit tests use temporary directories.