### PR TITLE
Added workaround for networkx bug

### DIFF
--- a/src/tools/convert_legacy_topology.py
+++ b/src/tools/convert_legacy_topology.py
@@ -8,6 +8,11 @@ import xml.etree.ElementTree as ET
 from xml.dom import minidom
 from xml.sax.saxutils import unescape
 
+# required to fix a networkx bug
+# https://github.com/networkx/networkx/issues/5367
+import importlib
+import importlib.machinery
+
 import networkx as nx
 
 import yaml


### PR DESCRIPTION
This bug causes our Fedora 35 CI tests to fail, which uses the recently released [networkx 2.7](https://github.com/networkx/networkx/releases/tag/networkx-2.7).

Workaround for https://github.com/networkx/networkx/issues/5367