### PR TITLE
Fixed crash when attempting to capture UDP packets in pcap

### DIFF
--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -339,6 +339,12 @@ void networkinterface_disassociate(NetworkInterface* interface, const CompatSock
 }
 
 static void _networkinterface_capturePacket(NetworkInterface* interface, Packet* packet) {
+    if (packet_getProtocol(packet) != PTCP) {
+        /* we don't support capturing UDP packets */
+        debug("Network interface skipped capturing a UDP packet");
+        return;
+    }
+
     PCapPacket* pcapPacket = g_new0(PCapPacket, 1);
 
     pcapPacket->headerSize = packet_getHeaderSize(packet);


### PR DESCRIPTION
Logging on every UDP packet when pcap logging is enabled might be overkill, but on the other hand we should expect debug logging to generate a lot of noise.