### PR TITLE
Patch vdso

### DIFF
--- a/src/lib/shim/CMakeLists.txt
+++ b/src/lib/shim/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(${SHIM_HELPER_LIB} INTERFACE logger shadow-shmem)
 
 set(SHIM_LIB shadow-shim)
 set(SHIM_FILES
+  patch_vdso.c
   shim.c
   shim_api_addrinfo.c
   shim_api_ifaddrs.c

--- a/src/lib/shim/patch_vdso.c
+++ b/src/lib/shim/patch_vdso.c
@@ -1,0 +1,203 @@
+#include <assert.h>
+#include <elf.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "lib/logger/logger.h"
+
+static void _getVdsoBounds(void** start, void** end) {
+    assert(start);
+    *start = NULL;
+    assert(end);
+    *end = NULL;
+
+    FILE* maps = fopen("/proc/self/maps", "r");
+    size_t n = 100;
+    char* line = malloc(n);
+    while (true) {
+        ssize_t rv = getline(&line, &n, maps);
+        if (rv < 0) {
+            break;
+        }
+        const char* name = "[vdso]\n";
+        size_t name_len = strlen(name);
+        if (rv < name_len) {
+            // Can't be [vdso].
+            continue;
+        }
+        if (strcmp(&line[rv - name_len], name) != 0) {
+            // Isn't [vdso].
+            continue;
+        }
+        // *is* [vdso]. Parse the line.
+        if (sscanf(line, "%p-%p", start, end) != 2) {
+            warning("Couldn't parse maps line: %s", line);
+            // Ensure both are still NULL.
+            *start = NULL;
+            *end = NULL;
+            // Might as well keep going and see if another line matches and parses.
+            continue;
+        }
+        // Success
+        break;
+    }
+
+    free(line);
+    fclose(maps);
+}
+
+static void _checkIdentByte(const unsigned char ident[EI_NIDENT], size_t idx, char expected) {
+    if (ident[idx] != expected) {
+        panic("Expected byte %zu of elf header to be %x; got %x", idx, expected, ident[idx]);
+    }
+}
+
+static const Elf64_Shdr* _findSection(const Elf64_Ehdr* elfHdr, const char* sectionName) {
+    if (elfHdr->e_shoff == 0) {
+        panic("No section headers");
+    }
+    const Elf64_Shdr* sections = ((void*)elfHdr) + elfHdr->e_shoff;
+
+    if (elfHdr->e_shstrndx == SHN_UNDEF) {
+        panic("No section header names");
+    }
+    if (elfHdr->e_shstrndx == SHN_XINDEX) {
+        panic("SHN_XINDEX unimplemented");
+    }
+    const Elf64_Shdr* sectionNameSection = &sections[elfHdr->e_shstrndx];
+    const char* sectionNames = (void*)elfHdr + sectionNameSection->sh_offset;
+
+    for (int i = 0; i < elfHdr->e_shnum; ++i) {
+        const char* thisSectionName = &sectionNames[sections[i].sh_name];
+        if (strcmp(sectionName, thisSectionName) == 0) {
+            return &sections[i];
+        }
+    }
+    return NULL;
+}
+
+struct ParsedElf {
+    const void* mapStart;
+    const void* mapEnd;
+    const Elf64_Ehdr* hdr;
+    const Elf64_Shdr* dynSymSectionHdr;
+    const Elf64_Shdr* dynSymNameSectionHdr;
+};
+
+static struct ParsedElf _parseElf(const void* base) {
+    const Elf64_Ehdr* elfHdr = base;
+
+    void* mapStart;
+    void* mapEnd;
+    _getVdsoBounds(&mapStart, &mapEnd);
+    if (mapStart == NULL || mapEnd == NULL) {
+        panic("Couldn't find VDSO bounds");
+    }
+    if (base < mapStart || base > mapEnd) {
+        panic("vdso base %p not within mapping bounds %p-%p", base, mapStart, mapEnd);
+    }
+
+    _checkIdentByte(elfHdr->e_ident, EI_MAG0, ELFMAG0);
+    _checkIdentByte(elfHdr->e_ident, EI_MAG1, ELFMAG1);
+    _checkIdentByte(elfHdr->e_ident, EI_MAG2, ELFMAG2);
+    _checkIdentByte(elfHdr->e_ident, EI_MAG3, ELFMAG3);
+    _checkIdentByte(elfHdr->e_ident, EI_CLASS, ELFCLASS64);
+    _checkIdentByte(elfHdr->e_ident, EI_DATA, ELFDATA2LSB);
+    _checkIdentByte(elfHdr->e_ident, EI_VERSION, EV_CURRENT);
+    _checkIdentByte(elfHdr->e_ident, EI_OSABI, ELFOSABI_NONE);
+    _checkIdentByte(elfHdr->e_ident, EI_ABIVERSION, 0);
+
+    const Elf64_Shdr* dynSymSectionHdr = _findSection(elfHdr, ".dynsym");
+    if (!dynSymSectionHdr) {
+        panic("Couldn't find dynamic symbols");
+    }
+    const Elf64_Shdr* dynSymNameSectionHdr = _findSection(elfHdr, ".dynstr");
+    if (!dynSymNameSectionHdr) {
+        panic("Couldn't find dynamic symbol names");
+    }
+
+    return (struct ParsedElf){
+        .mapStart = mapStart,
+        .mapEnd = mapEnd,
+        .hdr = elfHdr,
+        .dynSymSectionHdr = dynSymSectionHdr,
+        .dynSymNameSectionHdr = dynSymNameSectionHdr,
+    };
+}
+
+static const Elf64_Sym* _findSymbol(const struct ParsedElf* parsedElf, const char* symbolName) {
+    size_t numEntries =
+        parsedElf->dynSymSectionHdr->sh_size / parsedElf->dynSymSectionHdr->sh_entsize;
+    const Elf64_Sym* symbols = (void*)parsedElf->hdr + parsedElf->dynSymSectionHdr->sh_offset;
+    const char* symbolNames = (void*)parsedElf->hdr + parsedElf->dynSymNameSectionHdr->sh_offset;
+    for (int i = 0; i < numEntries; ++i) {
+        const char* thisSymbolName = &symbolNames[symbols[i].st_name];
+        if (strcmp(thisSymbolName, symbolName) == 0) {
+            return &symbols[i];
+        }
+    }
+    return NULL;
+}
+
+static int _replacement_gettimeofday(void* arg1, void* arg2) {
+    return (int)syscall(SYS_gettimeofday, arg1, arg2);
+}
+
+static int _replacement_time(void* arg1) { return (int)syscall(SYS_time, arg1); }
+
+static int _replacement_clock_gettime(void* arg1, void* arg2) {
+    return (int)syscall(SYS_clock_gettime, arg1, arg2);
+}
+
+static int _replacement_getcpu(void* arg1, void* arg2, void* arg3) {
+    return (int)syscall(SYS_getcpu, arg1, arg2, arg3);
+}
+
+static void _inject_trampoline(struct ParsedElf* parsedElf, const char* vdsoFnName,
+                               void* replacementFn) {
+    const Elf64_Sym* symbol = _findSymbol(parsedElf, vdsoFnName);
+    if (symbol == NULL) {
+        warning("Couldn't find symbol '%s' to override", vdsoFnName);
+        return;
+    }
+    // Loose upper bound on size of instructions we're writing, below.
+    if (symbol->st_size < 20) {
+        warning("Symbol '%s' not large enough to inject trampoline", vdsoFnName);
+        return;
+    }
+
+    uint8_t* current = (void*)parsedElf->hdr + symbol->st_value;
+
+    // movabs $...,%r10
+    *(current++) = 0x49;
+    *(current++) = 0xba;
+    *(void**)current = replacementFn;
+    current += sizeof(void*);
+
+    // jmpq *%r10
+    *(current++) = 0x41;
+    *(current++) = 0xff;
+    *(current++) = 0xe2;
+}
+
+void patch_vdso(void* vdsoBase) {
+    struct ParsedElf parsedElf = _parseElf(vdsoBase);
+    size_t regionSize = (size_t)parsedElf.mapEnd - (size_t)parsedElf.mapStart;
+
+    if (mprotect((void*)parsedElf.mapStart, regionSize, PROT_READ | PROT_WRITE | PROT_EXEC)) {
+        panic("mprotect: %s", strerror(errno));
+    }
+
+    _inject_trampoline(&parsedElf, "__vdso_gettimeofday", _replacement_gettimeofday);
+    _inject_trampoline(&parsedElf, "__vdso_time", _replacement_time);
+    _inject_trampoline(&parsedElf, "__vdso_clock_gettime", _replacement_clock_gettime);
+    _inject_trampoline(&parsedElf, "__vdso_getcpu", _replacement_getcpu);
+
+    if (mprotect((void*)parsedElf.mapStart, regionSize, PROT_READ | PROT_EXEC)) {
+        panic("mprotect: %s", strerror(errno));
+    }
+}

--- a/src/lib/shim/patch_vdso.h
+++ b/src/lib/shim/patch_vdso.h
@@ -1,0 +1,8 @@
+#ifndef SHIM_PATCH_VDSO_H
+#define SHIM_PATCH_VDSO_H
+
+// Hot-patch VDSO functions in the current-running programming to call the
+// `syscall(2)` function, which can be intercepted via LD_PRELOAD. 
+void patch_vdso(void* vdsoBase);
+
+#endif

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/auxv.h>
 #include <sys/mman.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>
@@ -19,6 +20,7 @@
 
 #include "lib/logger/logger.h"
 #include "lib/shim/ipc.h"
+#include "lib/shim/patch_vdso.h"
 #include "lib/shim/shadow_sem.h"
 #include "lib/shim/shadow_signals.h"
 #include "lib/shim/shadow_spinlock.h"
@@ -457,6 +459,7 @@ static void _shim_ipc_wait_for_start_event() {
 static void _shim_parent_init_ptrace() {
     bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
 
+    patch_vdso((void*)getauxval(AT_SYSINFO_EHDR));
     _shim_parent_init_host_shm();
     _shim_parent_init_process_shm();
     _shim_parent_init_logging();
@@ -477,8 +480,7 @@ static void _shim_parent_init_rdtsc_emu() {
 static void _shim_parent_init_preload() {
     bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
 
-    // The shim logger internally disables interposition while logging, so we open the log
-    // file with interposition disabled too to get a native file descriptor.
+    patch_vdso((void*)getauxval(AT_SYSINFO_EHDR));
     _shim_parent_init_host_shm();
     _shim_parent_init_process_shm();
     _shim_parent_init_thread_shm();

--- a/src/test/golang/CMakeLists.txt
+++ b/src/test/golang/CMakeLists.txt
@@ -47,6 +47,13 @@ add_shadow_tests(
     PROPERTIES
       LABELS golang)
 
+add_golang_test_exe(BASENAME test_intercept_golang_time)
+add_shadow_tests(
+    BASENAME intercept_golang_time
+    CONFIGURATIONS extra 
+    PROPERTIES
+      LABELS golang)
+
 add_golang_test_exe(BASENAME test_goroutines)
 add_linux_tests(
     BASENAME goroutines

--- a/src/test/golang/CMakeLists.txt
+++ b/src/test/golang/CMakeLists.txt
@@ -63,8 +63,6 @@ add_linux_tests(
       LABELS golang)
 add_shadow_tests(
     BASENAME goroutines
-    # BUG: https://github.com/shadow/shadow/issues/1932
-    SKIP_METHODS preload ptrace
     CONFIGURATIONS extra
     PROPERTIES
       LABELS golang)

--- a/src/test/golang/intercept_golang_time.yaml
+++ b/src/test/golang/intercept_golang_time.yaml
@@ -1,0 +1,13 @@
+general:
+  stop_time: 2000s
+
+network:
+  graph:
+    type: 1_gbit_switch
+
+hosts:
+  host:
+    network_node_id: 0
+    processes:
+    - path: ./test_intercept_golang_time
+      start_time: 1s

--- a/src/test/golang/test_intercept_golang_time.go
+++ b/src/test/golang/test_intercept_golang_time.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+// Validate that time is being intercepted.
+// Won't pass natively.
+func main() {
+	var t0 = time.Now()
+	var t1 = time.Now()
+
+	if t0 != t1 {
+		panic(fmt.Sprint(t0, " != ", t1))
+	}
+}


### PR DESCRIPTION
Overwrite the VDSO functions at run-time to call the `syscall` function, which we already intercept via LD_PRELOAD. This directly fixes #1091, which in turn allows us to simulate time in golang programs (fixing #1948). It also appears to fix #1932 .