### PR TITLE
Support alternative strace formatting modes

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -77,6 +77,7 @@ hosts:
 - [`experimental.socket_recv_buffer`](#experimentalsocket_recv_buffer)
 - [`experimental.socket_send_autotune`](#experimentalsocket_send_autotune)
 - [`experimental.socket_send_buffer`](#experimentalsocket_send_buffer)
+- [`experimental.strace_logging_mode`](#experimentalstrace_logging_mode)
 - [`experimental.use_cpu_pinning`](#experimentaluse_cpu_pinning)
 - [`experimental.use_dynamic_runahead`](#experimentaluse_dynamic_runahead)
 - [`experimental.use_explicit_block_message`](#experimentaluse_explicit_block_message)
@@ -90,7 +91,6 @@ hosts:
 - [`experimental.use_sched_fifo`](#experimentaluse_sched_fifo)
 - [`experimental.use_shim_syscall_handler`](#experimentaluse_shim_syscall_handler)
 - [`experimental.use_seccomp`](#experimentaluse_seccomp)
-- [`experimental.use_strace_logging`](#experimentaluse_strace_logging)
 - [`experimental.use_syscall_counters`](#experimentaluse_syscall_counters)
 - [`experimental.worker_threads`](#experimentalworker_threads)
 - [`host_defaults`](#host_defaults)
@@ -385,6 +385,20 @@ Type: String OR Integer
 
 Initial size of the socket's send buffer.
 
+#### `experimental.strace_logging_mode`
+
+Default: "off"  
+Type: "off" OR "standard" OR "deterministic"
+
+Log the syscalls for each process to individual "strace" files.
+
+The mode determines the format that the syscalls are logged in. For example,
+the "deterministic" mode will avoid logging memory addresses or potentially
+uninitialized memory.
+
+The logs will be stored at
+`shadow.data/hosts/<hostname>/<hostname>.<procname>.<pid>.strace`.
+
 #### `experimental.use_cpu_pinning`
 
 Default: true  
@@ -489,16 +503,6 @@ Default: true iff `experimental.interpose_method == preload`.
 Type: Bool
 
 Use seccomp to trap syscalls.
-
-#### `experimental.use_strace_logging`
-
-Default: false  
-Type: Bool
-
-Log the syscalls for each process to individual "strace" files.
-
-For example, the logs will be stored at
-`shadow.data/hosts/<hostname>/<hostname>.<procname>.<pid>.strace`.
 
 #### `experimental.use_syscall_counters`
 

--- a/src/main/bindings/c/bindings-opaque.h
+++ b/src/main/bindings/c/bindings-opaque.h
@@ -23,6 +23,12 @@ typedef enum QDiscMode {
   Q_DISC_MODE_ROUND_ROBIN,
 } QDiscMode;
 
+typedef enum StraceFmtMode {
+  STRACE_FMT_MODE_OFF,
+  STRACE_FMT_MODE_STANDARD,
+  STRACE_FMT_MODE_DETERMINISTIC,
+} StraceFmtMode;
+
 // Memory allocated by Shadow, in a remote address space.
 typedef struct AllocdMem_u8 AllocdMem_u8;
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -369,7 +369,7 @@ LogInfoFlags config_getHostHeartbeatLogInfo(const struct ConfigOptions *config);
 
 SimulationTime config_getHostHeartbeatInterval(const struct ConfigOptions *config);
 
-bool config_getUseStraceLogging(const struct ConfigOptions *config);
+enum StraceFmtMode config_getStraceLoggingMode(const struct ConfigOptions *config);
 
 bool config_getUseShortestPath(const struct ConfigOptions *config);
 
@@ -676,6 +676,7 @@ void process_deregisterLegacyDescriptor(Process *proc, LegacyDescriptor *desc);
 LegacyDescriptor *process_getRegisteredLegacyDescriptor(Process *proc, int handle);
 
 SysCallReturn log_syscall(Process *proc,
+                          enum StraceFmtMode logging_mode,
                           pid_t tid,
                           const char *name,
                           const char *args,

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -124,6 +124,10 @@ pub type InterposeMethod = ::std::os::raw::c_uint;
 pub const QDiscMode_Q_DISC_MODE_FIFO: QDiscMode = 0;
 pub const QDiscMode_Q_DISC_MODE_ROUND_ROBIN: QDiscMode = 1;
 pub type QDiscMode = ::std::os::raw::c_uint;
+pub const StraceFmtMode_STRACE_FMT_MODE_OFF: StraceFmtMode = 0;
+pub const StraceFmtMode_STRACE_FMT_MODE_STANDARD: StraceFmtMode = 1;
+pub const StraceFmtMode_STRACE_FMT_MODE_DETERMINISTIC: StraceFmtMode = 2;
+pub type StraceFmtMode = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ChildPidWatcher {
@@ -938,7 +942,7 @@ extern "C" {
     pub fn process_getName(proc_: *mut Process) -> *const gchar;
 }
 extern "C" {
-    pub fn process_straceLoggingEnabled(proc_: *mut Process) -> bool;
+    pub fn process_straceLoggingMode(proc_: *mut Process) -> StraceFmtMode;
 }
 extern "C" {
     pub fn process_getStraceFd(proc_: *mut Process) -> ::std::os::raw::c_int;

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -73,7 +73,7 @@ gboolean process_isRunning(Process* proc);
  * outside of the process module. */
 const gchar* process_getName(Process* proc);
 
-bool process_straceLoggingEnabled(Process* proc);
+StraceFmtMode process_straceLoggingMode(Process* proc);
 int process_getStraceFd(Process* proc);
 
 /* Returns the name of the plugin from an internal buffer.

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -4,6 +4,7 @@ use nix::unistd::Pid;
 
 use crate::cshadow;
 use crate::host::descriptor::CompatDescriptor;
+use crate::host::syscall::format::{FmtOptions, StraceFmtMode};
 
 use super::{host::HostId, memory_manager::MemoryManager};
 
@@ -111,8 +112,10 @@ impl Process {
         removed_desc
     }
 
-    pub fn strace_logging_enabled(&self) -> bool {
-        unsafe { cshadow::process_straceLoggingEnabled(self.cprocess) }
+    pub fn strace_logging_options(&self) -> Option<FmtOptions> {
+        StraceFmtMode::try_from(unsafe { cshadow::process_straceLoggingMode(self.cprocess) })
+            .unwrap()
+            .into()
     }
 
     /// If strace logging is disabled, this function will do nothing and return `None`.

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -111,8 +111,8 @@ macro(add_shadow_tests)
    endif()
 
    # If strace logging is not explicitly set, we enable it
-   if(NOT "${SHADOW_TEST_ARGS}" MATCHES ".*--use-strace-logging.*")
-      list(APPEND SHADOW_TEST_ARGS "--use-strace-logging" "true")
+   if(NOT "${SHADOW_TEST_ARGS}" MATCHES ".*--strace-logging-mode.*")
+      list(APPEND SHADOW_TEST_ARGS "--strace-logging-mode" "standard")
    endif()
 
    string(REPLACE ";" " " SHADOW_TEST_ARGS "${SHADOW_TEST_ARGS}")

--- a/src/test/socket/bind/CMakeLists.txt
+++ b/src/test/socket/bind/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_linux_tests(BASENAME bind COMMAND sh -c "../../target/debug/test_bind --libc-passing")
-add_shadow_tests(BASENAME bind LOGLEVEL debug ARGS --use-strace-logging false)
+add_shadow_tests(BASENAME bind LOGLEVEL debug ARGS --strace-logging-mode off)
 
 add_shadow_tests(BASENAME bind_in_new_process CHECK_RETVAL false)

--- a/src/test/tor/minimal/CMakeLists.txt
+++ b/src/test/tor/minimal/CMakeLists.txt
@@ -28,7 +28,7 @@ add_shadow_tests(BASENAME tor-minimal
                  ARGS
                    --use-cpu-pinning true
                    --parallelism 2
-                   --use-strace-logging false
+                   --strace-logging-mode off
                    --template-directory "shadow.data.template"
                  POST_CMD "${CMAKE_CURRENT_SOURCE_DIR}/verify.sh"
                  PROPERTIES


### PR DESCRIPTION
Changes the option `use_strace_logging: <bool>` to `strace_logging_mode: <"off", "standard", "deterministic">`. The "deterministic" mode hides memory addresses and plugin memory.