### PR TITLE
Rearranged a few syscall helper functions

### DIFF
--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -16,7 +16,7 @@ impl SyscallHandler {
         let cmd: i32 = args.args[1].into();
 
         // get the descriptor, or return early if it doesn't exist
-        let desc = match self.get_descriptor_mut(ctx.process, fd)? {
+        let desc = match Self::get_descriptor_mut(ctx.process, fd)? {
             CompatDescriptor::New(d) => d,
             // if it's a legacy descriptor, use the C syscall handler instead
             CompatDescriptor::Legacy(_) => {

--- a/src/main/host/syscall/handler/ioctl.rs
+++ b/src/main/host/syscall/handler/ioctl.rs
@@ -16,7 +16,7 @@ impl SyscallHandler {
         log::trace!("Called ioctl() on fd {} with request {}", fd, request);
 
         // get the descriptor, or return early if it doesn't exist
-        let desc = match self.get_descriptor_mut(ctx.process, fd)? {
+        let desc = match Self::get_descriptor_mut(ctx.process, fd)? {
             CompatDescriptor::New(desc) => desc,
             // if it's a legacy descriptor, use the C syscall handler instead
             CompatDescriptor::Legacy(_) => unsafe {

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -55,9 +55,8 @@ impl SyscallHandler {
 
     /// Internal helper that returns the `CompatDescriptor` for the fd if it
     /// exists, otherwise returns EBADF.
-    fn get_descriptor<'a>(
-        &'a self,
-        process: &'a Process,
+    fn get_descriptor(
+        process: &Process,
         fd: impl TryInto<u32>,
     ) -> Result<&CompatDescriptor, nix::errno::Errno> {
         // check that fd is within bounds
@@ -71,9 +70,8 @@ impl SyscallHandler {
 
     /// Internal helper that returns the `CompatDescriptor` for the fd if it
     /// exists, otherwise returns EBADF.
-    fn get_descriptor_mut<'a>(
-        &'a self,
-        process: &'a mut Process,
+    fn get_descriptor_mut(
+        process: &mut Process,
         fd: impl TryInto<u32>,
     ) -> Result<&mut CompatDescriptor, nix::errno::Errno> {
         // check that fd is within bounds

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -102,7 +102,7 @@ impl SyscallHandler {
         let addr_len: libc::socklen_t = args.get(2).into();
 
         // get the descriptor, or return early if it doesn't exist
-        let desc = match self.get_descriptor(ctx.process, fd)? {
+        let desc = match Self::get_descriptor(ctx.process, fd)? {
             CompatDescriptor::New(desc) => desc,
             // if it's a legacy descriptor, use the C syscall handler instead
             CompatDescriptor::Legacy(_) => {
@@ -143,7 +143,7 @@ impl SyscallHandler {
         let addr_len: libc::socklen_t = args.get(5).into();
 
         // get the descriptor, or return early if it doesn't exist
-        let desc = match self.get_descriptor(ctx.process, fd)? {
+        let desc = match Self::get_descriptor(ctx.process, fd)? {
             CompatDescriptor::New(desc) => desc,
             // if it's a legacy descriptor, use the C syscall handler instead
             CompatDescriptor::Legacy(_) => {
@@ -237,7 +237,7 @@ impl SyscallHandler {
         let addr_len_ptr: PluginPtr = args.get(5).into();
 
         // get the descriptor, or return early if it doesn't exist
-        let desc = match self.get_descriptor(ctx.process, fd)? {
+        let desc = match Self::get_descriptor(ctx.process, fd)? {
             CompatDescriptor::New(desc) => desc,
             // if it's a legacy descriptor, use the C syscall handler instead
             CompatDescriptor::Legacy(_) => {
@@ -336,7 +336,7 @@ impl SyscallHandler {
             TypedPluginPtr::new::<libc::socklen_t>(args.get(2).into(), 1);
 
         // get the descriptor, or return early if it doesn't exist
-        let desc = match self.get_descriptor(ctx.process, fd)? {
+        let desc = match Self::get_descriptor(ctx.process, fd)? {
             CompatDescriptor::New(desc) => desc,
             // if it's a legacy descriptor, use the C syscall handler instead
             CompatDescriptor::Legacy(_) => {
@@ -376,7 +376,7 @@ impl SyscallHandler {
             TypedPluginPtr::new::<libc::socklen_t>(args.get(2).into(), 1);
 
         // get the descriptor, or return early if it doesn't exist
-        let desc = match self.get_descriptor(ctx.process, fd)? {
+        let desc = match Self::get_descriptor(ctx.process, fd)? {
             CompatDescriptor::New(desc) => desc,
             // if it's a legacy descriptor, use the C syscall handler instead
             CompatDescriptor::Legacy(_) => {

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -48,7 +48,7 @@ impl SyscallHandler {
         let fd = libc::c_int::from(args.get(0));
 
         // get the descriptor, or return early if it doesn't exist
-        let desc = match self.get_descriptor(ctx.process, fd)? {
+        let desc = match Self::get_descriptor(ctx.process, fd)? {
             CompatDescriptor::New(desc) => desc,
             // if it's a legacy descriptor, use the C syscall handler instead
             CompatDescriptor::Legacy(_) => unsafe {
@@ -74,7 +74,7 @@ impl SyscallHandler {
         let new_fd = libc::c_int::from(args.get(1));
 
         // get the descriptor, or return early if it doesn't exist
-        let desc = match self.get_descriptor(ctx.process, old_fd)? {
+        let desc = match Self::get_descriptor(ctx.process, old_fd)? {
             CompatDescriptor::New(desc) => desc,
             // we don't support dup2 for legacy descriptors
             CompatDescriptor::Legacy(_) => {
@@ -119,7 +119,7 @@ impl SyscallHandler {
         let flags = libc::c_int::from(args.get(2));
 
         // get the descriptor, or return early if it doesn't exist
-        let desc = match self.get_descriptor(ctx.process, old_fd)? {
+        let desc = match Self::get_descriptor(ctx.process, old_fd)? {
             CompatDescriptor::New(desc) => desc,
             // we don't support dup3 for legacy descriptors
             CompatDescriptor::Legacy(_) => {
@@ -171,7 +171,7 @@ impl SyscallHandler {
         let offset = 0;
 
         // get the descriptor, or return early if it doesn't exist
-        match self.get_descriptor(ctx.process, fd)? {
+        match Self::get_descriptor(ctx.process, fd)? {
             CompatDescriptor::New(desc) => {
                 let file = desc.get_file().clone();
                 self.read_helper(ctx, fd, &file, buf_ptr, buf_size, offset)
@@ -193,7 +193,7 @@ impl SyscallHandler {
         let offset = libc::off_t::from(args.get(3));
 
         // get the descriptor, or return early if it doesn't exist
-        match self.get_descriptor(ctx.process, fd)? {
+        match Self::get_descriptor(ctx.process, fd)? {
             CompatDescriptor::New(desc) => {
                 let file = desc.get_file().clone();
                 self.read_helper(ctx, fd, &file, buf_ptr, buf_size, offset)
@@ -266,7 +266,7 @@ impl SyscallHandler {
         let offset = 0;
 
         // get the descriptor, or return early if it doesn't exist
-        match self.get_descriptor(ctx.process, fd)? {
+        match Self::get_descriptor(ctx.process, fd)? {
             CompatDescriptor::New(desc) => {
                 let file = desc.get_file().clone();
                 self.write_helper(ctx, fd, &file, buf_ptr, buf_size, offset)
@@ -288,7 +288,7 @@ impl SyscallHandler {
         let offset = libc::off_t::from(args.get(3));
 
         // get the descriptor, or return early if it doesn't exist
-        match self.get_descriptor(ctx.process, fd)? {
+        match Self::get_descriptor(ctx.process, fd)? {
             CompatDescriptor::New(desc) => {
                 let file = desc.get_file().clone();
                 self.write_helper(ctx, fd, &file, buf_ptr, buf_size, offset)


### PR DESCRIPTION
`get_descriptor()` and `get_descriptor_mut()` - these tied the lifetime of the descriptor refs to the lifetime of the syscall handler ref, but we don't need this restriction.

`empty_sockaddr()`, `write_sockaddr()`, and `read_sockaddr()` - these are standalone helpers that should be independent of a syscall handler object.

Also simplified a few socket plugin memory helpers (only needed the process memory, not the process itself).