### PR TITLE
Don't override the exit function

### DIFF
--- a/src/lib/libc_preload/gen_syscall_wrappers_c.py
+++ b/src/lib/libc_preload/gen_syscall_wrappers_c.py
@@ -17,7 +17,11 @@ remap['eventfd'] = 'eventfd2' # libc eventfd() calls SYS_eventfd2
 
 # syscalls we should not generate C wrappers for
 skip = set()
-skip.add('eventfd2') # libc doesn't have an eventfd2() wrapper
+# libc doesn't have an eventfd2() wrapper
+skip.add('eventfd2')
+# `exit` has a non-trivial wrapper that calls `atexit` hooks, flushes open
+# `FILE*` objects, etc.
+skip.add('exit')
 
 # syscall wrappers that return errors directly instead of through errno.
 direct_errors = set()

--- a/src/lib/libc_preload/syscall_wrappers.c
+++ b/src/lib/libc_preload/syscall_wrappers.c
@@ -142,9 +142,7 @@ INTERPOSE(execve);
 #ifdef SYS_execveat // kernel entry: num=322 func=sys_execveat
 INTERPOSE(execveat);
 #endif
-#ifdef SYS_exit // kernel entry: num=60 func=sys_exit
-INTERPOSE(exit);
-#endif
+// Skipping SYS_exit
 #ifdef SYS_exit_group // kernel entry: num=231 func=sys_exit_group
 INTERPOSE(exit_group);
 #endif

--- a/src/test/regression/CMakeLists.txt
+++ b/src/test/regression/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_shadow_tests(BASENAME signal_resched)
 add_shadow_tests(BASENAME exit_after_signal_sched)
 add_shadow_tests(BASENAME small_stop_time CHECK_RETVAL FALSE)
+
+add_executable(test_flush_after_exit test_flush_after_exit.c)
+add_linux_tests(BASENAME flush_after_exit COMMAND bash -c "test `./test_flush_after_exit` == 'Hello'")
+add_shadow_tests(BASENAME flush_after_exit POST_CMD "test `cat hosts/*/*.stdout` = 'Hello'")

--- a/src/test/regression/flush_after_exit.yaml
+++ b/src/test/regression/flush_after_exit.yaml
@@ -1,0 +1,10 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  testnode:
+    network_node_id: 0
+    processes:
+    - path: ./test_flush_after_exit

--- a/src/test/regression/test_flush_after_exit.c
+++ b/src/test/regression/test_flush_after_exit.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, const char* argv[]) {
+    printf("Hello");
+    // We've previously accidentally overridden the `exit` libc function with a
+    // bare wrapper around the `exit` syscall.  This is incorrect since the
+    // `exit` libc function actually does some cleanup tasks (including flushing
+    // open `FILE*` objects, including `stdout`), and then calls the `exit_group`
+    // syscall.
+    //
+    // When that bug is present, this program has no output, since the `printf`
+    // above is never flushed.
+    exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
`exit` has a non-trivial wrapper that calls `atexit` hooks, flushes open `FILE*` objects, etc.