### PR TITLE
When resuming blocked syscall handlers, use a cached/saved file reference

### DIFF
--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -64,6 +64,8 @@ add_custom_command(OUTPUT wrapper.rs
         --whitelist-function "statuslistener_onStatusChanged"
         --whitelist-function "syscallcondition_new"
         --whitelist-function "syscallcondition_unref"
+        --whitelist-function "syscallcondition_getActiveFile"
+        --whitelist-function "syscallcondition_setActiveFile"
         --whitelist-function "syscallhandler_.*"
         --whitelist-function "worker_.*"
         --whitelist-function "workerc_.*"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2163,7 +2163,13 @@ extern "C" {
     pub fn syscallcondition_new(trigger: Trigger) -> *mut SysCallCondition;
 }
 extern "C" {
+    pub fn syscallcondition_setActiveFile(cond: *mut SysCallCondition, file: *mut OpenFile);
+}
+extern "C" {
     pub fn syscallcondition_unref(cond: *mut SysCallCondition);
+}
+extern "C" {
+    pub fn syscallcondition_getActiveFile(cond: *mut SysCallCondition) -> *mut OpenFile;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -172,18 +172,35 @@ impl SyscallHandler {
         let buf_size = libc::size_t::from(args.get(2));
         let offset = 0;
 
-        // get the descriptor, or return early if it doesn't exist
-        match Self::get_descriptor(ctx.process, fd)? {
-            CompatDescriptor::New(desc) => {
-                let file = desc.open_file().clone();
-                self.read_helper(ctx, fd, file, buf_ptr, buf_size, offset)
-            }
-            // if it's a legacy descriptor, use the C syscall handler instead
-            CompatDescriptor::Legacy(_) => unsafe {
-                c::syscallhandler_read(ctx.thread.csyscallhandler(), args as *const SysCallArgs)
-                    .into()
+        // if we were previously blocked, get the active file from the last syscall handler
+        // invocation since it may no longer exist in the descriptor table
+        let file = ctx
+            .thread
+            .syscall_condition()
+            // if this was for a C descriptor, then there won't be an active file object
+            .map(|x| x.active_file().cloned())
+            .flatten();
+
+        let file = match file {
+            // we were previously blocked, so re-use the file from the previous syscall invocation
+            Some(x) => x,
+            // get the file from the descriptor table, or return early if it doesn't exist
+            None => match Self::get_descriptor(ctx.process, fd)? {
+                CompatDescriptor::New(desc) => desc.open_file().clone(),
+                // if it's a legacy descriptor, use the C syscall handler instead
+                CompatDescriptor::Legacy(_) => {
+                    return unsafe {
+                        c::syscallhandler_read(
+                            ctx.thread.csyscallhandler(),
+                            args as *const SysCallArgs,
+                        )
+                        .into()
+                    };
+                }
             },
-        }
+        };
+
+        self.read_helper(ctx, fd, file, buf_ptr, buf_size, offset)
     }
 
     #[log_syscall(/* rv */ libc::ssize_t, /* fd */ libc::c_int, /* buf */ *const libc::c_void,
@@ -194,21 +211,35 @@ impl SyscallHandler {
         let buf_size = libc::size_t::from(args.get(2));
         let offset = libc::off_t::from(args.get(3));
 
-        // get the descriptor, or return early if it doesn't exist
-        match Self::get_descriptor(ctx.process, fd)? {
-            CompatDescriptor::New(desc) => {
-                let file = desc.open_file().clone();
-                self.read_helper(ctx, fd, file, buf_ptr, buf_size, offset)
-            }
-            // if it's a legacy descriptor, use the C syscall handler instead
-            CompatDescriptor::Legacy(_) => unsafe {
-                c::syscallhandler_pread64(
-                    ctx.thread.csyscallhandler(),
-                    args as *const c::SysCallArgs,
-                )
-                .into()
+        // if we were previously blocked, get the active file from the last syscall handler
+        // invocation since it may no longer exist in the descriptor table
+        let file = ctx
+            .thread
+            .syscall_condition()
+            // if this was for a C descriptor, then there won't be an active file object
+            .map(|x| x.active_file().cloned())
+            .flatten();
+
+        let file = match file {
+            // we were previously blocked, so re-use the file from the previous syscall invocation
+            Some(x) => x,
+            // get the file from the descriptor table, or return early if it doesn't exist
+            None => match Self::get_descriptor(ctx.process, fd)? {
+                CompatDescriptor::New(desc) => desc.open_file().clone(),
+                // if it's a legacy descriptor, use the C syscall handler instead
+                CompatDescriptor::Legacy(_) => {
+                    return unsafe {
+                        c::syscallhandler_pread64(
+                            ctx.thread.csyscallhandler(),
+                            args as *const SysCallArgs,
+                        )
+                        .into()
+                    };
+                }
             },
-        }
+        };
+
+        self.read_helper(ctx, fd, file, buf_ptr, buf_size, offset)
     }
 
     fn read_helper(
@@ -253,9 +284,11 @@ impl SyscallHandler {
 
         // if the syscall would block and it's a blocking descriptor
         if result == Err(Errno::EWOULDBLOCK.into()) && !file_status.contains(FileStatus::NONBLOCK) {
-            let trigger = Trigger::from_open_file(open_file, FileState::READABLE);
+            let trigger = Trigger::from_open_file(open_file.clone(), FileState::READABLE);
+            let mut cond = SysCallCondition::new(trigger);
+            cond.set_active_file(open_file);
 
-            return Err(SyscallError::Cond(SysCallCondition::new(trigger)));
+            return Err(SyscallError::Cond(cond));
         }
 
         result
@@ -269,18 +302,35 @@ impl SyscallHandler {
         let buf_size = libc::size_t::from(args.get(2));
         let offset = 0;
 
-        // get the descriptor, or return early if it doesn't exist
-        match Self::get_descriptor(ctx.process, fd)? {
-            CompatDescriptor::New(desc) => {
-                let file = desc.open_file().clone();
-                self.write_helper(ctx, fd, file, buf_ptr, buf_size, offset)
-            }
-            // if it's a legacy descriptor, use the C syscall handler instead
-            CompatDescriptor::Legacy(_) => unsafe {
-                c::syscallhandler_write(ctx.thread.csyscallhandler(), args as *const c::SysCallArgs)
-                    .into()
+        // if we were previously blocked, get the active file from the last syscall handler
+        // invocation since it may no longer exist in the descriptor table
+        let file = ctx
+            .thread
+            .syscall_condition()
+            // if this was for a C descriptor, then there won't be an active file object
+            .map(|x| x.active_file().cloned())
+            .flatten();
+
+        let file = match file {
+            // we were previously blocked, so re-use the file from the previous syscall invocation
+            Some(x) => x,
+            // get the file from the descriptor table, or return early if it doesn't exist
+            None => match Self::get_descriptor(ctx.process, fd)? {
+                CompatDescriptor::New(desc) => desc.open_file().clone(),
+                // if it's a legacy descriptor, use the C syscall handler instead
+                CompatDescriptor::Legacy(_) => {
+                    return unsafe {
+                        c::syscallhandler_write(
+                            ctx.thread.csyscallhandler(),
+                            args as *const SysCallArgs,
+                        )
+                        .into()
+                    };
+                }
             },
-        }
+        };
+
+        self.write_helper(ctx, fd, file, buf_ptr, buf_size, offset)
     }
 
     #[log_syscall(/* rv */ libc::ssize_t, /* fd */ libc::c_int, /* buf */ *const libc::c_char,
@@ -291,18 +341,35 @@ impl SyscallHandler {
         let buf_size = libc::size_t::from(args.get(2));
         let offset = libc::off_t::from(args.get(3));
 
-        // get the descriptor, or return early if it doesn't exist
-        match Self::get_descriptor(ctx.process, fd)? {
-            CompatDescriptor::New(desc) => {
-                let file = desc.open_file().clone();
-                self.write_helper(ctx, fd, file, buf_ptr, buf_size, offset)
-            }
-            // if it's a legacy descriptor, use the C syscall handler instead
-            CompatDescriptor::Legacy(_) => unsafe {
-                c::syscallhandler_pwrite64(ctx.thread.csyscallhandler(), args as *const SysCallArgs)
-                    .into()
+        // if we were previously blocked, get the active file from the last syscall handler
+        // invocation since it may no longer exist in the descriptor table
+        let file = ctx
+            .thread
+            .syscall_condition()
+            // if this was for a C descriptor, then there won't be an active file object
+            .map(|x| x.active_file().cloned())
+            .flatten();
+
+        let file = match file {
+            // we were previously blocked, so re-use the file from the previous syscall invocation
+            Some(x) => x,
+            // get the file from the descriptor table, or return early if it doesn't exist
+            None => match Self::get_descriptor(ctx.process, fd)? {
+                CompatDescriptor::New(desc) => desc.open_file().clone(),
+                // if it's a legacy descriptor, use the C syscall handler instead
+                CompatDescriptor::Legacy(_) => {
+                    return unsafe {
+                        c::syscallhandler_pwrite64(
+                            ctx.thread.csyscallhandler(),
+                            args as *const SysCallArgs,
+                        )
+                        .into()
+                    };
+                }
             },
-        }
+        };
+
+        self.write_helper(ctx, fd, file, buf_ptr, buf_size, offset)
     }
 
     fn write_helper(
@@ -339,9 +406,11 @@ impl SyscallHandler {
 
         // if the syscall would block and it's a blocking descriptor
         if result == Err(Errno::EWOULDBLOCK.into()) && !file_status.contains(FileStatus::NONBLOCK) {
-            let trigger = Trigger::from_open_file(open_file, FileState::WRITABLE);
+            let trigger = Trigger::from_open_file(open_file.clone(), FileState::WRITABLE);
+            let mut cond = SysCallCondition::new(trigger);
+            cond.set_active_file(open_file);
 
-            return Err(SyscallError::Cond(SysCallCondition::new(trigger)));
+            return Err(SyscallError::Cond(cond));
         };
 
         result

--- a/src/main/host/syscall_condition.h
+++ b/src/main/host/syscall_condition.h
@@ -52,6 +52,11 @@ SysCallCondition* syscallcondition_new(Trigger trigger);
  * `worker_getEmulatedTime`. */
 void syscallcondition_setTimeout(SysCallCondition* cond, Host* host, EmulatedTime t);
 
+/* Add a file to the condition which can be used in the syscall handler once it becomes unblocked,
+ * without needing to lookup the file again in the descriptor table (since it may no longer exist in
+ * the descriptor table). */
+void syscallcondition_setActiveFile(SysCallCondition* cond, OpenFile* file);
+
 /* Increment the reference count on the given condition. */
 void syscallcondition_ref(SysCallCondition* cond);
 
@@ -72,6 +77,9 @@ void syscallcondition_cancel(SysCallCondition* cond);
 
 /* Get the timer for the condition, or NULL if there isn't one. */
 Timer* syscallcondition_getTimeout(SysCallCondition* cond);
+
+/* Get the active file for the condition, or NULL if there isn't one. */
+OpenFile* syscallcondition_getActiveFile(SysCallCondition* cond);
 
 /* If the condition's thread doesn't have `signo` blocked, schedule a wakeup.
  *

--- a/src/main/host/syscall_condition.rs
+++ b/src/main/host/syscall_condition.rs
@@ -1,19 +1,74 @@
 use crate::cshadow;
 use crate::host::syscall::Trigger;
 
-/// Wrapper
+use std::marker::PhantomData;
+
+/// An immutable reference to a syscall condition.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SysCallConditionRef<'a> {
+    c_ptr: *mut cshadow::SysCallCondition,
+    _phantom: PhantomData<&'a ()>,
+}
+
+// do not define any mutable methods for this type
+impl<'a> SysCallConditionRef<'a> {
+    /// Borrows from a C pointer. i.e. doesn't increase the ref count, nor decrease the ref count
+    /// when dropped.
+    /// `ptr` must point to a valid object that will not be accessed by other threads
+    /// for the lifetime of this object.
+    pub fn borrow_from_c(ptr: *mut cshadow::SysCallCondition) -> Self {
+        assert!(!ptr.is_null());
+        Self {
+            c_ptr: ptr,
+            _phantom: PhantomData::default(),
+        }
+    }
+}
+
+/// A mutable reference to a syscall condition.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SysCallConditionRefMut<'a> {
+    condition: SysCallConditionRef<'a>,
+}
+
+// any immutable methods should be implemented on SysCallConditionRef instead
+impl<'a> SysCallConditionRefMut<'a> {
+    /// Borrows from a C pointer. i.e. doesn't increase the ref count, nor decrease the ref count
+    /// when dropped.
+    /// `ptr` must point to a valid object that will not be accessed by other threads
+    /// for the lifetime of this object.
+    pub fn borrow_from_c(ptr: *mut cshadow::SysCallCondition) -> Self {
+        assert!(!ptr.is_null());
+        Self {
+            condition: SysCallConditionRef::borrow_from_c(ptr),
+        }
+    }
+}
+
+impl<'a> std::ops::Deref for SysCallConditionRefMut<'a> {
+    type Target = SysCallConditionRef<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.condition
+    }
+}
+
+/// An owned syscall condition.
 #[derive(Debug, PartialEq, Eq)]
 pub struct SysCallCondition {
-    c_ptr: *mut cshadow::SysCallCondition,
+    condition: Option<SysCallConditionRefMut<'static>>,
 }
 
 impl SysCallCondition {
-    /// "Steal" from a C pointer. i.e. doesn't increase ref count.
+    /// "Steal" from a C pointer. i.e. doesn't increase ref count, but will decrease the ref count
+    /// when dropped.
     /// `ptr` must point to a valid object that will not be accessed by other threads
     /// for the lifetime of this object.
     pub unsafe fn consume_from_c(ptr: *mut cshadow::SysCallCondition) -> Self {
         assert!(!ptr.is_null());
-        Self { c_ptr: ptr }
+        Self {
+            condition: Some(SysCallConditionRefMut::borrow_from_c(ptr)),
+        }
     }
 
     /// Constructor.
@@ -21,23 +76,39 @@ impl SysCallCondition {
     // implementation or wrapper.
     pub fn new(trigger: Trigger) -> Self {
         SysCallCondition {
-            c_ptr: unsafe { cshadow::syscallcondition_new(trigger.into()) },
+            condition: Some(SysCallConditionRefMut::borrow_from_c(unsafe {
+                cshadow::syscallcondition_new(trigger.into())
+            })),
         }
     }
 
     /// "Steal" the inner pointer without unref'ing it.
     pub fn into_inner(mut self) -> *mut cshadow::SysCallCondition {
-        let ptr = self.c_ptr;
-        // We *don't* want Drop to deref
-        self.c_ptr = std::ptr::null_mut() as *mut cshadow::SysCallCondition;
-        ptr
+        let condition = self.condition.take().unwrap();
+        condition.c_ptr
     }
 }
 
 impl Drop for SysCallCondition {
     fn drop(&mut self) {
-        if !self.c_ptr.is_null() {
-            unsafe { cshadow::syscallcondition_unref(self.c_ptr) }
+        if let Some(condition) = &self.condition {
+            if !condition.c_ptr.is_null() {
+                unsafe { cshadow::syscallcondition_unref(condition.c_ptr) }
+            }
         }
+    }
+}
+
+impl std::ops::Deref for SysCallCondition {
+    type Target = SysCallConditionRefMut<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        self.condition.as_ref().unwrap()
+    }
+}
+
+impl std::ops::DerefMut for SysCallCondition {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.condition.as_mut().unwrap()
     }
 }

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -2,6 +2,7 @@ use super::host::HostId;
 use super::process::ProcessId;
 use super::syscall_types::{PluginPtr, SysCallReg};
 use crate::cshadow as c;
+use crate::host::syscall_condition::{SysCallConditionRef, SysCallConditionRefMut};
 use crate::utility::syscall;
 use nix::unistd::Pid;
 
@@ -15,6 +16,8 @@ pub trait Thread {
     fn system_tid(&self) -> Pid;
     fn csyscallhandler(&mut self) -> *mut c::SysCallHandler;
     fn id(&self) -> ThreadId;
+    fn syscall_condition(&self) -> Option<SysCallConditionRef>;
+    fn syscall_condition_mut(&mut self) -> Option<SysCallConditionRefMut>;
 
     /// Natively execute munmap(2) on the given thread.
     fn native_munmap(&mut self, ptr: PluginPtr, size: usize) -> nix::Result<()> {
@@ -185,6 +188,24 @@ impl Thread for CThread {
 
     fn id(&self) -> ThreadId {
         ThreadId(unsafe { c::thread_getID(self.cthread).try_into().unwrap() })
+    }
+
+    fn syscall_condition(&self) -> Option<SysCallConditionRef> {
+        let syscall_condition_ptr = unsafe { c::thread_getSysCallCondition(self.cthread) };
+        if syscall_condition_ptr.is_null() {
+            return None;
+        }
+
+        Some(SysCallConditionRef::borrow_from_c(syscall_condition_ptr))
+    }
+
+    fn syscall_condition_mut(&mut self) -> Option<SysCallConditionRefMut> {
+        let syscall_condition_ptr = unsafe { c::thread_getSysCallCondition(self.cthread) };
+        if syscall_condition_ptr.is_null() {
+            return None;
+        }
+
+        Some(SysCallConditionRefMut::borrow_from_c(syscall_condition_ptr))
     }
 
     fn process_id(&self) -> ProcessId {

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -196,7 +196,7 @@ impl Thread for CThread {
             return None;
         }
 
-        Some(SysCallConditionRef::borrow_from_c(syscall_condition_ptr))
+        Some(unsafe { SysCallConditionRef::borrow_from_c(syscall_condition_ptr) })
     }
 
     fn syscall_condition_mut(&mut self) -> Option<SysCallConditionRefMut> {
@@ -205,7 +205,7 @@ impl Thread for CThread {
             return None;
         }
 
-        Some(SysCallConditionRefMut::borrow_from_c(syscall_condition_ptr))
+        Some(unsafe { SysCallConditionRefMut::borrow_from_c(syscall_condition_ptr) })
     }
 
     fn process_id(&self) -> ProcessId {

--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -17,6 +17,7 @@
 #include "lib/shim/shim_event.h"
 #include "main/core/worker.h"
 #include "main/host/shimipc.h"
+#include "main/host/syscall_condition.h"
 #include "main/host/thread_protected.h"
 #include "main/shmem/shmem_allocator.h"
 
@@ -279,6 +280,12 @@ SysCallCondition* threadpreload_resume(Thread* base) {
                     handler, &thread->currentEvent.event_data.syscall.syscall_args);
                 syscallhandler_unref(handler);
                 handler = NULL;
+
+                // remove the thread's old syscall condition since it's no longer needed
+                if (thread->base.cond) {
+                    syscallcondition_unref(thread->base.cond);
+                    thread->base.cond = NULL;
+                }
 
                 if (!thread->isRunning) {
                     return NULL;

--- a/src/main/host/thread_ptrace.c
+++ b/src/main/host/thread_ptrace.c
@@ -22,6 +22,7 @@
 #include "main/core/support/config_handlers.h"
 #include "main/core/worker.h"
 #include "main/host/shimipc.h"
+#include "main/host/syscall_condition.h"
 #include "main/host/syscall_numbers.h"
 #include "main/host/thread_protected.h"
 #include "main/utility/fork_proxy.h"
@@ -957,6 +958,13 @@ SysCallCondition* threadptrace_resume(Thread* base) {
             case THREAD_PTRACE_CHILD_STATE_IPC_SYSCALL: {
                 trace("THREAD_PTRACE_CHILD_STATE_IPC_SYSCALL");
                 SysCallCondition* condition = _threadptrace_resumeIpcSyscall(thread, &changedState);
+
+                // remove the thread's old syscall condition since it's no longer needed
+                if (thread->base.cond) {
+                    syscallcondition_unref(thread->base.cond);
+                    thread->base.cond = NULL;
+                }
+
                 if (condition) {
                     if (_useONWaitpidWorkarounds) {
                         // Keep inactive plugins off worker thread's tracee
@@ -970,6 +978,13 @@ SysCallCondition* threadptrace_resume(Thread* base) {
             case THREAD_PTRACE_CHILD_STATE_SYSCALL: {
                 trace("THREAD_PTRACE_CHILD_STATE_SYSCALL");
                 SysCallCondition* condition = _threadptrace_resumeSyscall(thread, &changedState);
+
+                // remove the thread's old syscall condition since it's no longer needed
+                if (thread->base.cond) {
+                    syscallcondition_unref(thread->base.cond);
+                    thread->base.cond = NULL;
+                }
+
                 if (condition) {
                     if (_useONWaitpidWorkarounds) {
                         // Keep inactive plugins off worker thread's tracee

--- a/src/test/pipe/pipe.yaml
+++ b/src/test/pipe/pipe.yaml
@@ -1,5 +1,5 @@
 general:
-  stop_time: 5
+  stop_time: 20
 network:
   graph:
     type: 1_gbit_switch


### PR DESCRIPTION
When a syscall handler restarts after being blocked, it will look up the fd in the descriptor table again. But if the fd was closed while the syscall handler was blocked, this lookup will fail and the blocked syscall handler will return `EBADF`. Instead, the reference-counted file object will be saved/cached in the syscall condition object so that it can be used when resuming the syscall handler. This better models Linux's behaviour.