### PR TITLE
ShimSharedMem locking refactor

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1506,6 +1506,15 @@ extern "C" {
     pub fn host_getSharedMem(host: *mut Host) -> *mut ShimShmemHost;
 }
 extern "C" {
+    pub fn host_getShimShmemLock(host: *mut Host) -> *mut ShimShmemHostLock;
+}
+extern "C" {
+    pub fn host_lockShimShmemLock(host: *mut Host);
+}
+extern "C" {
+    pub fn host_unlockShimShmemLock(host: *mut Host);
+}
+extern "C" {
     pub fn worker_runEvent(event: *mut Event);
 }
 extern "C" {
@@ -1717,7 +1726,6 @@ pub struct _SysCallHandler {
     pub process: *mut Process,
     pub thread: *mut Thread,
     pub syscall_handler_rs: *mut SyscallHandler,
-    pub shimShmemHostLock: *mut ShimShmemHostLock,
     pub epoll: *mut Epoll,
     pub blockedSyscallNR: ::std::os::raw::c_long,
     pub perfTimer: *mut GTimer,
@@ -1732,7 +1740,7 @@ pub struct _SysCallHandler {
 fn bindgen_test_layout__SysCallHandler() {
     assert_eq!(
         ::std::mem::size_of::<_SysCallHandler>(),
-        104usize,
+        96usize,
         concat!("Size of: ", stringify!(_SysCallHandler))
     );
     assert_eq!(
@@ -1783,20 +1791,8 @@ fn bindgen_test_layout__SysCallHandler() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<_SysCallHandler>())).shimShmemHostLock as *const _ as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_SysCallHandler),
-            "::",
-            stringify!(shimShmemHostLock)
-        )
-    );
-    assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).epoll as *const _ as usize },
-        40usize,
+        32usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1808,7 +1804,7 @@ fn bindgen_test_layout__SysCallHandler() {
         unsafe {
             &(*(::std::ptr::null::<_SysCallHandler>())).blockedSyscallNR as *const _ as usize
         },
-        48usize,
+        40usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1818,7 +1814,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).perfTimer as *const _ as usize },
-        56usize,
+        48usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1830,7 +1826,7 @@ fn bindgen_test_layout__SysCallHandler() {
         unsafe {
             &(*(::std::ptr::null::<_SysCallHandler>())).perfSecondsCurrent as *const _ as usize
         },
-        64usize,
+        56usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1842,7 +1838,7 @@ fn bindgen_test_layout__SysCallHandler() {
         unsafe {
             &(*(::std::ptr::null::<_SysCallHandler>())).perfSecondsTotal as *const _ as usize
         },
-        72usize,
+        64usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1852,7 +1848,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).numSyscalls as *const _ as usize },
-        80usize,
+        72usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1862,7 +1858,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).syscall_counter as *const _ as usize },
-        88usize,
+        80usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1872,7 +1868,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).referenceCount as *const _ as usize },
-        96usize,
+        88usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1882,7 +1878,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).magic as *const _ as usize },
-        100usize,
+        92usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -82,6 +82,9 @@ struct _Host {
     /* Shared memory allocation for shared state with shim. */
     ShMemBlock shimSharedMemBlock;
 
+    /* Lock protecting parts of shimSharedMemBlock. */
+    ShimShmemHostLock* shimShmemHostLock;
+
     /* random stream */
     Random* random;
 
@@ -753,4 +756,19 @@ ShimShmemHost* host_getSharedMem(Host* host) {
     MAGIC_ASSERT(host);
     utility_assert(host->shimSharedMemBlock.p);
     return host->shimSharedMemBlock.p;
+}
+
+ShimShmemHostLock* host_getShimShmemLock(Host* host) {
+    MAGIC_ASSERT(host);
+    return host->shimShmemHostLock;
+}
+
+void host_lockShimShmemLock(Host* host) {
+    MAGIC_ASSERT(host);
+    host->shimShmemHostLock = shimshmemhost_lock(host_getSharedMem(host));
+}
+
+void host_unlockShimShmemLock(Host* host) {
+    MAGIC_ASSERT(host);
+    shimshmemhost_unlock(host_getSharedMem(host), &host->shimShmemHostLock);
 }

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -113,4 +113,20 @@ Thread* host_getThread(Host* host, pid_t virtualTID);
 // Returns host-specific state that's kept in memory shared with the shim(s).
 ShimShmemHost* host_getSharedMem(Host* host);
 
+// Returns the lock, or NULL if the lock isn't held by Shadow.
+//
+// Generally the lock can and should be held when Shadow is running, and *not*
+// held when any of the host's managed threads are running (leaving it available
+// to be taken by the shim). While this can be a little fragile to ensure
+// properly, debug builds detect if we get it wrong (e.g. we try accessing
+// protected data without holding the lock, or the shim tries to take the lock
+// but can't).
+ShimShmemHostLock* host_getShimShmemLock(Host* host);
+
+// Take the host's shared memory lock. See `host_getShimShmemLock`.
+void host_lockShimShmemLock(Host* host);
+
+// Release the host's shared memory lock. See `host_getShimShmemLock`.
+void host_unlockShimShmemLock(Host* host);
+
 #endif /* SHD_HOST_H_ */

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -639,6 +639,8 @@ void process_continue(Process* proc, Thread* thread) {
     worker_setActiveProcess(proc);
     worker_setActiveThread(thread);
 
+    host_lockShimShmemLock(proc->host);
+
 #ifdef USE_PERF_TIMERS
     /* time how long we execute the program */
     g_timer_start(proc->cpuDelayTimer);
@@ -665,6 +667,8 @@ void process_continue(Process* proc, Thread* thread) {
     } else {
         _process_check_thread(proc, thread);
     }
+
+    host_unlockShimShmemLock(proc->host);
 
     worker_setActiveProcess(NULL);
     worker_setActiveThread(NULL);

--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -41,14 +41,6 @@ struct _SysCallHandler {
     // For syscalls implemented in rust. Will eventually replace the C handler.
     SyscallHandler* syscall_handler_rs;
 
-    // Lock for the host's shared memory with the shim. The lock is taken at the
-    // start of processing a syscall, and released at completion.
-    //
-    // Should eventually be moved to an ephemeral object passed to the syscall
-    // handlers (e.g. ThreadContextObjs), rather than storing it here (where
-    // it's NULL when the lock isn't held).
-    ShimShmemHostLock* shimShmemHostLock;
-
     /* We use this epoll to service syscalls that need to block on the status
      * of multiple descriptors, like poll. */
     Epoll* epoll;

--- a/src/main/host/syscall/time.c
+++ b/src/main/host/syscall/time.c
@@ -74,7 +74,8 @@ static SysCallReturn _syscallhandler_nanosleep_helper(SysCallHandler* sys, clock
     utility_assert(timer);
     if (timer_getExpirationCount(timer) == 0) {
         // Should only happen if we were interrupted by a signal.
-        utility_assert(thread_unblockedSignalPending(sys->thread, sys->shimShmemHostLock));
+        utility_assert(
+            thread_unblockedSignalPending(sys->thread, host_getShimShmemLock(sys->host)));
 
         struct itimerspec timer_val;
         timer_getTime(timer, &timer_val);

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -249,8 +249,8 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
                                           const SysCallArgs* args) {
     MAGIC_ASSERT(sys);
 
-    utility_assert(!sys->shimShmemHostLock);
-    sys->shimShmemHostLock = shimshmemhost_lock(host_getSharedMem(sys->host));
+    utility_assert(!host_getShimShmemLock(sys->host));
+    host_lockShimShmemLock(sys->host);
 
     StraceFmtMode straceLoggingMode = process_straceLoggingMode(sys->process);
 
@@ -546,7 +546,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
     // call will return a success  status  (normally,  the  number of bytes
     // transferred)."
     if (scr.state == SYSCALL_BLOCK &&
-        thread_unblockedSignalPending(sys->thread, sys->shimShmemHostLock)) {
+        thread_unblockedSignalPending(sys->thread, host_getShimShmemLock(sys->host))) {
         SysCallCondition* condition = scr.cond;
         utility_assert(condition);
         syscallcondition_unref(condition);
@@ -567,7 +567,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         process_freePtrsWithoutFlushing(sys->process);
     }
 
-    shimshmemhost_unlock(host_getSharedMem(sys->host), &sys->shimShmemHostLock);
+    host_unlockShimShmemLock(sys->host);
 
     return scr;
 }

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -249,9 +249,6 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
                                           const SysCallArgs* args) {
     MAGIC_ASSERT(sys);
 
-    utility_assert(!host_getShimShmemLock(sys->host));
-    host_lockShimShmemLock(sys->host);
-
     StraceFmtMode straceLoggingMode = process_straceLoggingMode(sys->process);
 
     SysCallReturn scr;
@@ -566,8 +563,6 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         trace("Syscall didn't complete successfully; discarding plugin ptrs without writing back.");
         process_freePtrsWithoutFlushing(sys->process);
     }
-
-    host_unlockShimShmemLock(sys->host);
 
     return scr;
 }


### PR DESCRIPTION
Hold the HostShimSharedMemLock in a wider scope on the Shadow side. This is in preparation to add and use more protected state, which will be accessed outside of the SyscallHandler.

This should be roughly the same amount of locking and unlocking as before in practice.

Progress on #1792 