### PR TITLE
Add feature to escape busy loops

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -78,6 +78,8 @@ hosts:
 - [`experimental.socket_send_autotune`](#experimentalsocket_send_autotune)
 - [`experimental.socket_send_buffer`](#experimentalsocket_send_buffer)
 - [`experimental.strace_logging_mode`](#experimentalstrace_logging_mode)
+- [`experimental.unblocked_syscall_latency`](#experimentalunblocked_syscal_latency)
+- [`experimental.unblocked_syscall_limit`](#experimentalunblocked_syscal_limit)
 - [`experimental.use_cpu_pinning`](#experimentaluse_cpu_pinning)
 - [`experimental.use_dynamic_runahead`](#experimentaluse_dynamic_runahead)
 - [`experimental.use_explicit_block_message`](#experimentaluse_explicit_block_message)
@@ -398,6 +400,25 @@ uninitialized memory.
 
 The logs will be stored at
 `shadow.data/hosts/<hostname>/<hostname>.<procname>.<pid>.strace`.
+
+#### `experimental.unblocked_syscall_latency`
+
+Default: "2 microseconds"  
+Type: String
+
+The simulated latency of an unblocked syscall. For simulation efficiency, this
+latency is only added when `unblocked_syscall_limit` is reached.
+
+#### `experimental.unblocked_syscall_limit`
+
+Default: 0
+Type: Integer
+
+If non-zero, the number of consecutive unblocked syscalls that Shadow will
+allow a thread to execute before `unblocked_syscall_latency` is applied.
+Setting this to a value of 0 allows time to eventually move forward in cases
+where the managed thread is in a "busy loop" that executes forever until a
+timeout or some other condition is satisfied.
 
 #### `experimental.use_cpu_pinning`
 

--- a/src/lib/shim/shim_shmem.h
+++ b/src/lib/shim/shim_shmem.h
@@ -37,7 +37,7 @@ typedef struct _ShimHostProtectedSharedMem ShimShmemHostLock;
 // parameter are still thread-safe, and internally use atomics.
 
 size_t shimshmemhost_size();
-void shimshmemhost_init(ShimShmemHost* hostMem, Host* host);
+void shimshmemhost_init(ShimShmemHost* hostMem, Host* host, uint32_t unblockedSyscallLimit);
 
 ShimShmemHostLock* shimshmemhost_lock(ShimShmemHost* host);
 
@@ -106,6 +106,15 @@ void shimshmem_setSigAltStack(const ShimShmemHostLock* host, ShimShmemThread* th
 // Returns 0 if no unblocked signal is pending.
 int shimshmem_takePendingUnblockedSignal(const ShimShmemHostLock* lock, ShimShmemProcess* process,
                                          ShimShmemThread* thread, siginfo_t* info);
+
+// Track the number of consecutive unblocked syscalls.
+void shimshmem_incrementUnblockedSyscallCount(ShimShmemHostLock* host);
+uint32_t shimshmem_getUnblockedSyscallCount(ShimShmemHostLock* host);
+void shimshmem_resetUnblockedSyscallCount(ShimShmemHostLock* host);
+
+// Get the configured maximum unmber of unblocked syscalls to execute before
+// yielding.
+uint32_t shimshmem_unblockedSyscallLimit(ShimShmemHost* host);
 
 // Handle SHD_SHIM_EVENT_CLONE_REQ
 void shim_shmemHandleClone(const ShimEvent* ev);

--- a/src/lib/shim/shim_sys.c
+++ b/src/lib/shim/shim_sys.c
@@ -105,6 +105,14 @@ bool shim_sys_handle_syscall_locally(long syscall_num, long* rv, va_list args) {
             break;
         }
 
+        case SYS_sched_yield: {
+            // Do nothing. We already yield and move time forward after some
+            // number of unblocked syscalls.
+            *rv = 0;
+
+            break;
+        }
+
         default: {
             // the syscall was not handled
             return false;

--- a/src/lib/shim/shim_sys.c
+++ b/src/lib/shim/shim_sys.c
@@ -15,6 +15,7 @@
 #include "lib/shim/shim.h"
 #include "lib/shim/shim_sys.h"
 #include "main/core/support/definitions.h" // for SIMTIME definitions
+#include "main/host/syscall_numbers.h"
 
 static EmulatedTime _shim_sys_get_time() {
     ShimShmemProcess* mem = shim_processSharedMem();
@@ -107,6 +108,30 @@ bool shim_sys_handle_syscall_locally(long syscall_num, long* rv, va_list args) {
         default: {
             // the syscall was not handled
             return false;
+        }
+    }
+
+    uint32_t unblockedLimit = shimshmem_unblockedSyscallLimit(shim_hostSharedMem());
+    if (unblockedLimit > 0) {
+        ShimShmemHostLock* host_lock = shimshmemhost_lock(shim_hostSharedMem());
+        shimshmem_incrementUnblockedSyscallCount(host_lock);
+        uint32_t unblockedCount = shimshmem_getUnblockedSyscallCount(host_lock);
+        shimshmemhost_unlock(shim_hostSharedMem(), &host_lock);
+
+        // Count the syscall and check whether we ought to yield.
+        trace("Unblocked syscall count=%u limit=%u", unblockedCount, unblockedLimit);
+        if (unblockedCount >= unblockedLimit) {
+            // We still want to eventually return the syscall result we just
+            // got, but first we yield control to Shadow so that it can move
+            // time forward and reschedule this thread. This syscall itself is
+            // a no-op, but the Shadow side will itself check and see that
+            // unblockedCount > unblockedLimit, as it does before executing any
+            // syscall.
+            //
+            // Since this is a Shadow syscall, it will always be passed through
+            // to Shadow instead of being executed natively.
+            trace("Reached unblocked syscall limit. Yielding.");
+            syscall(SYS_shadow_yield);
         }
     }
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -348,6 +348,10 @@ bool config_getUseShimSyscallHandler(const struct ConfigOptions *config);
 
 int32_t config_getPreloadSpinMax(const struct ConfigOptions *config);
 
+int32_t config_getUnblockedSyscallLimit(const struct ConfigOptions *config);
+
+SimulationTime config_getUnblockedSyscallLatency(const struct ConfigOptions *config);
+
 uint32_t config_getParallelism(const struct ConfigOptions *config);
 
 SimulationTime config_getStopTime(const struct ConfigOptions *config);

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1720,7 +1720,7 @@ pub struct _Epoll {
 }
 pub type Epoll = _Epoll;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
 pub struct _SysCallHandler {
     pub host: *mut Host,
     pub process: *mut Process,
@@ -1733,6 +1733,8 @@ pub struct _SysCallHandler {
     pub perfSecondsTotal: gdouble,
     pub numSyscalls: ::std::os::raw::c_long,
     pub syscall_counter: *mut Counter,
+    pub havePendingResult: bool,
+    pub pendingResult: SysCallReturn,
     pub referenceCount: ::std::os::raw::c_int,
     pub magic: guint,
 }
@@ -1740,7 +1742,7 @@ pub struct _SysCallHandler {
 fn bindgen_test_layout__SysCallHandler() {
     assert_eq!(
         ::std::mem::size_of::<_SysCallHandler>(),
-        96usize,
+        128usize,
         concat!("Size of: ", stringify!(_SysCallHandler))
     );
     assert_eq!(
@@ -1867,8 +1869,30 @@ fn bindgen_test_layout__SysCallHandler() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).referenceCount as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<_SysCallHandler>())).havePendingResult as *const _ as usize
+        },
         88usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_SysCallHandler),
+            "::",
+            stringify!(havePendingResult)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).pendingResult as *const _ as usize },
+        96usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_SysCallHandler),
+            "::",
+            stringify!(pendingResult)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).referenceCount as *const _ as usize },
+        120usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),
@@ -1878,7 +1902,7 @@ fn bindgen_test_layout__SysCallHandler() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<_SysCallHandler>())).magic as *const _ as usize },
-        92usize,
+        124usize,
         concat!(
             "Offset of field: ",
             stringify!(_SysCallHandler),

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -431,10 +431,11 @@ impl Default for ExperimentalOptions {
             use_preload_openssl_rng: Some(true),
             use_preload_openssl_crypto: Some(false),
             preload_spin_max: Some(0),
-            // Experimentally, this is high enough to trigger infrequently
+            // Experimentally, 500 is high enough to trigger infrequently
             // outside of a true "busy loop", and low enough to get out of such
-            // loops fairly quickly.
-            unblocked_syscall_limit: Some(500),
+            // loops fairly quickly. Disabled by default for now, pending further
+            // testing.
+            unblocked_syscall_limit: Some(0),
             // 2 microseconds is a ballpark estimate of the minimal latency for
             // context switching to the kernel and back on modern machines.
             unblocked_syscall_latency: Some(units::Time::new(2, units::TimePrefix::Micro)),

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -395,6 +395,19 @@ pub struct ExperimentalOptions {
     #[clap(long, value_name = "mode")]
     #[clap(help = EXP_HELP.get("strace_logging_mode").unwrap().as_str())]
     pub strace_logging_mode: Option<StraceLoggingMode>,
+
+    /// Number of consecutive unblocked syscalls before a thread applies
+    /// `unblocked_syscall_latency` and yields. 0 to never yield.
+    #[clap(long, value_name = "count")]
+    #[clap(help = EXP_HELP.get("unblocked_syscall_limit").unwrap().as_str())]
+    pub unblocked_syscall_limit: Option<i32>,
+
+    /// Simulated latency of an unblocked syscall. For efficiency Shadow only
+    /// actually adds this latency if and when `unblocked_syscall_limit` is
+    /// reached.
+    #[clap(long, value_name = "seconds")]
+    #[clap(help = EXP_HELP.get("unblocked_syscall_latency").unwrap().as_str())]
+    pub unblocked_syscall_latency: Option<units::Time<units::TimePrefix>>,
 }
 
 impl ExperimentalOptions {
@@ -418,6 +431,13 @@ impl Default for ExperimentalOptions {
             use_preload_openssl_rng: Some(true),
             use_preload_openssl_crypto: Some(false),
             preload_spin_max: Some(0),
+            // Experimentally, this is high enough to trigger infrequently
+            // outside of a true "busy loop", and low enough to get out of such
+            // loops fairly quickly.
+            unblocked_syscall_limit: Some(500),
+            // 2 microseconds is a ballpark estimate of the minimal latency for
+            // context switching to the kernel and back on modern machines.
+            unblocked_syscall_latency: Some(units::Time::new(2, units::TimePrefix::Micro)),
             use_memory_manager: Some(true),
             use_shim_syscall_handler: Some(true),
             use_cpu_pinning: Some(true),
@@ -1223,6 +1243,26 @@ mod export {
         assert!(!config.is_null());
         let config = unsafe { &*config };
         config.experimental.preload_spin_max.unwrap()
+    }
+
+    #[no_mangle]
+    pub extern "C" fn config_getUnblockedSyscallLimit(config: *const ConfigOptions) -> i32 {
+        assert!(!config.is_null());
+        let config = unsafe { &*config };
+        config.experimental.unblocked_syscall_limit.unwrap()
+    }
+
+    #[no_mangle]
+    pub extern "C" fn config_getUnblockedSyscallLatency(
+        config: *const ConfigOptions,
+    ) -> c::SimulationTime {
+        assert!(!config.is_null());
+        let config = unsafe { &*config };
+        match config.experimental.unblocked_syscall_latency {
+            Some(x) => x.convert(units::TimePrefix::Nano).unwrap().value() * SIMTIME_ONE_NANOSECOND,
+            // shadow uses a value of 0 as "not set" instead of SIMTIME_INVALID
+            None => 0,
+        }
     }
 
     #[no_mangle]

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -20,6 +20,7 @@
 #include "lib/logger/log_level.h"
 #include "lib/logger/logger.h"
 #include "lib/tsc/tsc.h"
+#include "main/core/support/config_handlers.h"
 #include "main/core/support/definitions.h"
 #include "main/core/worker.h"
 #include "main/host/cpu.h"
@@ -99,6 +100,9 @@ struct _Host {
     MAGIC_DECLARE;
 };
 
+static uint32_t _unblockedSyscallLimit = 0;
+ADD_CONFIG_HANDLER(config_getUnblockedSyscallLimit, _unblockedSyscallLimit)
+
 /* this function is called by manager before the workers exist */
 Host* host_new(HostParameters* params) {
     utility_assert(params);
@@ -133,7 +137,7 @@ Host* host_new(HostParameters* params) {
          g_quark_to_string(host->params.id));
 
     host->shimSharedMemBlock = shmemallocator_globalAlloc(shimshmemhost_size());
-    shimshmemhost_init(host_getSharedMem(host), host);
+    shimshmemhost_init(host_getSharedMem(host), host, _unblockedSyscallLimit);
 
     host->processIDCounter = 1000;
     host->referenceCount = 1;

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -648,6 +648,7 @@ void process_continue(Process* proc, Thread* thread) {
 
     _process_setSharedTime(proc);
 
+    shimshmem_resetUnblockedSyscallCount(host_getShimShmemLock(proc->host));
     proc->plugin.isExecuting = TRUE;
     thread_resume(thread);
     proc->plugin.isExecuting = FALSE;

--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -68,6 +68,12 @@ struct _SysCallHandler {
     // A counter for individual syscalls
     Counter* syscall_counter;
 
+    // In some cases the syscallhandler comples, but we block the caller anyway
+    // to move time forward. This stores the result of the completed syscall, to
+    // be returned when the caller resumes.
+    bool havePendingResult;
+    SysCallReturn pendingResult;
+
     int referenceCount;
 
     // Since this structure is shared with Rust, we should always include the magic struct

--- a/src/main/host/syscall/shadow.c
+++ b/src/main/host/syscall/shadow.c
@@ -139,3 +139,7 @@ SysCallReturn syscallhandler_shadow_init_memory_manager(SysCallHandler* sys, con
     }
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
 }
+
+SysCallReturn syscallhandler_shadow_yield(SysCallHandler* sys, const SysCallArgs* args) {
+    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+}

--- a/src/main/host/syscall/shadow.h
+++ b/src/main/host/syscall/shadow.h
@@ -14,5 +14,6 @@ SYSCALL_HANDLER(shadow_get_ipc_blk);
 SYSCALL_HANDLER(shadow_get_shm_blk);
 SYSCALL_HANDLER(shadow_hostname_to_addr_ipv4);
 SYSCALL_HANDLER(shadow_init_memory_manager);
+SYSCALL_HANDLER(shadow_yield);
 
 #endif /* SRC_MAIN_HOST_SYSCALL_CUSTOM_H_ */

--- a/src/main/host/syscall/time.c
+++ b/src/main/host/syscall/time.c
@@ -168,3 +168,9 @@ SysCallReturn syscallhandler_gettimeofday(SysCallHandler* sys, const SysCallArgs
 
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
 }
+
+SysCallReturn syscallhandler_sched_yield(SysCallHandler* sys, const SysCallArgs* args) {
+    // Do nothing. We already yield and reschedule after some number of
+    // unblocked syscalls.
+    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+}

--- a/src/main/host/syscall/time.h
+++ b/src/main/host/syscall/time.h
@@ -13,5 +13,6 @@ SYSCALL_HANDLER(clock_nanosleep);
 SYSCALL_HANDLER(gettimeofday);
 SYSCALL_HANDLER(nanosleep);
 SYSCALL_HANDLER(time);
+SYSCALL_HANDLER(sched_yield);
 
 #endif /* SRC_MAIN_HOST_SYSCALL_TIME_H_ */

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -387,6 +387,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
             HANDLE_RUST(recvfrom);
             HANDLE_C(renameat);
             HANDLE_C(renameat2);
+            HANDLE_C(sched_yield);
             HANDLE_C(shadow_set_ptrace_allow_native_syscalls);
             HANDLE_C(shadow_get_ipc_blk);
             HANDLE_C(shadow_get_shm_blk);

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -50,6 +50,9 @@
 static bool _countSyscalls = false;
 ADD_CONFIG_HANDLER(config_getUseSyscallCounters, _countSyscalls)
 
+static SimulationTime _unblockedSyscallLatency;
+ADD_CONFIG_HANDLER(config_getUnblockedSyscallLatency, _unblockedSyscallLatency)
+
 SysCallHandler* syscallhandler_new(Host* host, Process* process,
                                    Thread* thread) {
     utility_assert(host);
@@ -262,266 +265,277 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
                       sys->blockedSyscallNR, args->number);
     }
 
-    switch (args->number) {
-        HANDLE_C(accept);
-        HANDLE_C(accept4);
-        HANDLE_RUST(bind);
-        HANDLE_C(brk);
-        HANDLE_C(clock_gettime);
-        HANDLE_C(clock_nanosleep);
-        HANDLE_C(clone);
-        HANDLE_RUST(close);
-        HANDLE_C(connect);
-        HANDLE_C(creat);
-        HANDLE_RUST(dup);
-        HANDLE_RUST(dup2);
-        HANDLE_RUST(dup3);
-        HANDLE_C(epoll_create);
-        HANDLE_C(epoll_create1);
-        HANDLE_C(epoll_ctl);
-        HANDLE_C(epoll_pwait);
-        HANDLE_C(epoll_wait);
-        HANDLE_RUST(eventfd);
-        HANDLE_RUST(eventfd2);
-        HANDLE_C(execve);
-        HANDLE_C(exit_group);
-        HANDLE_C(faccessat);
-        HANDLE_C(fadvise64);
-        HANDLE_C(fallocate);
-        HANDLE_C(fchmod);
-        HANDLE_C(fchmodat);
-        HANDLE_C(fchown);
-        HANDLE_C(fchownat);
-        HANDLE_RUST(fcntl);
+    if (sys->havePendingResult) {
+        // The syscall was already completed, but we delayed the response to yield the CPU.
+        // Return that response now.
+        trace("Returning delayed result");
+        sys->havePendingResult = false;
+        scr = sys->pendingResult;
+    } else {
+        switch (args->number) {
+            HANDLE_C(accept);
+            HANDLE_C(accept4);
+            HANDLE_RUST(bind);
+            HANDLE_C(brk);
+            HANDLE_C(clock_gettime);
+            HANDLE_C(clock_nanosleep);
+            HANDLE_C(clone);
+            HANDLE_RUST(close);
+            HANDLE_C(connect);
+            HANDLE_C(creat);
+            HANDLE_RUST(dup);
+            HANDLE_RUST(dup2);
+            HANDLE_RUST(dup3);
+            HANDLE_C(epoll_create);
+            HANDLE_C(epoll_create1);
+            HANDLE_C(epoll_ctl);
+            HANDLE_C(epoll_pwait);
+            HANDLE_C(epoll_wait);
+            HANDLE_RUST(eventfd);
+            HANDLE_RUST(eventfd2);
+            HANDLE_C(execve);
+            HANDLE_C(exit_group);
+            HANDLE_C(faccessat);
+            HANDLE_C(fadvise64);
+            HANDLE_C(fallocate);
+            HANDLE_C(fchmod);
+            HANDLE_C(fchmodat);
+            HANDLE_C(fchown);
+            HANDLE_C(fchownat);
+            HANDLE_RUST(fcntl);
 #ifdef SYS_fcntl64
-        // TODO: is there a nicer way to do this? Rust libc::SYS_fcntl64 does not exist.
-        case SYS_fcntl64: {
-            _syscallhandler_pre_syscall(sys, args->number, "fcntl64");
-            SyscallHandler* handler = sys->syscall_handler_rs;
-            sys->syscall_handler_rs = NULL;
-            args->number = SYS_fcntl;
-            scr = rustsyscallhandler_syscall(handler, sys, args);
-            args->number = SYS_fcntl64;
-            sys->syscall_handler_rs = handler;
-            _syscallhandler_post_syscall(sys, args->number, "fcntl64", &scr);
-        } break;
+            // TODO: is there a nicer way to do this? Rust libc::SYS_fcntl64 does not exist.
+            case SYS_fcntl64: {
+                _syscallhandler_pre_syscall(sys, args->number, "fcntl64");
+                SyscallHandler* handler = sys->syscall_handler_rs;
+                sys->syscall_handler_rs = NULL;
+                args->number = SYS_fcntl;
+                scr = rustsyscallhandler_syscall(handler, sys, args);
+                args->number = SYS_fcntl64;
+                sys->syscall_handler_rs = handler;
+                _syscallhandler_post_syscall(sys, args->number, "fcntl64", &scr);
+                break;
+            }
 #endif
-        HANDLE_C(fdatasync);
-        HANDLE_C(fgetxattr);
-        HANDLE_C(flistxattr);
-        HANDLE_C(flock);
-        HANDLE_C(fremovexattr);
-        HANDLE_C(fsetxattr);
-        HANDLE_C(fstat);
-        HANDLE_C(fstatfs);
-        HANDLE_C(fsync);
-        HANDLE_C(ftruncate);
-        HANDLE_C(futex);
-        HANDLE_C(futimesat);
-        HANDLE_C(getdents);
-        HANDLE_C(getdents64);
-        HANDLE_RUST(getpeername);
-        HANDLE_C(getpid);
-        HANDLE_C(getppid);
-        HANDLE_C(gettid);
-        HANDLE_RUST(getrandom);
-        HANDLE_C(get_robust_list);
-        HANDLE_RUST(getsockname);
-        HANDLE_C(getsockopt);
-        HANDLE_C(gettimeofday);
-        HANDLE_RUST(ioctl);
-        HANDLE_C(kill);
-        HANDLE_C(linkat);
-        HANDLE_C(listen);
-        HANDLE_C(lseek);
-        HANDLE_C(mkdirat);
-        HANDLE_C(mknodat);
-        HANDLE_C(mmap);
+            HANDLE_C(fdatasync);
+            HANDLE_C(fgetxattr);
+            HANDLE_C(flistxattr);
+            HANDLE_C(flock);
+            HANDLE_C(fremovexattr);
+            HANDLE_C(fsetxattr);
+            HANDLE_C(fstat);
+            HANDLE_C(fstatfs);
+            HANDLE_C(fsync);
+            HANDLE_C(ftruncate);
+            HANDLE_C(futex);
+            HANDLE_C(futimesat);
+            HANDLE_C(getdents);
+            HANDLE_C(getdents64);
+            HANDLE_RUST(getpeername);
+            HANDLE_C(getpid);
+            HANDLE_C(getppid);
+            HANDLE_C(gettid);
+            HANDLE_RUST(getrandom);
+            HANDLE_C(get_robust_list);
+            HANDLE_RUST(getsockname);
+            HANDLE_C(getsockopt);
+            HANDLE_C(gettimeofday);
+            HANDLE_RUST(ioctl);
+            HANDLE_C(kill);
+            HANDLE_C(linkat);
+            HANDLE_C(listen);
+            HANDLE_C(lseek);
+            HANDLE_C(mkdirat);
+            HANDLE_C(mknodat);
+            HANDLE_C(mmap);
 #ifdef SYS_mmap2
-        HANDLE_C(mmap2);
+            HANDLE_C(mmap2);
 #endif
-        HANDLE_C(mprotect);
-        HANDLE_C(mremap);
-        HANDLE_C(munmap);
-        HANDLE_C(nanosleep);
-        HANDLE_C(newfstatat);
-        HANDLE_C(open);
-        HANDLE_C(openat);
-        HANDLE_RUST(pipe);
-        HANDLE_RUST(pipe2);
-        HANDLE_C(poll);
-        HANDLE_C(ppoll);
-        HANDLE_C(prctl);
-        HANDLE_RUST(pread64);
-        HANDLE_C(preadv);
+            HANDLE_C(mprotect);
+            HANDLE_C(mremap);
+            HANDLE_C(munmap);
+            HANDLE_C(nanosleep);
+            HANDLE_C(newfstatat);
+            HANDLE_C(open);
+            HANDLE_C(openat);
+            HANDLE_RUST(pipe);
+            HANDLE_RUST(pipe2);
+            HANDLE_C(poll);
+            HANDLE_C(ppoll);
+            HANDLE_C(prctl);
+            HANDLE_RUST(pread64);
+            HANDLE_C(preadv);
 #ifdef SYS_preadv2
-        HANDLE_C(preadv2);
+            HANDLE_C(preadv2);
 #endif
 #ifdef SYS_prlimit
-        HANDLE_C(prlimit);
+            HANDLE_C(prlimit);
 #endif
 #ifdef SYS_prlimit64
-        HANDLE_C(prlimit64);
+            HANDLE_C(prlimit64);
 #endif
-        HANDLE_C(pselect6);
-        HANDLE_RUST(pwrite64);
-        HANDLE_C(pwritev);
+            HANDLE_C(pselect6);
+            HANDLE_RUST(pwrite64);
+            HANDLE_C(pwritev);
 #ifdef SYS_pwritev2
-        HANDLE_C(pwritev2);
+            HANDLE_C(pwritev2);
 #endif
-        HANDLE_RUST(read);
-        HANDLE_C(readahead);
-        HANDLE_C(readlinkat);
-        HANDLE_C(readv);
-        HANDLE_RUST(recvfrom);
-        HANDLE_C(renameat);
-        HANDLE_C(renameat2);
-        HANDLE_C(shadow_set_ptrace_allow_native_syscalls);
-        HANDLE_C(shadow_get_ipc_blk);
-        HANDLE_C(shadow_get_shm_blk);
-        HANDLE_C(shadow_hostname_to_addr_ipv4);
-        HANDLE_C(shadow_init_memory_manager);
-        HANDLE_C(select);
-        HANDLE_RUST(sendto);
-        HANDLE_C(setsockopt);
+            HANDLE_RUST(read);
+            HANDLE_C(readahead);
+            HANDLE_C(readlinkat);
+            HANDLE_C(readv);
+            HANDLE_RUST(recvfrom);
+            HANDLE_C(renameat);
+            HANDLE_C(renameat2);
+            HANDLE_C(shadow_set_ptrace_allow_native_syscalls);
+            HANDLE_C(shadow_get_ipc_blk);
+            HANDLE_C(shadow_get_shm_blk);
+            HANDLE_C(shadow_hostname_to_addr_ipv4);
+            HANDLE_C(shadow_init_memory_manager);
+            HANDLE_C(shadow_yield);
+            HANDLE_C(select);
+            HANDLE_RUST(sendto);
+            HANDLE_C(setsockopt);
 #ifdef SYS_sigaction
-        // Superseded by rt_sigaction in Linux 2.2
-        UNSUPPORTED(sigaction);
+            // Superseded by rt_sigaction in Linux 2.2
+            UNSUPPORTED(sigaction);
 #endif
-        HANDLE_C(rt_sigaction);
-        HANDLE_C(sigaltstack);
+            HANDLE_C(rt_sigaction);
+            HANDLE_C(sigaltstack);
 #ifdef SYS_signal
-        // Superseded by sigaction in glibc 2.0
-        UNSUPPORTED(signal);
+            // Superseded by sigaction in glibc 2.0
+            UNSUPPORTED(signal);
 #endif
 #ifdef SYS_sigprocmask
-        // Superseded by rt_sigprocmask in Linux 2.2
-        UNSUPPORTED(sigprocmask);
+            // Superseded by rt_sigprocmask in Linux 2.2
+            UNSUPPORTED(sigprocmask);
 #endif
-        HANDLE_C(rt_sigprocmask);
-        HANDLE_C(set_robust_list);
-        HANDLE_C(set_tid_address);
-        HANDLE_C(shutdown);
-        HANDLE_RUST(socket);
-        HANDLE_RUST(socketpair);
+            HANDLE_C(rt_sigprocmask);
+            HANDLE_C(set_robust_list);
+            HANDLE_C(set_tid_address);
+            HANDLE_C(shutdown);
+            HANDLE_RUST(socket);
+            HANDLE_RUST(socketpair);
 #ifdef SYS_statx
-        HANDLE_C(statx);
+            HANDLE_C(statx);
 #endif
-        HANDLE_C(symlinkat);
-        HANDLE_C(sync_file_range);
-        HANDLE_C(syncfs);
-        HANDLE_RUST(sysinfo);
-        HANDLE_C(tgkill);
-        HANDLE_C(time);
-        HANDLE_C(timerfd_create);
-        HANDLE_C(timerfd_gettime);
-        HANDLE_C(timerfd_settime);
-        HANDLE_C(tkill);
-        HANDLE_C(uname);
-        HANDLE_C(unlinkat);
-        HANDLE_C(utimensat);
-        HANDLE_RUST(write);
-        HANDLE_C(writev);
+            HANDLE_C(symlinkat);
+            HANDLE_C(sync_file_range);
+            HANDLE_C(syncfs);
+            HANDLE_RUST(sysinfo);
+            HANDLE_C(tgkill);
+            HANDLE_C(time);
+            HANDLE_C(timerfd_create);
+            HANDLE_C(timerfd_gettime);
+            HANDLE_C(timerfd_settime);
+            HANDLE_C(tkill);
+            HANDLE_C(uname);
+            HANDLE_C(unlinkat);
+            HANDLE_C(utimensat);
+            HANDLE_RUST(write);
+            HANDLE_C(writev);
 
-        // **************************************
-        // Not handled (yet):
-        // **************************************
-        // NATIVE(chdir);
-        // NATIVE(fchdir);
-        // NATIVE(io_getevents);
-        // NATIVE(waitid);
-        // NATIVE(msync);
+            // **************************************
+            // Not handled (yet):
+            // **************************************
+            // NATIVE(chdir);
+            // NATIVE(fchdir);
+            // NATIVE(io_getevents);
+            // NATIVE(waitid);
+            // NATIVE(msync);
 
-        //// operations on pids (shadow overrides pids)
-        // NATIVE(sched_getaffinity);
-        // NATIVE(sched_setaffinity);
+            //// operations on pids (shadow overrides pids)
+            // NATIVE(sched_getaffinity);
+            // NATIVE(sched_setaffinity);
 
-        //// copying data between various types of fds
-        // NATIVE(copy_file_range);
-        // NATIVE(sendfile);
-        // NATIVE(splice);
-        // NATIVE(vmsplice);
-        // NATIVE(tee);
+            //// copying data between various types of fds
+            // NATIVE(copy_file_range);
+            // NATIVE(sendfile);
+            // NATIVE(splice);
+            // NATIVE(vmsplice);
+            // NATIVE(tee);
 
-        //// additional socket io
-        // NATIVE(recvmsg);
-        // NATIVE(sendmsg);
-        // NATIVE(recvmmsg);
-        // NATIVE(sendmmsg);
+            //// additional socket io
+            // NATIVE(recvmsg);
+            // NATIVE(sendmsg);
+            // NATIVE(recvmmsg);
+            // NATIVE(sendmmsg);
 
-        // ***************************************
-        // We think we don't need to handle these
-        // (because the plugin can natively):
-        // ***************************************
-        NATIVE(access);
-        NATIVE(arch_prctl);
-        NATIVE(chmod);
-        NATIVE(chown);
-        NATIVE(exit);
-        NATIVE(getcwd);
-        NATIVE(geteuid);
-        NATIVE(getegid);
-        NATIVE(getgid);
-        NATIVE(getresgid);
-        NATIVE(getresuid);
-        NATIVE(getrlimit);
-        NATIVE(getuid);
-        NATIVE(getxattr);
-        NATIVE(lchown);
-        NATIVE(lgetxattr);
-        NATIVE(link);
-        NATIVE(listxattr);
-        NATIVE(llistxattr);
-        NATIVE(lremovexattr);
-        NATIVE(lsetxattr);
-        NATIVE(lstat);
-        NATIVE(madvise);
-        NATIVE(mkdir);
-        NATIVE(mknod);
-        NATIVE(readlink);
-        NATIVE(removexattr);
-        NATIVE(rename);
-        NATIVE(rmdir);
-        NATIVE(rt_sigreturn);
-        NATIVE(setfsgid);
-        NATIVE(setfsuid);
-        NATIVE(setgid);
-        NATIVE(setregid);
-        NATIVE(setresgid);
-        NATIVE(setresuid);
-        NATIVE(setreuid);
-        NATIVE(setrlimit);
-        NATIVE(setuid);
-        NATIVE(setxattr);
-        NATIVE(stat);
+            // ***************************************
+            // We think we don't need to handle these
+            // (because the plugin can natively):
+            // ***************************************
+            NATIVE(access);
+            NATIVE(arch_prctl);
+            NATIVE(chmod);
+            NATIVE(chown);
+            NATIVE(exit);
+            NATIVE(getcwd);
+            NATIVE(geteuid);
+            NATIVE(getegid);
+            NATIVE(getgid);
+            NATIVE(getresgid);
+            NATIVE(getresuid);
+            NATIVE(getrlimit);
+            NATIVE(getuid);
+            NATIVE(getxattr);
+            NATIVE(lchown);
+            NATIVE(lgetxattr);
+            NATIVE(link);
+            NATIVE(listxattr);
+            NATIVE(llistxattr);
+            NATIVE(lremovexattr);
+            NATIVE(lsetxattr);
+            NATIVE(lstat);
+            NATIVE(madvise);
+            NATIVE(mkdir);
+            NATIVE(mknod);
+            NATIVE(readlink);
+            NATIVE(removexattr);
+            NATIVE(rename);
+            NATIVE(rmdir);
+            NATIVE(rt_sigreturn);
+            NATIVE(setfsgid);
+            NATIVE(setfsuid);
+            NATIVE(setgid);
+            NATIVE(setregid);
+            NATIVE(setresgid);
+            NATIVE(setresuid);
+            NATIVE(setreuid);
+            NATIVE(setrlimit);
+            NATIVE(setuid);
+            NATIVE(setxattr);
+            NATIVE(stat);
 #ifdef SYS_stat64
-        NATIVE(stat64);
+            NATIVE(stat64);
 #endif
-        NATIVE(statfs);
-        NATIVE(symlink);
-        NATIVE(truncate);
-        NATIVE(unlink);
-        NATIVE(utime);
-        NATIVE(utimes);
+            NATIVE(statfs);
+            NATIVE(symlink);
+            NATIVE(truncate);
+            NATIVE(unlink);
+            NATIVE(utime);
+            NATIVE(utimes);
 
-        default:
-            warning(
-                "Detected unsupported syscall %ld called from thread %i in process %s on host %s",
-                args->number, thread_getID(sys->thread), process_getName(sys->process),
-                host_getName(sys->host));
-            error("Returning error %i (ENOSYS) for unsupported syscall %li, which may result in "
-                  "unusual behavior",
-                  ENOSYS, args->number);
-            scr = (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+            default: {
+                warning(
+                    "Detected unsupported syscall %ld called from thread %i in process %s on host %s",
+                    args->number, thread_getID(sys->thread), process_getName(sys->process),
+                    host_getName(sys->host));
+                error("Returning error %i (ENOSYS) for unsupported syscall %li, which may result in "
+                      "unusual behavior",
+                      ENOSYS, args->number);
+                scr = (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
 
-            if (straceLoggingMode != STRACE_FMT_MODE_OFF) {
-                char arg_str[20] = {0};
-                snprintf(arg_str, sizeof(arg_str), "%ld, ...", args->number);
-                scr = log_syscall(sys->process, straceLoggingMode, thread_getID(sys->thread),
-                                  "syscall", arg_str, scr);
+                if (straceLoggingMode != STRACE_FMT_MODE_OFF) {
+                    char arg_str[20] = {0};
+                    snprintf(arg_str, sizeof(arg_str), "%ld, ...", args->number);
+                    scr = log_syscall(sys->process, straceLoggingMode, thread_getID(sys->thread),
+                                      "syscall", arg_str, scr);
+                }
+
+                break;
             }
-
-            break;
+        }
     }
 
     // If the syscall would be blocked, but there's a signal pending, fail with
@@ -550,6 +564,36 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         scr = (SysCallReturn){.state = SYSCALL_DONE, .retval = -EINTR};
     }
 
+    if (!(scr.state == SYSCALL_DONE && syscall_rawReturnValueToErrno(scr.retval.as_i64) == 0)) {
+        // The syscall didn't complete successfully; don't write back pointers.
+        trace("Syscall didn't complete successfully; discarding plugin ptrs without writing back.");
+        process_freePtrsWithoutFlushing(sys->process);
+    }
+
+    if (scr.state == SYSCALL_DONE || scr.state == SYSCALL_NATIVE) {
+        uint32_t unblockedLimit = shimshmem_unblockedSyscallLimit(host_getSharedMem(sys->host));
+        if (unblockedLimit > 0) {
+            uint32_t unblockedCount =
+                shimshmem_getUnblockedSyscallCount(host_getShimShmemLock(sys->host));
+            trace("Unblocked syscall count=%u limit=%u", unblockedCount, unblockedLimit);
+            if (unblockedCount >= unblockedLimit) {
+                // Block instead, but save the result so that we can return it
+                // later instead of re-executing the syscall.
+                utility_assert(!sys->havePendingResult);
+                sys->havePendingResult = true;
+                sys->pendingResult = scr;
+
+                utility_assert(scr.cond == NULL);
+                scr.cond = syscallcondition_new((Trigger){.type = TRIGGER_NONE});
+                syscallcondition_setTimeout(
+                    scr.cond, sys->host,
+                    worker_getEmulatedTime() + unblockedCount * _unblockedSyscallLatency);
+                scr.state = SYSCALL_BLOCK;
+                trace("Reached unblocked syscall limit. Yielding.");
+            }
+        }
+    }
+
     if (scr.state == SYSCALL_BLOCK) {
         /* We are blocking: store the syscall number so we know
          * to expect the same syscall again when it unblocks. */
@@ -558,11 +602,6 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         sys->blockedSyscallNR = -1;
     }
 
-    if (!(scr.state == SYSCALL_DONE && syscall_rawReturnValueToErrno(scr.retval.as_i64) == 0)) {
-        // The syscall didn't complete successfully; don't write back pointers.
-        trace("Syscall didn't complete successfully; discarding plugin ptrs without writing back.");
-        process_freePtrsWithoutFlushing(sys->process);
-    }
 
     return scr;
 }

--- a/src/main/host/syscall_numbers.h
+++ b/src/main/host/syscall_numbers.h
@@ -15,7 +15,12 @@ typedef enum {
     SYS_shadow_get_shm_blk = 1002,
     SYS_shadow_hostname_to_addr_ipv4 = 1003,
     SYS_shadow_init_memory_manager = 1004,
-    SYS_shadow_max = 1004,
+    // Conceptually similar to SYS_sched_yield, but made by the shim to return
+    // control to Shadow. For now, using a different syscall here is mostly for
+    // debugging purposes, so that it doesn't appear that the managed code
+    // issues a SYS_sched_yield.
+    SYS_shadow_yield = 1005,
+    SYS_shadow_max = 1005,
 } ShadowSyscallNum;
 
 static inline bool syscall_num_is_shadow(long n) {

--- a/src/main/host/thread_ptrace.c
+++ b/src/main/host/thread_ptrace.c
@@ -1024,10 +1024,18 @@ SysCallCondition* threadptrace_resume(Thread* base) {
             process_flushPtrs(thread->base.process);
 
             trace("ptrace resuming with signal %ld", thread->signalToDeliver);
-            // Allow child to start executing.
+            // Allow child to start executing.  We release the shared memory
+            // lock, which we will reacquire when the child stops again.
+            //
+            // XXX: This is currently a bit fragile - stopping and starting the
+            // managed thread ideally should be refactored into helper functions
+            // that also take and release the lock. Not worth it for now since
+            // we plan to remove ptrace mode
+            // https://github.com/shadow/shadow/issues/1945.
+            host_unlockShimShmemLock(thread->base.host);
             if (ptrace(PTRACE_SYSEMU, thread->base.nativeTid, 0, thread->signalToDeliver) < 0) {
                 utility_panic("ptrace %d: %s", thread->base.nativeTid, g_strerror(errno));
-                return NULL;
+                abort();
             }
             thread->regs.valid = false;
             thread->signalToDeliver = 0;
@@ -1035,6 +1043,8 @@ SysCallCondition* threadptrace_resume(Thread* base) {
         }
         trace("waiting for next state");
         _threadptrace_nextChildState(thread);
+        // Now that the child has stopped, re-acquire the shared memory lock.
+        host_lockShimShmemLock(thread->base.host);
     }
 }
 

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -141,6 +141,10 @@ path = "select/test_select.rs"
 name = "test_sysinfo"
 path = "sysinfo/test_sysinfo.rs"
 
+[[bin]]
+name = "test_busy_wait"
+path = "regression/test_busy_wait.rs"
+
 [dependencies]
 libc = "0.2"
 nix = "0.23.1"

--- a/src/test/regression/CMakeLists.txt
+++ b/src/test/regression/CMakeLists.txt
@@ -5,3 +5,11 @@ add_shadow_tests(BASENAME small_stop_time CHECK_RETVAL FALSE)
 add_executable(test_flush_after_exit test_flush_after_exit.c)
 add_linux_tests(BASENAME flush_after_exit COMMAND bash -c "test `./test_flush_after_exit` == 'Hello'")
 add_shadow_tests(BASENAME flush_after_exit POST_CMD "test `cat hosts/*/*.stdout` = 'Hello'")
+add_linux_tests(BASENAME busy_wait COMMAND ../target/debug/test_busy_wait)
+add_shadow_tests(
+    BASENAME busy_wait
+    PROPERTIES
+      # This test should be very fast when it succeeds, but will generally take
+      # the full timeout to fail otherwise.
+      TIMEOUT 5
+    )

--- a/src/test/regression/busy_wait.yaml
+++ b/src/test/regression/busy_wait.yaml
@@ -1,0 +1,15 @@
+# https://github.com/shadow/shadow/issues/1968
+
+general:
+  stop_time: 15s
+
+network:
+  graph:
+    type: 1_gbit_switch
+
+hosts:
+  host:
+    network_node_id: 0
+    processes:
+    - path: ../target/debug/test_busy_wait
+      start_time: 1s

--- a/src/test/regression/busy_wait.yaml
+++ b/src/test/regression/busy_wait.yaml
@@ -3,6 +3,9 @@
 general:
   stop_time: 15s
 
+experimental:
+  unblocked_syscall_limit: 500
+
 network:
   graph:
     type: 1_gbit_switch

--- a/src/test/regression/test_busy_wait.rs
+++ b/src/test/regression/test_busy_wait.rs
@@ -1,0 +1,22 @@
+use std::time::{Duration, Instant};
+
+// We've found several real-world examples where the process does a busy wait
+// until either some timeout has passed, or work shows up to do. Having Shadow
+// eventually move time forward even when the only thing being done is to check
+// the time (and maybe make other non-blocking syscalls) prevents these examples
+// from deadlocking.
+//
+// * the golang runtime (https://github.com/shadow/shadow/issues/1968)
+// * openblas (https://github.com/shadow/shadow/issues/1792)
+// * older versions of Curl (https://github.com/shadow/shadow/issues/1794#issuecomment-985909442)
+fn test_wait_for_timeout() {
+    let t0 = Instant::now();
+    let target = t0 + Duration::from_millis(1);
+    while Instant::now() < target {
+        // wait
+    }
+}
+
+fn main() {
+    test_wait_for_timeout();
+}


### PR DESCRIPTION
* Add regression test that loops until time moves forward.
* Add options to allow moving time forward after some number of consecutive unblocked syscalls.
* Implement `sched_yield` as a no-op and on the shim side to help make busy loops that use it fast.
* Fix a previously-latent bug in thread_preload, where it overwrote the thread's "current event" when executing a syscall in the managed thread on behalf of Shadow.