### PR TITLE
Fix a case where getaddrinfo() incorrectly returns 0

### DIFF
--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -368,7 +368,11 @@ int shim_api_getaddrinfo(const char* node, const char* service, const struct add
             }
         }
         // We've finished adding all relevant addresses.
-        return 0;
+        if (*res != NULL) {
+            return 0;
+        } else {
+            return EAI_NONAME;
+        }
     }
 
     // "`node` specifies either a numerical network address..."

--- a/src/test/resolver/CMakeLists.txt
+++ b/src/test/resolver/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(GLIB REQUIRED)
 include_directories(${GLIB_INCLUDES})
 
 ## create and install an executable that can run outside of shadow
-add_executable(test-getaddrinfo test_getaddrinfo.c)
+add_executable(test-getaddrinfo test_getaddrinfo.c ../test_common.c)
 
 ## if the test needs any libraries, link them here
 target_link_libraries(test-getaddrinfo ${GLIB_LIBRARIES})


### PR DESCRIPTION
This causes iperf3 to segfault in [`netannounce()`](https://github.com/esnet/iperf/blob/dfcea9f6a09ead01089a3c9d20c7032f2c0af2c1/src/net.c#L251). (iperf3 still doesn't run correctly under shadow, but this fixes the segfault.)