### PR TITLE
Increment time locally when able

### DIFF
--- a/src/lib/shim/shim_shmem.c
+++ b/src/lib/shim/shim_shmem.c
@@ -35,6 +35,9 @@ struct _ShimShmemHost {
     //
     // Thread Safety: immutable after initialization.
     const uint32_t unblocked_syscall_limit;
+
+    // Current simulation time.
+    _Atomic EmulatedTime sim_time;
 };
 
 typedef struct _ShimProcessProtectedSharedMem ShimProcessProtectedSharedMem;
@@ -56,9 +59,6 @@ struct _ShimProcessProtectedSharedMem {
 
 struct _ShimShmemProcess {
     GQuark host_id;
-
-    // Current simulation time.
-    _Atomic EmulatedTime sim_time;
 
     // Guarded by ShimShmemHost.mutex.
     ShimProcessProtectedSharedMem protected;
@@ -205,12 +205,12 @@ void shimshmemprocess_init(ShimShmemProcess* processMem, Process* process) {
     };
 }
 
-EmulatedTime shimshmem_getEmulatedTime(ShimShmemProcess* processMem) {
-    return atomic_load(&processMem->sim_time);
+EmulatedTime shimshmem_getEmulatedTime(ShimShmemHost* hostMem) {
+    return atomic_load(&hostMem->sim_time);
 }
 
-void shimshmem_setEmulatedTime(ShimShmemProcess* processMem, EmulatedTime t) {
-    atomic_store(&processMem->sim_time, t);
+void shimshmem_setEmulatedTime(ShimShmemHost* hostMem, EmulatedTime t) {
+    atomic_store(&hostMem->sim_time, t);
 }
 
 shd_kernel_sigset_t shimshmem_getThreadPendingSignals(const ShimShmemHostLock* host,

--- a/src/lib/shim/shim_shmem.c
+++ b/src/lib/shim/shim_shmem.c
@@ -16,6 +16,10 @@ struct _ShimHostProtectedSharedMem {
 
     // Number of syscalls that have executed without blocking.
     uint32_t unblocked_syscall_count;
+
+    // Max simulation time to which sim_time may be incremented.  Moving time
+    // beyond this value requires the current thread to be rescheduled.
+    EmulatedTime max_runahead_time;
 };
 
 struct _ShimShmemHost {
@@ -36,12 +40,16 @@ struct _ShimShmemHost {
     // Thread Safety: immutable after initialization.
     const uint32_t unblocked_syscall_limit;
 
+    // How much to move time forward for each unblocked syscall.
+    // TODO: Move to a "ShimShmemGlobal" struct if we make one, and if this
+    // stays a global constant; Or down into the process if we make it a
+    // per-process option.
+    //
+    // Thread Safety: immutable after initialization.
+    const SimulationTime unblocked_syscall_latency;
+
     // Current simulation time.
     _Atomic EmulatedTime sim_time;
-
-    // Max simulation time to which sim_time may be incremented.  Moving time
-    // beyond this value requires the current thread to be rescheduled.
-    _Atomic EmulatedTime max_sim_time;
 };
 
 typedef struct _ShimProcessProtectedSharedMem ShimProcessProtectedSharedMem;
@@ -99,7 +107,8 @@ struct _ShimShmemThread {
 
 size_t shimshmemhost_size() { return sizeof(ShimShmemHost); }
 
-void shimshmemhost_init(ShimShmemHost* hostMem, Host* host, uint32_t unblockedSyscallLimit) {
+void shimshmemhost_init(ShimShmemHost* hostMem, Host* host, uint32_t unblockedSyscallLimit,
+                        SimulationTime unblockedSyscallLatency) {
     assert(hostMem);
     // We use `memcpy` instead of struct assignment here to allow us to
     // initialize the const members of `hostMem`.
@@ -108,6 +117,7 @@ void shimshmemhost_init(ShimShmemHost* hostMem, Host* host, uint32_t unblockedSy
                .host_id = host_getID(host),
                .mutex = PTHREAD_MUTEX_INITIALIZER,
                .unblocked_syscall_limit = unblockedSyscallLimit,
+               .unblocked_syscall_latency = unblockedSyscallLatency,
                .protected =
                    {
                        .host_id = host_getID(host),
@@ -134,6 +144,11 @@ uint32_t shimshmem_getUnblockedSyscallCount(ShimShmemHostLock* host) {
 uint32_t shimshmem_unblockedSyscallLimit(ShimShmemHost* host) {
     assert(host);
     return host->unblocked_syscall_limit;
+}
+
+SimulationTime shimshmem_unblockedSyscallLatency(ShimShmemHost* host) {
+    assert(host);
+    return host->unblocked_syscall_latency;
 }
 
 void shimshmem_resetUnblockedSyscallCount(ShimShmemHostLock* host) {
@@ -216,18 +231,17 @@ EmulatedTime shimshmem_getEmulatedTime(ShimShmemHost* hostMem) {
 
 void shimshmem_setEmulatedTime(ShimShmemHost* hostMem, EmulatedTime t) {
     assert(hostMem);
-    assert(t <= shimshmem_getMaxEmulatedTime(hostMem));
     atomic_store(&hostMem->sim_time, t);
 }
 
-EmulatedTime shimshmem_getMaxEmulatedTime(ShimShmemHost* hostMem) {
+EmulatedTime shimshmem_getMaxRunaheadTime(ShimShmemHostLock* hostMem) {
     assert(hostMem);
-    return atomic_load(&hostMem->max_sim_time);
+    return hostMem->max_runahead_time;
 }
 
-void shimshmem_setMaxEmulatedTime(ShimShmemHost* hostMem, EmulatedTime t) {
+void shimshmem_setMaxRunaheadTime(ShimShmemHostLock* hostMem, EmulatedTime t) {
     assert(hostMem);
-    atomic_store(&hostMem->max_sim_time, t);
+    hostMem->max_runahead_time = t;
 }
 
 shd_kernel_sigset_t shimshmem_getThreadPendingSignals(const ShimShmemHostLock* host,

--- a/src/lib/shim/shim_shmem.h
+++ b/src/lib/shim/shim_shmem.h
@@ -37,7 +37,8 @@ typedef struct _ShimHostProtectedSharedMem ShimShmemHostLock;
 // parameter are still thread-safe, and internally use atomics.
 
 size_t shimshmemhost_size();
-void shimshmemhost_init(ShimShmemHost* hostMem, Host* host, uint32_t unblockedSyscallLimit);
+void shimshmemhost_init(ShimShmemHost* hostMem, Host* host, uint32_t unblockedSyscallLimit,
+                        SimulationTime unblockedSyscallLatency);
 void shimshmemhost_destroy(ShimShmemHost* hostMem);
 
 ShimShmemHostLock* shimshmemhost_lock(ShimShmemHost* host);
@@ -54,8 +55,8 @@ void shimshmem_setEmulatedTime(ShimShmemHost* hostMem, EmulatedTime t);
 
 // Get and set the *max* emulated time to which the current time can be incremented.
 // Moving time beyond this value requires the current thread to be rescheduled.
-EmulatedTime shimshmem_getMaxEmulatedTime(ShimShmemHost* hostMem);
-void shimshmem_setMaxEmulatedTime(ShimShmemHost* hostMem, EmulatedTime t);
+EmulatedTime shimshmem_getMaxRunaheadTime(ShimShmemHostLock* hostMem);
+void shimshmem_setMaxRunaheadTime(ShimShmemHostLock* hostMem, EmulatedTime t);
 
 // Get and set the process's pending signal set.
 shd_kernel_sigset_t shimshmem_getProcessPendingSignals(const ShimShmemHostLock* host,
@@ -121,6 +122,9 @@ void shimshmem_resetUnblockedSyscallCount(ShimShmemHostLock* host);
 // Get the configured maximum unmber of unblocked syscalls to execute before
 // yielding.
 uint32_t shimshmem_unblockedSyscallLimit(ShimShmemHost* host);
+
+// Get the configured latency to emulate for each unblocked syscall.
+SimulationTime shimshmem_unblockedSyscallLatency(ShimShmemHost* host);
 
 // Handle SHD_SHIM_EVENT_CLONE_REQ
 void shim_shmemHandleClone(const ShimEvent* ev);

--- a/src/lib/shim/shim_shmem.h
+++ b/src/lib/shim/shim_shmem.h
@@ -48,9 +48,9 @@ void shimshmemhost_unlock(ShimShmemHost* host, ShimShmemHostLock** protected);
 size_t shimshmemprocess_size();
 void shimshmemprocess_init(ShimShmemProcess* processMem, Process* process);
 
-// Get and set the emulated time. TODO: move up to Host?
-EmulatedTime shimshmem_getEmulatedTime(ShimShmemProcess* processMem);
-void shimshmem_setEmulatedTime(ShimShmemProcess* processMem, EmulatedTime t);
+// Get and set the emulated time.
+EmulatedTime shimshmem_getEmulatedTime(ShimShmemHost* hostMem);
+void shimshmem_setEmulatedTime(ShimShmemHost* hostMem, EmulatedTime t);
 
 // Get and set the process's pending signal set.
 shd_kernel_sigset_t shimshmem_getProcessPendingSignals(const ShimShmemHostLock* host,

--- a/src/lib/shim/shim_shmem.h
+++ b/src/lib/shim/shim_shmem.h
@@ -52,6 +52,11 @@ void shimshmemprocess_init(ShimShmemProcess* processMem, Process* process);
 EmulatedTime shimshmem_getEmulatedTime(ShimShmemHost* hostMem);
 void shimshmem_setEmulatedTime(ShimShmemHost* hostMem, EmulatedTime t);
 
+// Get and set the *max* emulated time to which the current time can be incremented.
+// Moving time beyond this value requires the current thread to be rescheduled.
+EmulatedTime shimshmem_getMaxEmulatedTime(ShimShmemHost* hostMem);
+void shimshmem_setMaxEmulatedTime(ShimShmemHost* hostMem, EmulatedTime t);
+
 // Get and set the process's pending signal set.
 shd_kernel_sigset_t shimshmem_getProcessPendingSignals(const ShimShmemHostLock* host,
                                                        const ShimShmemProcess* process);

--- a/src/lib/shim/shim_sys.c
+++ b/src/lib/shim/shim_sys.c
@@ -18,7 +18,7 @@
 #include "main/host/syscall_numbers.h"
 
 static EmulatedTime _shim_sys_get_time() {
-    ShimShmemProcess* mem = shim_processSharedMem();
+    ShimShmemHost* mem = shim_hostSharedMem();
 
     // If that's unavailable, fail. This can happen during early init.
     if (mem == NULL) {

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -487,7 +487,7 @@ void worker_setCurrentTime(SimulationTime t);
 
 SimulationTime worker_getCurrentTime(void);
 
-void worker_updateMinRunahead(SimulationTime t);
+void worker_updateMinHostRunahead(SimulationTime t);
 
 void _worker_setLastEventTime(SimulationTime t);
 

--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -54,7 +54,7 @@ add_custom_command(OUTPUT wrapper.rs
         --whitelist-function "runConfigHandlers"
         --whitelist-function "rustlogger_new"
 
-        --whitelist-function "workerpool_updateMinRunahead"
+        --whitelist-function "workerpool_updateMinHostRunahead"
 
         --whitelist-function "process_.*"
         --whitelist-function "shadow_logger_getDefault"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1582,7 +1582,7 @@ extern "C" {
     pub fn worker_getNodeBandwidthDown(nodeID: GQuark, ip: in_addr_t) -> guint32;
 }
 extern "C" {
-    pub fn workerpool_updateMinRunahead(pool: *mut WorkerPool, time: SimulationTime);
+    pub fn workerpool_updateMinHostRunahead(pool: *mut WorkerPool, time: SimulationTime);
 }
 extern "C" {
     pub fn worker_getLatencyForAddresses(
@@ -1656,7 +1656,7 @@ extern "C" {
     pub fn worker_setActiveThread(thread: *mut Thread);
 }
 extern "C" {
-    pub fn worker_updateMinRunahead(t: SimulationTime);
+    pub fn worker_updateMinHostRunahead(t: SimulationTime);
 }
 extern "C" {
     pub fn process_registerCompatDescriptor(

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1564,6 +1564,9 @@ extern "C" {
     pub fn worker_isAlive() -> bool;
 }
 extern "C" {
+    pub fn worker_maxEventRunaheadTime(host: *mut Host) -> EmulatedTime;
+}
+extern "C" {
     pub fn worker_getCurrentTime() -> SimulationTime;
 }
 extern "C" {

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -253,6 +253,16 @@ gboolean scheduler_push(Scheduler* scheduler, Event* event, Host* sender, Host* 
     return TRUE;
 }
 
+EmulatedTime scheduler_nextHostEventTime(Scheduler* scheduler, Host* host) {
+    MAGIC_ASSERT(scheduler);
+
+    if (!scheduler->policy->nextHostEventTime) {
+        /* TODO: implement for remaining schedulers or remove them. */
+        panic("scheduler_nextHostEventTime not implemented for scheduler type %d", scheduler->policy->type);
+    }
+    return scheduler->policy->nextHostEventTime(scheduler->policy, host);
+}
+
 int scheduler_addHost(Scheduler* scheduler, Host* host) {
     MAGIC_ASSERT(scheduler);
 

--- a/src/main/core/scheduler/scheduler.h
+++ b/src/main/core/scheduler/scheduler.h
@@ -33,6 +33,8 @@ void scheduler_finish(Scheduler*);
 
 gboolean scheduler_push(Scheduler*, Event*, Host* sender, Host* receiver);
 Event* scheduler_pop(Scheduler*);
+// Scheduled time of next event for `host`, or 0 if there is none.
+EmulatedTime scheduler_nextHostEventTime(Scheduler*, Host* host);
 
 int scheduler_addHost(Scheduler*, Host*);
 Host* scheduler_getHost(Scheduler*, GQuark);

--- a/src/main/core/scheduler/scheduler_policy.h
+++ b/src/main/core/scheduler/scheduler_policy.h
@@ -17,6 +17,7 @@ typedef void (*SchedulerPolicyAddHostFunc)(SchedulerPolicy*, Host*, pthread_t);
 typedef GQueue* (*SchedulerPolicyGetHostsFunc)(SchedulerPolicy*);
 typedef void (*SchedulerPolicyPushFunc)(SchedulerPolicy*, Event*, Host*, Host*, SimulationTime);
 typedef Event* (*SchedulerPolicyPopFunc)(SchedulerPolicy*, SimulationTime);
+typedef EmulatedTime (*SchedulerPolicyNextHostEventTimeFunc)(SchedulerPolicy*, Host*);
 typedef SimulationTime (*SchedulerPolicyGetNextTimeFunc)(SchedulerPolicy*);
 typedef void (*SchedulerPolicyFreeFunc)(SchedulerPolicy*);
 
@@ -28,6 +29,7 @@ struct _SchedulerPolicy {
     SchedulerPolicyGetHostsFunc getAssignedHosts;
     SchedulerPolicyPushFunc push;
     SchedulerPolicyPopFunc pop;
+    SchedulerPolicyNextHostEventTimeFunc nextHostEventTime;
     SchedulerPolicyGetNextTimeFunc getNextTime;
     SchedulerPolicyFreeFunc free;
     MAGIC_DECLARE;

--- a/src/main/core/scheduler/scheduler_policy_thread_single.c
+++ b/src/main/core/scheduler/scheduler_policy_thread_single.c
@@ -67,7 +67,9 @@ static void _schedulerpolicythreadsingle_addHost(SchedulerPolicy* policy, Host* 
     }
     g_queue_push_tail(tdata->assignedHosts2, host);
 
-    /* finally, store the host-to-thread mapping */
+    /* finally, store the host-to-thread mapping. TODO: simplify, since this
+     * each scheduler instance of this type only ever has a single host. */
+    utility_assert(g_hash_table_size(data->hostToThreadMap) == 0);
     g_hash_table_replace(data->hostToThreadMap, host, GUINT_TO_POINTER(assignedThread));
 }
 
@@ -106,6 +108,27 @@ static void _schedulerpolicythreadsingle_push(SchedulerPolicy* policy, Event* ev
     priorityqueue_push(tdata->pq, event);
     tdata->nPushed++;
     g_mutex_unlock(&(tdata->lock));
+}
+
+static EmulatedTime _schedulerpolicythreadsingle_nextHostEventTime(SchedulerPolicy* policy, Host* host) {
+    MAGIC_ASSERT(policy);
+    ThreadSinglePolicyData* data = policy->data;
+
+    /* Get the data for our host */
+    ThreadSingleThreadData* tdata =
+        g_hash_table_lookup(data->threadToThreadDataMap, GUINT_TO_POINTER(pthread_self()));
+    utility_assert(tdata);
+
+    EmulatedTime nextEventTime = 0;
+    g_mutex_lock(&(tdata->lock));
+    Event* nextEvent = priorityqueue_peek(tdata->pq);
+    if (nextEvent) {
+        utility_assert(event_getHost(nextEvent) == host);
+        nextEventTime = event_getTime(nextEvent) + EMULATED_TIME_OFFSET;
+    }
+    g_mutex_unlock(&(tdata->lock));
+
+    return nextEventTime;
 }
 
 static Event* _schedulerpolicythreadsingle_pop(SchedulerPolicy* policy, SimulationTime barrier) {
@@ -182,6 +205,7 @@ SchedulerPolicy* schedulerpolicythreadsingle_new() {
     policy->getAssignedHosts = _schedulerpolicythreadsingle_getHosts;
     policy->push = _schedulerpolicythreadsingle_push;
     policy->pop = _schedulerpolicythreadsingle_pop;
+    policy->nextHostEventTime = _schedulerpolicythreadsingle_nextHostEventTime;
     policy->getNextTime = _schedulerpolicythreadsingle_getNextTime;
     policy->free = _schedulerpolicythreadsingle_free;
 

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -508,6 +508,18 @@ gboolean worker_scheduleTask(Task* task, Host* host, SimulationTime nanoDelay) {
     return scheduler_push(_worker_pool()->scheduler, event, host, host);
 }
 
+EmulatedTime worker_maxThreadTime(Host* host) {
+    utility_assert(host);
+    EmulatedTime max = _worker_getRoundEndTime() + EMULATED_TIME_OFFSET;
+
+    EmulatedTime nextEventTime = scheduler_nextHostEventTime(_worker_pool()->scheduler, host);
+    if (nextEventTime != 0) {
+        max = MIN(max, nextEventTime);
+    }
+
+    return max;
+}
+
 static void _worker_runDeliverPacketTask(Host* host, gpointer voidPacket, gpointer userData) {
     Packet* packet = voidPacket;
     in_addr_t ip = packet_getDestinationIP(packet);

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -508,7 +508,7 @@ gboolean worker_scheduleTask(Task* task, Host* host, SimulationTime nanoDelay) {
     return scheduler_push(_worker_pool()->scheduler, event, host, host);
 }
 
-EmulatedTime worker_maxThreadTime(Host* host) {
+EmulatedTime worker_maxEventRunaheadTime(Host* host) {
     utility_assert(host);
     EmulatedTime max = _worker_getRoundEndTime() + EMULATED_TIME_OFFSET;
 

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -560,7 +560,7 @@ void worker_sendPacket(Host* srcHost, Packet* packet) {
     if (bootstrapping || chance <= reliability || packet_getPayloadLength(packet) == 0) {
         /* the sender's packet will make it through, find latency */
         SimulationTime delay = worker_getLatencyForAddresses(srcAddress, dstAddress);
-        worker_updateMinRunahead(delay);
+        worker_updateMinHostRunahead(delay);
         SimulationTime deliverTime = worker_getCurrentTime() + delay;
 
         worker_incrementPacketCount(srcAddress, dstAddress);
@@ -632,7 +632,7 @@ guint32 worker_getNodeBandwidthDown(GQuark nodeID, in_addr_t ip) {
     return manager_getNodeBandwidthDown(_worker_pool()->manager, nodeID, ip);
 }
 
-void workerpool_updateMinRunahead(WorkerPool* pool, SimulationTime time) {
+void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time) {
     manager_updateMinRunahead(pool->manager, time);
 }
 

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -76,8 +76,8 @@ const ConfigOptions* worker_getConfig();
 gboolean worker_scheduleTask(Task* task, Host* host, SimulationTime nanoDelay);
 void worker_sendPacket(Host* src, Packet* packet);
 bool worker_isAlive(void);
-// Maximum time that the current thread may run ahead to.
-EmulatedTime worker_maxThreadTime(Host* host);
+// Maximum time that the current event may run ahead to.
+EmulatedTime worker_maxEventRunaheadTime(Host* host);
 
 SimulationTime worker_getCurrentTime();
 EmulatedTime worker_getEmulatedTime();

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -86,7 +86,7 @@ bool worker_isBootstrapActive(void);
 guint32 worker_getNodeBandwidthUp(GQuark nodeID, in_addr_t ip);
 guint32 worker_getNodeBandwidthDown(GQuark nodeID, in_addr_t ip);
 
-void workerpool_updateMinRunahead(WorkerPool* pool, SimulationTime time);
+void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time);
 SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress);
 SimulationTime worker_getLatency(GQuark sourceHostID, GQuark destinationHostID);
 gdouble worker_getReliabilityForAddresses(Address* sourceAddress, Address* destinationAddress);

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -76,6 +76,8 @@ const ConfigOptions* worker_getConfig();
 gboolean worker_scheduleTask(Task* task, Host* host, SimulationTime nanoDelay);
 void worker_sendPacket(Host* src, Packet* packet);
 bool worker_isAlive(void);
+// Maximum time that the current thread may run ahead to.
+EmulatedTime worker_maxThreadTime(Host* host);
 
 SimulationTime worker_getCurrentTime();
 EmulatedTime worker_getEmulatedTime();

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -211,7 +211,7 @@ impl Worker {
         Worker::with_mut(|w| w.clock.last.replace(t)).unwrap();
     }
 
-    pub fn update_min_runahead(t: Duration) {
+    pub fn update_min_host_runahead(t: Duration) {
         assert!(!t.is_zero());
 
         Worker::with(|w| {
@@ -219,7 +219,7 @@ impl Worker {
             if min_latency_cache.is_none() || t < min_latency_cache.unwrap() {
                 w.min_latency_cache.set(Some(t));
                 unsafe {
-                    cshadow::workerpool_updateMinRunahead(
+                    cshadow::workerpool_updateMinHostRunahead(
                         w.worker_pool,
                         SimulationTime::to_c_simtime(Some(t.into())),
                     )
@@ -359,8 +359,8 @@ mod export {
     }
 
     #[no_mangle]
-    pub extern "C" fn worker_updateMinRunahead(t: cshadow::SimulationTime) {
-        Worker::update_min_runahead(*SimulationTime::from_c_simtime(t).unwrap());
+    pub extern "C" fn worker_updateMinHostRunahead(t: cshadow::SimulationTime) {
+        Worker::update_min_host_runahead(*SimulationTime::from_c_simtime(t).unwrap());
     }
 
     #[no_mangle]

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -103,6 +103,9 @@ struct _Host {
 static uint32_t _unblockedSyscallLimit = 0;
 ADD_CONFIG_HANDLER(config_getUnblockedSyscallLimit, _unblockedSyscallLimit)
 
+static SimulationTime _unblockedSyscallLatency;
+ADD_CONFIG_HANDLER(config_getUnblockedSyscallLatency, _unblockedSyscallLatency)
+
 /* this function is called by manager before the workers exist */
 Host* host_new(HostParameters* params) {
     utility_assert(params);
@@ -137,7 +140,7 @@ Host* host_new(HostParameters* params) {
          g_quark_to_string(host->params.id));
 
     host->shimSharedMemBlock = shmemallocator_globalAlloc(shimshmemhost_size());
-    shimshmemhost_init(host_getSharedMem(host), host, _unblockedSyscallLimit);
+    shimshmemhost_init(host_getSharedMem(host), host, _unblockedSyscallLimit, _unblockedSyscallLatency);
 
     host->processIDCounter = 1000;
     host->referenceCount = 1;

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -171,7 +171,10 @@ ShimShmemProcess* process_getSharedMem(Process* proc) {
 }
 
 static void _process_setSharedTime(Process* proc) {
-    shimshmem_setEmulatedTime(host_getSharedMem(proc->host), worker_getEmulatedTime());
+    EmulatedTime now = worker_getEmulatedTime();
+
+    shimshmem_setMaxEmulatedTime(host_getSharedMem(proc->host), worker_maxThreadTime(proc->host));
+    shimshmem_setEmulatedTime(host_getSharedMem(proc->host), now);
 }
 
 const gchar* process_getName(Process* proc) {

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -171,7 +171,7 @@ ShimShmemProcess* process_getSharedMem(Process* proc) {
 }
 
 static void _process_setSharedTime(Process* proc) {
-    shimshmem_setEmulatedTime(process_getSharedMem(proc), worker_getEmulatedTime());
+    shimshmem_setEmulatedTime(host_getSharedMem(proc->host), worker_getEmulatedTime());
 }
 
 const gchar* process_getName(Process* proc) {

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -170,11 +170,12 @@ ShimShmemProcess* process_getSharedMem(Process* proc) {
     return proc->shimSharedMemBlock.p;
 }
 
+// FIXME: still needed? Time is now updated more granularly in the Thread code
+// when xferring control to/from shim.
 static void _process_setSharedTime(Process* proc) {
-    EmulatedTime now = worker_getEmulatedTime();
-
-    shimshmem_setMaxEmulatedTime(host_getSharedMem(proc->host), worker_maxThreadTime(proc->host));
-    shimshmem_setEmulatedTime(host_getSharedMem(proc->host), now);
+    shimshmem_setMaxRunaheadTime(
+        host_getShimShmemLock(proc->host), worker_maxEventRunaheadTime(proc->host));
+    shimshmem_setEmulatedTime(host_getSharedMem(proc->host), worker_getEmulatedTime());
 }
 
 const gchar* process_getName(Process* proc) {

--- a/src/test/golang/test_intercept_golang_time.go
+++ b/src/test/golang/test_intercept_golang_time.go
@@ -6,12 +6,13 @@ import (
 )
 
 // Validate that time is being intercepted.
-// Won't pass natively.
+// Won't pass natively. (At least without resetting the system clock)
 func main() {
-	var t0 = time.Now()
-	var t1 = time.Now()
-
-	if t0 != t1 {
-		panic(fmt.Sprint(t0, " != ", t1))
+	var shadowSimStartTime = time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC)
+	var now = time.Now()
+	var dt = now.Sub(shadowSimStartTime)
+	var maxDelta, _ = time.ParseDuration("5m")
+	if dt > maxDelta {
+		panic(fmt.Sprint("Time is now ", now, "; ", dt, " since sim start of ", shadowSimStartTime))
 	}
 }

--- a/src/test/regression/busy_wait.yaml
+++ b/src/test/regression/busy_wait.yaml
@@ -4,7 +4,7 @@ general:
   stop_time: 15s
 
 experimental:
-  unblocked_syscall_limit: 500
+  unblocked_syscall_limit: 1
 
 network:
   graph:

--- a/src/test/regression/exit_after_signal_sched.yaml
+++ b/src/test/regression/exit_after_signal_sched.yaml
@@ -3,6 +3,9 @@ general:
 network:
   graph:
     type: 1_gbit_switch
+experimental:
+  # This test needs precise control over when its threads run.
+  unblocked_syscall_latency: 0
 hosts:
   testnode:
     network_node_id: 0

--- a/src/test/regression/signal_resched.yaml
+++ b/src/test/regression/signal_resched.yaml
@@ -3,6 +3,9 @@ general:
 network:
   graph:
     type: 1_gbit_switch
+experimental:
+  # This test needs precise control over when its threads run.
+  unblocked_syscall_latency: 0
 hosts:
   testnode:
     network_node_id: 0


### PR DESCRIPTION
* Add a scheduler API `scheduler_nextHostEventTime` to peek at the time of the next scheduled event for a given Host. I only implemented this for the couple schedulers we use in practice - the others panic if this API is called. I could implement this API for the other schedulers, but it doesn't seem worth it since we don't currently use them, and plan to remove them.
* Allow time to be moved forward during the execution of an event. Use this to account for unblocked syscall latency without having to schedule a new event, or without even having to context switch from the shim to Shadow, as long as the maximum runahead time isn't exceeded. The max runahead time is the first of: the time of the next event scheduled for the current host, and the end of the current scheduler round.
* Update tests so that all tests pass when the default `--unblocked-syscall-limit` is 1 instead of its current default of 0; i.e. when moving time forward on every unblocked syscall is enabled by default. This PR doesn't actually change the default, though.