### PR TITLE
Changed `SharedBuf` to use a new `BufferState` rather than `FileState`

### DIFF
--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -96,6 +96,7 @@ impl FileMode {
 }
 
 bitflags::bitflags! {
+    #[derive(Default)]
     pub struct FileState: libc::c_int {
         /// Has been initialized and it is now OK to unblock any plugin waiting
         /// on a particular state.


### PR DESCRIPTION
Previously the `SharedBuf` used the `FileState::READABLE` state to indicate that the buffer was readable or that it had no writers (and a similar behaviour for the `FileState::WRITABLE` state). This is the behaviour expected by pipes (ex: a pipe should always be readable when there are no writers), but is not the behaviour expected by unix sockets (ex: a unix socket should *not* always be readable when there are no connected sockets). With the new state type `BufferState`, there are two new state flags `NO_READERS` and `NO_WRITERS`. So the object (a pipe or unix socket) using the buffer can listen for the `READABLE`, `WRITABLE`, `NO_READERS`, and `NO_WRITERS` state flags individually (or not at all). For example, unix sockets would ignore these two new flags.