### PR TITLE
Update syscall latency modeling default parameters

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -350,7 +350,7 @@ Which interposition method to use.
 
 #### `experimental.max_unapplied_cpu_latency`
 
-Default: "10 microseconds"  
+Default: "1 microsecond"  
 Type: String
 
 Max amount of execution-time latency allowed to accumulate before the clock is
@@ -444,7 +444,7 @@ Limitations:
 
 #### `experimental.unblocked_syscall_latency`
 
-Default: "2 microseconds"  
+Default: "1 microseconds"  
 Type: String
 
 The simulated latency of an unblocked syscall. For simulation efficiency, this
@@ -456,7 +456,7 @@ is false.
 
 #### `experimental.unblocked_vdso_latency`
 
-Default: "100 nanoseconds"  
+Default: "10 nanoseconds"  
 Type: String
 
 The simulated latency of an unblocked vdso function. For simulation efficiency, this

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -440,10 +440,8 @@ pub struct ExperimentalOptions {
     /// expensive operation, so larger values reduce simulation overhead, at the
     /// cost of coarser time jumps. Note also that accumulated-but-unapplied
     /// latency is discarded when a thread is blocked on a syscall.
-    ///
-    /// 0 to never account for CPU latency.
     #[clap(hide_short_help = true)]
-    #[clap(long, value_name = "count")]
+    #[clap(long, value_name = "seconds")]
     #[clap(help = EXP_HELP.get("max_unapplied_cpu_latency").unwrap().as_str())]
     pub max_unapplied_cpu_latency: Option<units::Time<units::TimePrefix>>,
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -448,7 +448,7 @@ pub struct ExperimentalOptions {
     pub max_unapplied_cpu_latency: Option<units::Time<units::TimePrefix>>,
 
     /// Simulated latency of an unblocked syscall. For efficiency Shadow only
-    /// actually adds this latency if and when `unblocked_syscall_limit` is
+    /// actually adds this latency if and when `max_unapplied_cpu_latency` is
     /// reached.
     #[clap(hide_short_help = true)]
     #[clap(long, value_name = "seconds")]
@@ -456,7 +456,7 @@ pub struct ExperimentalOptions {
     pub unblocked_syscall_latency: Option<units::Time<units::TimePrefix>>,
 
     /// Simulated latency of a vdso "syscall". For efficiency Shadow only
-    /// actually adds this latency if and when `unblocked_syscall_limit` is
+    /// actually adds this latency if and when `max_unapplied_cpu_latency` is
     /// reached.
     #[clap(long, value_name = "seconds")]
     #[clap(help = EXP_HELP.get("unblocked_vdso_latency").unwrap().as_str())]

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -491,12 +491,14 @@ impl Default for ExperimentalOptions {
             use_preload_openssl_rng: Some(true),
             use_preload_openssl_crypto: Some(false),
             preload_spin_max: Some(0),
-            max_unapplied_cpu_latency: Some(units::Time::new(10, units::TimePrefix::Micro)),
-            // 2 microseconds is a ballpark estimate of the minimal latency for
+            max_unapplied_cpu_latency: Some(units::Time::new(1, units::TimePrefix::Micro)),
+            // 1-2 microseconds is a ballpark estimate of the minimal latency for
             // context switching to the kernel and back on modern machines.
-            unblocked_syscall_latency: Some(units::Time::new(2, units::TimePrefix::Micro)),
+            // Default to the lower end to minimize effect in simualations without busy loops.
+            unblocked_syscall_latency: Some(units::Time::new(1, units::TimePrefix::Micro)),
             // Actual latencies vary from ~40 to ~400 CPU cycles. https://stackoverflow.com/a/13096917
-            unblocked_vdso_latency: Some(units::Time::new(100, units::TimePrefix::Nano)),
+            // Default to the lower end to minimize effect in simualations without busy loops.
+            unblocked_vdso_latency: Some(units::Time::new(10, units::TimePrefix::Nano)),
             use_memory_manager: Some(true),
             use_shim_syscall_handler: Some(true),
             use_cpu_pinning: Some(true),


### PR DESCRIPTION
Update defaults for syscall latency modeling    
    
These defaults significantly improve simulation performance of our test snowflake simulation. On my machine it brings the simulation time down from 55s to 33s. See https://github.com/shadow/shadow/issues/2046#issuecomment-1105765653 through https://github.com/shadow/shadow/issues/2046#issuecomment-1105821624                                
    
This decrease in max-unapplied-cpu-latency does appear to make tor *simulated* performance worse, but not tor *simulation* performance.  i.e. it doesn't make the simulation take longer, but it results in higher transfer latencies and lower goodput. This could use further investigation, especially before defaulting latency modeling on as a whole, but doesn't seem necessarily incorrect. See https://github.com/shadow/shadow/issues/2046#issuecomment-1110414532
