### PR TITLE
Continued reorganization of the unix socket code

### DIFF
--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -234,3 +234,12 @@ impl std::fmt::Debug for SocketFileRefMut<'_> {
         )
     }
 }
+
+/// Returns a nix socket address object where only the family is set.
+pub fn empty_sockaddr(family: nix::sys::socket::AddressFamily) -> nix::sys::socket::SockAddr {
+    let family = family as libc::sa_family_t;
+    let mut addr: nix::sys::socket::sockaddr_storage = unsafe { std::mem::zeroed() };
+    addr.ss_family = family;
+    // the size of ss_family will be 2 bytes on linux
+    nix::sys::socket::sockaddr_storage_to_addr(&addr, 2).unwrap()
+}

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -713,24 +713,6 @@ impl Protocol for ConnOrientedInitial {
         common.ioctl(request, arg_ptr, memory_manager)
     }
 
-    fn connect(
-        &mut self,
-        common: &mut UnixSocketCommon,
-        socket: &Arc<AtomicRefCell<UnixSocketFile>>,
-        addr: nix::sys::socket::UnixAddr,
-        send_buffer: Arc<AtomicRefCell<SharedBuf>>,
-        event_queue: &mut EventQueue,
-    ) -> Result<(), SyscallError> {
-        assert!(self.peer_addr.is_none());
-        self.peer_addr = Some(addr);
-
-        self.send_buffer_event_handle =
-            Some(common.connect_buffer(socket, &send_buffer, event_queue));
-        self.send_buffer = Some(send_buffer);
-
-        Ok(())
-    }
-
     fn connect_unnamed(
         &mut self,
         common: &mut UnixSocketCommon,


### PR DESCRIPTION
More work on reorganizing the unix sockets. This PR begins moving some unix socket data from the `UnixSocketCommon` into the specific states. This also reorganizes some of the socketpair() related code, and removes the broken connect() implementation for connection-oriented unix sockets.