### PR TITLE
Added 'must_use' attr to event 'Handle' object

### DIFF
--- a/src/main/utility/event_queue.rs
+++ b/src/main/utility/event_queue.rs
@@ -49,6 +49,7 @@ impl EventQueue {
 #[derive(Clone, Copy, PartialEq, PartialOrd)]
 struct HandleId(u32);
 
+#[must_use = "Stops listening when the handle is dropped"]
 /// A handle allows you to stop listening for events.
 pub struct Handle<T> {
     id: HandleId,


### PR DESCRIPTION
The listener is removed when the handle is dropped, so if the handle returned from an expression isn't used then it's likely an error.