### PR TITLE
Calculate host RNG seeds more consistently

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -634,13 +634,10 @@ configuration, with the field name being used as the network hostname.
 
 Shadow assigns each host to a network node in the [network graph](network_graph_overview.md).
 
-When Shadow iterates over these hosts, Shadow iterates over them in the order
-of their sorted hostnames. While this implementation detail is generally
-unimportant, it's important to note that Shadow assigns each host its own RNG.
-These host-specific RNGs are seeded from a global RNG, so the seed used for
-each host depends on the order that Shadow iterates over the hosts. This means
-that changing a hostname or adding a new host may change the seed used for the
-hosts' RNGs, and may subtly affect the simulation results.
+In Shadow, each host is given an RNG whose seed is derived from the global seed
+([`general.seed`](#generalseed)) and the hostname. This means that changing a
+host's name will change that host's RNG seed, subtly affecting the simulation
+results.
 
 #### `hosts.<hostname>.bandwidth_down`
 

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -446,7 +446,6 @@ int manager_addNewVirtualHost(Manager* manager, HostParameters* params) {
 
     /* quarks are unique per manager process, so do the conversion here */
     params->id = g_quark_from_string(params->hostname);
-    params->nodeSeed = _manager_nextRandomUInt(manager);
 
     Host* host = host_new(params);
     host_setup(host, manager_getDNS(manager), manager_getRawCPUFrequency(manager),


### PR DESCRIPTION
Host RNG seeds now vary only based on their hostname (and the global seed) and not the order of hosts. This means you can add or remove hosts without affecting the seeds of other hosts.

@robgjansen You told me not to work on this for 2.1, but I wrote it on a plane so I don't think it counts :)

(I did check that each host was being given a different seed.)

Closes #2074.