### PR TITLE
Add "#[allow(deprecated)]" wherever we use deprecated nix socket address types/fns

### DIFF
--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -10,6 +10,8 @@ use crate::utility::event_queue::EventQueue;
 
 use unix::UnixSocketFile;
 
+// https://github.com/shadow/shadow/issues/2093
+#[allow(deprecated)]
 use nix::sys::socket::SockAddr;
 
 pub mod abstract_unix_ns;
@@ -51,6 +53,8 @@ impl SocketFile {
         }
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     pub fn bind(
         socket: &Self,
         addr: Option<&nix::sys::socket::SockAddr>,
@@ -110,12 +114,16 @@ impl SocketFileRef<'_> {
 
 // socket-specific functions
 impl SocketFileRef<'_> {
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     pub fn get_peer_address(&self) -> Option<SockAddr> {
         match self {
             Self::Unix(socket) => socket.get_peer_address().map(|x| SockAddr::Unix(x)),
         }
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     pub fn get_bound_address(&self) -> Option<SockAddr> {
         match self {
             Self::Unix(socket) => socket.get_bound_address().map(|x| SockAddr::Unix(x)),
@@ -176,12 +184,16 @@ impl SocketFileRefMut<'_> {
 
 // socket-specific functions
 impl SocketFileRefMut<'_> {
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     pub fn get_peer_address(&self) -> Option<SockAddr> {
         match self {
             Self::Unix(socket) => socket.get_peer_address().map(|x| SockAddr::Unix(x)),
         }
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     pub fn get_bound_address(&self) -> Option<SockAddr> {
         match self {
             Self::Unix(socket) => socket.get_bound_address().map(|x| SockAddr::Unix(x)),
@@ -193,12 +205,16 @@ impl SocketFileRefMut<'_> {
     );
 
     enum_passthrough_generic!(self, (source, addr, event_queue), Unix;
+        // https://github.com/shadow/shadow/issues/2093
+        #[allow(deprecated)]
         pub fn sendto<R>(&mut self, source: R, addr: Option<nix::sys::socket::SockAddr>, event_queue: &mut EventQueue)
             -> SyscallResult
         where R: std::io::Read + std::io::Seek
     );
 
     enum_passthrough_generic!(self, (bytes, event_queue), Unix;
+        // https://github.com/shadow/shadow/issues/2093
+        #[allow(deprecated)]
         pub fn recvfrom<W>(&mut self, bytes: W, event_queue: &mut EventQueue)
             -> Result<(SysCallReg, Option<nix::sys::socket::SockAddr>), SyscallError>
         where W: std::io::Write + std::io::Seek
@@ -236,6 +252,8 @@ impl std::fmt::Debug for SocketFileRefMut<'_> {
 }
 
 /// Returns a nix socket address object where only the family is set.
+// https://github.com/shadow/shadow/issues/2093
+#[allow(deprecated)]
 pub fn empty_sockaddr(family: nix::sys::socket::AddressFamily) -> nix::sys::socket::SockAddr {
     let family = family as libc::sa_family_t;
     let mut addr: nix::sys::socket::sockaddr_storage = unsafe { std::mem::zeroed() };

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -136,6 +136,8 @@ impl UnixSocketFile {
         self.protocol_state.close(&mut self.common, event_queue)
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     pub fn bind(
         socket: &Arc<AtomicRefCell<Self>>,
         addr: Option<&nix::sys::socket::SockAddr>,
@@ -177,6 +179,8 @@ impl UnixSocketFile {
         panic!("Called UnixSocketFile::write() on a unix socket");
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     pub fn sendto<R>(
         &mut self,
         bytes: R,
@@ -190,6 +194,8 @@ impl UnixSocketFile {
             .sendto(&mut self.common, bytes, addr, event_queue)
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     pub fn recvfrom<W>(
         &mut self,
         bytes: W,
@@ -392,6 +398,8 @@ impl ProtocolState {
         rv
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn bind(
         &mut self,
         common: &mut UnixSocketCommon,
@@ -408,6 +416,8 @@ impl ProtocolState {
         }
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn sendto<R>(
         &mut self,
         common: &mut UnixSocketCommon,
@@ -435,6 +445,8 @@ impl ProtocolState {
         }
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn recvfrom<W>(
         &mut self,
         common: &mut UnixSocketCommon,
@@ -592,6 +604,8 @@ where
         (self.into(), Err(Errno::EOPNOTSUPP.into()))
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn bind(
         &mut self,
         _common: &mut UnixSocketCommon,
@@ -603,6 +617,8 @@ where
         Err(Errno::EOPNOTSUPP.into())
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn sendto<R>(
         &mut self,
         _common: &mut UnixSocketCommon,
@@ -617,6 +633,8 @@ where
         Err(Errno::EOPNOTSUPP.into())
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn recvfrom<W>(
         &mut self,
         _common: &mut UnixSocketCommon,
@@ -689,6 +707,8 @@ impl Protocol for ConnOrientedInitial {
         (new_state.into(), common.close(event_queue))
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn bind(
         &mut self,
         common: &mut UnixSocketCommon,
@@ -705,6 +725,8 @@ impl Protocol for ConnOrientedInitial {
         Ok(0.into())
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn sendto<R>(
         &mut self,
         common: &mut UnixSocketCommon,
@@ -726,6 +748,8 @@ impl Protocol for ConnOrientedInitial {
         }
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn recvfrom<W>(
         &mut self,
         common: &mut UnixSocketCommon,
@@ -780,10 +804,14 @@ impl Protocol for ConnOrientedInitial {
 }
 
 impl Protocol for ConnOrientedConnected {
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn peer_address(&self) -> Option<nix::sys::socket::UnixAddr> {
         Some(self.peer_addr)
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn bound_address(&self) -> Option<nix::sys::socket::UnixAddr> {
         self.bound_addr
     }
@@ -800,6 +828,8 @@ impl Protocol for ConnOrientedConnected {
         (new_state.into(), common.close(event_queue))
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn sendto<R>(
         &mut self,
         common: &mut UnixSocketCommon,
@@ -813,6 +843,8 @@ impl Protocol for ConnOrientedConnected {
         common.sendto(bytes, Some(&self.send_buffer), addr, event_queue)
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn recvfrom<W>(
         &mut self,
         common: &mut UnixSocketCommon,
@@ -837,10 +869,14 @@ impl Protocol for ConnOrientedConnected {
 }
 
 impl Protocol for ConnOrientedClosed {
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn peer_address(&self) -> Option<nix::sys::socket::UnixAddr> {
         None
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn bound_address(&self) -> Option<nix::sys::socket::UnixAddr> {
         None
     }
@@ -856,10 +892,14 @@ impl Protocol for ConnOrientedClosed {
 }
 
 impl Protocol for ConnLessInitial {
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn peer_address(&self) -> Option<nix::sys::socket::UnixAddr> {
         self.peer_addr
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn bound_address(&self) -> Option<nix::sys::socket::UnixAddr> {
         self.bound_addr
     }
@@ -878,6 +918,8 @@ impl Protocol for ConnLessInitial {
         (new_state.into(), common.close(event_queue))
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn bind(
         &mut self,
         common: &mut UnixSocketCommon,
@@ -894,6 +936,8 @@ impl Protocol for ConnLessInitial {
         Ok(0.into())
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn sendto<R>(
         &mut self,
         common: &mut UnixSocketCommon,
@@ -907,6 +951,8 @@ impl Protocol for ConnLessInitial {
         common.sendto(bytes, self.send_buffer.as_ref(), addr, event_queue)
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn recvfrom<W>(
         &mut self,
         common: &mut UnixSocketCommon,
@@ -929,6 +975,8 @@ impl Protocol for ConnLessInitial {
         common.ioctl(request, arg_ptr, memory_manager)
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn connect(
         mut self,
         common: &mut UnixSocketCommon,
@@ -971,10 +1019,14 @@ impl Protocol for ConnLessInitial {
 }
 
 impl Protocol for ConnLessClosed {
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn peer_address(&self) -> Option<nix::sys::socket::UnixAddr> {
         None
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     fn bound_address(&self) -> Option<nix::sys::socket::UnixAddr> {
         None
     }
@@ -1021,6 +1073,8 @@ impl UnixSocketCommon {
         Ok(())
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     pub fn bind(
         &mut self,
         socket: &Arc<AtomicRefCell<UnixSocketFile>>,
@@ -1075,6 +1129,8 @@ impl UnixSocketCommon {
         Ok(bound_addr)
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     pub fn sendto<R>(
         &mut self,
         mut bytes: R,
@@ -1160,6 +1216,8 @@ impl UnixSocketCommon {
         }
     }
 
+    // https://github.com/shadow/shadow/issues/2093
+    #[allow(deprecated)]
     pub fn recvfrom<W>(
         &mut self,
         mut bytes: W,
@@ -1299,6 +1357,8 @@ impl std::fmt::Display for UnixSocketTypeConversionError {
 
 fn empty_unix_sockaddr() -> nix::sys::socket::UnixAddr {
     match empty_sockaddr(nix::sys::socket::AddressFamily::Unix) {
+        // https://github.com/shadow/shadow/issues/2093
+        #[allow(deprecated)]
         nix::sys::socket::SockAddr::Unix(x) => x,
         x => panic!("Unexpected socket address type: {:?}", x),
     }

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -812,6 +812,8 @@ impl SyscallHandler {
 /// length pointers are NULL. The plugin's address length will be updated to store the size of the
 /// socket address, even if greater than the provided buffer size. If the address is `None`, the
 /// plugin's address length will be set to 0.
+// https://github.com/shadow/shadow/issues/2093
+#[allow(deprecated)]
 fn write_sockaddr(
     mem: &mut MemoryManager,
     addr: Option<nix::sys::socket::SockAddr>,
@@ -868,6 +870,8 @@ fn write_sockaddr(
 /// Reads a sockaddr pointer from the plugin. Returns `None` if the pointer is null, otherwise
 /// returns a nix `SockAddr`. The address length must be at most the size of
 /// [`nix::sys::socket::sockaddr_storage`].
+// https://github.com/shadow/shadow/issues/2093
+#[allow(deprecated)]
 fn read_sockaddr(
     mem: &MemoryManager,
     addr_ptr: PluginPtr,
@@ -1011,6 +1015,8 @@ mod tests {
         let corrected_addr_len = sockaddr_storage_len_workaround(&addr, addr_len);
         assert_eq!(corrected_addr_len, 5);
 
+        // https://github.com/shadow/shadow/issues/2093
+        #[allow(deprecated)]
         nix::sys::socket::sockaddr_storage_to_addr(&addr, corrected_addr_len).unwrap();
     }
 
@@ -1045,6 +1051,8 @@ mod tests {
         let corrected_addr_len = sockaddr_storage_len_workaround(&addr, addr_len);
         assert_eq!(corrected_addr_len, 5);
 
+        // https://github.com/shadow/shadow/issues/2093
+        #[allow(deprecated)]
         nix::sys::socket::sockaddr_storage_to_addr(&addr, corrected_addr_len).unwrap();
     }
 
@@ -1061,6 +1069,8 @@ mod tests {
         let corrected_addr_len = sockaddr_storage_len_workaround(&addr, addr_len);
         assert!(corrected_addr_len <= addr_len);
 
+        // https://github.com/shadow/shadow/issues/2093
+        #[allow(deprecated)]
         nix::sys::socket::sockaddr_storage_to_addr(&addr, corrected_addr_len).unwrap();
     }
 
@@ -1092,6 +1102,8 @@ mod tests {
         let corrected_addr_len = sockaddr_storage_len_workaround(&addr, addr_len);
         assert!(corrected_addr_len <= addr_len);
 
+        // https://github.com/shadow/shadow/issues/2093
+        #[allow(deprecated)]
         nix::sys::socket::sockaddr_storage_to_addr(&addr, corrected_addr_len).unwrap();
     }
 
@@ -1124,6 +1136,8 @@ mod tests {
         let corrected_addr_len = sockaddr_storage_len_workaround(&addr, addr_len);
         assert!(corrected_addr_len <= addr_len);
 
+        // https://github.com/shadow/shadow/issues/2093
+        #[allow(deprecated)]
         nix::sys::socket::sockaddr_storage_to_addr(&addr, corrected_addr_len).unwrap();
     }
 }

--- a/src/main/utility/enum_passthrough.rs
+++ b/src/main/utility/enum_passthrough.rs
@@ -41,7 +41,8 @@ enum_passthrough_generic!(self, (bytes, offset, event_queue), Pipe, Socket;
 ```
 **/
 macro_rules! enum_passthrough_generic {
-    ($self:ident, $args2:tt, $($variant:ident),+; $v:vis fn $name:ident <$($generics:ident),+> $args:tt $(-> $($rv:tt)+)?) => {
+    ($self:ident, $args2:tt, $($variant:ident),+; $(#[$($mac:tt)+])? $v:vis fn $name:ident <$($generics:ident),+> $args:tt $(-> $($rv:tt)+)?) => {
+        $(#[$($mac)+])?
         $v fn $name <$($generics)+> $args $(-> $($rv)+)? {
             match $self {
                 $(
@@ -62,7 +63,8 @@ enum_passthrough_into!(self, (event_queue), Pipe, Socket;
 **/
 
 macro_rules! enum_passthrough_into {
-    ($self:ident, $args2:tt, $($variant:ident),+; $v:vis fn $name:ident $args:tt $(-> $($rv:tt)+)?) => {
+    ($self:ident, $args2:tt, $($variant:ident),+; $(#[$($mac:tt)+])? $v:vis fn $name:ident $args:tt $(-> $($rv:tt)+)?) => {
+        $(#[$($mac)+])?
         $v fn $name $args $(-> $($rv)+)? {
             match $self {
                 $(


### PR DESCRIPTION
I don't know of a nicer way to do this, since I don't see a way to allow *specific* deprecated types/fns globally.

Fixing the deprecation issues is in #2093.