### PR TITLE
Support listen() for unix sockets

### DIFF
--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -104,6 +104,7 @@ add_custom_command(OUTPUT wrapper.rs
         --whitelist-type "ProtocolTCPFlags"
         --whitelist-var "CONFIG_PIPE_BUFFER_SIZE"
         --whitelist-var "SYSCALL_IO_BUFSIZE"
+        --whitelist-var "SHADOW_SOMAXCONN"
         --opaque-type "LegacyDescriptor"
         --opaque-type "CompatDescriptor"
         --opaque-type "OpenFile"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -13,6 +13,7 @@ use crate::host::descriptor::socket::abstract_unix_ns::AbstractUnixNamespace;
 type Arc_AtomicRefCell_AbstractUnixNamespace = Arc<AtomicRefCell<AbstractUnixNamespace>>;
 type HashSet_String = HashSet<String>;
 
+pub const SHADOW_SOMAXCONN: u32 = 4096;
 pub const CONFIG_PIPE_BUFFER_SIZE: u32 = 65536;
 pub const SYSCALL_IO_BUFSIZE: u32 = 10485760;
 pub type size_t = ::std::os::raw::c_ulong;

--- a/src/main/core/support/definitions.h
+++ b/src/main/core/support/definitions.h
@@ -93,6 +93,12 @@ typedef guint64 EmulatedTime;
 #define MIN_RANDOM_PORT 10000
 
 /**
+ * An upper limit to the maximum number of pending incoming connections.
+ * On a laptop: net.core.somaxconn = 4096
+ */
+#define SHADOW_SOMAXCONN 4096
+
+/**
  * We always use TCP_autotuning unless this is set to FALSE
  *
  * @todo change this to a command line option accessible via #Configuration

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -219,6 +219,10 @@ impl SocketFileRefMut<'_> {
             -> Result<(SysCallReg, Option<nix::sys::socket::SockAddr>), SyscallError>
         where W: std::io::Write + std::io::Seek
     );
+
+    enum_passthrough!(self, (backlog, event_queue), Unix;
+        pub fn listen(&mut self, backlog: i32, event_queue: &mut EventQueue) -> Result<(), SyscallError>
+    );
 }
 
 impl std::fmt::Debug for SocketFileRef<'_> {


### PR DESCRIPTION
Added support for the listen() syscall, updated all of the existing listen() tests to test unix sockets, and added a (currently disabled in shadow) additional listen() test.