### PR TITLE
Update socket accept() tests to support unix sockets

### DIFF
--- a/src/test/socket/accept/test_accept.rs
+++ b/src/test/socket/accept/test_accept.rs
@@ -3,12 +3,14 @@
  * See LICENSE for licensing information
  */
 
+use test_utils::socket_utils;
+use test_utils::socket_utils::SockAddr;
 use test_utils::TestEnvironment as TestEnv;
 use test_utils::{set, AsMutPtr};
 
 struct AcceptArguments {
     fd: libc::c_int,
-    addr: Option<libc::sockaddr_in>,
+    addr: Option<SockAddr>,
     addr_len: Option<libc::socklen_t>,
     flags: libc::c_int,
 }
@@ -52,7 +54,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
     for &accept_fn in [AcceptFn::Accept, AcceptFn::Accept4].iter() {
         let append_args = |s| format!("{} <fn={:?}>", s, accept_fn);
 
-        let more_tests: Vec<test_utils::ShadowTest<_, _>> = vec![
+        tests.extend(vec![
             test_utils::ShadowTest::new(
                 &append_args("test_invalid_fd"),
                 move || test_invalid_fd(accept_fn),
@@ -73,9 +75,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                 move || test_invalid_sock_type(accept_fn),
                 set![TestEnv::Libc, TestEnv::Shadow],
             ),
-        ];
-
-        tests.extend(more_tests);
+        ]);
 
         let accept_flags = [
             0,
@@ -84,59 +84,143 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
             libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC,
         ];
 
-        for &sock_flag in [0, libc::SOCK_NONBLOCK, libc::SOCK_CLOEXEC].iter() {
-            for &accept_flag in accept_flags.iter() {
-                // since accept() doesn't accept flags, we should skip them
-                if accept_flag != 0 && accept_fn != AcceptFn::Accept4 {
+        for &domain in [libc::AF_INET, libc::AF_UNIX].iter() {
+            let passing = if domain != libc::AF_UNIX {
+                set![TestEnv::Libc, TestEnv::Shadow]
+            } else {
+                set![TestEnv::Libc] // TODO: enable once we support connect() for unix sockets
+            };
+
+            for &sock_type in [libc::SOCK_STREAM, libc::SOCK_DGRAM, libc::SOCK_SEQPACKET].iter() {
+                // skip tests that use SOCK_SEQPACKET with INET sockets
+                if domain == libc::AF_INET && sock_type == libc::SOCK_SEQPACKET {
                     continue;
                 }
 
-                let append_args = |s| {
-                    format!(
-                        "{} <fn={:?},sock_flag={},accept_flag={:?}>",
-                        s, accept_fn, sock_flag, accept_flag
-                    )
-                };
+                for &sock_flag in [0, libc::SOCK_NONBLOCK, libc::SOCK_CLOEXEC].iter() {
+                    for &accept_flag in accept_flags.iter() {
+                        // since accept() doesn't accept flags, we should skip them
+                        if accept_flag != 0 && accept_fn != AcceptFn::Accept4 {
+                            continue;
+                        }
 
-                let more_tests: Vec<test_utils::ShadowTest<_, _>> = vec![
-                    test_utils::ShadowTest::new(
-                        &append_args("test_non_listening_fd"),
-                        move || test_non_listening_fd(accept_fn, sock_flag, accept_flag),
-                        set![TestEnv::Libc, TestEnv::Shadow],
-                    ),
-                    test_utils::ShadowTest::new(
-                        &append_args("test_null_addr"),
-                        move || test_null_addr(accept_fn, sock_flag, accept_flag),
-                        set![TestEnv::Libc, TestEnv::Shadow],
-                    ),
-                    test_utils::ShadowTest::new(
-                        &append_args("test_null_len"),
-                        move || test_null_len(accept_fn, sock_flag, accept_flag),
-                        set![TestEnv::Libc, TestEnv::Shadow],
-                    ),
-                    test_utils::ShadowTest::new(
-                        &append_args("test_short_len"),
-                        move || test_short_len(accept_fn, sock_flag, accept_flag),
-                        set![TestEnv::Libc, TestEnv::Shadow],
-                    ),
-                    test_utils::ShadowTest::new(
-                        &append_args("test_zero_len"),
-                        move || test_zero_len(accept_fn, sock_flag, accept_flag),
-                        set![TestEnv::Libc, TestEnv::Shadow],
-                    ),
-                    test_utils::ShadowTest::new(
-                        &append_args("test_after_close"),
-                        move || test_after_close(accept_fn, sock_flag, accept_flag),
-                        set![TestEnv::Libc, TestEnv::Shadow],
-                    ),
-                    test_utils::ShadowTest::new(
-                        &append_args("test_correctness <sleep=true>"),
-                        move || test_correctness(accept_fn, sock_flag, accept_flag),
-                        set![TestEnv::Libc, TestEnv::Shadow],
-                    ),
-                ];
+                        let append_args = |s| {
+                            format!(
+                                "{} <fn={:?},domain={},sock_type={},sock_flag={},accept_flag={:?}>",
+                                s, accept_fn, domain, sock_type, sock_flag, accept_flag
+                            )
+                        };
 
-                tests.extend(more_tests);
+                        tests.extend(vec![
+                            test_utils::ShadowTest::new(
+                                &append_args("test_non_listening_fd"),
+                                move || {
+                                    test_non_listening_fd(
+                                        accept_fn,
+                                        domain,
+                                        sock_type,
+                                        sock_flag,
+                                        accept_flag,
+                                    )
+                                },
+                                passing.clone(),
+                            ),
+                            test_utils::ShadowTest::new(
+                                &append_args("test_null_addr"),
+                                move || {
+                                    test_null_addr(
+                                        accept_fn,
+                                        domain,
+                                        sock_type,
+                                        sock_flag,
+                                        accept_flag,
+                                    )
+                                },
+                                passing.clone(),
+                            ),
+                            test_utils::ShadowTest::new(
+                                &append_args("test_null_len"),
+                                move || {
+                                    test_null_len(
+                                        accept_fn,
+                                        domain,
+                                        sock_type,
+                                        sock_flag,
+                                        accept_flag,
+                                    )
+                                },
+                                passing.clone(),
+                            ),
+                            test_utils::ShadowTest::new(
+                                &append_args("test_short_len"),
+                                move || {
+                                    test_short_len(
+                                        accept_fn,
+                                        domain,
+                                        sock_type,
+                                        sock_flag,
+                                        accept_flag,
+                                    )
+                                },
+                                passing.clone(),
+                            ),
+                            test_utils::ShadowTest::new(
+                                &append_args("test_zero_len"),
+                                move || {
+                                    test_zero_len(
+                                        accept_fn,
+                                        domain,
+                                        sock_type,
+                                        sock_flag,
+                                        accept_flag,
+                                    )
+                                },
+                                passing.clone(),
+                            ),
+                            test_utils::ShadowTest::new(
+                                &append_args("test_after_close"),
+                                move || {
+                                    test_after_close(
+                                        accept_fn,
+                                        domain,
+                                        sock_type,
+                                        sock_flag,
+                                        accept_flag,
+                                    )
+                                },
+                                passing.clone(),
+                            ),
+                            test_utils::ShadowTest::new(
+                                &append_args("test_correctness <bind_client=false>"),
+                                move || {
+                                    test_correctness(
+                                        accept_fn,
+                                        domain,
+                                        sock_type,
+                                        sock_flag,
+                                        accept_flag,
+                                        /* bind_client= */ false,
+                                    )
+                                },
+                                passing.clone(),
+                            ),
+                            test_utils::ShadowTest::new(
+                                &append_args("test_correctness <bind_client=true>"),
+                                move || {
+                                    test_correctness(
+                                        accept_fn,
+                                        domain,
+                                        sock_type,
+                                        sock_flag,
+                                        accept_flag,
+                                        /* bind_client= */ true,
+                                    )
+                                },
+                                passing.clone(),
+                            ),
+                        ]);
+                    }
+                }
             }
         }
     }
@@ -224,10 +308,12 @@ fn test_invalid_sock_type(accept_fn: AcceptFn) -> Result<(), String> {
 /// Test accept using a non-listening socket.
 fn test_non_listening_fd(
     accept_fn: AcceptFn,
+    domain: libc::c_int,
+    sock_type: libc::c_int,
     sock_flag: libc::c_int,
     accept_flag: libc::c_int,
 ) -> Result<(), String> {
-    let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
+    let fd = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
     assert!(fd >= 0);
 
     let mut args = AcceptArguments {
@@ -237,8 +323,15 @@ fn test_non_listening_fd(
         flags: accept_flag,
     };
 
+    let expected_errno = match (domain, sock_type) {
+        (libc::AF_INET, libc::SOCK_STREAM) => Some(libc::EINVAL),
+        (libc::AF_UNIX, libc::SOCK_STREAM | libc::SOCK_SEQPACKET) => Some(libc::EINVAL),
+        (_, libc::SOCK_DGRAM) => Some(libc::EOPNOTSUPP),
+        _ => unimplemented!(),
+    };
+
     test_utils::run_and_close_fds(&[fd], || {
-        let fd = check_accept_call(&mut args, accept_fn, Some(libc::EINVAL))?;
+        let fd = check_accept_call(&mut args, accept_fn, expected_errno)?;
         if let Some(fd) = fd {
             let rv = unsafe { libc::close(fd) };
             assert_eq!(rv, 0, "Could not close the fd");
@@ -250,58 +343,26 @@ fn test_non_listening_fd(
 /// Test accept using a NULL pointer in the address argument.
 fn test_null_addr(
     accept_fn: AcceptFn,
+    domain: libc::c_int,
+    sock_type: libc::c_int,
     sock_flag: libc::c_int,
     accept_flag: libc::c_int,
 ) -> Result<(), String> {
-    let fd_client = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
-    let fd_server = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
+    let fd_client = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
+    let fd_server = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
     assert!(fd_client >= 0);
     assert!(fd_server >= 0);
 
-    // the server address
-    let mut server_addr = libc::sockaddr_in {
-        sin_family: libc::AF_INET as u16,
-        sin_port: 0u16.to_be(),
-        sin_addr: libc::in_addr {
-            s_addr: libc::INADDR_LOOPBACK.to_be(),
-        },
-        sin_zero: [0; 8],
-    };
+    let (server_addr, server_addr_len) = socket_utils::autobind_helper(fd_server, domain);
 
-    // bind on the server address
-    let rv = unsafe {
-        libc::bind(
-            fd_server,
-            &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
-            std::mem::size_of_val(&server_addr) as u32,
-        )
-    };
-    assert_eq!(rv, 0);
-
-    // get the assigned port number
-    let mut server_addr_size = std::mem::size_of_val(&server_addr) as u32;
-    let rv = unsafe {
-        libc::getsockname(
-            fd_server,
-            &mut server_addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
-            &mut server_addr_size as *mut libc::socklen_t,
-        )
-    };
-    assert_eq!(rv, 0);
-    assert_eq!(server_addr_size, std::mem::size_of_val(&server_addr) as u32);
-
-    // listen for connections
-    let rv = unsafe { libc::listen(fd_server, 10) };
-    assert_eq!(rv, 0);
+    if sock_type != libc::SOCK_DGRAM {
+        // listen for connections
+        let rv = unsafe { libc::listen(fd_server, 10) };
+        assert_eq!(rv, 0);
+    }
 
     // connect to the server address
-    let rv = unsafe {
-        libc::connect(
-            fd_client,
-            &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
-            std::mem::size_of_val(&server_addr) as u32,
-        )
-    };
+    let rv = unsafe { libc::connect(fd_client, server_addr.as_ptr(), server_addr_len) };
     assert!(rv == 0 || (rv == -1 && test_utils::get_errno() == libc::EINPROGRESS));
 
     // shadow needs to run events, otherwise the accept call won't know it
@@ -317,8 +378,15 @@ fn test_null_addr(
         flags: accept_flag,
     };
 
+    let expected_errno = match (domain, sock_type) {
+        (libc::AF_INET, libc::SOCK_STREAM) => None,
+        (libc::AF_UNIX, libc::SOCK_STREAM | libc::SOCK_SEQPACKET) => None,
+        (_, libc::SOCK_DGRAM) => Some(libc::EOPNOTSUPP),
+        _ => unimplemented!(),
+    };
+
     test_utils::run_and_close_fds(&[fd_client, fd_server], || {
-        let fd = check_accept_call(&mut args, accept_fn, None)?;
+        let fd = check_accept_call(&mut args, accept_fn, expected_errno)?;
         if let Some(fd) = fd {
             let rv = unsafe { libc::close(fd) };
             assert_eq!(rv, 0, "Could not close the fd");
@@ -330,58 +398,26 @@ fn test_null_addr(
 /// Test accept using a NULL pointer in the address length argument.
 fn test_null_len(
     accept_fn: AcceptFn,
+    domain: libc::c_int,
+    sock_type: libc::c_int,
     sock_flag: libc::c_int,
     accept_flag: libc::c_int,
 ) -> Result<(), String> {
-    let fd_client = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
-    let fd_server = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
+    let fd_client = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
+    let fd_server = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
     assert!(fd_client >= 0);
     assert!(fd_server >= 0);
 
-    // the server address
-    let mut server_addr = libc::sockaddr_in {
-        sin_family: libc::AF_INET as u16,
-        sin_port: 0u16.to_be(),
-        sin_addr: libc::in_addr {
-            s_addr: libc::INADDR_LOOPBACK.to_be(),
-        },
-        sin_zero: [0; 8],
-    };
+    let (server_addr, server_addr_len) = socket_utils::autobind_helper(fd_server, domain);
 
-    // bind on the server address
-    let rv = unsafe {
-        libc::bind(
-            fd_server,
-            &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
-            std::mem::size_of_val(&server_addr) as u32,
-        )
-    };
-    assert_eq!(rv, 0);
-
-    // get the assigned port number
-    let mut server_addr_size = std::mem::size_of_val(&server_addr) as u32;
-    let rv = unsafe {
-        libc::getsockname(
-            fd_server,
-            &mut server_addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
-            &mut server_addr_size as *mut libc::socklen_t,
-        )
-    };
-    assert_eq!(rv, 0);
-    assert_eq!(server_addr_size, std::mem::size_of_val(&server_addr) as u32);
-
-    // listen for connections
-    let rv = unsafe { libc::listen(fd_server, 10) };
-    assert_eq!(rv, 0);
+    if sock_type != libc::SOCK_DGRAM {
+        // listen for connections
+        let rv = unsafe { libc::listen(fd_server, 10) };
+        assert_eq!(rv, 0);
+    }
 
     // connect to the server address
-    let rv = unsafe {
-        libc::connect(
-            fd_client,
-            &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
-            std::mem::size_of_val(&server_addr) as u32,
-        )
-    };
+    let rv = unsafe { libc::connect(fd_client, server_addr.as_ptr(), server_addr_len) };
     //assert_eq!(rv, 0, "{}", test_utils::get_errno_message(test_utils::get_errno()));
     assert!(rv == 0 || (rv == -1 && test_utils::get_errno() == libc::EINPROGRESS));
 
@@ -390,26 +426,23 @@ fn test_null_len(
     let rv = unsafe { libc::usleep(2000) };
     assert_eq!(rv, 0);
 
-    // fill the sockaddr with dummy data
-    let addr = libc::sockaddr_in {
-        sin_family: 123u16,
-        sin_port: 456u16.to_be(),
-        sin_addr: libc::in_addr {
-            s_addr: 789u32.to_be(),
-        },
-        sin_zero: [1; 8],
-    };
-
     // accept() may mutate addr and addr_len
     let mut args = AcceptArguments {
         fd: fd_server,
-        addr: Some(addr),
+        addr: Some(SockAddr::dummy_init_generic()),
         addr_len: None,
         flags: accept_flag,
     };
 
+    let expected_errno = match (domain, sock_type) {
+        (libc::AF_INET, libc::SOCK_STREAM) => Some(libc::EFAULT),
+        (libc::AF_UNIX, libc::SOCK_STREAM | libc::SOCK_SEQPACKET) => Some(libc::EFAULT),
+        (_, libc::SOCK_DGRAM) => Some(libc::EOPNOTSUPP),
+        _ => unimplemented!(),
+    };
+
     test_utils::run_and_close_fds(&[fd_client, fd_server], || {
-        let fd = check_accept_call(&mut args, accept_fn, Some(libc::EFAULT))?;
+        let fd = check_accept_call(&mut args, accept_fn, expected_errno)?;
         if let Some(fd) = fd {
             let rv = unsafe { libc::close(fd) };
             assert_eq!(rv, 0, "Could not close the fd");
@@ -421,58 +454,26 @@ fn test_null_len(
 /// Test accept using an address length that is too small.
 fn test_short_len(
     accept_fn: AcceptFn,
+    domain: libc::c_int,
+    sock_type: libc::c_int,
     sock_flag: libc::c_int,
     accept_flag: libc::c_int,
 ) -> Result<(), String> {
-    let fd_client = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
-    let fd_server = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
+    let fd_client = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
+    let fd_server = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
     assert!(fd_client >= 0);
     assert!(fd_server >= 0);
 
-    // the server address
-    let mut server_addr = libc::sockaddr_in {
-        sin_family: libc::AF_INET as u16,
-        sin_port: 0u16.to_be(),
-        sin_addr: libc::in_addr {
-            s_addr: libc::INADDR_LOOPBACK.to_be(),
-        },
-        sin_zero: [0; 8],
-    };
+    let (server_addr, server_addr_len) = socket_utils::autobind_helper(fd_server, domain);
 
-    // bind on the server address
-    let rv = unsafe {
-        libc::bind(
-            fd_server,
-            &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
-            std::mem::size_of_val(&server_addr) as u32,
-        )
-    };
-    assert_eq!(rv, 0);
-
-    // get the assigned port number
-    let mut server_addr_size = std::mem::size_of_val(&server_addr) as u32;
-    let rv = unsafe {
-        libc::getsockname(
-            fd_server,
-            &mut server_addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
-            &mut server_addr_size as *mut libc::socklen_t,
-        )
-    };
-    assert_eq!(rv, 0);
-    assert_eq!(server_addr_size, std::mem::size_of_val(&server_addr) as u32);
-
-    // listen for connections
-    let rv = unsafe { libc::listen(fd_server, 10) };
-    assert_eq!(rv, 0);
+    if sock_type != libc::SOCK_DGRAM {
+        // listen for connections
+        let rv = unsafe { libc::listen(fd_server, 10) };
+        assert_eq!(rv, 0);
+    }
 
     // connect to the server address
-    let rv = unsafe {
-        libc::connect(
-            fd_client,
-            &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
-            std::mem::size_of_val(&server_addr) as u32,
-        )
-    };
+    let rv = unsafe { libc::connect(fd_client, server_addr.as_ptr(), server_addr_len) };
     //assert_eq!(rv, 0, "{}", test_utils::get_errno_message(test_utils::get_errno()));
     assert!(rv == 0 || (rv == -1 && test_utils::get_errno() == libc::EINPROGRESS));
 
@@ -481,26 +482,29 @@ fn test_short_len(
     let rv = unsafe { libc::usleep(10000) };
     assert_eq!(rv, 0);
 
-    // fill the sockaddr with dummy data
-    let addr = libc::sockaddr_in {
-        sin_family: 123u16,
-        sin_port: 456u16.to_be(),
-        sin_addr: libc::in_addr {
-            s_addr: 789u32.to_be(),
-        },
-        sin_zero: [1; 8],
+    let accept_addr = match domain {
+        libc::AF_INET => SockAddr::dummy_init_inet(),
+        libc::AF_UNIX => SockAddr::dummy_init_unix(),
+        _ => unimplemented!(),
     };
 
     // accept() may mutate addr and addr_len
     let mut args = AcceptArguments {
         fd: fd_server,
-        addr: Some(addr),
-        addr_len: Some((std::mem::size_of_val(&addr) - 1) as u32),
+        addr: Some(accept_addr),
+        addr_len: Some(accept_addr.ptr_size() - 1),
         flags: accept_flag,
     };
 
+    let expected_errno = match (domain, sock_type) {
+        (libc::AF_INET, libc::SOCK_STREAM) => None,
+        (libc::AF_UNIX, libc::SOCK_STREAM | libc::SOCK_SEQPACKET) => None,
+        (_, libc::SOCK_DGRAM) => Some(libc::EOPNOTSUPP),
+        _ => unimplemented!(),
+    };
+
     test_utils::run_and_close_fds(&[fd_client, fd_server], || -> Result<(), String> {
-        let fd = check_accept_call(&mut args, accept_fn, None)?;
+        let fd = check_accept_call(&mut args, accept_fn, expected_errno)?;
         if let Some(fd) = fd {
             let rv = unsafe { libc::close(fd) };
             assert_eq!(rv, 0, "Could not close the fd");
@@ -508,33 +512,56 @@ fn test_short_len(
         Ok(())
     })?;
 
+    // there was an error and the syscall didn't complete, so skip the later checks
+    if expected_errno.is_some() {
+        return Ok(());
+    }
+
+    let expected_addr_len = match domain {
+        libc::AF_INET => std::mem::size_of::<libc::sockaddr_in>() as u32,
+        libc::AF_UNIX => 2, // domain only
+        _ => unimplemented!(),
+    };
+
     // check that the returned length is expected
     test_utils::result_assert_eq(
-        args.addr_len.unwrap() as usize,
-        std::mem::size_of_val(&addr),
+        args.addr_len.unwrap(),
+        expected_addr_len,
         "Unexpected addr length",
     )?;
 
-    // check that the returned client address is expected
-    test_utils::result_assert_eq(
-        args.addr.unwrap().sin_family,
-        libc::AF_INET as u16,
-        "Unexpected family",
-    )?;
-    test_utils::result_assert(
-        args.addr.unwrap().sin_port != 0u16.to_be(),
-        "Unexpected port",
-    )?;
-    test_utils::result_assert_eq(
-        args.addr.unwrap().sin_addr.s_addr,
-        libc::INADDR_LOOPBACK.to_be(),
-        "Unexpected address",
-    )?;
-    test_utils::result_assert_eq(
-        args.addr.unwrap().sin_zero,
-        [0, 0, 0, 0, 0, 0, 0, 1],
-        "Unexpected padding",
-    )?;
+    match domain {
+        libc::AF_INET => {
+            // check that the returned client address is expected
+            test_utils::result_assert_eq(
+                args.addr.unwrap().as_inet().unwrap().sin_family,
+                libc::AF_INET as u16,
+                "Unexpected family",
+            )?;
+            test_utils::result_assert(
+                args.addr.unwrap().as_inet().unwrap().sin_port != 0u16.to_be(),
+                "Unexpected port",
+            )?;
+            test_utils::result_assert_eq(
+                args.addr.unwrap().as_inet().unwrap().sin_addr.s_addr,
+                libc::INADDR_LOOPBACK.to_be(),
+                "Unexpected address",
+            )?;
+            test_utils::result_assert_eq(
+                args.addr.unwrap().as_inet().unwrap().sin_zero,
+                [0, 0, 0, 0, 0, 0, 0, 1],
+                "Unexpected padding",
+            )?;
+        }
+        libc::AF_UNIX => {
+            test_utils::result_assert_eq(
+                args.addr.unwrap().as_unix().unwrap().sun_family,
+                libc::AF_UNIX as u16,
+                "Unexpected family",
+            )?;
+        }
+        _ => unimplemented!(),
+    }
 
     Ok(())
 }
@@ -542,59 +569,26 @@ fn test_short_len(
 /// Test accept using an address length of 0.
 fn test_zero_len(
     accept_fn: AcceptFn,
+    domain: libc::c_int,
+    sock_type: libc::c_int,
     sock_flag: libc::c_int,
     accept_flag: libc::c_int,
 ) -> Result<(), String> {
-    let fd_client = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
-    let fd_server = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
+    let fd_client = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
+    let fd_server = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
     assert!(fd_client >= 0);
     assert!(fd_server >= 0);
 
-    // the server address
-    let mut server_addr = libc::sockaddr_in {
-        sin_family: libc::AF_INET as u16,
-        sin_port: 0u16.to_be(),
-        sin_addr: libc::in_addr {
-            s_addr: libc::INADDR_LOOPBACK.to_be(),
-        },
-        sin_zero: [0; 8],
-    };
+    let (server_addr, server_addr_len) = socket_utils::autobind_helper(fd_server, domain);
 
-    // bind on the server address
-    let rv = unsafe {
-        libc::bind(
-            fd_server,
-            &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
-            std::mem::size_of_val(&server_addr) as u32,
-        )
-    };
-    assert_eq!(rv, 0);
-
-    // get the assigned port number
-    let mut server_addr_size = std::mem::size_of_val(&server_addr) as u32;
-    let rv = unsafe {
-        libc::getsockname(
-            fd_server,
-            &mut server_addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
-            &mut server_addr_size as *mut libc::socklen_t,
-        )
-    };
-    assert_eq!(rv, 0);
-    assert_eq!(server_addr_size, std::mem::size_of_val(&server_addr) as u32);
-
-    // listen for connections
-    let rv = unsafe { libc::listen(fd_server, 10) };
-    assert_eq!(rv, 0);
+    if sock_type != libc::SOCK_DGRAM {
+        // listen for connections
+        let rv = unsafe { libc::listen(fd_server, 10) };
+        assert_eq!(rv, 0);
+    }
 
     // connect to the server address
-    let rv = unsafe {
-        libc::connect(
-            fd_client,
-            &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
-            std::mem::size_of_val(&server_addr) as u32,
-        )
-    };
-    //assert_eq!(rv, 0, "{}", test_utils::get_errno_message(test_utils::get_errno()));
+    let rv = unsafe { libc::connect(fd_client, server_addr.as_ptr(), server_addr_len) };
     assert!(rv == 0 || (rv == -1 && test_utils::get_errno() == libc::EINPROGRESS));
 
     // shadow needs to run events, otherwise the accept call won't know it
@@ -602,26 +596,29 @@ fn test_zero_len(
     let rv = unsafe { libc::usleep(10000) };
     assert_eq!(rv, 0);
 
-    // fill the sockaddr with dummy data
-    let addr = libc::sockaddr_in {
-        sin_family: 123u16,
-        sin_port: 456u16.to_be(),
-        sin_addr: libc::in_addr {
-            s_addr: 789u32.to_be(),
-        },
-        sin_zero: [1; 8],
+    let accept_addr = match domain {
+        libc::AF_INET => SockAddr::dummy_init_inet(),
+        libc::AF_UNIX => SockAddr::dummy_init_unix(),
+        _ => unimplemented!(),
     };
 
     // accept() may mutate addr and addr_len
     let mut args = AcceptArguments {
         fd: fd_server,
-        addr: Some(addr),
+        addr: Some(accept_addr),
         addr_len: Some(0u32),
         flags: accept_flag,
     };
 
+    let expected_errno = match (domain, sock_type) {
+        (libc::AF_INET, libc::SOCK_STREAM) => None,
+        (libc::AF_UNIX, libc::SOCK_STREAM | libc::SOCK_SEQPACKET) => None,
+        (_, libc::SOCK_DGRAM) => Some(libc::EOPNOTSUPP),
+        _ => unimplemented!(),
+    };
+
     test_utils::run_and_close_fds(&[fd_client, fd_server], || -> Result<(), String> {
-        let fd = check_accept_call(&mut args, accept_fn, None)?;
+        let fd = check_accept_call(&mut args, accept_fn, expected_errno)?;
         if let Some(fd) = fd {
             let rv = unsafe { libc::close(fd) };
             assert_eq!(rv, 0, "Could not close the fd");
@@ -629,26 +626,57 @@ fn test_zero_len(
         Ok(())
     })?;
 
+    // there was an error and the syscall didn't complete, so skip the later checks
+    if expected_errno.is_some() {
+        return Ok(());
+    }
+
+    let expected_addr_len = match domain {
+        libc::AF_INET => std::mem::size_of::<libc::sockaddr_in>() as u32,
+        libc::AF_UNIX => 2, // domain only
+        _ => unimplemented!(),
+    };
+
     // check that the returned length is expected
     test_utils::result_assert_eq(
-        args.addr_len.unwrap() as usize,
-        std::mem::size_of_val(&addr),
+        args.addr_len.unwrap(),
+        expected_addr_len,
         "Unexpected addr length",
     )?;
 
-    // check that the returned client address is expected
-    test_utils::result_assert_eq(args.addr.unwrap().sin_family, 123u16, "Unexpected family")?;
-    test_utils::result_assert_eq(
-        args.addr.unwrap().sin_port,
-        456u16.to_be(),
-        "Unexpected port",
-    )?;
-    test_utils::result_assert_eq(
-        args.addr.unwrap().sin_addr.s_addr,
-        789u32.to_be(),
-        "Unexpected address",
-    )?;
-    test_utils::result_assert_eq(args.addr.unwrap().sin_zero, [1; 8], "Unexpected padding")?;
+    match domain {
+        libc::AF_INET => {
+            // check that the returned client address is expected
+            test_utils::result_assert_eq(
+                args.addr.unwrap().as_inet().unwrap().sin_family,
+                accept_addr.as_inet().unwrap().sin_family,
+                "Unexpected family",
+            )?;
+            test_utils::result_assert_eq(
+                args.addr.unwrap().as_inet().unwrap().sin_port,
+                accept_addr.as_inet().unwrap().sin_port,
+                "Unexpected port",
+            )?;
+            test_utils::result_assert_eq(
+                args.addr.unwrap().as_inet().unwrap().sin_addr.s_addr,
+                accept_addr.as_inet().unwrap().sin_addr.s_addr,
+                "Unexpected address",
+            )?;
+            test_utils::result_assert_eq(
+                args.addr.unwrap().as_inet().unwrap().sin_zero,
+                accept_addr.as_inet().unwrap().sin_zero,
+                "Unexpected padding",
+            )?;
+        }
+        libc::AF_UNIX => {
+            test_utils::result_assert_eq(
+                args.addr.unwrap().as_unix().unwrap().sun_family,
+                accept_addr.as_unix().unwrap().sun_family,
+                "Unexpected family",
+            )?;
+        }
+        _ => unimplemented!(),
+    }
 
     Ok(())
 }
@@ -656,35 +684,21 @@ fn test_zero_len(
 /// Test accept after closing the socket.
 fn test_after_close(
     accept_fn: AcceptFn,
+    domain: libc::c_int,
+    sock_type: libc::c_int,
     sock_flag: libc::c_int,
     accept_flag: libc::c_int,
 ) -> Result<(), String> {
-    let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
+    let fd = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
     assert!(fd >= 0);
 
-    // the server address
-    let server_addr = libc::sockaddr_in {
-        sin_family: libc::AF_INET as u16,
-        sin_port: 0u16.to_be(),
-        sin_addr: libc::in_addr {
-            s_addr: libc::INADDR_LOOPBACK.to_be(),
-        },
-        sin_zero: [0; 8],
-    };
+    socket_utils::autobind_helper(fd, domain);
 
-    // bind on the server address
-    let rv = unsafe {
-        libc::bind(
-            fd,
-            &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
-            std::mem::size_of_val(&server_addr) as u32,
-        )
-    };
-    assert_eq!(rv, 0);
-
-    // listen for connections
-    let rv = unsafe { libc::listen(fd, 10) };
-    assert_eq!(rv, 0);
+    if sock_type != libc::SOCK_DGRAM {
+        // listen for connections
+        let rv = unsafe { libc::listen(fd, 10) };
+        assert_eq!(rv, 0);
+    }
 
     // close the connection
     let rv = unsafe { libc::close(fd) };
@@ -710,58 +724,34 @@ fn test_after_close(
 /// Test accept by checking the returned address fields.
 fn test_correctness(
     accept_fn: AcceptFn,
+    domain: libc::c_int,
+    sock_type: libc::c_int,
     sock_flag: libc::c_int,
     accept_flag: libc::c_int,
+    bind_client: bool,
 ) -> Result<(), String> {
-    let fd_client = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
-    let fd_server = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | sock_flag, 0) };
+    let fd_client = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
+    let fd_server = unsafe { libc::socket(domain, sock_type | sock_flag, 0) };
     assert!(fd_client >= 0);
     assert!(fd_server >= 0);
 
-    // the server address
-    let mut server_addr = libc::sockaddr_in {
-        sin_family: libc::AF_INET as u16,
-        sin_port: 0u16.to_be(),
-        sin_addr: libc::in_addr {
-            s_addr: libc::INADDR_LOOPBACK.to_be(),
-        },
-        sin_zero: [0; 8],
+    let (server_addr, server_addr_len) = socket_utils::autobind_helper(fd_server, domain);
+
+    // optionally bind the client
+    let client_bind_addr_and_len = if bind_client {
+        Some(socket_utils::autobind_helper(fd_client, domain))
+    } else {
+        None
     };
 
-    // bind on the server address
-    let rv = unsafe {
-        libc::bind(
-            fd_server,
-            &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
-            std::mem::size_of_val(&server_addr) as u32,
-        )
-    };
-    assert_eq!(rv, 0);
-
-    // get the assigned port number
-    let mut server_addr_size = std::mem::size_of_val(&server_addr) as u32;
-    let rv = unsafe {
-        libc::getsockname(
-            fd_server,
-            &mut server_addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
-            &mut server_addr_size as *mut libc::socklen_t,
-        )
-    };
-    assert_eq!(rv, 0);
-    assert_eq!(server_addr_size, std::mem::size_of_val(&server_addr) as u32);
-
-    // listen for connections
-    let rv = unsafe { libc::listen(fd_server, 10) };
-    assert_eq!(rv, 0);
+    if sock_type != libc::SOCK_DGRAM {
+        // listen for connections
+        let rv = unsafe { libc::listen(fd_server, 10) };
+        assert_eq!(rv, 0);
+    }
 
     // connect to the server address
-    let rv = unsafe {
-        libc::connect(
-            fd_client,
-            &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
-            std::mem::size_of_val(&server_addr) as u32,
-        )
-    };
+    let rv = unsafe { libc::connect(fd_client, server_addr.as_ptr(), server_addr_len) };
 
     assert!(rv == 0 || (rv == -1 && test_utils::get_errno() == libc::EINPROGRESS));
 
@@ -772,24 +762,30 @@ fn test_correctness(
     let rv = unsafe { libc::usleep(10000) };
     assert_eq!(rv, 0);
 
+    let accept_addr = match domain {
+        libc::AF_INET => SockAddr::dummy_init_inet(),
+        libc::AF_UNIX => SockAddr::dummy_init_unix(),
+        _ => unimplemented!(),
+    };
+
     // accept() may mutate addr and addr_len
     let mut args = AcceptArguments {
         fd: fd_server,
         // fill the sockaddr with dummy data
-        addr: Some(libc::sockaddr_in {
-            sin_family: 123u16,
-            sin_port: 456u16.to_be(),
-            sin_addr: libc::in_addr {
-                s_addr: 789u32.to_be(),
-            },
-            sin_zero: [1; 8],
-        }),
-        addr_len: Some(std::mem::size_of::<libc::sockaddr_in>() as u32),
+        addr: Some(accept_addr),
+        addr_len: Some(accept_addr.ptr_size()),
         flags: accept_flag,
     };
 
+    let expected_errno = match (domain, sock_type) {
+        (libc::AF_INET, libc::SOCK_STREAM) => None,
+        (libc::AF_UNIX, libc::SOCK_STREAM | libc::SOCK_SEQPACKET) => None,
+        (_, libc::SOCK_DGRAM) => Some(libc::EOPNOTSUPP),
+        _ => unimplemented!(),
+    };
+
     test_utils::run_and_close_fds(&[fd_client, fd_server], || -> Result<(), String> {
-        let fd = check_accept_call(&mut args, accept_fn, None)?;
+        let fd = check_accept_call(&mut args, accept_fn, expected_errno)?;
         if let Some(fd) = fd {
             let rv = unsafe { libc::close(fd) };
             assert_eq!(rv, 0, "Could not close the fd");
@@ -797,30 +793,75 @@ fn test_correctness(
         Ok(())
     })?;
 
-    // check that the returned length is expected
-    test_utils::result_assert_eq(
-        args.addr_len.unwrap() as usize,
-        std::mem::size_of_val(&args.addr.unwrap()),
-        "Unexpected addr length",
-    )?;
+    // there was an error and the syscall didn't complete, so skip the later checks
+    if expected_errno.is_some() {
+        return Ok(());
+    }
 
-    // check that the returned client address is expected (except the port which is not
-    // deterministic)
-    test_utils::result_assert_eq(
-        args.addr.unwrap().sin_family,
-        libc::AF_INET as u16,
-        "Unexpected family",
-    )?;
-    test_utils::result_assert(
-        args.addr.unwrap().sin_port != 0u16.to_be(),
-        "Unexpected port",
-    )?;
-    test_utils::result_assert_eq(
-        args.addr.unwrap().sin_addr.s_addr,
-        libc::INADDR_LOOPBACK.to_be(),
-        "Unexpected address",
-    )?;
-    test_utils::result_assert_eq(args.addr.unwrap().sin_zero, [0; 8], "Unexpected padding")?;
+    // if the client was bound
+    if let Some((expected_addr, expected_len)) = client_bind_addr_and_len {
+        // check that the returned length is expected
+        test_utils::result_assert_eq(
+            args.addr_len.unwrap(),
+            expected_len,
+            "Unexpected addr length",
+        )?;
+
+        // the client was bound, so the returned address should be exactly the same as the client's
+        // address
+        let expected_len = expected_len as usize;
+        test_utils::result_assert_eq(
+            &args.addr.unwrap().as_slice()[..expected_len],
+            &expected_addr.as_slice()[..expected_len],
+            "Unexpected address",
+        )?;
+    } else {
+        // check that the returned length is expected
+        let expected_addr_len = match domain {
+            libc::AF_INET => std::mem::size_of::<libc::sockaddr_in>() as u32,
+            libc::AF_UNIX => 2, // domain only
+            _ => unimplemented!(),
+        };
+        test_utils::result_assert_eq(
+            args.addr_len.unwrap(),
+            expected_addr_len,
+            "Unexpected addr length",
+        )?;
+
+        // the client was not bound, so we don't know exactly what address to expect
+        match domain {
+            libc::AF_INET => {
+                // check that the returned client address is expected
+                test_utils::result_assert_eq(
+                    args.addr.unwrap().as_inet().unwrap().sin_family,
+                    libc::AF_INET as u16,
+                    "Unexpected family",
+                )?;
+                test_utils::result_assert(
+                    args.addr.unwrap().as_inet().unwrap().sin_port != 0u16.to_be(),
+                    "Unexpected port",
+                )?;
+                test_utils::result_assert_eq(
+                    args.addr.unwrap().as_inet().unwrap().sin_addr.s_addr,
+                    libc::INADDR_LOOPBACK.to_be(),
+                    "Unexpected address",
+                )?;
+                test_utils::result_assert_eq(
+                    args.addr.unwrap().as_inet().unwrap().sin_zero,
+                    [0; 8],
+                    "Unexpected padding",
+                )?;
+            }
+            libc::AF_UNIX => {
+                test_utils::result_assert_eq(
+                    args.addr.unwrap().as_unix().unwrap().sun_family,
+                    libc::AF_UNIX as u16,
+                    "Unexpected family",
+                )?;
+            }
+            _ => unimplemented!(),
+        }
+    }
 
     Ok(())
 }
@@ -830,28 +871,26 @@ fn check_accept_call(
     accept_fn: AcceptFn,
     expected_errno: Option<libc::c_int>,
 ) -> Result<Option<libc::c_int>, String> {
-    // if the pointers will be non-null, make sure the length is not greater than the actual data size
-    // so that we don't segfault
+    // get a pointer to the sockaddr and the size of the structure
+    // careful use of references here makes sure we don't copy memory, leading to stale pointers
+    let (addr_ptr, addr_max_len) = match args.addr {
+        Some(ref mut x) => (x.as_mut_ptr(), x.ptr_size()),
+        None => (std::ptr::null_mut(), 0),
+    };
+
+    // if the pointer is non-null, make sure the provided size is not greater than the actual data
+    // size so that we don't segfault
     if args.addr.is_some() && args.addr_len.is_some() {
-        assert!(args.addr_len.unwrap() as usize <= std::mem::size_of_val(&args.addr.unwrap()));
+        assert!(args.addr_len.unwrap() <= addr_max_len);
     }
 
     let rv = match accept_fn {
         AcceptFn::Accept => unsafe {
             assert_eq!(args.flags, 0);
-            libc::accept(
-                args.fd,
-                args.addr.as_mut_ptr() as *mut libc::sockaddr,
-                args.addr_len.as_mut_ptr(),
-            )
+            libc::accept(args.fd, addr_ptr, args.addr_len.as_mut_ptr())
         },
         AcceptFn::Accept4 => unsafe {
-            libc::accept4(
-                args.fd,
-                args.addr.as_mut_ptr() as *mut libc::sockaddr,
-                args.addr_len.as_mut_ptr(),
-                args.flags,
-            )
+            libc::accept4(args.fd, addr_ptr, args.addr_len.as_mut_ptr(), args.flags)
         },
     };
 


### PR DESCRIPTION
These tests are currently disabled in Shadow.