### PR TITLE
Improve unix socket sendto()/recvfrom() behaviour 

### DIFF
--- a/src/test/socket/accept/accept.yaml
+++ b/src/test/socket/accept/accept.yaml
@@ -1,5 +1,5 @@
 general:
-  stop_time: 5
+  stop_time: 10
 network:
   graph:
     type: 1_gbit_switch


### PR DESCRIPTION
The behaviour of unix sockets during the close/shutdown phase is not well documented, but at least this seems better than before.

Also added a test for `accept()` after closing the connecting socket.