### PR TITLE
Clean up and extend time types

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -462,6 +462,18 @@ int64_t parse_bandwidth(const char *s);
 // Parses a string as a time in nanoseconds. Returns '-1' on error.
 int64_t parse_time_nanosec(const char *s);
 
+SimulationTime simtime_from_timeval(struct timeval val);
+
+SimulationTime simtime_from_timespec(struct timespec val);
+
+__attribute__((warn_unused_result))
+bool simtime_to_timeval(SimulationTime val,
+                        struct timeval *out);
+
+__attribute__((warn_unused_result))
+bool simtime_to_timespec(SimulationTime val,
+                         struct timespec *out);
+
 // Initialize a Worker for this thread.
 void worker_newForThisThread(WorkerPool *worker_pool,
                              int32_t worker_id,

--- a/src/main/bindings/c/cbindgen-opaque.toml
+++ b/src/main/bindings/c/cbindgen-opaque.toml
@@ -20,6 +20,6 @@ must_use = "__attribute__((warn_unused_result))"
 
 [export]
 # Avoid exporting C types back through again.
-exclude = ["LogLevel", "PluginPtr", "SysCallReg", "Process", "Host", "Thread", "EmulatedTime"]
+exclude = ["LogLevel", "PluginPtr", "SysCallReg", "Process", "Host", "Thread", "EmulatedTime", "SimulationTime"]
 # Generate only opaque and enum types
 item_types = ["opaque", "enums"]

--- a/src/main/bindings/c/cbindgen.toml
+++ b/src/main/bindings/c/cbindgen.toml
@@ -30,7 +30,7 @@ must_use = "__attribute__((warn_unused_result))"
 
 [export]
 # Avoid exporting C types back through again.
-exclude = ["LogLevel", "PluginPtr", "SysCallReg", "SysCallArgs", "Process", "Host", "Thread", "EmulatedTime"]
+exclude = ["LogLevel", "PluginPtr", "SysCallReg", "SysCallArgs", "Process", "Host", "Thread", "EmulatedTime", "SimulationTime"]
 # Generate all item types, excluding enum types.
 # 
 # While the opaque items are already exported, and included here via
@@ -38,3 +38,7 @@ exclude = ["LogLevel", "PluginPtr", "SysCallReg", "SysCallArgs", "Process", "Hos
 # re-export them again here. i.e. it appears to not actually parse the headers
 # included in the `includes` list.
 item_types = ["constants", "globals", "structs", "unions", "typedefs", "opaque", "functions"]
+
+[export.rename]
+"timeval" = "struct timeval"
+"timespec" = "struct timespec"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -28,48 +28,7 @@ pub type __uint32_t = ::std::os::raw::c_uint;
 pub type __int64_t = ::std::os::raw::c_long;
 pub type __uint64_t = ::std::os::raw::c_ulong;
 pub type __pid_t = ::std::os::raw::c_int;
-pub type __time_t = ::std::os::raw::c_long;
 pub type __ssize_t = ::std::os::raw::c_long;
-pub type __syscall_slong_t = ::std::os::raw::c_long;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timespec {
-    pub tv_sec: __time_t,
-    pub tv_nsec: __syscall_slong_t,
-}
-#[test]
-fn bindgen_test_layout_timespec() {
-    assert_eq!(
-        ::std::mem::size_of::<timespec>(),
-        16usize,
-        concat!("Size of: ", stringify!(timespec))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<timespec>(),
-        8usize,
-        concat!("Alignment of ", stringify!(timespec))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<timespec>())).tv_sec as *const _ as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(timespec),
-            "::",
-            stringify!(tv_sec)
-        )
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<timespec>())).tv_nsec as *const _ as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(timespec),
-            "::",
-            stringify!(tv_nsec)
-        )
-    );
-}
 pub type pid_t = __pid_t;
 pub type gchar = ::std::os::raw::c_char;
 pub type gint = ::std::os::raw::c_int;
@@ -1013,13 +972,6 @@ extern "C" {
         src: PluginVirtualPtr,
         n: size_t,
     ) -> ssize_t;
-}
-extern "C" {
-    pub fn process_readTimespec(
-        proc_: *mut Process,
-        ts: *mut timespec,
-        src: PluginVirtualPtr,
-    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn process_writePtr(

--- a/src/main/core/logger/shadow_logger.rs
+++ b/src/main/core/logger/shadow_logger.rs
@@ -1,4 +1,4 @@
-use crate::core::support::emulated_time::{self, EmulatedTime};
+use crate::core::support::emulated_time::EmulatedTime;
 use crate::core::worker::Worker;
 use crate::host::host::HostInfo;
 use crate::utility::time::TimeParts;
@@ -186,7 +186,7 @@ impl ShadowLogger {
             }
             write!(stdout, " [{}:{}]", record.thread_id, record.thread_name)?;
             if let Some(emu_time) = record.emu_time {
-                let sim_time = emu_time.duration_since(&emulated_time::SIMULATION_START);
+                let sim_time = emu_time.duration_since(&EmulatedTime::SIMULATION_START);
                 let parts = TimeParts::from_nanos(sim_time.as_nanos());
                 write!(
                     stdout,

--- a/src/main/core/support/emulated_time.rs
+++ b/src/main/core/support/emulated_time.rs
@@ -5,16 +5,12 @@ Deals with instances of time in a Shadow simulation.
 use crate::core::support::simulation_time;
 use crate::core::support::simulation_time::SimulationTime;
 use crate::cshadow as c;
-use std::time::Duration;
 
 /// An instant in time (analagous to std::time::Instant) in the Shadow
 /// simulation.
 // Internally represented as Duration since the Unix Epoch.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, PartialOrd, Ord)]
-pub struct EmulatedTime(Duration);
-
-/// The  Unix epoch (00:00:00 UTC on 1 January 1970)
-pub const UNIX_EPOCH: EmulatedTime = EmulatedTime(Duration::from_secs(0));
+pub struct EmulatedTime(c::EmulatedTime);
 
 // Duplicated from the EMULATED_TIME_OFFSET macro in definitions.h.
 pub(super) const SIMULATION_START_SEC: u64 = 946684800;
@@ -22,57 +18,86 @@ pub const EMUTIME_INVALID: c::EmulatedTime = u64::MAX;
 pub const EMUTIME_MAX: c::EmulatedTime = u64::MAX - 1;
 pub const EMUTIME_MIN: c::EmulatedTime = 0;
 
-/// The start time of the simulation - 00:00:00 UTC on 1 January, 2000.
-pub const SIMULATION_START: EmulatedTime = EmulatedTime(Duration::from_secs(SIMULATION_START_SEC));
-
 impl EmulatedTime {
+    /// The start time of the simulation - 00:00:00 UTC on 1 January, 2000.
+    pub const SIMULATION_START: Self =
+        Self(SIMULATION_START_SEC * simulation_time::SIMTIME_ONE_SECOND);
+    /// The  Unix epoch (00:00:00 UTC on 1 January 1970)
+    pub const UNIX_EPOCH: Self = Self(0);
+
+    pub const MAX: Self = Self(EMUTIME_MAX);
+
     /// Get the instance corresponding to `val` SimulationTime units since the Unix Epoch.
     pub fn from_c_emutime(val: c::EmulatedTime) -> Option<Self> {
         if val == EMUTIME_INVALID {
             None
+        } else if val > EMUTIME_MAX {
+            None
         } else {
-            Some(Self(Duration::from_nanos(
-                val * simulation_time::SIMTIME_ONE_NANOSECOND,
-            )))
+            Some(Self(val))
         }
     }
 
     /// Convert to number of SimulationTime units since the Unix Epoch.
     pub fn to_c_emutime(val: Option<Self>) -> c::EmulatedTime {
         match val {
-            Some(val) => SimulationTime::to_c_simtime(Some(SimulationTime::from(
-                val.duration_since(&UNIX_EPOCH),
-            ))),
+            Some(v) => v.0,
             None => EMUTIME_INVALID,
         }
     }
 
     /// Get the instant corresponding to `val` time units since the simulation began.
     pub fn from_abs_simtime(val: SimulationTime) -> Self {
-        SIMULATION_START + *val
+        Self::SIMULATION_START + val
     }
 
     /// Convert to the SimulationTime since the simulation began.
     pub fn to_abs_simtime(self) -> SimulationTime {
-        SimulationTime::from(self.duration_since(&SIMULATION_START))
+        SimulationTime::from(self.duration_since(&Self::SIMULATION_START))
     }
 
-    /// Returns the duration since `earlier`, or panics if `earlier` is after `self`.
-    pub fn duration_since(&self, earlier: &EmulatedTime) -> Duration {
+    /// Returns the duration since `earlier`, or panics if `earlier` is after `self`, or
+    /// if the difference can't be represented as SimulationTime.
+    pub fn duration_since(&self, earlier: &EmulatedTime) -> SimulationTime {
         self.checked_duration_since(earlier).unwrap()
     }
 
     /// Returns the duration since `earlier`, or `None` if `earlier` is after `self`.
-    pub fn checked_duration_since(&self, earlier: &EmulatedTime) -> Option<Duration> {
-        self.0.checked_sub(earlier.0)
+    pub fn checked_duration_since(&self, earlier: &EmulatedTime) -> Option<SimulationTime> {
+        let d = self.0.checked_sub(earlier.0)?;
+        SimulationTime::from_c_simtime(d)
+    }
+
+    pub fn checked_add(&self, other: SimulationTime) -> Option<EmulatedTime> {
+        EmulatedTime::from_c_emutime(self.0.checked_add(c::SimulationTime::from(other))?)
+    }
+
+    pub fn checked_sub(&self, other: SimulationTime) -> Option<EmulatedTime> {
+        EmulatedTime::from_c_emutime(self.0.checked_sub(c::SimulationTime::from(other))?)
     }
 }
 
-impl std::ops::Add<Duration> for EmulatedTime {
+impl std::ops::Add<SimulationTime> for EmulatedTime {
     type Output = EmulatedTime;
 
-    fn add(self, dur: Duration) -> Self {
-        Self(self.0 + dur)
+    fn add(self, other: SimulationTime) -> Self {
+        self.checked_add(other).unwrap()
+    }
+}
+
+impl std::ops::Sub<SimulationTime> for EmulatedTime {
+    type Output = EmulatedTime;
+
+    fn sub(self, other: SimulationTime) -> Self {
+        self.checked_sub(other).unwrap()
+    }
+}
+
+impl std::ops::Sub<EmulatedTime> for EmulatedTime {
+    type Output = SimulationTime;
+
+    fn sub(self, other: EmulatedTime) -> Self::Output {
+        self.duration_since(&other)
     }
 }
 
@@ -86,51 +111,55 @@ mod tests {
             5 * simulation_time::SIMTIME_ONE_MINUTE + 7 * simulation_time::SIMTIME_ONE_MILLISECOND;
         let rust_time = EmulatedTime::from_c_emutime(emu_time).unwrap();
 
-        assert_eq!(rust_time.duration_since(&UNIX_EPOCH).as_secs(), 5 * 60);
         assert_eq!(
-            rust_time.duration_since(&UNIX_EPOCH).as_millis(),
+            rust_time
+                .duration_since(&EmulatedTime::UNIX_EPOCH)
+                .as_secs(),
+            5 * 60
+        );
+        assert_eq!(
+            rust_time
+                .duration_since(&EmulatedTime::UNIX_EPOCH)
+                .as_millis(),
             5 * 60 * 1_000 + 7
         );
     }
 
     #[test]
     fn test_to_emu_time() {
-        let rust_time = UNIX_EPOCH
-            + 5 * std::time::Duration::from_secs(60)
-            + 7 * std::time::Duration::from_micros(1000);
+        let rust_time = EmulatedTime::UNIX_EPOCH
+            + SimulationTime::SECOND * 60 * 5
+            + SimulationTime::MILLISECOND * 7;
         let sim_time =
             5 * simulation_time::SIMTIME_ONE_MINUTE + 7 * simulation_time::SIMTIME_ONE_MILLISECOND;
 
         assert_eq!(EmulatedTime::to_c_emutime(Some(rust_time)), sim_time);
-        assert_eq!(
-            EmulatedTime::to_c_emutime(None),
-            simulation_time::SIMTIME_INVALID
-        );
+        assert_eq!(EmulatedTime::to_c_emutime(None), EMUTIME_INVALID);
     }
 
     #[test]
     fn test_from_abs_simtime() {
         assert_eq!(
-            EmulatedTime::from_abs_simtime(SimulationTime::from(Duration::from_secs(0))),
-            SIMULATION_START
+            EmulatedTime::from_abs_simtime(SimulationTime::ZERO),
+            EmulatedTime::SIMULATION_START
         );
 
         assert_eq!(
-            EmulatedTime::from_abs_simtime(SimulationTime::from(Duration::from_secs(1))),
-            SIMULATION_START + Duration::from_secs(1)
+            EmulatedTime::from_abs_simtime(SimulationTime::SECOND),
+            EmulatedTime::SIMULATION_START + SimulationTime::SECOND
         );
     }
 
     #[test]
     fn test_to_abs_simtime() {
         assert_eq!(
-            SIMULATION_START.to_abs_simtime(),
-            SimulationTime::from(Duration::from_secs(0))
+            EmulatedTime::SIMULATION_START.to_abs_simtime(),
+            SimulationTime::ZERO
         );
 
         assert_eq!(
-            (SIMULATION_START + Duration::from_secs(1)).to_abs_simtime(),
-            SimulationTime::from(Duration::from_secs(1))
+            (EmulatedTime::SIMULATION_START + SimulationTime::SECOND).to_abs_simtime(),
+            SimulationTime::SECOND
         );
     }
 }

--- a/src/main/core/support/mod.rs
+++ b/src/main/core/support/mod.rs
@@ -2,5 +2,4 @@ pub mod configuration;
 pub mod units;
 
 pub mod emulated_time;
-/// cbindgen:ignore
 pub mod simulation_time;

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -1085,27 +1085,6 @@ ssize_t process_readString(Process* proc, char* str, PluginVirtualPtr src, size_
     return memorymanager_readString(proc->memoryManager, src, str, n);
 }
 
-int process_readTimespec(Process* proc, struct timespec* dst, PluginVirtualPtr src) {
-    MAGIC_ASSERT(proc);
-
-    // Disallow additional references while there's a mutable reference.
-    utility_assert(!proc->memoryMutRef);
-
-    int rv = memorymanager_readPtr(proc->memoryManager, dst, src, sizeof(*dst));
-    if (rv != 0) {
-        warning("Couldn't read timespec at address %p", (void*)src.val);
-        return rv;
-    }
-
-    if (dst->tv_nsec < 0 || dst->tv_nsec < 0 || dst->tv_nsec > 999999999) {
-        warning(
-            "Invalid timespec %ld.%09ld at address %p", dst->tv_sec, dst->tv_nsec, (void*)src.val);
-        return -EINVAL;
-    }
-
-    return 0;
-}
-
 // Returns a writable pointer corresponding to the named region. The initial
 // contents of the returned memory are unspecified.
 //

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -129,14 +129,6 @@ int process_getReadableString(Process* process, PluginPtr plugin_src, size_t n, 
 // -EFAULT if the string extends beyond the accessible address space.
 ssize_t process_readString(Process* proc, char* str, PluginVirtualPtr src, size_t n);
 
-// Convenience function to read and validate a timespec.
-//
-// Returns:
-// 0 on success.
-// -EFAULT if `src` couldn't be read.
-// -EINVAL if `src` didn't contain a valid timespec.
-int process_readTimespec(Process* proc, struct timespec* ts, PluginVirtualPtr src);
-
 // Copy `n` bytes from `src` to `dst`. Returns 0 on success or EFAULT if any of
 // the specified range couldn't be accessed. The write is flushed immediately.
 int process_writePtr(Process* proc, PluginVirtualPtr dst, const void* src, size_t n);

--- a/src/main/host/syscall/format.rs
+++ b/src/main/host/syscall/format.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use std::marker::PhantomData;
 use std::num::NonZeroU8;
 
-use crate::core::support::emulated_time::{self, EmulatedTime};
+use crate::core::support::emulated_time::EmulatedTime;
 use crate::host::memory_manager::MemoryManager;
 use crate::host::syscall_types::{
     PluginPtr, SysCallArgs, SysCallReg, SyscallError, SyscallResult, TypedPluginPtr,
@@ -552,8 +552,8 @@ pub fn write_syscall(
     args: impl Display,
     rv: impl Display,
 ) -> std::io::Result<()> {
-    let sim_time = sim_time.duration_since(&emulated_time::SIMULATION_START);
-    let sim_time = TimeParts::from_nanos(sim_time.as_nanos());
+    let sim_time = sim_time.duration_since(&EmulatedTime::SIMULATION_START);
+    let sim_time = TimeParts::from_nanos(sim_time.as_nanos().into());
     let sim_time = sim_time.fmt_hr_min_sec_milli();
 
     writeln!(

--- a/src/main/host/syscall/futex.c
+++ b/src/main/host/syscall/futex.c
@@ -28,11 +28,16 @@ static SysCallReturn _syscallhandler_futexWaitHelper(SysCallHandler* sys, Plugin
                                                      TimeoutType type) {
     // This is a new wait operation on the futex for this thread.
     // Check if a timeout was given in the syscall args.
-    struct timespec timeout = {0};
+    SimulationTime timeoutSimTime = SIMTIME_INVALID;
     if (timeoutVPtr.val) {
-        int rv = process_readTimespec(sys->process, &timeout, timeoutVPtr);
+        struct timespec ts = {0};
+        int rv = process_readPtr(sys->process, &ts, timeoutVPtr, sizeof(ts));
         if (rv < 0) {
             return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = rv};
+        }
+        timeoutSimTime = simtime_from_timespec(ts);
+        if (timeoutSimTime == SIMTIME_INVALID) {
+            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
         }
     }
 
@@ -64,7 +69,7 @@ static SysCallReturn _syscallhandler_futexWaitHelper(SysCallHandler* sys, Plugin
         int result = 0;
 
         // We already blocked on wait, so this is either a timeout or wakeup
-        if (timeoutVPtr.val && _syscallhandler_didListenTimeoutExpire(sys)) {
+        if (timeoutSimTime != SIMTIME_INVALID && _syscallhandler_didListenTimeoutExpire(sys)) {
             // Timeout while waiting for a wakeup
             trace("Futex %p timeout out while waiting", (void*)futexPPtr.val);
             result = -ETIMEDOUT;
@@ -93,15 +98,15 @@ static SysCallReturn _syscallhandler_futexWaitHelper(SysCallHandler* sys, Plugin
     }
 
     // Now we need to block until another thread does a wake on the futex.
-    trace("Futex blocking for wakeup %s timeout", timeoutVPtr.val ? "with" : "without");
+    trace("Futex blocking for wakeup %s timeout",
+          timeoutSimTime != SIMTIME_INVALID ? "with" : "without");
     Trigger trigger =
         (Trigger){.type = TRIGGER_FUTEX, .object = futex, .status = STATUS_FUTEX_WAKEUP};
     SysCallCondition* cond = syscallcondition_new(trigger);
-    if (timeoutVPtr.val) {
-        SimulationTime timeoutSimulationTime = timeout.tv_sec * SIMTIME_ONE_SECOND + timeout.tv_nsec * SIMTIME_ONE_NANOSECOND;
-        EmulatedTime timeoutEmulatedTime =
-            (type == TIMEOUT_RELATIVE) ? timeoutSimulationTime + worker_getCurrentEmulatedTime()
-                                       : timeoutSimulationTime;
+    if (timeoutSimTime != SIMTIME_INVALID) {
+        EmulatedTime timeoutEmulatedTime = (type == TIMEOUT_RELATIVE)
+                                               ? timeoutSimTime + worker_getCurrentEmulatedTime()
+                                               : timeoutSimTime;
         syscallcondition_setTimeout(cond, sys->host, timeoutEmulatedTime);
     }
     return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = cond, .restartable = true};

--- a/src/main/host/syscall/handler/sysinfo.rs
+++ b/src/main/host/syscall/handler/sysinfo.rs
@@ -1,4 +1,4 @@
-use crate::core::support::emulated_time;
+use crate::core::support::emulated_time::EmulatedTime;
 use crate::core::worker::Worker;
 use crate::host::context::ThreadContext;
 use crate::host::syscall::handler::SyscallHandler;
@@ -16,7 +16,7 @@ impl SyscallHandler {
         // Seconds are needed for uptime.
         let seconds = Worker::current_time()
             .unwrap()
-            .duration_since(&emulated_time::SIMULATION_START)
+            .duration_since(&EmulatedTime::SIMULATION_START)
             .as_secs();
 
         // Get a zeroed struct to make sure we init all fields.

--- a/src/main/utility/status_bar.rs
+++ b/src/main/utility/status_bar.rs
@@ -1,4 +1,4 @@
-use crate::core::support::emulated_time::{self, EmulatedTime};
+use crate::core::support::emulated_time::EmulatedTime;
 use crate::core::support::simulation_time::SimulationTime;
 use crate::utility::time::TimeParts;
 
@@ -180,14 +180,12 @@ pub struct ShadowStatusBarState {
 
 impl std::fmt::Display for ShadowStatusBarState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let sim_current = self
-            .current
-            .duration_since(&emulated_time::SIMULATION_START);
-        let sim_end = self.end.duration_since(&emulated_time::SIMULATION_START);
+        let sim_current = self.current.duration_since(&EmulatedTime::SIMULATION_START);
+        let sim_end = self.end.duration_since(&EmulatedTime::SIMULATION_START);
         let frac = sim_current.as_millis() as f32 / sim_end.as_millis() as f32;
 
-        let sim_current = TimeParts::from_nanos(sim_current.as_nanos());
-        let sim_end = TimeParts::from_nanos(sim_end.as_nanos());
+        let sim_current = TimeParts::from_nanos(sim_current.as_nanos().into());
+        let sim_end = TimeParts::from_nanos(sim_end.as_nanos().into());
         let realtime = TimeParts::from_nanos(self.start.elapsed().as_nanos());
 
         write!(
@@ -205,7 +203,7 @@ impl ShadowStatusBarState {
     pub fn new(end: EmulatedTime) -> Self {
         Self {
             start: std::time::Instant::now(),
-            current: emulated_time::SIMULATION_START,
+            current: EmulatedTime::SIMULATION_START,
             end,
         }
     }


### PR DESCRIPTION
Replaced `process_readTimeSpec` with helpers in Rust for converting to and from `libc::timespec`, and exposed those back to C. Also added conversions for `libc::timeval`, which we'll need for the itimer syscalls.

While writing the unit tests I decided that having the Rust SimulationTime support a wider range of values than the C SimulationTime is too likely to cause confusion. I changed it to wrap a C SimulationTime, and likewise for the Rust EmulationTime.

I think it's probably worth using SimulationTime broadly in Rust code after all rather than using Duration. e.g. here it was useful because we can implement the `From` trait between `SimulationTime` and `libc::timeval` and `libc::timespec`. We can't do the same for `Duration` since we don't own the type.