### PR TITLE
Initialize `tcp->send.unacked` as 0 not 1

### DIFF
--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -2663,7 +2663,8 @@ TCP* tcp_new(Host* host, guint receiveBufferSize, guint sendBufferSize) {
     /* 0 is saved for representing control packets */
     guint32 initialSequenceNumber = 1;
 
-    tcp->send.unacked = initialSequenceNumber;
+    // the first packet (the SYN packet) has a sequence number of 0
+    tcp->send.unacked = 0;
     tcp->send.next = initialSequenceNumber;
     tcp->send.end = initialSequenceNumber;
     tcp->send.lastAcknowledgment = initialSequenceNumber;


### PR DESCRIPTION
When enabling SYN packet retransmission, we noticed that the network performance was changing during Tor simulations. The performance change was narrowed down to the behaviour of the initial `tcp->send.unacked` value, which represents the next un-acked sequence number. In current Shadow since the first packet of a connection (the SYN packet) has a sequence number of 0 and the resulting ACK value is 1, I think it's more correct to initialize this `tcp->send.unacked` value as 0 instead of 1. Otherwise the first ACK isn't considered to be a valid ACK.

https://github.com/shadow/shadow/blob/87f5d75063fa4908e734c15513ebcb4800920f06/src/main/host/descriptor/tcp.c#L1778-L1780

Changing this value allows the connection to simultaneously send multiple data packets after the handshake has completed rather than only sending a single packet, and this changes the network performance.

After making this change, we should be able to enable the retransmission of SYN packets without any further performance changes.

The effects of this change can be seen at https://github.com/shadow/benchmark-results/tree/master/tor/2022-05-06-T18-54-44.

![transfer_time_51200 exit](https://user-images.githubusercontent.com/3708797/167271490-32a74403-15c3-4ab2-bc2d-deda0186792f.png)

![1651957081_grim](https://user-images.githubusercontent.com/3708797/167271517-57116fc3-e9d6-4ef1-94b1-c545072d1574.png)
