### PR TITLE
Make time arithmetic more explicit

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -465,6 +465,10 @@ int64_t parse_bandwidth(const char *s);
 // Parses a string as a time in nanoseconds. Returns '-1' on error.
 int64_t parse_time_nanosec(const char *s);
 
+EmulatedTime emutime_add_simtime(EmulatedTime lhs, SimulationTime rhs);
+
+SimulationTime emutime_sub_emutime(EmulatedTime lhs, EmulatedTime rhs);
+
 SimulationTime simtime_from_timeval(struct timeval val);
 
 SimulationTime simtime_from_timespec(struct timespec val);

--- a/src/main/core/scheduler/scheduler_policy_host_single.c
+++ b/src/main/core/scheduler/scheduler_policy_host_single.c
@@ -312,7 +312,8 @@ static EmulatedTime _schedulerpolicyhostsingle_nextHostEventTime(SchedulerPolicy
     Event* nextEvent = priorityqueue_peek(qdata->pq);
     if (nextEvent) {
         utility_assert(event_getHost(nextEvent) == host);
-        nextEventTime = SIMULATED_TIME_TO_EMULATED_TIME(event_getTime(nextEvent));
+        nextEventTime = emutime_add_simtime(EMUTIME_SIMULATION_START, event_getTime(nextEvent));
+        utility_assert(nextEventTime != EMUTIME_INVALID);
     }
 
     g_mutex_unlock(&(qdata->lock));

--- a/src/main/core/scheduler/scheduler_policy_thread_single.c
+++ b/src/main/core/scheduler/scheduler_policy_thread_single.c
@@ -124,7 +124,8 @@ static EmulatedTime _schedulerpolicythreadsingle_nextHostEventTime(SchedulerPoli
     Event* nextEvent = priorityqueue_peek(tdata->pq);
     if (nextEvent) {
         utility_assert(event_getHost(nextEvent) == host);
-        nextEventTime = SIMULATED_TIME_TO_EMULATED_TIME(event_getTime(nextEvent));
+        nextEventTime = emutime_add_simtime(EMUTIME_SIMULATION_START, event_getTime(nextEvent));
+        utility_assert(nextEventTime != EMUTIME_INVALID);
     }
     g_mutex_unlock(&(tdata->lock));
 

--- a/src/main/core/support/definitions.h
+++ b/src/main/core/support/definitions.h
@@ -72,12 +72,12 @@ typedef guint64 EmulatedTime;
  *
  * Duplicated as SIMULATION_START_SEC in `emulated_time.rs`.
  */
-#define EMULATED_TIME_OFFSET (G_GUINT64_CONSTANT(946684800) * SIMTIME_ONE_SECOND)
+#define EMUTIME_SIMULATION_START (G_GUINT64_CONSTANT(946684800) * SIMTIME_ONE_SECOND)
 
 /**
  * The Unix Epoch as EmulatedTime
  */
-#define EMULATED_TIME_UNIX_EPOCH (0)
+#define EMUTIME_UNIX_EPOCH (0)
 
 /**
  * Represents an invalid emulation time.
@@ -91,38 +91,8 @@ typedef guint64 EmulatedTime;
 #define EMUTIME_MIN 0
 
 /* Ensure it can be converted to EmulatedTime */
-#define SIMTIME_MAX (EMUTIME_MAX - EMULATED_TIME_OFFSET)
+#define SIMTIME_MAX (EMUTIME_MAX - EMUTIME_SIMULATION_START)
 #define SIMTIME_MIN 0
-
-/**
- * Conversion from emulated time to simulated time.
- */
-static inline SimulationTime EMULATED_TIME_TO_SIMULATED_TIME(EmulatedTime emtime) {
-    if (emtime == EMUTIME_INVALID) {
-        return SIMTIME_INVALID;
-    }
-    SimulationTime rv = emtime - EMULATED_TIME_OFFSET;
-
-    // Underflow check
-    g_assert(rv < emtime);
-
-    return rv;
-}
-
-/**
- * Conversion from emulated time to simulated time.
- */
-static inline EmulatedTime SIMULATED_TIME_TO_EMULATED_TIME(SimulationTime simtime) {
-    if (simtime == SIMTIME_INVALID) {
-        return EMUTIME_INVALID;
-    }
-    EmulatedTime rv = simtime + EMULATED_TIME_OFFSET;
-
-    // overflow check
-    g_assert(rv > simtime);
-
-    return rv;
-}
 
 /**
  * The start of our random port range in host order, used if application doesn't

--- a/src/main/core/support/emulated_time.rs
+++ b/src/main/core/support/emulated_time.rs
@@ -101,6 +101,48 @@ impl std::ops::Sub<EmulatedTime> for EmulatedTime {
     }
 }
 
+pub mod export {
+    use super::*;
+
+    #[no_mangle]
+    pub unsafe extern "C" fn emutime_add_simtime(
+        lhs: c::EmulatedTime,
+        rhs: c::SimulationTime,
+    ) -> c::EmulatedTime {
+        let lhs = if let Some(e) = EmulatedTime::from_c_emutime(lhs) {
+            e
+        } else {
+            return EmulatedTime::to_c_emutime(None);
+        };
+        let rhs = if let Some(e) = SimulationTime::from_c_simtime(rhs) {
+            e
+        } else {
+            return EmulatedTime::to_c_emutime(None);
+        };
+        let sum = lhs.checked_add(rhs);
+        EmulatedTime::to_c_emutime(sum)
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn emutime_sub_emutime(
+        lhs: c::EmulatedTime,
+        rhs: c::EmulatedTime,
+    ) -> c::SimulationTime {
+        let lhs = if let Some(e) = EmulatedTime::from_c_emutime(lhs) {
+            e
+        } else {
+            return EmulatedTime::to_c_emutime(None);
+        };
+        let rhs = if let Some(e) = EmulatedTime::from_c_emutime(rhs) {
+            e
+        } else {
+            return EmulatedTime::to_c_emutime(None);
+        };
+        let diff = lhs.checked_duration_since(&rhs);
+        SimulationTime::to_c_simtime(diff)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main/host/descriptor/timerfd.c
+++ b/src/main/host/descriptor/timerfd.c
@@ -123,7 +123,7 @@ static void _timerfd_arm(TimerFd* timerfd, Host* host, const struct itimerspec* 
     utility_assert(configSimTime != SIMTIME_INVALID);
 
     EmulatedTime now = worker_getCurrentEmulatedTime();
-    EmulatedTime base = (flags == TFD_TIMER_ABSTIME) ? EMULATED_TIME_UNIX_EPOCH : now;
+    EmulatedTime base = (flags == TFD_TIMER_ABSTIME) ? EMUTIME_UNIX_EPOCH : now;
     EmulatedTime nextExpireTime = base + configSimTime;
     /* the man page does not specify what happens if the time
      * they gave us is in the past. on linux, the result is an

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -347,7 +347,8 @@ static void _process_getAndLogReturnCode(Process* proc) {
 
     if (!process_hasStarted(proc)) {
         error("Process '%s' with a start time of %" G_GUINT64_FORMAT " did not start",
-              process_getName(proc), EMULATED_TIME_TO_SIMULATED_TIME(proc->startTime));
+              process_getName(proc),
+              emutime_sub_emutime(proc->startTime, EMUTIME_SIMULATION_START));
         return;
     }
 
@@ -801,8 +802,8 @@ Process* process_new(Host* host, guint processID, SimulationTime startTime, Simu
 #endif
 
     utility_assert(stopTime == 0 || stopTime > startTime);
-    proc->startTime = SIMULATED_TIME_TO_EMULATED_TIME(startTime);
-    proc->stopTime = SIMULATED_TIME_TO_EMULATED_TIME(stopTime);
+    proc->startTime = emutime_add_simtime(EMUTIME_SIMULATION_START, startTime);
+    proc->stopTime = emutime_add_simtime(EMUTIME_SIMULATION_START, stopTime);
 
     proc->interposeMethod = interposeMethod;
 


### PR DESCRIPTION
* Replaces `SIMULATED_TIME_TO_EMULATED_TIME` with `emutime_add_simtime`
* Replaces `EMULATED_TIME_TO_SIMULATED_TIME` with `emutime_sub_emutime`

These make it a bit clearer at the call site what's being done,
especially since the old helper names implicitly reference the
(deprecated) usage of `SimulatedTime` to reference an instant in time.

Also gets rid of some redundant C helpers in favor of wrapping the
equivalent Rust functionality.

Also:

* renames `EMULATED_TIME_UNIX_EPOCH` to `EMUTIME_UNIX_EPOCH` for conciseness and consistency with e.g. `EMUTIME_MAX`
* renames `EMULATED_TIME_OFFSET` to `EMUTIME_SIMULATION_START` for clarity.