### PR TITLE
SyncSendPointer: be more explicit about safety

### DIFF
--- a/src/main/core/work/task.rs
+++ b/src/main/core/work/task.rs
@@ -45,7 +45,7 @@ pub mod export {
     use crate::{
         cshadow,
         host::host::{Host, HostId},
-        utility::SyncSendPointer,
+        utility::{notnull::notnull_mut, HostTreePointer},
     };
 
     pub type TaskCallbackFunc =
@@ -55,79 +55,65 @@ pub mod export {
 
     /// Compatibility struct for creating a `TaskRef` from function pointers.
     struct CTask {
-        #[cfg(debug_assertions)]
-        host_id: HostId,
         callback: TaskCallbackFunc,
-        object: SyncSendPointer<libc::c_void>,
-        argument: SyncSendPointer<libc::c_void>,
+        object: HostTreePointer<libc::c_void>,
+        argument: HostTreePointer<libc::c_void>,
         object_free: TaskObjectFreeFunc,
         argument_free: TaskArgumentFreeFunc,
     }
 
     impl CTask {
-        /// SAFETY: Objects pointed to by `object` and `argument` must be
-        /// `Send`.
+        /// SAFETY: Given that the host lock is held when execution of a
+        /// callback starts, they must not cause `object` or `argument` to be
+        /// dereferenced without the host lock held. (e.g. by releasing the host
+        /// lock or exfiltrating the pointers to be dereferenced by other code
+        /// that might not hold the lock).
         unsafe fn new(
-            host_id: HostId,
             callback: TaskCallbackFunc,
-            object: *mut libc::c_void,
-            argument: *mut libc::c_void,
+            object: HostTreePointer<libc::c_void>,
+            argument: HostTreePointer<libc::c_void>,
             object_free: TaskObjectFreeFunc,
             argument_free: TaskArgumentFreeFunc,
         ) -> Self {
-            // Suppress "never read" warning in release builds.
-            let _ = host_id;
             Self {
-                #[cfg(debug_assertions)]
-                host_id,
                 callback,
-                object: SyncSendPointer(object),
-                argument: SyncSendPointer(argument),
+                object,
+                argument,
                 object_free,
                 argument_free,
             }
         }
 
-        #[cfg(debug_assertions)]
-        fn check_host_id(&self) {
-            Worker::with_active_host_info(|i| {
-                debug_assert_eq!(self.host_id, i.id);
-            });
-        }
-        #[cfg(not(debug_assertions))]
-        fn check_host_id(&self) {}
-
-        /// SAFETY: Objects pointed to by `object` and `argument` must either
-        /// be not accessible by other threads, or must be `Sync`.
-        unsafe fn execute(&self, host: *mut cshadow::Host) {
-            self.check_host_id();
-            (self.callback)(host, self.object.0, self.argument.0)
+        /// Panics if host lock for `object` and `argument` aren't held.
+        fn execute(&self, host: *mut cshadow::Host) {
+            (self.callback)(host, unsafe { self.object.ptr() }, unsafe {
+                self.argument.ptr()
+            })
         }
     }
 
     impl Drop for CTask {
         fn drop(&mut self) {
-            self.check_host_id();
             if let Some(object_free) = self.object_free {
-                object_free(self.object.0);
+                let ptr = unsafe { self.object.ptr() };
+                object_free(ptr);
             }
             if let Some(argument_free) = self.argument_free {
-                argument_free(self.argument.0);
+                let ptr = unsafe { self.argument.ptr() };
+                argument_free(ptr);
             }
         }
     }
 
     /// Create a new reference-counted task.
     ///
-    /// SAFETY: The underlying Task is assumed to be Send and Sync.
-    /// It is the responsibility of the provided callbacks to access
-    /// in a thread-safe way.
-    ///
-    /// `taskref_execute` and `taskref_drop` must only be called when the lock
-    /// of the `host_id` that was passed to `host_id` is held. In the (typical)
-    /// case where objects are only held within a single `Host`, the callbacks
-    /// can hence safely assume that the current thread is the only one
-    /// currently accessing these pointers.
+    /// SAFETY:
+    /// * `object` and `argument` must meet the requirements
+    ///    for `HostTreePointer::new`.
+    /// * Given that the host lock is held when execution of a callback
+    ///   starts, they must not cause `object` or `argument` to be dereferenced
+    ///   without the host lock held. (e.g. by releasing the host lock or exfiltrating
+    ///   the pointers to be dereferenced by other code that might not hold the lock).
     ///
     /// There must still be some coordination between the creator of the TaskRef
     /// and the callers of `taskref_execute` and `taskref_drop` to ensure that
@@ -136,7 +122,7 @@ pub mod export {
     /// the pointers while the callback transforms the pointer into another Rust
     /// reference).
     #[no_mangle]
-    pub unsafe extern "C" fn taskref_new(
+    pub unsafe extern "C" fn taskref_new_for_host(
         host_id: HostId,
         callback: TaskCallbackFunc,
         object: *mut libc::c_void,
@@ -146,15 +132,14 @@ pub mod export {
     ) -> *mut TaskRef {
         let objs = unsafe {
             CTask::new(
-                host_id,
                 callback,
-                object,
-                argument,
+                HostTreePointer::new_for_host(host_id, object),
+                HostTreePointer::new_for_host(host_id, argument),
                 object_free,
                 argument_free,
             )
         };
-        let task = TaskRef::new(move |host: &mut Host| unsafe { objs.execute(host.chost()) });
+        let task = TaskRef::new(move |host: &mut Host| objs.execute(host.chost()));
         // It'd be nice if we could use Arc::into_raw here, avoiding a level of
         // pointer indirection. Unfortunately that doesn't work because of the
         // internal dynamic Trait object, making the resulting pointer non-ABI
@@ -162,7 +147,33 @@ pub mod export {
         Box::into_raw(Box::new(task))
     }
 
+    /// Create a new reference-counted task for the current Host.
+    ///
+    /// SAFETY: see `taskref_new_for_host`
+    #[no_mangle]
+    pub unsafe extern "C" fn taskref_new(
+        callback: TaskCallbackFunc,
+        object: *mut libc::c_void,
+        argument: *mut libc::c_void,
+        object_free: TaskObjectFreeFunc,
+        argument_free: TaskArgumentFreeFunc,
+    ) -> *mut TaskRef {
+        let host_id = Worker::with_active_host_info(|i| i.id);
+        unsafe {
+            taskref_new_for_host(
+                host_id.unwrap(),
+                callback,
+                object,
+                argument,
+                object_free,
+                argument_free,
+            )
+        }
+    }
+
     /// Creates a new reference to the `Task`.
+    ///
+    /// SAFETY: `task` must be a valid pointer.
     #[no_mangle]
     pub unsafe extern "C" fn taskref_clone(task: *const TaskRef) -> *mut TaskRef {
         let task = unsafe { task.as_ref() }.unwrap();
@@ -170,12 +181,20 @@ pub mod export {
     }
 
     /// Destroys this reference to the `Task`, dropping the `Task` if no references remain.
+    ///
+    /// Panics if task's Host lock isn't held.
+    ///
+    /// SAFETY: `task` must be legally dereferencable.
     #[no_mangle]
     pub unsafe extern "C" fn taskref_drop(task: *mut TaskRef) {
-        unsafe { Box::from_raw(task) };
+        unsafe { Box::from_raw(notnull_mut(task)) };
     }
 
     /// Executes the task.
+    ///
+    /// Panics if task's Host lock isn't held.
+    ///
+    /// SAFETY: `task` must be legally dereferencable.
     #[no_mangle]
     pub unsafe extern "C" fn taskref_execute(task: *mut TaskRef, host: *mut cshadow::Host) {
         let task = unsafe { task.as_mut() }.unwrap();

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -586,8 +586,11 @@ void worker_sendPacket(Host* srcHost, Packet* packet) {
          * and unreffed after the task is finished executing. */
         Packet* packetCopy = packet_copy(packet);
 
-        TaskRef* packetTask = taskref_new_for_host(dstID, _worker_runDeliverPacketTask, packetCopy,
-                                                   NULL, (TaskObjectFreeFunc)packet_unref, NULL);
+        /* Safe to use the "unbound" constructor here, since there are no other references
+         * to `packetCopy`.
+         */
+        TaskRef* packetTask = taskref_new_unbound(
+            _worker_runDeliverPacketTask, packetCopy, NULL, (TaskObjectFreeFunc)packet_unref, NULL);
         Event* packetEvent = event_new_(packetTask, deliverTime, srcHost, dstHost);
         taskref_drop(packetTask);
 

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -586,8 +586,8 @@ void worker_sendPacket(Host* srcHost, Packet* packet) {
          * and unreffed after the task is finished executing. */
         Packet* packetCopy = packet_copy(packet);
 
-        TaskRef* packetTask = taskref_new(dstID, _worker_runDeliverPacketTask, packetCopy, NULL,
-                                          (TaskObjectFreeFunc)packet_unref, NULL);
+        TaskRef* packetTask = taskref_new_for_host(dstID, _worker_runDeliverPacketTask, packetCopy,
+                                                   NULL, (TaskObjectFreeFunc)packet_unref, NULL);
         Event* packetEvent = event_new_(packetTask, deliverTime, srcHost, dstHost);
         taskref_drop(packetTask);
 

--- a/src/main/host/descriptor/eventfd.rs
+++ b/src/main/host/descriptor/eventfd.rs
@@ -8,6 +8,7 @@ use crate::host::memory_manager::MemoryManager;
 use crate::host::syscall_types::{PluginPtr, SyscallError, SyscallResult};
 use crate::utility::event_queue::{EventQueue, Handle};
 use crate::utility::stream_len::StreamLen;
+use crate::utility::HostTreePointer;
 
 pub struct EventFd {
     counter: u64,
@@ -184,7 +185,7 @@ impl EventFd {
             .add_listener(monitoring, filter, notify_fn)
     }
 
-    pub fn add_legacy_listener(&mut self, ptr: *mut c::StatusListener) {
+    pub fn add_legacy_listener(&mut self, ptr: HostTreePointer<c::StatusListener>) {
         self.event_source.add_legacy_listener(ptr);
     }
 

--- a/src/main/host/descriptor/pipe.rs
+++ b/src/main/host/descriptor/pipe.rs
@@ -13,6 +13,7 @@ use crate::host::memory_manager::MemoryManager;
 use crate::host::syscall_types::{PluginPtr, SyscallError, SyscallResult};
 use crate::utility::event_queue::{EventQueue, Handle};
 use crate::utility::stream_len::StreamLen;
+use crate::utility::HostTreePointer;
 
 pub struct Pipe {
     buffer: Option<Arc<AtomicRefCell<SharedBuf>>>,
@@ -312,7 +313,7 @@ impl Pipe {
             .add_listener(monitoring, filter, notify_fn)
     }
 
-    pub fn add_legacy_listener(&mut self, ptr: *mut c::StatusListener) {
+    pub fn add_legacy_listener(&mut self, ptr: HostTreePointer<c::StatusListener>) {
         self.event_source.add_legacy_listener(ptr);
     }
 

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -7,6 +7,7 @@ use crate::host::descriptor::{FileMode, FileState, FileStatus, SyscallResult};
 use crate::host::memory_manager::MemoryManager;
 use crate::host::syscall_types::{PluginPtr, SysCallReg, SyscallError};
 use crate::utility::event_queue::EventQueue;
+use crate::utility::HostTreePointer;
 
 use unix::UnixSocket;
 
@@ -177,7 +178,7 @@ impl SocketRefMut<'_> {
         pub fn ioctl(&mut self, request: u64, arg_ptr: PluginPtr, memory_manager: &mut MemoryManager) -> SyscallResult
     );
     enum_passthrough!(self, (ptr), Unix;
-        pub fn add_legacy_listener(&mut self, ptr: *mut c::StatusListener)
+        pub fn add_legacy_listener(&mut self, ptr: HostTreePointer<c::StatusListener>)
     );
     enum_passthrough!(self, (ptr), Unix;
         pub fn remove_legacy_listener(&mut self, ptr: *mut c::StatusListener)

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -19,6 +19,7 @@ use crate::host::syscall_condition::SysCallCondition;
 use crate::host::syscall_types::{Blocked, PluginPtr, SysCallReg, SyscallError};
 use crate::utility::event_queue::{EventQueue, Handle};
 use crate::utility::stream_len::StreamLen;
+use crate::utility::HostTreePointer;
 
 const UNIX_SOCKET_DEFAULT_BUFFER_SIZE: usize = 212_992;
 
@@ -310,7 +311,7 @@ impl UnixSocket {
             .add_listener(monitoring, filter, notify_fn)
     }
 
-    pub fn add_legacy_listener(&mut self, ptr: *mut c::StatusListener) {
+    pub fn add_legacy_listener(&mut self, ptr: HostTreePointer<c::StatusListener>) {
         self.common.event_source.add_legacy_listener(ptr);
     }
 

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -690,7 +690,7 @@ static void _tcp_setState(TCP* tcp, Host* host, enum TCPState state) {
         case TCPS_TIMEWAIT: {
             /* schedule a close timer self-event to finish out the closing process */
             descriptor_ref(tcp);
-            TaskRef* closeTask = taskref_new_for_host(
+            TaskRef* closeTask = taskref_new_bound(
                 host_getID(host), _tcp_runCloseTimerExpiredTask, tcp, NULL, descriptor_unref, NULL);
             SimulationTime delay = CONFIG_TCPCLOSETIMER_DELAY;
 
@@ -1003,8 +1003,8 @@ static void _tcp_scheduleRetransmitTimer(TCP* tcp, Host* host, SimulationTime no
     if(success) {
         descriptor_ref(tcp);
         TaskRef* retexpTask =
-            taskref_new_for_host(host_getID(host), _tcp_runRetransmitTimerExpiredTask, tcp, NULL,
-                                 descriptor_unref, NULL);
+            taskref_new_bound(host_getID(host), _tcp_runRetransmitTimerExpiredTask, tcp, NULL,
+                              descriptor_unref, NULL);
         worker_scheduleTaskWithDelay(retexpTask, host, delay);
         taskref_drop(retexpTask);
 
@@ -2194,7 +2194,7 @@ static void _tcp_processPacket(LegacySocket* socket, Host* host, Packet* packet)
             if(tcp->send.delayedACKIsScheduled == FALSE) {
                 /* we need to send an ACK, lets schedule a task so we don't send an ACK
                  * for all packets that are received during this same simtime receiving round. */
-                TaskRef* sendACKTask = taskref_new_for_host(
+                TaskRef* sendACKTask = taskref_new_bound(
                     host_getID(host), _tcp_sendACKTaskCallback, tcp, NULL, descriptor_unref, NULL);
                 /* taks holds a ref to tcp */
                 descriptor_ref(tcp);
@@ -2479,7 +2479,7 @@ static gssize _tcp_receiveUserData(Transport* transport, Thread* thread, PluginV
          * make sure we don't send multiple events when read is called many times per instant */
         descriptor_ref(tcp);
 
-        TaskRef* updateWindowTask = taskref_new_for_host(
+        TaskRef* updateWindowTask = taskref_new_bound(
             host_getID(host), _tcp_sendWindowUpdate, tcp, NULL, descriptor_unref, NULL);
         worker_scheduleTaskWithDelay(updateWindowTask, thread_getHost(thread), 1);
         taskref_drop(updateWindowTask);

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -690,7 +690,7 @@ static void _tcp_setState(TCP* tcp, Host* host, enum TCPState state) {
         case TCPS_TIMEWAIT: {
             /* schedule a close timer self-event to finish out the closing process */
             descriptor_ref(tcp);
-            TaskRef* closeTask = taskref_new(
+            TaskRef* closeTask = taskref_new_for_host(
                 host_getID(host), _tcp_runCloseTimerExpiredTask, tcp, NULL, descriptor_unref, NULL);
             SimulationTime delay = CONFIG_TCPCLOSETIMER_DELAY;
 
@@ -1002,8 +1002,9 @@ static void _tcp_scheduleRetransmitTimer(TCP* tcp, Host* host, SimulationTime no
 
     if(success) {
         descriptor_ref(tcp);
-        TaskRef* retexpTask = taskref_new(host_getID(host), _tcp_runRetransmitTimerExpiredTask, tcp,
-                                          NULL, descriptor_unref, NULL);
+        TaskRef* retexpTask =
+            taskref_new_for_host(host_getID(host), _tcp_runRetransmitTimerExpiredTask, tcp, NULL,
+                                 descriptor_unref, NULL);
         worker_scheduleTaskWithDelay(retexpTask, host, delay);
         taskref_drop(retexpTask);
 
@@ -2193,7 +2194,7 @@ static void _tcp_processPacket(LegacySocket* socket, Host* host, Packet* packet)
             if(tcp->send.delayedACKIsScheduled == FALSE) {
                 /* we need to send an ACK, lets schedule a task so we don't send an ACK
                  * for all packets that are received during this same simtime receiving round. */
-                TaskRef* sendACKTask = taskref_new(
+                TaskRef* sendACKTask = taskref_new_for_host(
                     host_getID(host), _tcp_sendACKTaskCallback, tcp, NULL, descriptor_unref, NULL);
                 /* taks holds a ref to tcp */
                 descriptor_ref(tcp);
@@ -2478,8 +2479,8 @@ static gssize _tcp_receiveUserData(Transport* transport, Thread* thread, PluginV
          * make sure we don't send multiple events when read is called many times per instant */
         descriptor_ref(tcp);
 
-        TaskRef* updateWindowTask =
-            taskref_new(host_getID(host), _tcp_sendWindowUpdate, tcp, NULL, descriptor_unref, NULL);
+        TaskRef* updateWindowTask = taskref_new_for_host(
+            host_getID(host), _tcp_sendWindowUpdate, tcp, NULL, descriptor_unref, NULL);
         worker_scheduleTaskWithDelay(updateWindowTask, thread_getHost(thread), 1);
         taskref_drop(updateWindowTask);
 

--- a/src/main/host/descriptor/timerfd.c
+++ b/src/main/host/descriptor/timerfd.c
@@ -80,7 +80,7 @@ TimerFd* timerfd_new(HostId hostId) {
 
     descriptor_refWeak(timerfd);
     TaskRef* task =
-        taskref_new_for_host(hostId, _timerfd_expire, timerfd, NULL, descriptor_unrefWeak, NULL);
+        taskref_new_bound(hostId, _timerfd_expire, timerfd, NULL, descriptor_unrefWeak, NULL);
     timerfd->timer = timer_new(task);
     taskref_drop(task);
 

--- a/src/main/host/descriptor/timerfd.c
+++ b/src/main/host/descriptor/timerfd.c
@@ -79,7 +79,8 @@ TimerFd* timerfd_new(HostId hostId) {
     descriptor_adjustStatus(&(timerfd->super), STATUS_DESCRIPTOR_ACTIVE, TRUE);
 
     descriptor_refWeak(timerfd);
-    TaskRef* task = taskref_new(hostId, _timerfd_expire, timerfd, NULL, descriptor_unrefWeak, NULL);
+    TaskRef* task =
+        taskref_new_for_host(hostId, _timerfd_expire, timerfd, NULL, descriptor_unrefWeak, NULL);
     timerfd->timer = timer_new(task);
     taskref_drop(task);
 

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -124,7 +124,7 @@ _networkinterface_consumeTokenBucket(NetworkInterfaceTokenBucket* bucket,
 
 static void _networkinterface_scheduleRefillTask(NetworkInterface* interface, Host* host,
                                                  TaskCallbackFunc func, SimulationTime delay) {
-    TaskRef* refillTask = taskref_new(host_getID(host), func, interface, NULL, NULL, NULL);
+    TaskRef* refillTask = taskref_new_for_host(host_getID(host), func, interface, NULL, NULL, NULL);
     worker_scheduleTaskWithDelay(refillTask, host, delay);
     taskref_drop(refillTask);
     interface->isRefillPending = TRUE;
@@ -590,8 +590,9 @@ static void _networkinterface_sendPackets(NetworkInterface* interface, Host* src
             /* packet will arrive on our own interface, so it doesn't need to
              * go through the upstream router and does not consume bandwidth. */
             packet_ref(packet);
-            TaskRef* packetTask = taskref_new(host_getID(src), _networkinterface_receivePacketTask,
-                                              interface, packet, NULL, packet_unrefTaskFreeFunc);
+            TaskRef* packetTask =
+                taskref_new_for_host(host_getID(src), _networkinterface_receivePacketTask,
+                                     interface, packet, NULL, packet_unrefTaskFreeFunc);
             worker_scheduleTaskWithDelay(packetTask, src, 1);
             taskref_drop(packetTask);
         } else {

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -124,7 +124,7 @@ _networkinterface_consumeTokenBucket(NetworkInterfaceTokenBucket* bucket,
 
 static void _networkinterface_scheduleRefillTask(NetworkInterface* interface, Host* host,
                                                  TaskCallbackFunc func, SimulationTime delay) {
-    TaskRef* refillTask = taskref_new_for_host(host_getID(host), func, interface, NULL, NULL, NULL);
+    TaskRef* refillTask = taskref_new_bound(host_getID(host), func, interface, NULL, NULL, NULL);
     worker_scheduleTaskWithDelay(refillTask, host, delay);
     taskref_drop(refillTask);
     interface->isRefillPending = TRUE;
@@ -591,8 +591,8 @@ static void _networkinterface_sendPackets(NetworkInterface* interface, Host* src
              * go through the upstream router and does not consume bandwidth. */
             packet_ref(packet);
             TaskRef* packetTask =
-                taskref_new_for_host(host_getID(src), _networkinterface_receivePacketTask,
-                                     interface, packet, NULL, packet_unrefTaskFreeFunc);
+                taskref_new_bound(host_getID(src), _networkinterface_receivePacketTask, interface,
+                                  packet, NULL, packet_unrefTaskFreeFunc);
             worker_scheduleTaskWithDelay(packetTask, src, 1);
             taskref_drop(packetTask);
         } else {

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -622,8 +622,8 @@ void process_addThread(Process* proc, Thread* thread) {
     thread_ref(thread);
     process_ref(proc);
     TaskRef* task =
-        taskref_new_for_host(host_getID(proc->host), _start_thread_task, proc, thread,
-                             _start_thread_task_free_process, _start_thread_task_free_thread);
+        taskref_new_bound(host_getID(proc->host), _start_thread_task, proc, thread,
+                          _start_thread_task_free_process, _start_thread_task_free_thread);
     worker_scheduleTaskWithDelay(task, proc->host, 0);
     taskref_drop(task);
 }
@@ -731,8 +731,8 @@ void process_schedule(Process* proc, gpointer nothing) {
     if (proc->stopTime == EMUTIME_INVALID || proc->startTime < proc->stopTime) {
         process_ref(proc);
         TaskRef* startProcessTask =
-            taskref_new_for_host(host_getID(proc->host), _process_runStartTask, proc, NULL,
-                                 (TaskObjectFreeFunc)process_unref, NULL);
+            taskref_new_bound(host_getID(proc->host), _process_runStartTask, proc, NULL,
+                              (TaskObjectFreeFunc)process_unref, NULL);
         worker_scheduleTaskAtEmulatedTime(startProcessTask, proc->host, proc->startTime);
         taskref_drop(startProcessTask);
     }
@@ -740,8 +740,8 @@ void process_schedule(Process* proc, gpointer nothing) {
     if (proc->stopTime != EMUTIME_INVALID && proc->stopTime > proc->startTime) {
         process_ref(proc);
         TaskRef* stopProcessTask =
-            taskref_new_for_host(host_getID(proc->host), _process_runStopTask, proc, NULL,
-                                 (TaskObjectFreeFunc)process_unref, NULL);
+            taskref_new_bound(host_getID(proc->host), _process_runStopTask, proc, NULL,
+                              (TaskObjectFreeFunc)process_unref, NULL);
         worker_scheduleTaskAtEmulatedTime(stopProcessTask, proc->host, proc->stopTime);
         taskref_drop(stopProcessTask);
     }

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -621,8 +621,9 @@ void process_addThread(Process* proc, Thread* thread) {
     // Schedule thread to start.
     thread_ref(thread);
     process_ref(proc);
-    TaskRef* task = taskref_new(host_getID(proc->host), _start_thread_task, proc, thread,
-                                _start_thread_task_free_process, _start_thread_task_free_thread);
+    TaskRef* task =
+        taskref_new_for_host(host_getID(proc->host), _start_thread_task, proc, thread,
+                             _start_thread_task_free_process, _start_thread_task_free_thread);
     worker_scheduleTaskWithDelay(task, proc->host, 0);
     taskref_drop(task);
 }
@@ -729,16 +730,18 @@ void process_schedule(Process* proc, gpointer nothing) {
 
     if (proc->stopTime == EMUTIME_INVALID || proc->startTime < proc->stopTime) {
         process_ref(proc);
-        TaskRef* startProcessTask = taskref_new(host_getID(proc->host), _process_runStartTask, proc,
-                                                NULL, (TaskObjectFreeFunc)process_unref, NULL);
+        TaskRef* startProcessTask =
+            taskref_new_for_host(host_getID(proc->host), _process_runStartTask, proc, NULL,
+                                 (TaskObjectFreeFunc)process_unref, NULL);
         worker_scheduleTaskAtEmulatedTime(startProcessTask, proc->host, proc->startTime);
         taskref_drop(startProcessTask);
     }
 
     if (proc->stopTime != EMUTIME_INVALID && proc->stopTime > proc->startTime) {
         process_ref(proc);
-        TaskRef* stopProcessTask = taskref_new(host_getID(proc->host), _process_runStopTask, proc,
-                                               NULL, (TaskObjectFreeFunc)process_unref, NULL);
+        TaskRef* stopProcessTask =
+            taskref_new_for_host(host_getID(proc->host), _process_runStopTask, proc, NULL,
+                                 (TaskObjectFreeFunc)process_unref, NULL);
         worker_scheduleTaskAtEmulatedTime(stopProcessTask, proc->host, proc->stopTime);
         taskref_drop(stopProcessTask);
     }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -158,7 +158,7 @@ impl Process {
 
 mod export {
     use super::*;
-    use crate::host::descriptor::CountedLegacyDescriptorRef;
+    use crate::{host::descriptor::CountedLegacyDescriptorRef, utility::HostTreePointer};
 
     /// Register a `CompatDescriptor`. This takes ownership of the descriptor and you must not
     /// access it after.
@@ -225,7 +225,7 @@ mod export {
     /// Register a `LegacyDescriptor`. This takes ownership of the descriptor and you must
     /// increment the ref count if you are to hold a reference to this descriptor.
     #[no_mangle]
-    pub extern "C" fn process_registerLegacyDescriptor(
+    pub unsafe extern "C" fn process_registerLegacyDescriptor(
         proc: *mut cshadow::Process,
         desc: *mut cshadow::LegacyDescriptor,
     ) -> libc::c_int {
@@ -233,7 +233,8 @@ mod export {
         assert!(!desc.is_null());
 
         unsafe { cshadow::descriptor_setOwnerProcess(desc, proc.cprocess) };
-        let desc = CompatDescriptor::Legacy(CountedLegacyDescriptorRef::new(desc));
+        let desc =
+            CompatDescriptor::Legacy(CountedLegacyDescriptorRef::new(HostTreePointer::new(desc)));
 
         let fd = proc.register_descriptor(desc);
         fd.try_into().unwrap()
@@ -242,7 +243,7 @@ mod export {
     /// Unlike the deregister method for the `CompatDescriptor`, you do not need to manually
     /// unref the LegacyDescriptor as it's done automatically.
     #[no_mangle]
-    pub extern "C" fn process_deregisterLegacyDescriptor(
+    pub unsafe extern "C" fn process_deregisterLegacyDescriptor(
         proc: *mut cshadow::Process,
         desc: *mut cshadow::LegacyDescriptor,
     ) {
@@ -266,7 +267,7 @@ mod export {
 
         match proc.deregister_descriptor(handle.try_into().unwrap()) {
             Some(CompatDescriptor::Legacy(removed_desc)) => {
-                if removed_desc.ptr() != desc {
+                if unsafe { removed_desc.ptr() } != desc {
                     panic!("Deregistered the wrong descriptor with handle {}", handle);
                 }
             }
@@ -284,7 +285,7 @@ mod export {
 
     /// Get a temporary reference to a legacy descriptor.
     #[no_mangle]
-    pub extern "C" fn process_getRegisteredLegacyDescriptor(
+    pub unsafe extern "C" fn process_getRegisteredLegacyDescriptor(
         proc: *mut cshadow::Process,
         handle: libc::c_int,
     ) -> *mut cshadow::LegacyDescriptor {
@@ -299,7 +300,7 @@ mod export {
         };
 
         match proc.get_descriptor(handle) {
-            Some(CompatDescriptor::Legacy(desc)) => desc.ptr(),
+            Some(CompatDescriptor::Legacy(desc)) => unsafe { desc.ptr() },
             Some(_) => {
                 log::warn!("A descriptor exists for fd={}, but it is not a legacy descriptor. Returning NULL.",
                            handle);

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -380,8 +380,8 @@ static void _syscallcondition_scheduleWakeupTask(SysCallCondition* cond) {
      * we tell the process to run the plugin and potentially change
      * the state of the trigger object again. */
     TaskRef* wakeupTask =
-        taskref_new_for_host(thread_getHostId(cond->thread), _syscallcondition_trigger, cond, NULL,
-                             _syscallcondition_unrefcb, NULL);
+        taskref_new_bound(thread_getHostId(cond->thread), _syscallcondition_trigger, cond, NULL,
+                          _syscallcondition_unrefcb, NULL);
     worker_scheduleTaskWithDelay(
         wakeupTask, thread_getHost(cond->thread), 0); // Call without moving time forward
 
@@ -429,9 +429,9 @@ void syscallcondition_waitNonblock(SysCallCondition* cond, Host* host, Process* 
     if (cond->timeoutExpiration != EMUTIME_INVALID) {
         if (!cond->timeout) {
             syscallcondition_ref(cond);
-            TaskRef* task = taskref_new_for_host(thread_getHostId(cond->thread),
-                                                 _syscallcondition_notifyTimeoutExpired, cond, NULL,
-                                                 _syscallcondition_unrefcb, NULL);
+            TaskRef* task = taskref_new_bound(thread_getHostId(cond->thread),
+                                              _syscallcondition_notifyTimeoutExpired, cond, NULL,
+                                              _syscallcondition_unrefcb, NULL);
             cond->timeout = timer_new(task);
             taskref_drop(task);
         }

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -379,8 +379,9 @@ static void _syscallcondition_scheduleWakeupTask(SysCallCondition* cond) {
      * code triggered our listener finishes its logic first before
      * we tell the process to run the plugin and potentially change
      * the state of the trigger object again. */
-    TaskRef* wakeupTask = taskref_new(thread_getHostId(cond->thread), _syscallcondition_trigger,
-                                      cond, NULL, _syscallcondition_unrefcb, NULL);
+    TaskRef* wakeupTask =
+        taskref_new_for_host(thread_getHostId(cond->thread), _syscallcondition_trigger, cond, NULL,
+                             _syscallcondition_unrefcb, NULL);
     worker_scheduleTaskWithDelay(
         wakeupTask, thread_getHost(cond->thread), 0); // Call without moving time forward
 
@@ -428,9 +429,9 @@ void syscallcondition_waitNonblock(SysCallCondition* cond, Host* host, Process* 
     if (cond->timeoutExpiration != EMUTIME_INVALID) {
         if (!cond->timeout) {
             syscallcondition_ref(cond);
-            TaskRef* task =
-                taskref_new(thread_getHostId(cond->thread), _syscallcondition_notifyTimeoutExpired,
-                            cond, NULL, _syscallcondition_unrefcb, NULL);
+            TaskRef* task = taskref_new_for_host(thread_getHostId(cond->thread),
+                                                 _syscallcondition_notifyTimeoutExpired, cond, NULL,
+                                                 _syscallcondition_unrefcb, NULL);
             cond->timeout = timer_new(task);
             taskref_drop(task);
         }

--- a/src/main/host/timer.c
+++ b/src/main/host/timer.c
@@ -134,7 +134,7 @@ static void _timer_scheduleNewExpireEvent(Timer* timer, Host* host) {
 
     /* ref the timer storage in the callback event */
     timer_ref(timer);
-    TaskRef* task = taskref_new(
+    TaskRef* task = taskref_new_for_host(
         host_getID(host), _timer_expire, timer, next, _timer_unrefTaskObjectFreeFunc, NULL);
 
     SimulationTime delay = timer->nextExpireTime - worker_getCurrentEmulatedTime();

--- a/src/main/host/timer.c
+++ b/src/main/host/timer.c
@@ -134,7 +134,7 @@ static void _timer_scheduleNewExpireEvent(Timer* timer, Host* host) {
 
     /* ref the timer storage in the callback event */
     timer_ref(timer);
-    TaskRef* task = taskref_new_for_host(
+    TaskRef* task = taskref_new_bound(
         host_getID(host), _timer_expire, timer, next, _timer_unrefTaskObjectFreeFunc, NULL);
 
     SimulationTime delay = timer->nextExpireTime - worker_getCurrentEmulatedTime();

--- a/src/main/host/tracker.c
+++ b/src/main/host/tracker.c
@@ -603,7 +603,7 @@ void tracker_heartbeat(Tracker* tracker, Host* host) {
     /* schedule the next heartbeat */
     tracker->lastHeartbeat = worker_getCurrentEmulatedTime();
     TaskRef* heartbeatTask =
-        taskref_new(host_getID(host), tracker_heartbeatTask, tracker, NULL, NULL, NULL);
+        taskref_new_for_host(host_getID(host), tracker_heartbeatTask, tracker, NULL, NULL, NULL);
     worker_scheduleTaskWithDelay(heartbeatTask, host, tracker->interval);
     taskref_drop(heartbeatTask);
 }

--- a/src/main/host/tracker.c
+++ b/src/main/host/tracker.c
@@ -603,7 +603,7 @@ void tracker_heartbeat(Tracker* tracker, Host* host) {
     /* schedule the next heartbeat */
     tracker->lastHeartbeat = worker_getCurrentEmulatedTime();
     TaskRef* heartbeatTask =
-        taskref_new_for_host(host_getID(host), tracker_heartbeatTask, tracker, NULL, NULL, NULL);
+        taskref_new_bound(host_getID(host), tracker_heartbeatTask, tracker, NULL, NULL, NULL);
     worker_scheduleTaskWithDelay(heartbeatTask, host, tracker->interval);
     taskref_drop(heartbeatTask);
 }

--- a/src/test/regression/CMakeLists.txt
+++ b/src/test/regression/CMakeLists.txt
@@ -2,6 +2,16 @@ add_shadow_tests(BASENAME signal_resched)
 add_shadow_tests(BASENAME exit_after_signal_sched)
 add_shadow_tests(BASENAME small_stop_time CHECK_RETVAL FALSE)
 
+# Regression test for https://github.com/shadow/shadow/issues/2152
+add_shadow_tests(
+    BASENAME packet_after_simulation_end
+    # Processes still running at the end.
+    CHECK_RETVAL FALSE
+    PROPERTIES
+      # Requires curl and python
+      CONFIGURATIONS extra
+    )
+
 add_executable(test_flush_after_exit test_flush_after_exit.c)
 add_linux_tests(BASENAME flush_after_exit COMMAND bash -c "test `./test_flush_after_exit` == 'Hello'")
 add_shadow_tests(BASENAME flush_after_exit POST_CMD "test `cat hosts/*/*.stdout` = 'Hello'")

--- a/src/test/regression/packet_after_simulation_end.yaml
+++ b/src/test/regression/packet_after_simulation_end.yaml
@@ -1,0 +1,39 @@
+# Regression test for https://github.com/shadow/shadow/issues/2152
+general:
+  stop_time: 3s
+  # needed for https://github.com/shadow/shadow/issues/1794
+  model_unblocked_syscall_latency: true
+network:
+  graph:
+    type: gml
+    inline: |
+      graph [
+        directed 0
+        node [
+          id 0
+          label "node at 192.168.0.1"
+          host_bandwidth_down "100 Mbit"
+          host_bandwidth_up "100 Mbit"
+        ]
+        edge [
+          source 0
+          target 0
+          label "self loop"
+          latency "2 s"
+          jitter "0 ms"
+          packet_loss 0.0
+        ]
+      ]
+hosts:
+  server:
+    network_node_id: 0
+    processes:
+    - path: /usr/bin/python3
+      args: -m http.server 80
+      start_time: 1s
+  client:
+    network_node_id: 0
+    processes:
+    - path: /usr/bin/curl
+      args: -s server
+      start_time: 2s


### PR DESCRIPTION
Make SyncSendPointer unsafe and add HostObjectPointer    
    
Constructing a `SyncSendPointer` implies that the object pointed to by it as actually `Sync` and `Send`. Updated docs and marked unsafe to reflect that.
    
In most places we were using `SyncSendPointer`, the pointer is *not* actually fully thread-safe, and we instead rely on the Host lock being held at access time. Created `HostObjectPointer` for such pointers.