### PR TITLE
Fix documentation URLs, and other misc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ fairly well-supported and we are eager to continue extending support for it.
 Homepage:
 - <https://shadow.github.io>
 
-Detailed Documentation:
+Documentation:
 - [User documentation](https://shadow.github.io/docs/guide)
 - [Developer documentation](https://shadow.github.io/docs/rust)
 

--- a/README.md
+++ b/README.md
@@ -80,16 +80,16 @@ fairly well-supported and we are eager to continue extending support for it.
 ## More Information
 
 Homepage:
-- https://shadow.github.io
+- <https://shadow.github.io>
 
 Detailed Documentation:
 - [User documentation](https://shadow.github.io/docs/guide)
 - [Developer documentation](https://shadow.github.io/docs/rust)
 
 Community Support:
-- https://github.com/shadow/shadow/discussions
+- <https://github.com/shadow/shadow/discussions>
 
 Bug Reports:
-- https://github.com/shadow/shadow/issues
+- <https://github.com/shadow/shadow/issues>
 
 <!--- ANCHOR_END: body (for mdbook) -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,6 @@ can fix it.
      * [Dependencies](install_dependencies.md)
      * [Shadow](install_shadow.md)
      * [System Configuration](system_configuration.md)
-     * [(Experimental) Shadow with Docker](install_shadow_with_docker.md)
    * Usage Guide
      * [Overview](run_shadow_overview.md)
      * Running Your First Simulations
@@ -45,6 +44,7 @@ can fix it.
      * [Debugging and profiling](developer_guide.md)
      * [Continous integration tests](ci.md)
      * [Maintainer playbook](maintainer_playbook.md)
+     * [(Experimental) Shadow with Docker](install_shadow_with_docker.md)
  * The Shadow project
    * [Contributing](contributing.md)
      * [Coding style](coding_style.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,7 +9,6 @@
     - [Dependencies](install_dependencies.md)
     - [Shadow](install_shadow.md)
     - [System Configuration](system_configuration.md)
-    - [(Experimental) Shadow with Docker](install_shadow_with_docker.md)
 - [Usage Guide]()
     - [Overview](run_shadow_overview.md)
     - [Running Your First Simulations]()
@@ -40,6 +39,7 @@
     - [Debugging and profiling](developer_guide.md)
     - [Continous integration tests](ci.md)
     - [Maintainer playbook](maintainer_playbook.md)
+    - [(Experimental) Shadow with Docker](install_shadow_with_docker.md)
 
 # The Shadow Project
 

--- a/docs/design_1x.md
+++ b/docs/design_1x.md
@@ -154,13 +154,13 @@ that spawn threads [can be found here][cset-rpth-slides]. Checkout [Google
 Scholar](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=12341442653770148265)
 for research publications that cite Shadow.
 
-<!--<iframe width="420" height="315" src="http://www.youtube-nocookie.com/embed/Tb7m8OdpD8A" frameborder="0" allowfullscreen></iframe>-->
+<!--<iframe width="420" height="315" src="https://www.youtube-nocookie.com/embed/Tb7m8OdpD8A" frameborder="0" allowfullscreen></iframe>-->
 
 [tor]: https://www.torproject.org/
 [tormetrics]: https://metrics.torproject.org/
 [torsource]: https://gitweb.torproject.org/tor.git
 [wiki-scallion]: https://github.com/shadow/shadow-plugin-tor/wiki
 [wiki-custom-plugin]: https://github.com/shadow/shadow/wiki/2-Simulation-Execution-and-Analysis#shadow-plug-ins
-[youtube-shadow-design]: http://youtu.be/Tb7m8OdpD8A
-[cset-rpth-slides]: http://www.robgjansen.com/talks/shadowbitcoin-cset-20150810.pdf
+[youtube-shadow-design]: https://youtu.be/Tb7m8OdpD8A
+[cset-rpth-slides]: https://www.robgjansen.com/talks/shadowbitcoin-cset-20150810.pdf
 [gnu-pth]: https://www.gnu.org/software/pth/

--- a/docs/getting_started_basic.md
+++ b/docs/getting_started_basic.md
@@ -1,4 +1,4 @@
-# Getting Started Basic
+# Basic File Transfer Example
 
 Here we present a basic example that simulates the network traffic of an HTTP
 server with 3 clients, each running on different virtual hosts. If you do not
@@ -51,12 +51,12 @@ hosts:
 
 ## Running the Simulation
 
-Shadow stores simulation data to the `shadow.data` directory by default. We
+Shadow stores simulation data to the `shadow.data/` directory by default. We
 first remove this directory if it already exists, and then run Shadow.
 
 ```bash
 # delete any existing simulation data
-rm -rf shadow.data
+rm -rf shadow.data/
 shadow shadow.yaml > shadow.log
 ```
 
@@ -64,22 +64,22 @@ This small Shadow simulation should complete almost immediately.
 
 ## Viewing the Simulation Output
 
-Shadow will write simulation output to the data directory (in this example we'll
-assume the default directory of `shadow.data`). Each host has its own directory
-under `shadow.data/hosts`. For example:
+Shadow will write simulation output to the data directory `shadow.data/`. Each
+host has its own directory under `shadow.data/hosts/`. For example:
 
 ```bash
-$ ls -l shadow.data/hosts
+$ ls -l shadow.data/hosts/
 drwxrwxr-x 2 user user 4096 Jun  2 16:54 client1
 drwxrwxr-x 2 user user 4096 Jun  2 16:54 client2
 drwxrwxr-x 2 user user 4096 Jun  2 16:54 client3
 drwxrwxr-x 2 user user 4096 Jun  2 16:54 server
 ```
 
-Each host directory contains the output for each process running on that host. For example:
+Each host directory contains the output for each process running on that host.
+For example:
 
 ```bash
-$ ls -l shadow.data/hosts/client1
+$ ls -l shadow.data/hosts/client1/
 -rw-rw-r-- 1 user user   1 Jun  2 16:54 client1.curl.1000.exitcode
 -rw-rw-r-- 1 user user   0 Jun  2 16:54 client1.curl.1000.shimlog
 -rw-r--r-- 1 user user   0 Jun  2 16:54 client1.curl.1000.stderr

--- a/docs/getting_started_tgen.md
+++ b/docs/getting_started_tgen.md
@@ -1,4 +1,4 @@
-# Getting Started TGen
+# Traffic Generation Example
 
 _We recommend getting started with the [basic file
 transfer](getting_started_basic.md) before running this example, because it

--- a/docs/getting_started_tor.md
+++ b/docs/getting_started_tor.md
@@ -1,4 +1,4 @@
-# Getting Started Tor
+# Simple Tor Network Example
 
 _We recommend getting started with the [basic file
 transfer](getting_started_basic.md) and [traffic

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -11,7 +11,7 @@
   + cargo, rustc (version \~ latest)
 
 Notice: Clang 13.0 is unsupported as it has a miscompilation bug that affects
-        Shadow (see issue #1741).
+        Shadow (see [issue #1741](https://github.com/shadow/shadow/issues/1741)).
 
 ### Recommended Python Modules (for helper/analysis scripts):
   + numpy, scipy, matplotlib, networkx, lxml, pyyaml

--- a/docs/install_shadow_with_docker.md
+++ b/docs/install_shadow_with_docker.md
@@ -1,6 +1,6 @@
 # Run from the Dockerfile
 
-1. Install docker from https://docs.docker.com/engine/install/.
+1. Install docker from <https://docs.docker.com/engine/install/>.
 2. Build container:
 ```
 git clone https://github.com/shadow/shadow.git

--- a/docs/install_shadow_with_docker.md
+++ b/docs/install_shadow_with_docker.md
@@ -1,5 +1,8 @@
 # Run from the Dockerfile
 
+**Note:** You do not need to follow these steps to run Shadow within Docker.
+These steps are an experimental method for creating a Shadow image.
+
 1. Install docker from <https://docs.docker.com/engine/install/>.
 2. Build container:
 ```

--- a/docs/network_graph_overview.md
+++ b/docs/network_graph_overview.md
@@ -83,7 +83,7 @@ artifact](https://tmodel-ccs2018.github.io/data/shadow/network/atlas-lossless.20
 and more details about the measurement methodology is available on [the research
 artifacts site](https://tmodel-ccs2018.github.io).
 
-Note: [the scripts we used to create the graph](http://github.com/shadow/atlas)
+Note: [the scripts we used to create the graph](https://github.com/shadow/atlas)
 are also available, but are not recommended for general use. The scripts require
 advanced knowledge of RIPE Atlas and also require that you possess RIPE Atlas
 credits to conduct the measurements needed to create a new graph. We recommend
@@ -91,5 +91,5 @@ using our existing graph linked above instead, which we may periodically update.
 
 ## Creating Your Own Graph
 
-The python module [networkx](http://networkx.github.io/) can be used to create
+The python module [networkx](https://networkx.github.io/) can be used to create
 and manipulate more complicated graphs.

--- a/docs/sidechannels.md
+++ b/docs/sidechannels.md
@@ -17,9 +17,9 @@ The Speculative Store Bypass attack allows malicious code to read data it
 otherwise wouldn't be able to, e.g. due to software sandboxing such as in a
 javascript engine.  For a high-level overview of this attack and mitigations,
 see:
-https://www.redhat.com/en/blog/speculative-store-bypass-explained-what-it-how-it-works.
+<https://www.redhat.com/en/blog/speculative-store-bypass-explained-what-it-how-it-works>.
 For a more technical overview, see 
-https://software.intel.com/content/dam/develop/external/us/en/documents/336996-speculative-execution-side-channel-mitigations.pdf.
+<https://software.intel.com/content/dam/develop/external/us/en/documents/336996-speculative-execution-side-channel-mitigations.pdf>.
 
 We have observed the mitigation for this vulnerability to add roughly a [30%
 performance overhead](https://github.com/shadow/shadow/issues/1489#issuecomment-871445482) to Shadow simulations. Because process isolation is
@@ -53,7 +53,7 @@ running on the system that relies on the default behavior without explicitly
 opting in via `prctl`, so use some caution. For more discussion on this
 parameter, see this discussion on the kernel mailing list about whether the
 kernel default ought to be changed from `seccomp` to `prctl`:
-https://lore.kernel.org/lkml/20201104215702.GG24993@redhat.com/
+<https://lore.kernel.org/lkml/20201104215702.GG24993@redhat.com/>
 
 ## Other mitigations
 

--- a/docs/system_configuration.md
+++ b/docs/system_configuration.md
@@ -162,8 +162,8 @@ rjansen hard nproc unlimited
 
 ## For more information
 
-https://www.kernel.org/doc/Documentation/sysctl/fs.txt  
-https://www.kernel.org/doc/Documentation/sysctl/vm.txt
+<https://www.kernel.org/doc/Documentation/sysctl/fs.txt>  
+<https://www.kernel.org/doc/Documentation/sysctl/vm.txt>
 
 ```bash
 man proc


### PR DESCRIPTION
Documentation urls were changed to use https when possible, and surrounded by <> so that they are parsed correctly by mdbook's markdown parser.

Also made some other misc changes that I think are improvements, including moving the "(Experimental) Shadow with Docker" page further down in the documentation tree.