### PR TITLE
Run actions on pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ defaults:
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ permissions: read-all
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -4,7 +4,7 @@ name: Git Checks
 permissions: read-all
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ permissions: read-all
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 env:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ defaults:
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 env:

--- a/.github/workflows/run_tor.yml
+++ b/.github/workflows/run_tor.yml
@@ -11,7 +11,7 @@ defaults:
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 env:


### PR DESCRIPTION
This causes the actions to run on the head of the pull request instead
of on the merge result. This is generally what we want, particularly
since we require PRs to be up to date with the target branch before
merging anyway.

This also causes code to run in the context of the pull request branch.
If our actions used secrets this would cause them not to get them, or if
they tried to manipulate the repo they wouldn't be able to, etc. This
should be ok since these don't use secrets, and we probably don't *want*
a PR to be able to inject malicious code into a PR that can use our
permissions. (We already generally drop permissions, but even better if
the action never has them in the first place.)

Fixes https://github.com/shadow/shadow/issues/2166