### PR TITLE
Distinguish between sources of death by SIGKILL

### DIFF
--- a/src/lib/shim/shim_signals.c
+++ b/src/lib/shim/shim_signals.c
@@ -18,7 +18,9 @@ static void _call_signal_handler(const struct shd_kernel_sigaction* action, int 
 static _Noreturn void _die_with_fatal_signal(int signo) {
     shim_swapAllowNativeSyscalls(true);
     // Deliver natively to terminate/drop core.
-    if (sigaction(signo, &(struct sigaction){.sa_handler = SIG_DFL}, NULL) != 0) {
+    if (signo == SIGKILL) {
+        // No need to restore default action, and trying to do so would fail.
+    } else if (sigaction(signo, &(struct sigaction){.sa_handler = SIG_DFL}, NULL) != 0) {
         panic("sigaction: %s", strerror(errno));
     }
     raise(signo);

--- a/src/test/regression/CMakeLists.txt
+++ b/src/test/regression/CMakeLists.txt
@@ -12,6 +12,16 @@ add_shadow_tests(
       CONFIGURATIONS extra
     )
 
+# Regression test for https://github.com/shadow/shadow/issues/2151
+add_shadow_tests(
+  BASENAME sigkill_self
+  # Command should die with signal 9, giving exitcode 128+9=137
+  POST_CMD "test `cat hosts/*/*.exitcode` -eq 137"
+  # Shadow should return failure
+  EXPECT_ERROR TRUE
+  # ptrace doesn't support signals well enough
+  SKIP_METHODS ptrace)
+
 add_executable(test_flush_after_exit test_flush_after_exit.c)
 add_linux_tests(BASENAME flush_after_exit COMMAND bash -c "test `./test_flush_after_exit` == 'Hello'")
 add_shadow_tests(BASENAME flush_after_exit POST_CMD "test `cat hosts/*/*.stdout` = 'Hello'")

--- a/src/test/regression/sigkill_self.yaml
+++ b/src/test/regression/sigkill_self.yaml
@@ -1,0 +1,13 @@
+# Regression test for https://github.com/shadow/shadow/issues/2151
+general:
+  stop_time: 3s
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  host:
+    network_node_id: 0
+    processes:
+    - path: /bin/kill
+      args: -KILL 1000
+      start_time: 1s


### PR DESCRIPTION
* Add a regression test for https://github.com/shadow/shadow/issues/2151

* Treat death by signal 9 as an error if Shadow didn't    
  intentionally use it to stop the process.    
    
* Write an empty exitcode file when Shadow does kill the process (via    
  signal 9), which is a more intuitive result for a process that didn't    
  exit within the simulation itself.

Fixes https://github.com/shadow/shadow/issues/2151