### PR TITLE
Use 'ubuntu-18.04' environment in CI tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,10 @@ env:
 
 jobs:
   codecov:
-    runs-on: ubuntu-latest
+    # use the oldest kernel supported by github's CI (make sure to update the
+    # minimum supported kernel version in documentation when changing)
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-18.04
     container:
       image: 'ubuntu:20.04'
       # the default shm-size for ubuntu:18.04, but with the size increased from

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # use the oldest kernel supported by github's CI (make sure to update the
+    # minimum supported kernel version in documentation when changing)
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,7 +19,10 @@ env:
 
 jobs:
   shadow:
-    runs-on: ubuntu-latest
+    # use the oldest kernel supported by github's CI (make sure to update the
+    # minimum supported kernel version in documentation when changing)
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-18.04
     container:
       image: ${{ matrix.container }}
       # the default shm-size for ubuntu:18.04, but with the size increased from

--- a/.github/workflows/run_tor.yml
+++ b/.github/workflows/run_tor.yml
@@ -19,7 +19,10 @@ env:
 
 jobs:
   tor:
-    runs-on: ubuntu-latest
+    # use the oldest kernel supported by github's CI (make sure to update the
+    # minimum supported kernel version in documentation when changing)
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-18.04
 
     container:
       image: ${{ matrix.container }}


### PR DESCRIPTION
The 'ubuntu-18.04' environment currently uses kernel 5.4.

https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-Readme.md

This only changes the workflows that test Shadow. Others like the lint checks still use 'ubuntu-latest'.