### PR TITLE
Support Fedora 36

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -44,8 +44,10 @@ jobs:
           # EOL ~August 2022 https://wiki.debian.org/DebianReleases
           - 'debian:10-slim'
           - 'debian:11-slim'
+          # EOL June 7 2022 https://endoflife.date/fedora
           - 'fedora:34'
           - 'fedora:35'
+          - 'fedora:36'
           # EOL May 2024 https://www.centos.org/centos-stream/
           - 'quay.io/centos/centos:stream8'
         cc: ['gcc', 'clang']

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -15,6 +15,7 @@ CONTAINERS=(
     debian:11-slim
     fedora:34
     fedora:35
+    fedora:36
     quay.io/centos/centos:stream8
     )
 

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -4,7 +4,7 @@
 
   + Ubuntu 18.04, 20.04, 22.04
   + Debian 10 and 11
-  + Fedora 34 and 35
+  + Fedora 34, 35, 36
   + CentOS Stream 8
 
 We do not provide official support for other platforms. This means that we do


### PR DESCRIPTION
Fedora 36 was released in May 2022.

That makes Fedora 34 EOL on June 7 2022, but we'll wait for a major
version bump to deprecate it.
https://github.com/shadow/shadow/issues/2178