### PR TITLE
Support fixed-size send buffers for unix dgram sockets

### DIFF
--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -1009,6 +1009,13 @@ fn read_sockaddr(
         )?;
     }
 
+    // nix will panic if given an AF_UNSPEC sockaddr, so we'll just return an error and log a
+    // warning
+    if addr.ss_family == libc::AF_UNSPEC as u16 {
+        log::warn!("Addresses with a family of AF_UNSPEC are unsupported");
+        return Err(Errno::EINVAL.into());
+    }
+
     // apply a nix bug workaround that may shorten the addr length
     let corrected_addr_len = sockaddr_storage_len_workaround(&addr, addr_len);
     assert!(corrected_addr_len <= addr_len);

--- a/src/test/socket_utils.rs
+++ b/src/test/socket_utils.rs
@@ -261,7 +261,7 @@ pub fn dgram_connect_helper(fd_client: libc::c_int, addr: SockAddr, addr_len: li
 
     // connect to the server address
     let rv = unsafe { libc::connect(fd_client, addr_ptr, addr_len) };
-    assert!(rv == 0);
+    assert_eq!(rv, 0);
 }
 
 /// A helper function to autobind the socket to some unused address. Returns the address.


### PR DESCRIPTION
The amount of data that a socket can send needs to be tracker per-sender rather than per-receive-buffer. Also adds support for returning the sender's sockaddr in `recvfrom()` calls, and adds additional unix socket tests. About half of the additions in this PR are for tests.

Closes #2125 and closes #2124.