### PR TITLE
More misc unix sockets changes

### DIFF
--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -129,17 +129,17 @@ impl SocketRef<'_> {
 impl SocketRef<'_> {
     // https://github.com/shadow/shadow/issues/2093
     #[allow(deprecated)]
-    pub fn get_peer_address(&self) -> Option<SockAddr> {
+    pub fn getpeername(&self) -> Result<Option<SockAddr>, SyscallError> {
         match self {
-            Self::Unix(socket) => socket.get_peer_address().map(SockAddr::Unix),
+            Self::Unix(socket) => socket.getpeername().map(|x| x.map(SockAddr::Unix)),
         }
     }
 
     // https://github.com/shadow/shadow/issues/2093
     #[allow(deprecated)]
-    pub fn get_bound_address(&self) -> Option<SockAddr> {
+    pub fn getsockname(&self) -> Result<Option<SockAddr>, SyscallError> {
         match self {
-            Self::Unix(socket) => socket.get_bound_address().map(SockAddr::Unix),
+            Self::Unix(socket) => socket.getsockname().map(|x| x.map(SockAddr::Unix)),
         }
     }
 
@@ -199,17 +199,17 @@ impl SocketRefMut<'_> {
 impl SocketRefMut<'_> {
     // https://github.com/shadow/shadow/issues/2093
     #[allow(deprecated)]
-    pub fn get_peer_address(&self) -> Option<SockAddr> {
+    pub fn getpeername(&self) -> Result<Option<SockAddr>, SyscallError> {
         match self {
-            Self::Unix(socket) => socket.get_peer_address().map(SockAddr::Unix),
+            Self::Unix(socket) => socket.getpeername().map(|x| x.map(SockAddr::Unix)),
         }
     }
 
     // https://github.com/shadow/shadow/issues/2093
     #[allow(deprecated)]
-    pub fn get_bound_address(&self) -> Option<SockAddr> {
+    pub fn getsockname(&self) -> Result<Option<SockAddr>, SyscallError> {
         match self {
-            Self::Unix(socket) => socket.get_bound_address().map(SockAddr::Unix),
+            Self::Unix(socket) => socket.getsockname().map(|x| x.map(SockAddr::Unix)),
         }
     }
 


### PR DESCRIPTION
The first commit "Generalize the unix socket buffer listener code" will end up somewhat changing in #2180, but unfortunately all of the later commits depend on it so it's stuck here.

These changes are to eventually support #2125 and #2124.

- "Unix sockets now store ref to peer rather than peer's send buffer" - this is so that (in #2180) connection-oriented sockets can inform the sender when the receiver reads their bytes from the buffer.
- "Reorganized unix socket sockname/peername code" - this is to support the different address representations that linux returns for getsockname(), getpeername(), and recvfrom(), including for socketpair sockets.