### PR TITLE
Write the processed config to 'shadow.data/processed-config.yaml'

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -320,6 +320,8 @@ void lps_idleTimerStop(const struct LogicalProcessors *lps, int lpi);
 
 int main_runShadow(int argc, const char *const *argv);
 
+int manager_saveProcessedConfigYaml(const struct ConfigOptions *config, const char *filename);
+
 bool hashsetstring_contains(const struct HashSet_String *set, const char *hostname);
 
 void clioptions_freeString(char *string);

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -328,6 +328,13 @@ Manager* manager_new(Controller* controller, const ConfigOptions* config, Simula
     /* now make sure the hosts path exists, as it may not have been in the template */
     g_mkdir_with_parents(manager->hostsPath, 0775);
 
+    /* write the config to a yaml file */
+    gchar* configFilename = g_build_filename(manager->dataPath, "processed-config.yaml", NULL);
+    if (manager_saveProcessedConfigYaml(config, configFilename) != 0) {
+        utility_panic("Could not save the processed config yaml to '%s'", configFilename);
+    }
+    g_free(configFilename);
+
     if (config_getProgress(config)) {
         if (isatty(STDERR_FILENO) == 1) {
             manager->statusLogger = statusBar_new(endTime);

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -1,0 +1,33 @@
+mod export {
+    use std::ffi::CStr;
+
+    use crate::core::support::configuration::ConfigOptions;
+
+    #[no_mangle]
+    pub extern "C" fn manager_saveProcessedConfigYaml(
+        config: *const ConfigOptions,
+        filename: *const libc::c_char,
+    ) -> libc::c_int {
+        let config = unsafe { config.as_ref() }.unwrap();
+        let filename = unsafe { CStr::from_ptr(filename) }.to_str().unwrap();
+
+        let file = match std::fs::File::create(&filename) {
+            Ok(f) => f,
+            Err(e) => {
+                log::warn!("Could not create file {:?}: {}", filename, e);
+                return 1;
+            }
+        };
+
+        if let Err(e) = serde_yaml::to_writer(file, &config) {
+            log::warn!(
+                "Could not write processed config yaml to file {:?}: {}",
+                filename,
+                e
+            );
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/src/main/core/mod.rs
+++ b/src/main/core/mod.rs
@@ -1,6 +1,7 @@
 pub mod logger;
 pub mod logical_processor;
 pub mod main;
+pub mod manager;
 pub mod support;
 pub mod work;
 pub mod worker;

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -93,7 +93,7 @@ pub struct ConfigFileOptions {
 }
 
 /// Shadow configuration options after processing command-line and configuration file options.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ConfigOptions {
     pub general: GeneralOptions,
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -16,6 +16,8 @@ use super::simulation_time::{SIMTIME_INVALID, SIMTIME_ONE_NANOSECOND, SIMTIME_ON
 use super::units::{self, Unit};
 use crate::cshadow as c;
 use crate::host::syscall::format::StraceFmtMode;
+use crate::utility::tilde_expansion;
+
 use log_bindings as c_log;
 
 const START_HELP_TEXT: &str = "\
@@ -1056,26 +1058,6 @@ fn generate_help_strs(
         }
     }
     defaults
-}
-
-pub fn tilde_expansion(path: &str) -> std::path::PathBuf {
-    // if the path begins with a "~"
-    if let Some(x) = path.strip_prefix('~') {
-        // get the tilde-prefix (everything before the first separator)
-        let mut parts = x.splitn(2, '/');
-        let (tilde_prefix, remainder) = (parts.next().unwrap(), parts.next().unwrap_or(""));
-        assert!(parts.next().is_none());
-        // we only support expansion for our own home directory
-        // (nothing between the "~" and the separator)
-        if tilde_prefix.is_empty() {
-            if let Ok(ref home) = std::env::var("HOME") {
-                return [home, remainder].iter().collect::<std::path::PathBuf>();
-            }
-        }
-    }
-
-    // if we don't have a tilde-prefix that we support, just return the unmodified path
-    std::path::PathBuf::from(path)
 }
 
 /// Parses a string as a list of arguments following the shell's parsing rules. This

--- a/src/main/routing/network_graph.rs
+++ b/src/main/routing/network_graph.rs
@@ -8,6 +8,7 @@ use crate::core::support::configuration::{
 };
 use crate::core::support::{units, units::Unit};
 use crate::routing::petgraph_wrapper::GraphWrapper;
+use crate::utility::tilde_expansion;
 
 use log::*;
 use petgraph::graph::NodeIndex;
@@ -474,11 +475,11 @@ pub fn load_network_graph(graph_options: &GraphOptions) -> Result<String, Box<dy
         GraphOptions::Gml(GraphSource::File(FileSource {
             compression: None,
             path: f,
-        })) => std::fs::read_to_string(configuration::tilde_expansion(f))?,
+        })) => std::fs::read_to_string(tilde_expansion(f))?,
         GraphOptions::Gml(GraphSource::File(FileSource {
             compression: Some(Compression::Xz),
             path: f,
-        })) => read_xz(configuration::tilde_expansion(f))?,
+        })) => read_xz(tilde_expansion(f))?,
         GraphOptions::Gml(GraphSource::Inline(s)) => s.clone(),
         GraphOptions::OneGbitSwitch => configuration::ONE_GBIT_SWITCH_GRAPH.to_string(),
     })

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -177,3 +177,23 @@ impl Clone for ObjectCounter {
         Self { name: self.name }
     }
 }
+
+pub fn tilde_expansion(path: &str) -> std::path::PathBuf {
+    // if the path begins with a "~"
+    if let Some(x) = path.strip_prefix('~') {
+        // get the tilde-prefix (everything before the first separator)
+        let mut parts = x.splitn(2, '/');
+        let (tilde_prefix, remainder) = (parts.next().unwrap(), parts.next().unwrap_or(""));
+        assert!(parts.next().is_none());
+        // we only support expansion for our own home directory
+        // (nothing between the "~" and the separator)
+        if tilde_prefix.is_empty() {
+            if let Ok(ref home) = std::env::var("HOME") {
+                return [home, remainder].iter().collect::<std::path::PathBuf>();
+            }
+        }
+    }
+
+    // if we don't have a tilde-prefix that we support, just return the unmodified path
+    std::path::PathBuf::from(path)
+}


### PR DESCRIPTION
We had discussed wanting to save the final configuration settings as yaml. It seems like it's generating a yaml that can be passed back into Shadow, but I don't think we should guarantee that.

Example for the sendto-recvfrom test:

```yaml
---
general:
  stop_time: 5 sec
  seed: 1
  parallelism: 1
  bootstrap_end_time: 0 sec
  log_level: debug
  heartbeat_interval: 1 sec
  data_directory: sendto-recvfrom-shadow-preload.data
  template_directory: ~
  progress: false
  model_unblocked_syscall_latency: false
network:
  graph:
    type: 1_gbit_switch
  use_shortest_path: true
experimental:
  use_sched_fifo: false
  use_o_n_waitpid_workarounds: false
  use_explicit_block_message: false
  use_seccomp: ~
  use_syscall_counters: true
  use_object_counters: true
  use_preload_libc: true
  use_preload_openssl_rng: true
  use_preload_openssl_crypto: false
  preload_spin_max: 0
  use_memory_manager: true
  use_shim_syscall_handler: true
  use_cpu_pinning: false
  interpose_method: preload
  runahead: 1 ms
  use_dynamic_runahead: false
  scheduler_policy: host
  socket_send_buffer: 131072 B
  socket_send_autotune: true
  socket_recv_buffer: 174760 B
  socket_recv_autotune: true
  interface_buffer: 1024000 B
  interface_qdisc: fifo
  worker_threads: ~
  use_legacy_working_dir: false
  host_heartbeat_log_level: info
  host_heartbeat_log_info:
    - node
  host_heartbeat_interval: ~
  strace_logging_mode: standard
  max_unapplied_cpu_latency: 1 μs
  unblocked_syscall_latency: 1 μs
  unblocked_vdso_latency: 10 ns
  debug_hosts: []
hosts:
  testnode:
    network_node_id: 0
    processes:
      - path: "../../target/debug/test_sendto_recvfrom"
        args: "--shadow-passing"
        environment: ""
        quantity: 1
        start_time: 1 sec
        stop_time: ~
    ip_addr: ~
    quantity: 1
    bandwidth_down: ~
    bandwidth_up: ~
    options:
      log_level: ~
      pcap_directory: ~
      pcap_capture_size: 65535 B

```