### PR TITLE
poll: return EINTR when interrupted

### DIFF
--- a/src/lib/shim/shim_tls.h
+++ b/src/lib/shim/shim_tls.h
@@ -1,7 +1,7 @@
 #ifndef SHIM_TLS_H_
 #define SHIM_TLS_H_
 
-// Bare bones implementation of thread-local-storage. Never makes syscalls.
+// Bare bones implementation of thread-local-storage.
 //
 // The shim relies on thread-local-storage to track data such as the per-thread
 // IPC block, whether interposition is enabled, etc. However, many of the


### PR DESCRIPTION
Progress on #1889 .

* Adds Interruptor utility struct to test_utils, which arranges for the current thread to be sent a signal after a specified timeout.
* Adds tests to poll for being interrupted by a signal, and fixes poll to correctly return EINTR.
* The tests ran into the hard-coded limit on number of threads in shim_tls; I reworked to remove the limit.