### PR TITLE
Stop leaking thread-local-storage including signal stacks

### DIFF
--- a/src/lib/shim/shim.h
+++ b/src/lib/shim/shim.h
@@ -59,4 +59,9 @@ ShimShmemThread* shim_threadSharedMem();
 ShimShmemProcess* shim_processSharedMem();
 ShimShmemHost* shim_hostSharedMem();
 
+// Prepare to free the current thread's signal thread stack.  Should only be
+// done just before exiting, as the stack will be freed the next another thread
+// exits.
+void shim_freeSignalStack();
+
 #endif // SHD_SHIM_SHIM_H_

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -227,6 +227,11 @@ static SysCallReg _shim_emulated_syscall_event(const ShimEvent* syscall_event) {
 long shim_emulated_syscallv(long n, va_list args) {
     bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
 
+    if (n == SYS_exit) {
+        // This thread is exiting. Arrange for its signal stack to be freed.
+        shim_freeSignalStack();
+    }
+
     ShimEvent e = {
         .event_id = SHD_SHIM_EVENT_SYSCALL,
         .event_data.syscall.syscall_args.number = n,

--- a/src/lib/shim/shim_tls.c
+++ b/src/lib/shim/shim_tls.c
@@ -30,7 +30,7 @@ typedef struct ShimThreadLocalStorage {
 //
 // We could alternatively change `_shim_init_signal_stack` to dynamically
 // allocate its stack instead of using TLS, but that'd just move the leak there.
-static __thread ShimThreadLocalStorage* _tls = NULL;
+static __thread ShimThreadLocalStorage _tls = {0};
 
 // Each ShimTlsVar is assigned an offset in the ShimThreadLocalStorage's.
 // This is the next free offset.
@@ -41,20 +41,6 @@ static int _tlsIdx = 0;
 
 // Initialize storage and return whether it had already been initialized.
 void* shimtlsvar_ptr(ShimTlsVar* v, size_t sz) {
-    if (!_tls) {
-        // We have to use raw syscalls here and avoid logging to avoid recursion.
-        long raw_rv = shim_native_syscall(SYS_mmap, NULL, sizeof(*_tls), PROT_READ | PROT_WRITE,
-                                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (raw_rv <= -1 && raw_rv >= -4095) {
-            shim_native_syscall(SYS_rt_sigaction, SIGABRT,
-                                &(struct shd_kernel_sigaction){.ksa_handler = SIG_DFL}, NULL,
-                                sizeof(shd_kernel_sigset_t));
-            pid_t mypid = (pid_t)shim_native_syscall(SYS_getpid);
-            shim_native_syscall(SYS_kill, mypid, SIGABRT);
-            panic("Unreachable");
-        }
-        _tls = (void*)raw_rv;
-    }
     if (!v->_initd) {
         v->_offset = _nextByteOffset;
         _nextByteOffset += sz;
@@ -71,5 +57,5 @@ void* shimtlsvar_ptr(ShimTlsVar* v, size_t sz) {
         }
         v->_initd = true;
     }
-    return &_tls->_bytes[v->_offset];
+    return &_tls._bytes[v->_offset];
 }

--- a/src/lib/shim/shim_tls.c
+++ b/src/lib/shim/shim_tls.c
@@ -11,7 +11,7 @@
 
 // This needs to be big enough to store all thread-local variables for a single
 // thread. We fail at runtime if this limit is exceeded.
-#define BYTES_PER_THREAD (SHIM_SIGNAL_STACK_SIZE + 1024)
+#define BYTES_PER_THREAD 1024
 
 // Stores the TLS for a single thread.
 typedef struct ShimThreadLocalStorage {


### PR DESCRIPTION
* Allocate signal stacks explicitly using mmap instead of using thread-local-storage
* Arrange for signal stacks to be freed by another thread (the next one that exits and wants to free its own stack)
* Change ShimThreadLocalStorage to use native thread-local-storage directly, now that we're no longer using it to allocate the signal stack.