### PR TITLE
Remove kernel version requirement

### DIFF
--- a/docs/semver.md
+++ b/docs/semver.md
@@ -20,10 +20,6 @@ versions:
   will not change.
 - The PID numbering (the values and their order) will not change.
 - Any supported platforms will not be dropped.
-	- A platform refers to an OS distribution's libraries and software, but
-	  specifically not the kernel. Shadow may require a newer kernel version
-      than is provided by the distribution.
-- Any supported kernel versions will not be dropped.
 
 The following may change between ANY versions (MAJOR, MINOR, or PATCH):
 

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -7,21 +7,10 @@
 - Fedora 34, 35, 36
 - CentOS Stream 8
 
-A platform refers to an OS distribution's libraries and software, but
-specifically not the kernel. Shadow may require a newer kernel version than is
-provided by the distribution. Some platforms may provide a [Hardware Enablement
-(HWE)][hwe] stack with newer kernel versions.
-
-[hwe]: https://wiki.ubuntu.com/Kernel/LTSEnablementStack
-
 We do not provide official support for other platforms. This means that we do
 not ensure that Shadow successfully builds and passes tests on other platforms.
 However, we will review pull requests that allow Shadow to build and run on
 unsupported platforms.
-
-## Officially supported kernels
-
-- Linux 5.3 and later
 
 ## Docker
 
@@ -30,14 +19,12 @@ size of the container's `/dev/shm` mount and disable the seccomp security
 profile. You can do this by passing `--shm-size="1024g" --security-opt
 seccomp=unconfined` to `docker run`.
 
-## Known incompatible platforms and kernels
+## Known incompatible platforms
 
 - CentOS 7: We rely on features of glibc that aren't available on CentOS 7.
   Shadow won't compile there due to our use of C11 atomics, and threaded
   virtual processes running with preload-based interposition will deadlock due
   to an incompatible implementation of thread-local-storage.
-- Linux <5.3: Shadow requires support for the `SYS_pidfd_open` syscall, which
-  was introduced in kernel 5.3.
 
 If you are having difficulty installing Shadow on any supported platforms, you
 may find the [continuous integration build


### PR DESCRIPTION
We realized that we don't use `SYS_pidfd_open` anymore.