### PR TITLE
Fix default value of 'use_syscall_counters' in docs

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -555,7 +555,7 @@ Use seccomp to trap syscalls.
 
 #### `experimental.use_syscall_counters`
 
-Default: false  
+Default: true  
 Type: Bool
 
 Count the number of occurrences for individual syscalls.


### PR DESCRIPTION
Forgot to update this in #2019.