### PR TITLE
Simplified the logging init, and other small code simplifications 

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1557,6 +1557,7 @@ extern "C" {
 extern "C" {
     pub fn thread_run(
         thread: *mut Thread,
+        pluginPath: *mut ::std::os::raw::c_char,
         argv: *mut *mut ::std::os::raw::c_char,
         envv: *mut *mut ::std::os::raw::c_char,
         workingDir: *const ::std::os::raw::c_char,

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -60,9 +60,6 @@ struct _Controller {
     /* the simulator should attempt to end immediately after this time */
     SimulationTime endTime;
 
-    /* if we run in unlimited bandwidth mode, this is when we go back to bw enforcement */
-    SimulationTime bootstrapEndTime;
-
     Manager* manager;
 
     MAGIC_DECLARE;
@@ -99,7 +96,6 @@ Controller* controller_new(const ConfigOptions* config, const HashSet_String* ho
     controller->isRunaheadDynamic = config_getUseDynamicRunahead(config);
 
     controller->endTime = config_getStopTime(config);
-    controller->bootstrapEndTime = config_getBootstrapEndTime(config);
 
     g_rw_lock_init(&controller->nextMinRunaheadLock);
 
@@ -482,8 +478,8 @@ gint controller_run(Controller* controller) {
      * they all have a consistent view of the simulation, topology, etc.
      * For now we only have one manager so send it everything. */
     guint managerSeed = random_nextU32(controller->random);
-    controller->manager = manager_new(controller, controller->config, controller->endTime,
-                                      controller->bootstrapEndTime, managerSeed);
+    controller->manager =
+        manager_new(controller, controller->config, controller->endTime, managerSeed);
 
     if (controller->manager == NULL) {
         error("Unable to create manager");

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -298,8 +298,6 @@ static int _controller_registerHostCallback(const char* name, const ConfigOption
     MAGIC_ASSERT(controller);
     utility_assert(host);
 
-    guint managerCpuFreq = manager_getRawCPUFrequency(controller->manager);
-
     guint64 quantity = hostoptions_getQuantity(host);
     in_addr_t ipAddr = 0;
     bool ipAddrSet = (hostoptions_getIpAddr(host, &ipAddr) == 0);
@@ -350,7 +348,6 @@ static int _controller_registerHostCallback(const char* name, const ConfigOption
 
         params->hostname = hostnameBuffer->str;
 
-        params->cpuFrequency = MAX(0, managerCpuFreq);
         params->cpuThreshold = 0;
         params->cpuPrecision = 200;
 

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -35,9 +35,6 @@ struct _Controller {
     /* set of hostnames that we want to debug managed processes for */
     const HashSet_String* hostsToDebug;
 
-    /* tracks overall wall-clock runtime */
-    GTimer* runTimer;
-
     /* global random source from which all node random sources originate */
     Random* random;
 

--- a/src/main/core/controller.c
+++ b/src/main/core/controller.c
@@ -523,21 +523,8 @@ gint controller_run(Controller* controller) {
 
     info("running simulation");
 
-    /* dont buffer log messages in trace mode */
-    if (config_getLogLevel(controller->config) != LOGLEVEL_TRACE) {
-        info("log message buffering is enabled for efficiency");
-        shadow_logger_setEnableBuffering(TRUE);
-    }
-
     /* start running each manager */
     manager_run(controller->manager);
-
-    /* only need to disable buffering if it was enabled, otherwise
-     * don't log the message as it may confuse the user. */
-    if (config_getLogLevel(controller->config) != LOGLEVEL_TRACE) {
-        info("log message buffering is disabled during cleanup");
-        shadow_logger_setEnableBuffering(FALSE);
-    }
 
     info("simulation finished, cleaning up now");
 

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -157,8 +157,24 @@ pub fn run_shadow<'a>(args: Vec<&'a OsStr>) -> anyhow::Result<()> {
         let controller = unsafe { c::controller_new(&config, &debug_hosts) };
         assert!(!controller.is_null());
 
+        // enable log buffering if not at trace level
+        let buffer_log = log::max_level() < log::LevelFilter::Trace;
+
+        shadow_logger::set_buffering_enabled(buffer_log);
+        if buffer_log {
+            log::info!("Log message buffering is enabled for efficiency");
+        }
+
         // run the simulation
         let rv = unsafe { c::controller_run(controller) };
+
+        // disable log buffering
+        shadow_logger::set_buffering_enabled(false);
+        if buffer_log {
+            // only show if we disabled buffering above
+            log::info!("Log message buffering is disabled during cleanup");
+        }
+
         unsafe { c::controller_free(controller) };
         rv
     };

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -454,6 +454,9 @@ int manager_addNewVirtualHost(Manager* manager, HostParameters* params) {
     /* quarks are unique per manager process, so do the conversion here */
     params->id = g_quark_from_string(params->hostname);
 
+    guint managerCpuFreq = manager_getRawCPUFrequency(manager);
+    params->cpuFrequency = MAX(0, managerCpuFreq);
+
     Host* host = host_new(params);
     host_setup(host, manager_getDNS(manager), manager_getRawCPUFrequency(manager),
                manager_getHostsRootPath(manager));

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -206,7 +206,7 @@ static guint _manager_nextRandomUInt(Manager* manager) {
 ChildPidWatcher* manager_childpidwatcher(Manager* manager) { return manager->watcher; }
 
 Manager* manager_new(Controller* controller, const ConfigOptions* config, SimulationTime endTime,
-                     SimulationTime unlimBWEndTime, guint randomSeed) {
+                     guint randomSeed) {
     if (globalmanager != NULL) {
         return NULL;
     }
@@ -223,7 +223,7 @@ Manager* manager_new(Controller* controller, const ConfigOptions* config, Simula
     manager->controller = controller;
     manager->config = config;
     manager->random = random_new(randomSeed);
-    manager->bootstrapEndTime = unlimBWEndTime;
+    manager->bootstrapEndTime = config_getBootstrapEndTime(config);
 
     manager->rawFrequencyKHz = utility_getRawCPUFrequency(CONFIG_CPU_MAX_FREQ_FILE);
     if (manager->rawFrequencyKHz == 0) {

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -33,7 +33,7 @@
 typedef struct _Manager Manager;
 
 Manager* manager_new(Controller* controller, const ConfigOptions* config, SimulationTime endTime,
-                     SimulationTime bootstrapEndTime, guint randomSeed);
+                     guint randomSeed);
 gint manager_free(Manager* manager);
 
 ChildPidWatcher* manager_childpidwatcher(Manager* manager);

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -1123,41 +1123,6 @@ mod tests {
     }
 
     #[test]
-    fn test_tilde_expansion() {
-        if let Ok(ref home) = std::env::var("HOME") {
-            assert_eq!(
-                tilde_expansion("~/test"),
-                [home, "test"].iter().collect::<std::path::PathBuf>()
-            );
-
-            assert_eq!(
-                tilde_expansion("~"),
-                [home].iter().collect::<std::path::PathBuf>()
-            );
-
-            assert_eq!(
-                tilde_expansion("~/"),
-                [home].iter().collect::<std::path::PathBuf>()
-            );
-
-            assert_eq!(
-                tilde_expansion("~someuser/test"),
-                ["~someuser", "test"].iter().collect::<std::path::PathBuf>()
-            );
-
-            assert_eq!(
-                tilde_expansion("/~/test"),
-                ["/", "~", "test"].iter().collect::<std::path::PathBuf>()
-            );
-
-            assert_eq!(
-                tilde_expansion(""),
-                [""].iter().collect::<std::path::PathBuf>()
-            );
-        }
-    }
-
-    #[test]
     fn test_nullable_option() {
         // format the yaml with an optional general option
         let yaml_fmt_fn = |option| {

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -616,7 +616,7 @@ pub struct HostOptions {
     pub options: HostDefaultOptions,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     Error,
@@ -642,6 +642,18 @@ impl LogLevel {
             Self::Info => c_log::_LogLevel_LOGLEVEL_INFO,
             Self::Debug => c_log::_LogLevel_LOGLEVEL_DEBUG,
             Self::Trace => c_log::_LogLevel_LOGLEVEL_TRACE,
+        }
+    }
+}
+
+impl From<LogLevel> for log::Level {
+    fn from(level: LogLevel) -> Self {
+        match level {
+            LogLevel::Error => log::Level::Error,
+            LogLevel::Warning => log::Level::Warn,
+            LogLevel::Info => log::Level::Info,
+            LogLevel::Debug => log::Level::Debug,
+            LogLevel::Trace => log::Level::Trace,
         }
     }
 }

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -588,7 +588,7 @@ static void _process_start(Process* proc) {
     proc->plugin.isExecuting = TRUE;
     _process_setSharedTime(proc);
     /* exec the process */
-    thread_run(mainThread, proc->argv, proc->envv, proc->workingDir);
+    thread_run(mainThread, proc->plugin.exePath->str, proc->argv, proc->envv, proc->workingDir);
     proc->nativePid = thread_getNativePid(mainThread);
     proc->memoryManager = memorymanager_new(proc->nativePid);
 

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -87,13 +87,14 @@ void thread_unref(Thread* thread) {
     }
 }
 
-void thread_run(Thread* thread, gchar** argv, gchar** envv, const char* workingDir) {
+void thread_run(Thread* thread, char* pluginPath, char** argv, char** envv,
+                const char* workingDir) {
     MAGIC_ASSERT(thread);
     utility_assert(thread->methods.run);
 
     _thread_syncAffinityWithWorker(thread);
 
-    thread->nativePid = thread->methods.run(thread, argv, envv, workingDir);
+    thread->nativePid = thread->methods.run(thread, pluginPath, argv, envv, workingDir);
     // In Linux, the PID is equal to the TID of its first thread.
     thread->nativeTid = thread->nativePid;
 }

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -22,7 +22,7 @@ typedef struct _Thread Thread;
 void thread_ref(Thread* thread);
 void thread_unref(Thread* thread);
 
-void thread_run(Thread* thread, char** argv, char** envv, const char* workingDir);
+void thread_run(Thread* thread, char* pluginPath, char** argv, char** envv, const char* workingDir);
 void thread_resume(Thread* thread);
 void thread_handleProcessExit(Thread* thread);
 int thread_getReturnCode(Thread* thread);

--- a/src/main/host/thread_preload.c
+++ b/src/main/host/thread_preload.c
@@ -105,6 +105,8 @@ static gchar** _add_u64_to_env(gchar** envp, const char* var, uint64_t x) {
 
 static pid_t _threadpreload_fork_exec(ThreadPreload* thread, const char* file, char* const argv[],
                                       char* const envp[], const char* workingDir) {
+    utility_assert(file != NULL);
+
     // For childpidwatcher. We must create them O_CLOEXEC to prevent them from
     // "leaking" into a concurrently forked child.
     int pipefd[2];
@@ -177,7 +179,8 @@ static void _markPluginExited(pid_t pid, void* voidIPC) {
     ipcData_markPluginExited(ipc);
 }
 
-pid_t threadpreload_run(Thread* base, gchar** argv, gchar** envv, const char* workingDir) {
+pid_t threadpreload_run(Thread* base, char* pluginPath, char** argv, char** envv,
+                        const char* workingDir) {
     ThreadPreload* thread = _threadToThreadPreload(base);
 
     /* set the env for the child */
@@ -215,7 +218,7 @@ pid_t threadpreload_run(Thread* base, gchar** argv, gchar** envv, const char* wo
     g_free(envStr);
     g_free(argStr);
 
-    pid_t child_pid = _threadpreload_fork_exec(thread, argv[0], argv, myenvv, workingDir);
+    pid_t child_pid = _threadpreload_fork_exec(thread, pluginPath, argv, myenvv, workingDir);
     childpidwatcher_watch(
         worker_getChildPidWatcher(), child_pid, _markPluginExited, thread->ipc_data);
 

--- a/src/main/host/thread_protected.h
+++ b/src/main/host/thread_protected.h
@@ -17,7 +17,8 @@
 #include "main/utility/utility.h"
 
 typedef struct _ThreadMethods {
-    pid_t (*run)(Thread* thread, char** argv, char** envv, const char* workingDir);
+    pid_t (*run)(Thread* thread, char* pluginPath, char** argv, char** envv,
+                 const char* workingDir);
     SysCallCondition* (*resume)(Thread* thread);
     void (*handleProcessExit)(Thread* thread);
     int (*getReturnCode)(Thread* thread);

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -197,3 +197,43 @@ pub fn tilde_expansion(path: &str) -> std::path::PathBuf {
     // if we don't have a tilde-prefix that we support, just return the unmodified path
     std::path::PathBuf::from(path)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tilde_expansion() {
+        if let Ok(ref home) = std::env::var("HOME") {
+            assert_eq!(
+                tilde_expansion("~/test"),
+                [home, "test"].iter().collect::<std::path::PathBuf>()
+            );
+
+            assert_eq!(
+                tilde_expansion("~"),
+                [home].iter().collect::<std::path::PathBuf>()
+            );
+
+            assert_eq!(
+                tilde_expansion("~/"),
+                [home].iter().collect::<std::path::PathBuf>()
+            );
+
+            assert_eq!(
+                tilde_expansion("~someuser/test"),
+                ["~someuser", "test"].iter().collect::<std::path::PathBuf>()
+            );
+
+            assert_eq!(
+                tilde_expansion("/~/test"),
+                ["/", "~", "test"].iter().collect::<std::path::PathBuf>()
+            );
+
+            assert_eq!(
+                tilde_expansion(""),
+                [""].iter().collect::<std::path::PathBuf>()
+            );
+        }
+    }
+}


### PR DESCRIPTION
- simplified logging initialization
- moved log buffering decision from controller to main fn
- moved tilde expansion unit test to the utility module
- use the plugin path rather than argv[0] for execvpe()
- removed unused 'runTimer' field from controller

The following changes are in preparation for moving the controller to rust.

- set the host CPU frequency in the manager
- manager reads the bootstrap end time directly from config