### PR TITLE
Revert "Change random/seed/ordering behaviour to match older Shadow"

### DIFF
--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -50,7 +50,6 @@ add_custom_command(OUTPUT wrapper.rs
 
         # used by shadow's main function
         --whitelist-function "main_.*"
-        --whitelist-function "utility_hashString"
         --whitelist-function "shmemcleanup_tryCleanup"
         --whitelist-function "manager_(new|free|run|addNewVirtualHost|addNewVirtualProcess)"
         --whitelist-function "manager_increment_object_alloc_counter_global"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1675,9 +1675,6 @@ pub type _Status = i32;
 extern "C" {
     pub fn return_code_for_signal(signal: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
-extern "C" {
-    pub fn utility_hashString(str_: *const ::std::os::raw::c_char) -> ::std::os::raw::c_uint;
-}
 pub type DescriptorCloseFunc =
     ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyDescriptor, host: *mut Host)>;
 pub type DescriptorCleanupFunc =

--- a/src/main/utility/utility.c
+++ b/src/main/utility/utility.c
@@ -388,7 +388,3 @@ void die_after_vfork() {
     // Convince the compiler that we really don't return.
     _exit(1);
 }
-
-unsigned int utility_hashString(const char* str) {
-    return g_str_hash(str);
-}

--- a/src/main/utility/utility.h
+++ b/src/main/utility/utility.h
@@ -122,6 +122,4 @@ int return_code_for_signal(int signal);
  safely abort the process (with a core dump, if enabled). */
 _Noreturn void die_after_vfork();
 
-unsigned int utility_hashString(const char* str);
-
 #endif /* SHD_UTILITY_H_ */


### PR DESCRIPTION
This reverts commit 67badb26a66093807b98b583135035c4927942ef.

This will affect simulation results and performance, resulting in similar results/performance to https://github.com/shadow/benchmark-results/tree/master/tor/2022-06-13-T21-20-02.