### PR TITLE
Replace 'execinfo.h' backtrace with a rust-generated backtrace

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -805,6 +805,7 @@ version = "2.1.0"
 dependencies = [
  "anyhow",
  "atomic_refcell",
+ "backtrace",
  "bitflags",
  "bytes",
  "clap",

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["staticlib"]
 [dependencies]
 anyhow = { version = "1.0.58", features = ["backtrace"] }
 atomic_refcell = "0.1"
+backtrace = "0.3.65"
 bitflags = "1.3"
 # custom version of the bytes crate required to make the 'try_unsplit' method public
 # issue: https://github.com/tokio-rs/bytes/issues/287

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -293,6 +293,11 @@ void statusLogger_updateEmuTime(const struct StatusLogger_ShadowStatusBarState *
 void statusLogger_updateNumFailedProcesses(const struct StatusLogger_ShadowStatusBarState *status_logger,
                                            uint32_t num_failed_processes);
 
+// Get the backtrace. This function is slow. The string must be freed using `free_backtrace()`.
+char *backtrace(void);
+
+void backtrace_free(char *backtrace);
+
 DNS *controller_getDNS(const struct Controller *controller);
 
 SimulationTime controller_getLatency(const struct Controller *controller,

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -237,3 +237,28 @@ mod tests {
         }
     }
 }
+
+mod export {
+    /// Get the backtrace. This function is slow. The string must be freed using `free_backtrace()`.
+    #[no_mangle]
+    pub unsafe extern "C" fn backtrace() -> *mut libc::c_char {
+        let s = format!("{:?}", backtrace::Backtrace::new());
+
+        // add a tab at the start of every line
+        let s = s
+            .trim_end()
+            .split('\n')
+            .map(|x| format!("\t{}", x))
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        let s = std::ffi::CString::new(s).unwrap();
+        s.into_raw()
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn backtrace_free(backtrace: *mut libc::c_char) {
+        assert!(!backtrace.is_null());
+        unsafe { std::ffi::CString::from_raw(backtrace) };
+    }
+}


### PR DESCRIPTION
The rust backtrace has better symbol resolution.

Example:

```
**ERROR ENCOUNTERED**
        At process: 3260702 (parent 3260700)
        At file: /shared/code/shadow/rust-backtrace/src/main/host/process.c
        At line: 501
        At function: _process_openStdIOFileHelper
        Message: Assertion failed: 0
**BEGIN BACKTRACE**
           0: backtrace
                     at /shared/code/shadow/rust-backtrace/src/main/utility/mod.rs:245:33
           1: utility_handleError
                     at /shared/code/shadow/rust-backtrace/src/main/utility/utility.c:110:29
           2: _process_openStdIOFileHelper
                     at /shared/code/shadow/rust-backtrace/src/main/host/process.c:501:5
           3: _process_start
                     at /shared/code/shadow/rust-backtrace/src/main/host/process.c:540:5
           4: _process_runStartTask
                     at /shared/code/shadow/rust-backtrace/src/main/host/process.c:751:5
           5: shadow_rs::core::work::task::export::CTaskHostTreePtrs::execute
                     at /shared/code/shadow/rust-backtrace/src/main/core/work/task.rs:83:13
           6: shadow_rs::core::work::task::export::taskref_new_bound::{{closure}}
                     at /shared/code/shadow/rust-backtrace/src/main/core/work/task.rs:187:56
           7: shadow_rs::core::work::task::TaskRef::execute
                     at /shared/code/shadow/rust-backtrace/src/main/core/work/task.rs:29:9
           8: taskref_execute
                     at /shared/code/shadow/rust-backtrace/src/main/core/work/task.rs:261:9
           9: event_execute
                     at /shared/code/shadow/rust-backtrace/src/main/core/work/event.c:89:9
          10: worker_runEvent
                     at /shared/code/shadow/rust-backtrace/src/main/core/worker.c:459:5
          11: _scheduler_runEventsWorkerTaskFn
                     at /shared/code/shadow/rust-backtrace/src/main/core/scheduler/scheduler.c:85:9
          12: _worker_run
                     at /shared/code/shadow/rust-backtrace/src/main/core/worker.c:429:13
          13: start_thread
                     at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:477:8
          14: clone
**END BACKTRACE**
**ABORTING**
```