### PR TITLE
Remove handle field from `LegacyDescriptor`

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -802,10 +802,6 @@ const struct CompatDescriptor *process_getRegisteredCompatDescriptor(Process *pr
 // increment the ref count if you are to hold a reference to this descriptor.
 int process_registerLegacyDescriptor(Process *proc, LegacyDescriptor *desc);
 
-// Unlike the deregister method for the `CompatDescriptor`, you do not need to manually
-// unref the LegacyDescriptor as it's done automatically.
-void process_deregisterLegacyDescriptor(Process *proc, LegacyDescriptor *desc);
-
 // Get a temporary reference to a legacy descriptor.
 LegacyDescriptor *process_getRegisteredLegacyDescriptor(Process *proc, int handle);
 

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2400,9 +2400,6 @@ extern "C" {
     pub fn descriptor_setHandle(descriptor: *mut LegacyDescriptor, handle: gint);
 }
 extern "C" {
-    pub fn descriptor_getHandle(descriptor: *mut LegacyDescriptor) -> gint;
-}
-extern "C" {
     pub fn descriptor_setOwnerProcess(
         descriptor: *mut LegacyDescriptor,
         ownerProcess: *mut Process,

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2397,9 +2397,6 @@ extern "C" {
     pub fn descriptor_close(descriptor: *mut LegacyDescriptor, host: *mut Host);
 }
 extern "C" {
-    pub fn descriptor_setHandle(descriptor: *mut LegacyDescriptor, handle: gint);
-}
-extern "C" {
     pub fn descriptor_setOwnerProcess(
         descriptor: *mut LegacyDescriptor,
         ownerProcess: *mut Process,

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1662,7 +1662,7 @@ pub struct _Event {
     _unused: [u8; 0],
 }
 pub type Event = _Event;
-pub type LegacyDescriptor = [u64; 7usize];
+pub type LegacyDescriptor = [u64; 6usize];
 pub use self::_Status as Status;
 pub const _Status_STATUS_NONE: _Status = 0;
 pub const _Status_STATUS_DESCRIPTOR_ACTIVE: _Status = 1;
@@ -2563,7 +2563,7 @@ pub struct _Transport {
 fn bindgen_test_layout__Transport() {
     assert_eq!(
         ::std::mem::size_of::<_Transport>(),
-        72usize,
+        64usize,
         concat!("Size of: ", stringify!(_Transport))
     );
     assert_eq!(
@@ -2595,7 +2595,7 @@ fn bindgen_test_layout__Transport() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).vtable) as usize - ptr as usize
             },
-            56usize,
+            48usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_Transport),
@@ -2612,7 +2612,7 @@ fn bindgen_test_layout__Transport() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).magic) as usize - ptr as usize
             },
-            64usize,
+            56usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_Transport),

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -25,7 +25,6 @@ void descriptor_init(LegacyDescriptor* descriptor, LegacyDescriptorType type,
     MAGIC_INIT(funcTable);
     descriptor->funcTable = funcTable;
     descriptor->type = type;
-    descriptor->handle = -1;
     descriptor->listeners = g_hash_table_new_full(
         g_direct_hash, g_direct_equal, NULL, (GDestroyNotify)statuslistener_unref);
     descriptor->refCountStrong = 1;

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -165,11 +165,6 @@ void descriptor_setHandle(LegacyDescriptor* descriptor, gint handle) {
     descriptor->handle = handle;
 }
 
-gint descriptor_getHandle(LegacyDescriptor* descriptor) {
-    MAGIC_ASSERT(descriptor);
-    return descriptor->handle;
-}
-
 void descriptor_setOwnerProcess(LegacyDescriptor* descriptor, Process* ownerProcess) {
     MAGIC_ASSERT(descriptor);
     descriptor->ownerProcess = ownerProcess;

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -160,11 +160,6 @@ LegacyDescriptorType descriptor_getType(LegacyDescriptor* descriptor) {
     return descriptor->type;
 }
 
-void descriptor_setHandle(LegacyDescriptor* descriptor, gint handle) {
-    MAGIC_ASSERT(descriptor);
-    descriptor->handle = handle;
-}
-
 void descriptor_setOwnerProcess(LegacyDescriptor* descriptor, Process* ownerProcess) {
     MAGIC_ASSERT(descriptor);
     descriptor->ownerProcess = ownerProcess;

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -31,7 +31,7 @@ void descriptor_init(LegacyDescriptor* descriptor, LegacyDescriptorType type,
     descriptor->refCountStrong = 1;
     descriptor->refCountWeak = 0;
 
-    trace("Descriptor %i has been initialized now", descriptor->handle);
+    trace("Descriptor %p has been initialized now", descriptor);
 
     worker_count_allocation(LegacyDescriptor);
 }
@@ -49,7 +49,7 @@ static void _descriptor_cleanup(LegacyDescriptor* descriptor) {
     MAGIC_ASSERT(descriptor->funcTable);
 
     if (descriptor->funcTable->cleanup) {
-        trace("Descriptor %i calling vtable cleanup now", descriptor->handle);
+        trace("Descriptor %p calling vtable cleanup now", descriptor);
         descriptor->funcTable->cleanup(descriptor);
     }
 }
@@ -58,7 +58,7 @@ static void _descriptor_free(LegacyDescriptor* descriptor) {
     MAGIC_ASSERT(descriptor);
     MAGIC_ASSERT(descriptor->funcTable);
 
-    trace("Descriptor %i calling vtable free now", descriptor->handle);
+    trace("Descriptor %p calling vtable free now", descriptor);
     descriptor->funcTable->free(descriptor);
 
     worker_count_deallocation(LegacyDescriptor);
@@ -72,8 +72,8 @@ void descriptor_ref(gpointer data) {
     utility_assert(descriptor->refCountStrong > 0);
 
     (descriptor->refCountStrong)++;
-    trace("Descriptor %i strong_ref++ to %i (weak_ref=%i)", descriptor->handle,
-          descriptor->refCountStrong, descriptor->refCountWeak);
+    trace("Descriptor %p strong_ref++ to %i (weak_ref=%i)", descriptor, descriptor->refCountStrong,
+          descriptor->refCountWeak);
 }
 
 void descriptor_unref(gpointer data) {
@@ -81,8 +81,8 @@ void descriptor_unref(gpointer data) {
     MAGIC_ASSERT(descriptor);
 
     (descriptor->refCountStrong)--;
-    trace("Descriptor %i strong_ref-- to %i (weak_ref=%i)", descriptor->handle,
-          descriptor->refCountStrong, descriptor->refCountWeak);
+    trace("Descriptor %p strong_ref-- to %i (weak_ref=%i)", descriptor, descriptor->refCountStrong,
+          descriptor->refCountWeak);
 
     utility_assert(descriptor->refCountStrong >= 0);
 
@@ -93,8 +93,7 @@ void descriptor_unref(gpointer data) {
 
     if (descriptor->refCountWeak > 0) {
         // this was the last strong reference, but there are weak references, so cleanup only
-        trace("Descriptor %i kept alive by weak count of %d", descriptor->handle,
-              descriptor->refCountWeak);
+        trace("Descriptor %p kept alive by weak count of %d", descriptor, descriptor->refCountWeak);
 
         // create a temporary weak reference to prevent the _descriptor_cleanup() from calling
         // descriptor_unrefWeak() and running the _descriptor_free() while still running the
@@ -116,8 +115,8 @@ void descriptor_refWeak(gpointer data) {
     MAGIC_ASSERT(descriptor);
 
     (descriptor->refCountWeak)++;
-    trace("Descriptor %i weak_ref++ to %i (strong_ref=%i)", descriptor->handle,
-          descriptor->refCountWeak, descriptor->refCountStrong);
+    trace("Descriptor %p weak_ref++ to %i (strong_ref=%i)", descriptor, descriptor->refCountWeak,
+          descriptor->refCountStrong);
 }
 
 void descriptor_unrefWeak(gpointer data) {
@@ -125,8 +124,8 @@ void descriptor_unrefWeak(gpointer data) {
     MAGIC_ASSERT(descriptor);
 
     (descriptor->refCountWeak)--;
-    trace("Descriptor %i weak_ref-- to %i (strong_ref=%i)", descriptor->handle,
-          descriptor->refCountWeak, descriptor->refCountStrong);
+    trace("Descriptor %p weak_ref-- to %i (strong_ref=%i)", descriptor, descriptor->refCountWeak,
+          descriptor->refCountStrong);
 
     utility_assert(descriptor->refCountWeak >= 0);
 
@@ -150,7 +149,7 @@ void descriptor_close(LegacyDescriptor* descriptor, Host* host) {
         return;
     }
 
-    trace("Descriptor %i calling vtable close now", descriptor->handle);
+    trace("Descriptor %p calling vtable close now", descriptor);
     descriptor_adjustStatus(descriptor, STATUS_DESCRIPTOR_CLOSED, TRUE);
 
     descriptor->funcTable->close(descriptor, host);
@@ -228,7 +227,7 @@ static void _descriptor_handleStatusChange(LegacyDescriptor* descriptor, Status 
 #ifdef DEBUG
     gchar* before = _descriptor_statusToString(oldStatus);
     gchar* after = _descriptor_statusToString(descriptor->status);
-    trace("Status changed on desc %i, from %s to %s", descriptor->handle, before, after);
+    trace("Status changed on desc %p, from %s to %s", descriptor, before, after);
     g_free(before);
     g_free(after);
 #endif

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -155,12 +155,6 @@ void descriptor_close(LegacyDescriptor* descriptor, Host* host) {
     descriptor->funcTable->close(descriptor, host);
 }
 
-gint descriptor_compare(const LegacyDescriptor* foo, const LegacyDescriptor* bar, gpointer user_data) {
-    MAGIC_ASSERT(foo);
-    MAGIC_ASSERT(bar);
-    return foo->handle > bar->handle ? +1 : foo->handle == bar->handle ? 0 : -1;
-}
-
 LegacyDescriptorType descriptor_getType(LegacyDescriptor* descriptor) {
     MAGIC_ASSERT(descriptor);
     return descriptor->type;

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -180,11 +180,6 @@ Process* descriptor_getOwnerProcess(LegacyDescriptor* descriptor) {
     return descriptor->ownerProcess;
 }
 
-gint* descriptor_getHandleReference(LegacyDescriptor* descriptor) {
-    MAGIC_ASSERT(descriptor);
-    return &(descriptor->handle);
-}
-
 #ifdef DEBUG
 static gchar* _descriptor_statusToString(Status ds) {
     GString* string = g_string_new(NULL);

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -28,7 +28,6 @@ void descriptor_unrefWeak(gpointer data);
 void descriptor_close(LegacyDescriptor* descriptor, Host* host);
 
 void descriptor_setHandle(LegacyDescriptor* descriptor, gint handle);
-gint descriptor_getHandle(LegacyDescriptor* descriptor);
 void descriptor_setOwnerProcess(LegacyDescriptor* descriptor, Process* ownerProcess);
 Process* descriptor_getOwnerProcess(LegacyDescriptor* descriptor);
 LegacyDescriptorType descriptor_getType(LegacyDescriptor* descriptor);

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -32,7 +32,6 @@ gint descriptor_getHandle(LegacyDescriptor* descriptor);
 void descriptor_setOwnerProcess(LegacyDescriptor* descriptor, Process* ownerProcess);
 Process* descriptor_getOwnerProcess(LegacyDescriptor* descriptor);
 LegacyDescriptorType descriptor_getType(LegacyDescriptor* descriptor);
-gint* descriptor_getHandleReference(LegacyDescriptor* descriptor);
 
 gint descriptor_getFlags(LegacyDescriptor* descriptor);
 void descriptor_setFlags(LegacyDescriptor* descriptor, gint flags);

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -27,7 +27,6 @@ void descriptor_refWeak(gpointer data);
 void descriptor_unrefWeak(gpointer data);
 void descriptor_close(LegacyDescriptor* descriptor, Host* host);
 
-void descriptor_setHandle(LegacyDescriptor* descriptor, gint handle);
 void descriptor_setOwnerProcess(LegacyDescriptor* descriptor, Process* ownerProcess);
 Process* descriptor_getOwnerProcess(LegacyDescriptor* descriptor);
 LegacyDescriptorType descriptor_getType(LegacyDescriptor* descriptor);

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -26,7 +26,6 @@ void descriptor_unref(gpointer data);
 void descriptor_refWeak(gpointer data);
 void descriptor_unrefWeak(gpointer data);
 void descriptor_close(LegacyDescriptor* descriptor, Host* host);
-gint descriptor_compare(const LegacyDescriptor* foo, const LegacyDescriptor* bar, gpointer user_data);
 
 void descriptor_setHandle(LegacyDescriptor* descriptor, gint handle);
 gint descriptor_getHandle(LegacyDescriptor* descriptor);

--- a/src/main/host/descriptor/descriptor_types.h
+++ b/src/main/host/descriptor/descriptor_types.h
@@ -45,7 +45,6 @@ struct _DescriptorFunctionTable {
 struct _LegacyDescriptor {
     DescriptorFunctionTable* funcTable;
     Process* ownerProcess;
-    gint handle;
     LegacyDescriptorType type;
     Status status;
     GHashTable* listeners;

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -458,7 +458,7 @@ gint epoll_control(Epoll* epoll, gint operation, int fd, const CompatDescriptor*
                    const struct epoll_event* event, Host* host) {
     MAGIC_ASSERT(epoll);
 
-    trace("epoll descriptor %i, operation %s, descriptor %i", epoll->super.handle,
+    trace("epoll descriptor %p, operation %s, descriptor %i", &epoll->super,
           _epoll_operationToStr(operation), fd);
 
     EpollWatchTypes watchType;
@@ -658,8 +658,7 @@ gint epoll_getEvents(Epoll* epoll, struct epoll_event* eventArray, gint eventArr
                 not_ready_list = g_list_append(not_ready_list, key);
             }
         } else {
-            error("epoll descriptor %d ready list has items that aren't ready",
-                  descriptor_getHandle(&epoll->super));
+            error("epoll %p ready list has items that aren't ready", &epoll->super);
         }
 
         next_key = g_list_next(next_key);
@@ -672,7 +671,7 @@ gint epoll_getEvents(Epoll* epoll, struct epoll_event* eventArray, gint eventArr
 
     *nEvents = eventIndex;
 
-    trace("epoll descriptor %i collected %i events", descriptor_getHandle(&epoll->super), eventIndex);
+    trace("epoll descriptor %p collected %i events", &epoll->super, eventIndex);
 
     next_key = NULL;
     if (not_ready_list) {
@@ -703,13 +702,12 @@ gint epoll_getEvents(Epoll* epoll, struct epoll_event* eventArray, gint eventArr
 static void _epoll_descriptorStatusChanged(Epoll* epoll, const EpollKey* key) {
     MAGIC_ASSERT(epoll);
 
-    trace("status changed on epoll %i", descriptor_getHandle(&epoll->super));
+    trace("status changed on epoll %p", &epoll->super);
 
     if (key != NULL) {
         EpollWatch* watch = g_hash_table_lookup(epoll->watching, key);
         if (watch != NULL) {
-            trace("status changed in epoll %i on watched descriptor %i",
-                  descriptor_getHandle(&epoll->super), watch->fd);
+            trace("status changed in epoll %p on watched descriptor %i", &epoll->super, watch->fd);
 
             /* update the status for the child watch fd */
             _epollwatch_updateStatus(watch);

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -698,19 +698,6 @@ impl CompatDescriptor {
         unsafe { Some(Box::from_raw(descriptor)) }
     }
 
-    /// Update the handle.
-    /// This is a no-op for non-legacy descriptors.
-    pub fn set_handle(&mut self, handle: Option<u32>) {
-        if let CompatDescriptor::Legacy(d) = self {
-            let handle = match handle {
-                Some(x) => x.try_into().unwrap(),
-                None => -1,
-            };
-            unsafe { c::descriptor_setHandle(d.ptr(), handle) }
-        }
-        // new descriptor types don't store their file handle, so do nothing
-    }
-
     /// Close the descriptor. The `host` option is a legacy option for legacy descriptors.
     pub fn close(
         self,

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -86,11 +86,6 @@ static inline RegularFile* _regularfile_descriptorToFile(LegacyDescriptor* desc)
     return file;
 }
 
-static inline int _regularfile_getFD(RegularFile* file) {
-    MAGIC_ASSERT(file);
-    return descriptor_getHandle(&file->super);
-}
-
 static inline int _regularfile_getOSBackedFD(RegularFile* file) {
     MAGIC_ASSERT(file);
     return file->osfile.fd;
@@ -272,11 +267,6 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
     }
 #endif
 
-    int fd = _regularfile_getFD(file);
-    if (fd < 0) {
-        utility_panic("Cannot openat() on an unregistered descriptor object with fd %d", fd);
-    }
-
     /* The default case is a regular file. We do this first so that we have
      * an absolute path to compare for special files. */
     char* abspath = _regularfile_getAbsolutePath(dir, pathname, workingDir);
@@ -343,8 +333,7 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
     /* The os-backed file is now ready. */
     descriptor_adjustStatus(&file->super, STATUS_DESCRIPTOR_ACTIVE, TRUE);
 
-    /* We checked above that fd is non-negative. */
-    return fd;
+    return 0;
 }
 
 int regularfile_open(RegularFile* file, const char* pathname, int flags, mode_t mode,

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -99,8 +99,7 @@ int regularfile_getOSBackedFD(RegularFile* file) { return _regularfile_getOSBack
 
 static void _regularfile_closeHelper(RegularFile* file) {
     if (file && file->osfile.fd != OSFILE_INVALID) {
-        trace("On file %i, closing os-backed file %i", _regularfile_getFD(file),
-              _regularfile_getOSBackedFD(file));
+        trace("On file %p, closing os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
         close(file->osfile.fd);
         file->osfile.fd = OSFILE_INVALID;
@@ -113,8 +112,7 @@ static void _regularfile_closeHelper(RegularFile* file) {
 static void _regularfile_close(LegacyDescriptor* desc, Host* host) {
     RegularFile* file = _regularfile_descriptorToFile(desc);
 
-    trace("Closing file %i with os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("Closing file %p with os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     /* Make sure we mimic the close on the OS-backed file now. */
     _regularfile_closeHelper(file);
@@ -123,8 +121,7 @@ static void _regularfile_close(LegacyDescriptor* desc, Host* host) {
 static void _regularfile_free(LegacyDescriptor* desc) {
     RegularFile* file = _regularfile_descriptorToFile(desc);
 
-    trace("Freeing file %i with os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("Freeing file %p with os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     _regularfile_closeHelper(file);
 
@@ -325,8 +322,8 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
     }
 
     if (osfd < 0) {
-        trace("RegularFile %i opening path '%s' returned %i: %s", _regularfile_getFD(file), abspath,
-              osfd, strerror(errcode));
+        trace("RegularFile %p opening path '%s' returned %i: %s", file, abspath, osfd,
+              strerror(errcode));
         if (abspath) {
             free(abspath);
         }
@@ -340,7 +337,7 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
     file->osfile.flagsAtOpen = flags;
     file->osfile.modeAtOpen = mode;
 
-    trace("RegularFile %i opened os-backed file %i at absolute path %s", _regularfile_getFD(file),
+    trace("RegularFile %p opened os-backed file %i at absolute path %s", file,
           _regularfile_getOSBackedFD(file), file->osfile.absPathAtOpen);
 
     /* The os-backed file is now ready. */
@@ -361,8 +358,8 @@ static void _regularfile_readRandomBytes(RegularFile* file, Host* host, void* bu
 
     utility_assert(host != NULL);
 
-    trace("RegularFile %i will read %zu bytes from random source for host %s",
-          _regularfile_getFD(file), numBytes, host_getName(host));
+    trace("RegularFile %p will read %zu bytes from random source for host %s", file, numBytes,
+          host_getName(host));
 
     Random* rng = host_getRandom(host);
     random_nextNBytes(rng, buf, numBytes);
@@ -390,9 +387,8 @@ ssize_t regularfile_read(RegularFile* file, Host* host, void* buf, size_t bufSiz
         return (ssize_t)bufSize;
     }
 
-    trace("RegularFile %i will read %zu bytes from os-backed file %i at path '%s'",
-          _regularfile_getFD(file), bufSize, _regularfile_getOSBackedFD(file),
-          file->osfile.absPathAtOpen);
+    trace("RegularFile %p will read %zu bytes from os-backed file %i at path '%s'", file, bufSize,
+          _regularfile_getOSBackedFD(file), file->osfile.absPathAtOpen);
 
     /* TODO: this may block the shadow thread until we properly handle
      * os-backed files in non-blocking mode. */
@@ -412,9 +408,8 @@ ssize_t regularfile_pread(RegularFile* file, Host* host, void* buf, size_t bufSi
         return (ssize_t)bufSize;
     }
 
-    trace("RegularFile %i will pread %zu bytes from os-backed file %i offset %ld at path '%s'",
-          _regularfile_getFD(file), bufSize, _regularfile_getOSBackedFD(file), offset,
-          file->osfile.absPathAtOpen);
+    trace("RegularFile %p will pread %zu bytes from os-backed file %i offset %ld at path '%s'",
+          file, bufSize, _regularfile_getOSBackedFD(file), offset, file->osfile.absPathAtOpen);
 
     /* TODO: this may block the shadow thread until we properly handle
      * os-backed files in non-blocking mode. */
@@ -434,10 +429,8 @@ ssize_t regularfile_preadv(RegularFile* file, Host* host, const struct iovec* io
         return (ssize_t)_regularfile_readvRandomBytes(file, host, iov, iovcnt);
     }
 
-    trace("RegularFile %i will preadv %d vector items from os-backed file %i at path "
-          "'%s'",
-          _regularfile_getFD(file), iovcnt, _regularfile_getOSBackedFD(file),
-          file->osfile.absPathAtOpen);
+    trace("RegularFile %p will preadv %d vector items from os-backed file %i at path '%s'", file,
+          iovcnt, _regularfile_getOSBackedFD(file), file->osfile.absPathAtOpen);
 
     /* TODO: this may block the shadow thread until we properly handle
      * os-backed files in non-blocking mode. */
@@ -458,10 +451,8 @@ ssize_t regularfile_preadv2(RegularFile* file, Host* host, const struct iovec* i
         return (ssize_t)_regularfile_readvRandomBytes(file, host, iov, iovcnt);
     }
 
-    trace("RegularFile %i will preadv2 %d vector items from os-backed file %i at path "
-          "'%s'",
-          _regularfile_getFD(file), iovcnt, _regularfile_getOSBackedFD(file),
-          file->osfile.absPathAtOpen);
+    trace("RegularFile %p will preadv2 %d vector items from os-backed file %i at path '%s'", file,
+          iovcnt, _regularfile_getOSBackedFD(file), file->osfile.absPathAtOpen);
 
     /* TODO: this may block the shadow thread until we properly handle
      * os-backed files in non-blocking mode. */
@@ -478,9 +469,8 @@ ssize_t regularfile_write(RegularFile* file, const void* buf, size_t bufSize) {
         return -EBADF;
     }
 
-    trace("RegularFile %i will write %zu bytes to os-backed file %i at path '%s'",
-          _regularfile_getFD(file), bufSize, _regularfile_getOSBackedFD(file),
-          file->osfile.absPathAtOpen);
+    trace("RegularFile %p will write %zu bytes to os-backed file %i at path '%s'", file, bufSize,
+          _regularfile_getOSBackedFD(file), file->osfile.absPathAtOpen);
 
     /* TODO: this may block the shadow thread until we properly handle
      * os-backed files in non-blocking mode. */
@@ -495,9 +485,8 @@ ssize_t regularfile_pwrite(RegularFile* file, const void* buf, size_t bufSize, o
         return -EBADF;
     }
 
-    trace("RegularFile %i will pwrite %zu bytes to os-backed file %i offset %ld at path '%s'",
-          _regularfile_getFD(file), bufSize, _regularfile_getOSBackedFD(file), offset,
-          file->osfile.absPathAtOpen);
+    trace("RegularFile %p will pwrite %zu bytes to os-backed file %i offset %ld at path '%s'", file,
+          bufSize, _regularfile_getOSBackedFD(file), offset, file->osfile.absPathAtOpen);
 
     /* TODO: this may block the shadow thread until we properly handle
      * os-backed files in non-blocking mode. */
@@ -512,10 +501,8 @@ ssize_t regularfile_pwritev(RegularFile* file, const struct iovec* iov, int iovc
         return -EBADF;
     }
 
-    trace("RegularFile %i will pwritev %d vector items from os-backed file %i at "
-          "path '%s'",
-          _regularfile_getFD(file), iovcnt, _regularfile_getOSBackedFD(file),
-          file->osfile.absPathAtOpen);
+    trace("RegularFile %p will pwritev %d vector items from os-backed file %i at path '%s'", file,
+          iovcnt, _regularfile_getOSBackedFD(file), file->osfile.absPathAtOpen);
 
     /* TODO: this may block the shadow thread until we properly handle
      * os-backed files in non-blocking mode. */
@@ -532,10 +519,8 @@ ssize_t regularfile_pwritev2(RegularFile* file, const struct iovec* iov, int iov
         return -EBADF;
     }
 
-    trace("RegularFile %i will pwritev2 %d vector items from os-backed file %i at "
-          "path '%s'",
-          _regularfile_getFD(file), iovcnt, _regularfile_getOSBackedFD(file),
-          file->osfile.absPathAtOpen);
+    trace("RegularFile %p will pwritev2 %d vector items from os-backed file %i at path '%s'", file,
+          iovcnt, _regularfile_getOSBackedFD(file), file->osfile.absPathAtOpen);
 
     /* TODO: this may block the shadow thread until we properly handle
      * os-backed files in non-blocking mode. */
@@ -552,8 +537,7 @@ int regularfile_fstat(RegularFile* file, struct stat* statbuf) {
         return -EBADF;
     }
 
-    trace("RegularFile %i fstat os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p fstat os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = fstat(_regularfile_getOSBackedFD(file), statbuf);
     return (result < 0) ? -errno : result;
@@ -566,8 +550,7 @@ int regularfile_fstatfs(RegularFile* file, struct statfs* statbuf) {
         return -EBADF;
     }
 
-    trace("RegularFile %i fstatfs os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p fstatfs os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = fstatfs(_regularfile_getOSBackedFD(file), statbuf);
     return (result < 0) ? -errno : result;
@@ -580,8 +563,7 @@ int regularfile_fsync(RegularFile* file) {
         return -EBADF;
     }
 
-    trace("RegularFile %i fsync os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p fsync os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = fsync(_regularfile_getOSBackedFD(file));
     return (result < 0) ? -errno : result;
@@ -594,8 +576,7 @@ int regularfile_fchown(RegularFile* file, uid_t owner, gid_t group) {
         return -EBADF;
     }
 
-    trace("RegularFile %i fchown os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p fchown os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = fchown(_regularfile_getOSBackedFD(file), owner, group);
     return (result < 0) ? -errno : result;
@@ -608,8 +589,7 @@ int regularfile_fchmod(RegularFile* file, mode_t mode) {
         return -EBADF;
     }
 
-    trace("RegularFile %i fchmod os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p fchmod os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = fchmod(_regularfile_getOSBackedFD(file), mode);
     return (result < 0) ? -errno : result;
@@ -622,8 +602,7 @@ int regularfile_ftruncate(RegularFile* file, off_t length) {
         return -EBADF;
     }
 
-    trace("RegularFile %i ftruncate os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p ftruncate os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = ftruncate(_regularfile_getOSBackedFD(file), length);
     return (result < 0) ? -errno : result;
@@ -636,8 +615,7 @@ int regularfile_fallocate(RegularFile* file, int mode, off_t offset, off_t lengt
         return -EBADF;
     }
 
-    trace("RegularFile %i fallocate os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p fallocate os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = fallocate(_regularfile_getOSBackedFD(file), mode, offset, length);
     return (result < 0) ? -errno : result;
@@ -650,8 +628,7 @@ int regularfile_fadvise(RegularFile* file, off_t offset, off_t len, int advice) 
         return -EBADF;
     }
 
-    trace("RegularFile %i fadvise os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p fadvise os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = posix_fadvise(_regularfile_getOSBackedFD(file), offset, len, advice);
     return (result < 0) ? -errno : result;
@@ -664,8 +641,7 @@ int regularfile_flock(RegularFile* file, int operation) {
         return -EBADF;
     }
 
-    trace("RegularFile %i flock os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p flock os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = flock(_regularfile_getOSBackedFD(file), operation);
     return (result < 0) ? -errno : result;
@@ -679,8 +655,7 @@ int regularfile_fsetxattr(RegularFile* file, const char* name, const void* value
         return -EBADF;
     }
 
-    trace("RegularFile %i fsetxattr os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p fsetxattr os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = fsetxattr(_regularfile_getOSBackedFD(file), name, value, size, flags);
     return (result < 0) ? -errno : result;
@@ -693,8 +668,7 @@ ssize_t regularfile_fgetxattr(RegularFile* file, const char* name, void* value, 
         return -EBADF;
     }
 
-    trace("RegularFile %i fgetxattr os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p fgetxattr os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     ssize_t result = fgetxattr(_regularfile_getOSBackedFD(file), name, value, size);
     return (result < 0) ? -errno : result;
@@ -707,8 +681,7 @@ ssize_t regularfile_flistxattr(RegularFile* file, char* list, size_t size) {
         return -EBADF;
     }
 
-    trace("RegularFile %i flistxattr os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p flistxattr os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     ssize_t result = flistxattr(_regularfile_getOSBackedFD(file), list, size);
     return (result < 0) ? -errno : result;
@@ -721,8 +694,7 @@ int regularfile_fremovexattr(RegularFile* file, const char* name) {
         return -EBADF;
     }
 
-    trace("RegularFile %i fremovexattr os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p fremovexattr os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = fremovexattr(_regularfile_getOSBackedFD(file), name);
     return (result < 0) ? -errno : result;
@@ -735,8 +707,8 @@ int regularfile_sync_range(RegularFile* file, off64_t offset, off64_t nbytes, un
         return -EBADF;
     }
 
-    trace("RegularFile %i sync_file_range os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace(
+        "RegularFile %p sync_file_range os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result =
         sync_file_range(_regularfile_getOSBackedFD(file), offset, nbytes, flags);
@@ -750,8 +722,7 @@ ssize_t regularfile_readahead(RegularFile* file, off64_t offset, size_t count) {
         return -EBADF;
     }
 
-    trace("RegularFile %i readahead os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p readahead os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     ssize_t result = readahead(_regularfile_getOSBackedFD(file), offset, count);
     return (result < 0) ? -errno : result;
@@ -764,8 +735,7 @@ off_t regularfile_lseek(RegularFile* file, off_t offset, int whence) {
         return -EBADF;
     }
 
-    trace("RegularFile %i lseek os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p lseek os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     ssize_t result = lseek(_regularfile_getOSBackedFD(file), offset, whence);
     return (result < 0) ? -errno : result;
@@ -778,8 +748,7 @@ int regularfile_getdents(RegularFile* file, struct linux_dirent* dirp, unsigned 
         return -EBADF;
     }
 
-    trace("RegularFile %i getdents os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p getdents os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     // getdents is not available for a direct call
     int result =
@@ -795,8 +764,7 @@ int regularfile_getdents64(RegularFile* file, struct linux_dirent64* dirp,
         return -EBADF;
     }
 
-    trace("RegularFile %i getdents64 os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p getdents64 os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result =
         (int)syscall(SYS_getdents64, _regularfile_getOSBackedFD(file), dirp, count);
@@ -810,8 +778,7 @@ int regularfile_ioctl(RegularFile* file, unsigned long request, void* arg) {
         return -EBADF;
     }
 
-    trace("RegularFile %i ioctl os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p ioctl os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     int result = ioctl(_regularfile_getOSBackedFD(file), request, arg);
     return (result < 0) ? -errno : result;
@@ -824,8 +791,7 @@ int regularfile_fcntl(RegularFile* file, unsigned long command, void* arg) {
         return -EBADF;
     }
 
-    trace("RegularFile %i fcntl os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p fcntl os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     if (command == F_SETFD) {
         intptr_t arg_int = (intptr_t)arg;
@@ -861,8 +827,7 @@ int regularfile_poll(RegularFile* file, struct pollfd* pfd) {
         return -EBADF;
     }
 
-    trace("RegularFile %i poll os-backed file %i", _regularfile_getFD(file),
-          _regularfile_getOSBackedFD(file));
+    trace("RegularFile %p poll os-backed file %i", file, _regularfile_getOSBackedFD(file));
 
     // Don't let the OS block us
     int oldfd = pfd->fd;
@@ -890,8 +855,7 @@ int regularfile_fstatat(RegularFile* dir, const char* pathname, struct stat* sta
     int osFd = _regularfile_getOSDirFD(dir);
     const char* pathnameTmp = pathname;
 
-    trace("RegularFile %i fstatat os-backed file %i, flags %d", dir ? _regularfile_getFD(dir) : -1,
-          osFd, flags);
+    trace("RegularFile %p fstatat os-backed file %i, flags %d", dir, osFd, flags);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;
@@ -912,7 +876,7 @@ int regularfile_fchownat(RegularFile* dir, const char* pathname, uid_t owner, gi
     int osFd = _regularfile_getOSDirFD(dir);
     const char* pathnameTmp = pathname;
 
-    trace("RegularFile %i fchownat os-backed file %i", dir ? _regularfile_getFD(dir) : -1, osFd);
+    trace("RegularFile %p fchownat os-backed file %i", dir, osFd);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;
@@ -933,7 +897,7 @@ int regularfile_fchmodat(RegularFile* dir, const char* pathname, mode_t mode, in
     int osFd = _regularfile_getOSDirFD(dir);
     const char* pathnameTmp = pathname;
 
-    trace("RegularFile %i fchmodat os-backed file %i", dir ? _regularfile_getFD(dir) : -1, osFd);
+    trace("RegularFile %p fchmodat os-backed file %i", dir, osFd);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;
@@ -954,7 +918,7 @@ int regularfile_futimesat(RegularFile* dir, const char* pathname, const struct t
     int osFd = _regularfile_getOSDirFD(dir);
     const char* pathnameTmp = pathname;
 
-    trace("RegularFile %i futimesat os-backed file %i", dir ? _regularfile_getFD(dir) : -1, osFd);
+    trace("RegularFile %p futimesat os-backed file %i", dir, osFd);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;
@@ -975,7 +939,7 @@ int regularfile_utimensat(RegularFile* dir, const char* pathname, const struct t
     int osFd = _regularfile_getOSDirFD(dir);
     const char* pathnameTmp = pathname;
 
-    trace("RegularFile %i utimesat os-backed file %i", dir ? _regularfile_getFD(dir) : -1, osFd);
+    trace("RegularFile %p utimesat os-backed file %i", dir, osFd);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;
@@ -996,7 +960,7 @@ int regularfile_faccessat(RegularFile* dir, const char* pathname, int mode, int 
     int osFd = _regularfile_getOSDirFD(dir);
     const char* pathnameTmp = pathname;
 
-    trace("RegularFile %i faccessat os-backed file %i", dir ? _regularfile_getFD(dir) : -1, osFd);
+    trace("RegularFile %p faccessat os-backed file %i", dir, osFd);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;
@@ -1017,7 +981,7 @@ int regularfile_mkdirat(RegularFile* dir, const char* pathname, mode_t mode,
     int osFd = _regularfile_getOSDirFD(dir);
     const char* pathnameTmp = pathname;
 
-    trace("RegularFile %i mkdirat os-backed file %i", dir ? _regularfile_getFD(dir) : -1, osFd);
+    trace("RegularFile %p mkdirat os-backed file %i", dir, osFd);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;
@@ -1038,7 +1002,7 @@ int regularfile_mknodat(RegularFile* dir, const char* pathname, mode_t mode, dev
     int osFd = _regularfile_getOSDirFD(dir);
     const char* pathnameTmp = pathname;
 
-    trace("RegularFile %i mknodat os-backed file %i", dir ? _regularfile_getFD(dir) : -1, osFd);
+    trace("RegularFile %p mknodat os-backed file %i", dir, osFd);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;
@@ -1061,9 +1025,7 @@ int regularfile_linkat(RegularFile* oldDir, const char* oldPath, RegularFile* ne
     const char* oldPathTmp = oldPath;
     const char* newPathTmp = newPath;
 
-    trace("RegularFiles %i, %i linkat os-backed files %i, %i",
-          oldDir ? _regularfile_getFD(oldDir) : -1, newDir ? _regularfile_getFD(newDir) : -1,
-          oldOsFd, newOsFd);
+    trace("RegularFiles %p, %p linkat os-backed files %i, %i", oldDir, newDir, oldOsFd, newOsFd);
 
     if (oldOsFd == AT_FDCWD) {
         oldOsFd = -1;
@@ -1091,7 +1053,7 @@ int regularfile_unlinkat(RegularFile* dir, const char* pathname, int flags,
     int osFd = _regularfile_getOSDirFD(dir);
     const char* pathnameTmp = pathname;
 
-    trace("RegularFile %i unlinkat os-backed file %i", dir ? _regularfile_getFD(dir) : -1, osFd);
+    trace("RegularFile %p unlinkat os-backed file %i", dir, osFd);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;
@@ -1112,7 +1074,7 @@ int regularfile_symlinkat(RegularFile* dir, const char* linkpath, const char* ta
     int osFd = _regularfile_getOSDirFD(dir);
     const char* linkpathTmp = linkpath;
 
-    trace("RegularFile %i symlinkat os-backed file %i", dir ? _regularfile_getFD(dir) : -1, osFd);
+    trace("RegularFile %p symlinkat os-backed file %i", dir, osFd);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;
@@ -1133,7 +1095,7 @@ ssize_t regularfile_readlinkat(RegularFile* dir, const char* pathname, char* buf
     int osFd = _regularfile_getOSDirFD(dir);
     const char* pathnameTmp = pathname;
 
-    trace("RegularFile %i readlinkat os-backed file %i", dir ? _regularfile_getFD(dir) : -1, osFd);
+    trace("RegularFile %p readlinkat os-backed file %i", dir, osFd);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;
@@ -1156,9 +1118,7 @@ int regularfile_renameat2(RegularFile* oldDir, const char* oldPath, RegularFile*
     const char* oldPathTmp = oldPath;
     const char* newPathTmp = newPath;
 
-    trace("RegularFiles %i, %i renameat2 os-backed files %i, %i",
-          oldDir ? _regularfile_getFD(oldDir) : -1, newDir ? _regularfile_getFD(newDir) : -1,
-          oldOsFd, newOsFd);
+    trace("RegularFiles %p, %p renameat2 os-backed files %i, %i", oldDir, newDir, oldOsFd, newOsFd);
 
     if (oldOsFd == AT_FDCWD) {
         oldOsFd = -1;
@@ -1188,7 +1148,7 @@ int regularfile_statx(RegularFile* dir, const char* pathname, int flags, unsigne
     int osFd = _regularfile_getOSDirFD(dir);
     const char* pathnameTmp = pathname;
 
-    trace("RegularFile %i statx os-backed file %i", dir ? _regularfile_getFD(dir) : -1, osFd);
+    trace("RegularFile %p statx os-backed file %i", dir, osFd);
 
     if (osFd == AT_FDCWD) {
         osFd = -1;

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -269,7 +269,7 @@ void legacysocket_setSocketName(LegacySocket* socket, in_addr_t ip, in_port_t po
     gchar* ipString = address_ipToNewString(ip);
     GString* stringBuffer = g_string_new(ipString);
     g_free(ipString);
-    g_string_append_printf(stringBuffer, ":%u (descriptor %i)", ntohs(port), socket->super.super.handle);
+    g_string_append_printf(stringBuffer, ":%u (descriptor %p)", ntohs(port), &socket->super.super);
     socket->boundString = g_string_free(stringBuffer, FALSE);
 
     /* the socket is now bound */

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -84,7 +84,7 @@ static void _legacysocket_close(LegacyDescriptor* descriptor, Host* host) {
 
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
-        tracker_removeSocket(tracker, descriptor_getHandle(descriptor));
+        tracker_removeSocket(tracker, socket);
     }
 
     socket->vtable->close((LegacyDescriptor*)socket, host);
@@ -132,9 +132,8 @@ void legacysocket_init(LegacySocket* socket, Host* host, SocketFunctionTable* vt
 
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
-        LegacyDescriptor* descriptor = (LegacyDescriptor*)socket;
-        tracker_addSocket(tracker, descriptor->handle, socket->protocol, socket->inputBufferSize,
-                          socket->outputBufferSize);
+        tracker_addSocket(
+            tracker, socket, socket->protocol, socket->inputBufferSize, socket->outputBufferSize);
     }
 }
 
@@ -158,8 +157,7 @@ gint legacysocket_connectToPeer(LegacySocket* socket, Host* host, in_addr_t ip, 
 
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
-        LegacyDescriptor* descriptor = (LegacyDescriptor*)socket;
-        tracker_updateSocketPeer(tracker, descriptor->handle, ip, ntohs(port));
+        tracker_updateSocketPeer(tracker, socket, ip, ntohs(port));
     }
 
     return socket->vtable->connectToPeer(socket, host, ip, port, family);
@@ -365,9 +363,8 @@ gboolean legacysocket_addToInputBuffer(LegacySocket* socket, Host* host, Packet*
     /* update the tracker input buffer stats */
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
-        LegacyDescriptor* descriptor = (LegacyDescriptor*)socket;
         tracker_updateSocketInputBuffer(
-            tracker, descriptor->handle, socket->inputBufferLength, socket->inputBufferSize);
+            tracker, socket, socket->inputBufferLength, socket->inputBufferSize);
     }
 
     /* we just added a packet, so we are readable */
@@ -396,9 +393,8 @@ Packet* legacysocket_removeFromInputBuffer(LegacySocket* socket, Host* host) {
         /* update the tracker input buffer stats */
         Tracker* tracker = host_getTracker(host);
         if (tracker != NULL) {
-            LegacyDescriptor* descriptor = (LegacyDescriptor*)socket;
             tracker_updateSocketInputBuffer(
-                tracker, descriptor->handle, socket->inputBufferLength, socket->inputBufferSize);
+                tracker, socket, socket->inputBufferLength, socket->inputBufferSize);
         }
 
         /* we are not readable if we are now empty */
@@ -446,9 +442,8 @@ gboolean legacysocket_addToOutputBuffer(LegacySocket* socket, Host* host, Packet
     /* update the tracker input buffer stats */
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
-        LegacyDescriptor* descriptor = (LegacyDescriptor*)socket;
         tracker_updateSocketOutputBuffer(
-            tracker, descriptor->handle, socket->outputBufferLength, socket->outputBufferSize);
+            tracker, socket, socket->outputBufferLength, socket->outputBufferSize);
     }
 
     /* we just added a packet, we are no longer writable if full */
@@ -485,9 +480,8 @@ Packet* legacysocket_removeFromOutputBuffer(LegacySocket* socket, Host* host) {
         /* update the tracker input buffer stats */
         Tracker* tracker = host_getTracker(host);
         if (tracker != NULL) {
-            LegacyDescriptor* descriptor = (LegacyDescriptor*)socket;
             tracker_updateSocketOutputBuffer(
-                tracker, descriptor->handle, socket->outputBufferLength, socket->outputBufferSize);
+                tracker, socket, socket->outputBufferLength, socket->outputBufferSize);
         }
 
         /* we are writable if we now have space */

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -1338,14 +1338,13 @@ static void _tcp_flush(TCP* tcp, Host* host) {
     /* update the tracker input/output buffer stats */
     Tracker* tracker = host_getTracker(host);
     LegacySocket* socket = (LegacySocket*)tcp;
-    LegacyDescriptor* descriptor = (LegacyDescriptor *)socket;
     gsize inSize = legacysocket_getInputBufferSize(&(tcp->super));
     gsize outSize = legacysocket_getOutputBufferSize(&(tcp->super));
     if (tracker != NULL) {
         tracker_updateSocketInputBuffer(
-            tracker, descriptor->handle, inSize - _tcp_getBufferSpaceIn(tcp), inSize);
+            tracker, socket, inSize - _tcp_getBufferSpaceIn(tcp), inSize);
         tracker_updateSocketOutputBuffer(
-            tracker, descriptor->handle, outSize - _tcp_getBufferSpaceOut(tcp), outSize);
+            tracker, socket, outSize - _tcp_getBufferSpaceOut(tcp), outSize);
     }
 
     /* should we send a fin after clearing the output buffer */
@@ -1688,7 +1687,8 @@ gint tcp_acceptServerPeer(TCP* tcp, Host* host, in_addr_t* ip, in_port_t* port,
 
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
-        tracker_updateSocketPeer(tracker, *acceptedHandle, *ip, ntohs(tcpChild->super.peerPort));
+        tracker_updateSocketPeer(
+            tracker, &tcpChild->child->parent->super, *ip, ntohs(tcpChild->super.peerPort));
     }
 
     return 0;

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -1904,10 +1904,10 @@ static void _tcp_logCongestionInfo(TCP* tcp) {
     debug("[CONG-AVOID] cwnd=%d ssthresh=%d rtt=%d "
           "sndbufsize=%" G_GSIZE_FORMAT " sndbuflen=%" G_GSIZE_FORMAT " rcvbufsize=%" G_GSIZE_FORMAT
           " rcbuflen=%" G_GSIZE_FORMAT " "
-          "retrans=%" G_GSIZE_FORMAT " ploss=%f fd=%i",
+          "retrans=%" G_GSIZE_FORMAT " ploss=%f desc=%p",
           tcp->cong.cwnd, tcp->cong.hooks->tcp_cong_ssthresh(tcp), tcp->timing.rttSmoothed, outSize,
           outLength, inSize, inLength, tcp->info.retransmitCount, ploss,
-          tcp->super.super.super.handle);
+          &tcp->super.super.super);
 }
 
 static void _tcp_sendACKTaskCallback(Host* host, gpointer voidTcp, gpointer userData) {

--- a/src/main/host/descriptor/tcp_cong_reno.c
+++ b/src/main/host/descriptor/tcp_cong_reno.c
@@ -43,7 +43,7 @@ static inline void transition_to_cong_avoid(TCP *tcp, CAReno *reno, guint32 n) {
     reno->cong_avoid_nacked = 0;
     reno->state_hooks = cong_avoid_hooks_();
     reno->state_hooks->tcp_cong_new_ack_ev(tcp, n);
-    debug("[CONG] fd %i transition_to_cong_avoid", ((LegacyDescriptor*)tcp)->handle);
+    debug("[CONG] desc=%p transition_to_cong_avoid", (LegacyDescriptor*)tcp);
 }
 
 /* SLOW START *******************************************************/
@@ -55,8 +55,8 @@ static void ca_reno_slow_start_duplicate_ack_ev_(TCP *tcp) {
     if (reno->duplicate_ack_n == 3) { // transition to fast recovery
 
         trace("[CONG-AVOID] three duplicate acks");
-        debug("[CONG] fd %i three duplicate acks transition_to_fast_recovery",
-              ((LegacyDescriptor*)tcp)->handle);
+        debug("[CONG] desc %p three duplicate acks transition_to_fast_recovery",
+              (LegacyDescriptor*)tcp);
 
         ssthresh_halve(tcp, reno);
         tcp_cong(tcp)->cwnd = reno->ssthresh + 3;
@@ -160,7 +160,7 @@ static void tcp_cong_reno_timeout_ev_(TCP *tcp) {
 
     // transition to slow start
     reno->state_hooks = slow_start_hooks_();
-    debug("[CONG] fd %i transition_to_slow_start", ((LegacyDescriptor*)tcp)->handle);
+    debug("[CONG] desc %p transition_to_slow_start", (LegacyDescriptor*)tcp);
 }
 
 static guint32 tcp_cong_reno_ssthresh_(TCP *tcp) {

--- a/src/main/host/descriptor/timerfd.c
+++ b/src/main/host/descriptor/timerfd.c
@@ -35,7 +35,7 @@ static TimerFd* _timerfd_fromLegacyDescriptor(LegacyDescriptor* descriptor) {
 static void _timerfd_close(LegacyDescriptor* descriptor, Host* host) {
     TimerFd* timerfd = _timerfd_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(timerfd);
-    trace("timer fd %i closing now", timerfd->super.handle);
+    trace("timer desc %p closing now", &timerfd->super);
     timerfd->isClosed = TRUE;
     descriptor_adjustStatus(&(timerfd->super), STATUS_DESCRIPTOR_ACTIVE, FALSE);
 }
@@ -135,7 +135,7 @@ static void _timerfd_arm(TimerFd* timerfd, Host* host, const struct itimerspec* 
 
     timer_arm(timerfd->timer, host, nextExpireTime, interval);
 
-    trace("timer fd %i armed to expire in %" G_GUINT64_FORMAT " nanos", timerfd->super.handle,
+    trace("timer desc %p armed to expire in %" G_GUINT64_FORMAT " nanos", &timerfd->super,
           nextExpireTime - now);
 }
 
@@ -163,9 +163,9 @@ gint timerfd_setTime(TimerFd* timerfd, Host* host, gint flags, const struct itim
           "%" G_GUINT64_FORMAT ".%09" G_GUINT64_FORMAT " seconds "
           "and timer interval to "
           "%" G_GUINT64_FORMAT ".%09" G_GUINT64_FORMAT " seconds "
-          "on timer fd %d",
+          "on timer desc %p",
           new_value->it_value.tv_sec, new_value->it_value.tv_nsec, new_value->it_interval.tv_sec,
-          new_value->it_interval.tv_nsec, timerfd->super.handle);
+          new_value->it_interval.tv_nsec, &timerfd->super);
 
     /* first get the old value if requested */
     if (old_value) {
@@ -197,8 +197,8 @@ ssize_t timerfd_read(TimerFd* timerfd, void* buf, size_t count) {
             return (ssize_t)-EINVAL;
         }
 
-        trace("Reading %" G_GUINT64_FORMAT " expirations from timer fd %d", expirationCount,
-              timerfd->super.handle);
+        trace("Reading %" G_GUINT64_FORMAT " expirations from timer desc %p", expirationCount,
+              &timerfd->super);
 
         *(guint64*)buf = expirationCount;
 

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -412,8 +412,7 @@ static void _networkinterface_receivePacket(Host* host, NetworkInterface* interf
 
     gint socketHandle = -1;
     if (socket.type == CST_LEGACY_SOCKET) {
-        socketHandle =
-            *descriptor_getHandleReference((LegacyDescriptor*)socket.object.as_legacy_socket);
+        socketHandle = descriptor_getHandle((LegacyDescriptor*)socket.object.as_legacy_socket);
     }
 
     /* count our bandwidth usage by interface, and by socket handle if possible */
@@ -494,8 +493,7 @@ static Packet* _networkinterface_selectRoundRobin(NetworkInterface* interface, H
 
         packet = compatsocket_pullOutPacket(&socket, host);
         if (socket.type == CST_LEGACY_SOCKET) {
-            *socketHandle =
-                *descriptor_getHandleReference((LegacyDescriptor*)socket.object.as_legacy_socket);
+            *socketHandle = descriptor_getHandle((LegacyDescriptor*)socket.object.as_legacy_socket);
         }
 
         if (packet) {
@@ -532,8 +530,7 @@ static Packet* _networkinterface_selectFirstInFirstOut(NetworkInterface* interfa
 
         packet = compatsocket_pullOutPacket(&socket, host);
         if (socket.type == CST_LEGACY_SOCKET) {
-            *socketHandle =
-                *descriptor_getHandleReference((LegacyDescriptor*)socket.object.as_legacy_socket);
+            *socketHandle = descriptor_getHandle((LegacyDescriptor*)socket.object.as_legacy_socket);
         }
 
         if (packet) {

--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -77,11 +77,12 @@ static SysCallReturn _syscallhandler_openHelper(SysCallHandler* sys,
         utility_assert(removed_desc != NULL);
         utility_assert(compatdescriptor_asLegacy(removed_desc) == (LegacyDescriptor*)filed);
         compatdescriptor_free(removed_desc);
-    } else {
-        utility_assert(errcode == handle);
-    }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+    } else {
+        utility_assert(errcode == 0);
+        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = handle};
+    }
 }
 
 static SysCallReturn _syscallhandler_fsyncHelper(SysCallHandler* sys, int fd) {

--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -72,7 +72,11 @@ static SysCallReturn _syscallhandler_openHelper(SysCallHandler* sys,
     if (errcode < 0) {
         /* This will remove the descriptor entry and unref/free the RegularFile. */
         descriptor_close((LegacyDescriptor*)filed, sys->host);
-        process_deregisterLegacyDescriptor(sys->process, (LegacyDescriptor*)filed);
+
+        CompatDescriptor* removed_desc = process_deregisterCompatDescriptor(sys->process, handle);
+        utility_assert(removed_desc != NULL);
+        utility_assert(compatdescriptor_asLegacy(removed_desc) == (LegacyDescriptor*)filed);
+        compatdescriptor_free(removed_desc);
     } else {
         utility_assert(errcode == handle);
     }

--- a/src/main/host/syscall/fileat.c
+++ b/src/main/host/syscall/fileat.c
@@ -140,11 +140,12 @@ SysCallReturn syscallhandler_openat(SysCallHandler* sys,
         utility_assert(removed_desc != NULL);
         utility_assert(compatdescriptor_asLegacy(removed_desc) == (LegacyDescriptor*)file_desc);
         compatdescriptor_free(removed_desc);
-    } else {
-        utility_assert(errcode == handle);
-    }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+    } else {
+        utility_assert(errcode == 0);
+        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = handle};
+    }
 }
 
 SysCallReturn syscallhandler_newfstatat(SysCallHandler* sys,

--- a/src/main/host/syscall/fileat.c
+++ b/src/main/host/syscall/fileat.c
@@ -135,7 +135,11 @@ SysCallReturn syscallhandler_openat(SysCallHandler* sys,
     if (errcode < 0) {
         /* This will remove the descriptor entry and unref/free the RegularFile. */
         descriptor_close((LegacyDescriptor*)file_desc, sys->host);
-        process_deregisterLegacyDescriptor(sys->process, (LegacyDescriptor*)file_desc);
+
+        CompatDescriptor* removed_desc = process_deregisterCompatDescriptor(sys->process, handle);
+        utility_assert(removed_desc != NULL);
+        utility_assert(compatdescriptor_asLegacy(removed_desc) == (LegacyDescriptor*)file_desc);
+        compatdescriptor_free(removed_desc);
     } else {
         utility_assert(errcode == handle);
     }

--- a/src/main/host/syscall/mman.c
+++ b/src/main/host/syscall/mman.c
@@ -112,10 +112,8 @@ static char* _file_createPersistentMMapPath(int file_fd, int osfile_fd) {
     return NULL;
 }
 
-static int _syscallhandler_openPluginFile(SysCallHandler* sys, RegularFile* file) {
+static int _syscallhandler_openPluginFile(SysCallHandler* sys, int fd, RegularFile* file) {
     utility_assert(file);
-
-    int fd = descriptor_getHandle((LegacyDescriptor*)file);
 
     trace("Trying to open file %i in the plugin", fd);
 
@@ -212,7 +210,7 @@ static SysCallReturn _syscallhandler_mmap(SysCallHandler* sys, PluginPtr addrPtr
     int pluginFD = -1;
 
     if (file_desc) {
-        pluginFD = _syscallhandler_openPluginFile(sys, file_desc);
+        pluginFD = _syscallhandler_openPluginFile(sys, fd, file_desc);
         if (pluginFD < 0) {
             warning("mmap on fd %d for %zu bytes failed.", fd, len);
             return (SysCallReturn){

--- a/src/main/host/syscall/protected.c
+++ b/src/main/host/syscall/protected.c
@@ -50,16 +50,15 @@ int _syscallhandler_validateDescriptor(LegacyDescriptor* descriptor,
         Status status = descriptor_getStatus(descriptor);
 
         if (status & STATUS_DESCRIPTOR_CLOSED) {
-            warning("descriptor handle '%i' is closed",
-                    descriptor_getHandle(descriptor));
+            warning("descriptor %p is closed", descriptor);
             return -EBADF;
         }
 
         LegacyDescriptorType type = descriptor_getType(descriptor);
 
         if (expectedType != DT_NONE && type != expectedType) {
-            warning("descriptor handle '%i' is of type %i, expected type %i",
-                    descriptor_getHandle(descriptor), type, expectedType);
+            warning(
+                "descriptor %p is of type %i, expected type %i", descriptor, type, expectedType);
             return -EINVAL;
         }
 

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -245,10 +245,8 @@ static int _syscallhandler_bindHelper(SysCallHandler* sys, LegacySocket* socket_
 #ifdef DEBUG
     gchar* bindAddrStr = address_ipToNewString(addr);
     gchar* peerAddrStr = address_ipToNewString(peerAddr);
-    trace("trying to bind to inet address %s:%u on socket %i with peer %s:%u",
-          bindAddrStr, ntohs(port),
-          descriptor_getHandle((LegacyDescriptor*)socket_desc), peerAddrStr,
-          ntohs(peerPort));
+    trace("trying to bind to inet address %s:%u on socket %p with peer %s:%u", bindAddrStr,
+          ntohs(port), (LegacyDescriptor*)socket_desc, peerAddrStr, ntohs(peerPort));
     g_free(bindAddrStr);
     g_free(peerAddrStr);
 #endif

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -233,8 +233,8 @@ static void _syscallcondition_logListeningState(SysCallCondition* cond,
     if (cond->trigger.object.as_pointer) {
         switch (cond->trigger.type) {
             case TRIGGER_DESCRIPTOR: {
-                g_string_append_printf(string, "status on descriptor %d%s",
-                                       descriptor_getHandle(cond->trigger.object.as_descriptor),
+                g_string_append_printf(string, "status on descriptor %p%s",
+                                       cond->trigger.object.as_descriptor,
                                        cond->timeoutExpiration != EMUTIME_INVALID ? " and " : "");
                 break;
             }

--- a/src/main/host/tracker.h
+++ b/src/main/host/tracker.h
@@ -21,15 +21,15 @@ void tracker_free(Tracker* tracker);
 
 void tracker_addProcessingTime(Tracker* tracker, SimulationTime processingTime);
 void tracker_addVirtualProcessingDelay(Tracker* tracker, SimulationTime delay);
-void tracker_addInputBytes(Tracker* tracker, Packet* packet, gint handle);
-void tracker_addOutputBytes(Tracker* tracker, Packet* packet, gint handle);
+void tracker_addInputBytes(Tracker* tracker, Packet* packet, LegacySocket* socket);
+void tracker_addOutputBytes(Tracker* tracker, Packet* packet, LegacySocket* socket);
 void tracker_addAllocatedBytes(Tracker* tracker, gpointer location, gsize allocatedBytes);
 void tracker_removeAllocatedBytes(Tracker* tracker, gpointer location);
-void tracker_addSocket(Tracker* tracker, gint handle, ProtocolType type, gsize inputBufferSize, gsize outputBufferSize);
-void tracker_updateSocketPeer(Tracker* tracker, gint handle, in_addr_t peerIP, in_port_t peerPort);
-void tracker_updateSocketInputBuffer(Tracker* tracker, gint handle, gsize inputBufferLength, gsize inputBufferSize);
-void tracker_updateSocketOutputBuffer(Tracker* tracker, gint handle, gsize outputBufferLength, gsize outputBufferSize);
-void tracker_removeSocket(Tracker* tracker, gint handle);
+void tracker_addSocket(Tracker* tracker, LegacySocket* socket, ProtocolType type, gsize inputBufferSize, gsize outputBufferSize);
+void tracker_updateSocketPeer(Tracker* tracker, LegacySocket* socket, in_addr_t peerIP, in_port_t peerPort);
+void tracker_updateSocketInputBuffer(Tracker* tracker, LegacySocket* socket, gsize inputBufferLength, gsize inputBufferSize);
+void tracker_updateSocketOutputBuffer(Tracker* tracker, LegacySocket* socket, gsize outputBufferLength, gsize outputBufferSize);
+void tracker_removeSocket(Tracker* tracker, LegacySocket* socket);
 void tracker_heartbeat(Tracker* tracker, Host* host);
 static inline void tracker_heartbeatTask(Host* host, gpointer tracker, gpointer userData) {
     tracker_heartbeat(tracker, host);


### PR DESCRIPTION
The `LegacyDescriptor` struct combines the file descriptor and file description into a single object by combining the fd handle and CLOEXEC flag with the underlying file object. This forces them to have a 1:1 relationship, where they should have a n:1 relationship for n>=0 (any number of file descriptors for a file description).

This PR is a step towards removing this 1:1 relationship and towards supporting #1648. A follow-up PR will allow multiple fds for a `LegacyDescriptor`.