### PR TITLE
Renamed `descriptor_` functions to `legacydesc_`

### DIFF
--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -38,12 +38,12 @@ add_custom_command(OUTPUT wrapper.rs
 
         --whitelist-function "affinity_.*"
         --whitelist-function "thread_.*"
-        --whitelist-function "descriptor_close"
-        --whitelist-function "descriptor_unref"
-        --whitelist-function "descriptor_getHandle"
-        --whitelist-function "descriptor_setHandle"
-        --whitelist-function "descriptor_setOwnerProcess"
-        --whitelist-function "descriptor_shutdownHelper"
+        --whitelist-function "legacydesc_close"
+        --whitelist-function "legacydesc_unref"
+        --whitelist-function "legacydesc_getHandle"
+        --whitelist-function "legacydesc_setHandle"
+        --whitelist-function "legacydesc_setOwnerProcess"
+        --whitelist-function "legacydesc_shutdownHelper"
         --whitelist-function "host_.*"
         # Needs CompatSocket
         --blacklist-function "host_.*Interface"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2391,19 +2391,19 @@ pub struct _CPU {
 }
 pub type CPU = _CPU;
 extern "C" {
-    pub fn descriptor_unref(data: gpointer);
+    pub fn legacydesc_unref(data: gpointer);
 }
 extern "C" {
-    pub fn descriptor_close(descriptor: *mut LegacyDescriptor, host: *mut Host);
+    pub fn legacydesc_close(descriptor: *mut LegacyDescriptor, host: *mut Host);
 }
 extern "C" {
-    pub fn descriptor_setOwnerProcess(
+    pub fn legacydesc_setOwnerProcess(
         descriptor: *mut LegacyDescriptor,
         ownerProcess: *mut Process,
     );
 }
 extern "C" {
-    pub fn descriptor_shutdownHelper(legacyDesc: *mut LegacyDescriptor);
+    pub fn legacydesc_shutdownHelper(legacyDesc: *mut LegacyDescriptor);
 }
 pub type Transport = _Transport;
 pub type TransportFunctionTable = _TransportFunctionTable;

--- a/src/main/host/descriptor/compat_socket.c
+++ b/src/main/host/descriptor/compat_socket.c
@@ -35,7 +35,7 @@ CompatSocket compatsocket_refAs(const CompatSocket* socket) {
     };
 
     switch (new_socket.type) {
-        case CST_LEGACY_SOCKET: descriptor_ref(new_socket.object.as_legacy_socket); break;
+        case CST_LEGACY_SOCKET: legacydesc_ref(new_socket.object.as_legacy_socket); break;
         case CST_NONE: utility_panic("Unexpected CompatSocket type");
     }
 
@@ -46,7 +46,7 @@ CompatSocket compatsocket_refAs(const CompatSocket* socket) {
 
 void compatsocket_unref(const CompatSocket* socket) {
     switch (socket->type) {
-        case CST_LEGACY_SOCKET: descriptor_unref(socket->object.as_legacy_socket); break;
+        case CST_LEGACY_SOCKET: legacydesc_unref(socket->object.as_legacy_socket); break;
         case CST_NONE: utility_panic("Unexpected CompatSocket type");
     }
 

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -15,26 +15,26 @@
 
 /* Initialize the parent parts of a new descriptor subclass. This call should
  * be paired with a call to clear() before freeing the subclass object. */
-void descriptor_init(LegacyDescriptor* descriptor, LegacyDescriptorType type,
+void legacydesc_init(LegacyDescriptor* descriptor, LegacyDescriptorType type,
                      DescriptorFunctionTable* funcTable);
 /* Clear the bits that were initialized in init(). Following this call, the
  * descriptor becomes invalid and the subclass should be freed. */
-void descriptor_clear(LegacyDescriptor* descriptor);
+void legacydesc_clear(LegacyDescriptor* descriptor);
 
-void descriptor_ref(gpointer data);
-void descriptor_unref(gpointer data);
-void descriptor_refWeak(gpointer data);
-void descriptor_unrefWeak(gpointer data);
-void descriptor_close(LegacyDescriptor* descriptor, Host* host);
+void legacydesc_ref(gpointer data);
+void legacydesc_unref(gpointer data);
+void legacydesc_refWeak(gpointer data);
+void legacydesc_unrefWeak(gpointer data);
+void legacydesc_close(LegacyDescriptor* descriptor, Host* host);
 
-void descriptor_setOwnerProcess(LegacyDescriptor* descriptor, Process* ownerProcess);
-Process* descriptor_getOwnerProcess(LegacyDescriptor* descriptor);
-LegacyDescriptorType descriptor_getType(LegacyDescriptor* descriptor);
+void legacydesc_setOwnerProcess(LegacyDescriptor* descriptor, Process* ownerProcess);
+Process* legacydesc_getOwnerProcess(LegacyDescriptor* descriptor);
+LegacyDescriptorType legacydesc_getType(LegacyDescriptor* descriptor);
 
-gint descriptor_getFlags(LegacyDescriptor* descriptor);
-void descriptor_setFlags(LegacyDescriptor* descriptor, gint flags);
-void descriptor_addFlags(LegacyDescriptor* descriptor, gint flags);
-void descriptor_removeFlags(LegacyDescriptor* descriptor, gint flags);
+gint legacydesc_getFlags(LegacyDescriptor* descriptor);
+void legacydesc_setFlags(LegacyDescriptor* descriptor, gint flags);
+void legacydesc_addFlags(LegacyDescriptor* descriptor, gint flags);
+void legacydesc_removeFlags(LegacyDescriptor* descriptor, gint flags);
 
 /*
  * One of the main functions of the descriptor is to track its poll status,
@@ -60,19 +60,19 @@ void descriptor_removeFlags(LegacyDescriptor* descriptor, gint flags);
  * listener will trigger notifications via callback functions if the listener is
  * configured to monitor a bit that flipped.
  */
-void descriptor_adjustStatus(LegacyDescriptor* descriptor, Status status, gboolean doSetBits);
+void legacydesc_adjustStatus(LegacyDescriptor* descriptor, Status status, gboolean doSetBits);
 
 /* Gets the current status of the descriptor. */
-Status descriptor_getStatus(LegacyDescriptor* descriptor);
+Status legacydesc_getStatus(LegacyDescriptor* descriptor);
 
 /* Adds a listener that will get notified via descriptorlistener_onStatusChanged
  * on status transitions (bit flips).
  */
-void descriptor_addListener(LegacyDescriptor* descriptor, StatusListener* listener);
+void legacydesc_addListener(LegacyDescriptor* descriptor, StatusListener* listener);
 
 /* Remove the listener for our set of listeners that get notified on status
  * transitions (bit flips). */
-void descriptor_removeListener(LegacyDescriptor* descriptor, StatusListener* listener);
+void legacydesc_removeListener(LegacyDescriptor* descriptor, StatusListener* listener);
 
 /* This is a helper function that handles some corner cases where some
  * descriptors are linked to each other and we must remove that link in
@@ -82,11 +82,11 @@ void descriptor_removeListener(LegacyDescriptor* descriptor, StatusListener* lis
  *
  * Intended to be called only from descriptor_table.rs.
  */
-void descriptor_shutdownHelper(LegacyDescriptor* legacyDesc);
+void legacydesc_shutdownHelper(LegacyDescriptor* legacyDesc);
 
 /* Whether the descriptor's operations are restartable in conjunction with
  * SA_RESTART. See signal(7).
  */
-bool descriptor_supportsSaRestart(LegacyDescriptor* legacyDesc);
+bool legacydesc_supportsSaRestart(LegacyDescriptor* legacyDesc);
 
 #endif /* SHD_DESCRIPTOR_H_ */

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -127,7 +127,7 @@ impl DescriptorTable {
         for descriptor in self.descriptors.values() {
             match descriptor {
                 CompatDescriptor::New(_) => continue,
-                CompatDescriptor::Legacy(d) => unsafe { c::descriptor_shutdownHelper(d.ptr()) },
+                CompatDescriptor::Legacy(d) => unsafe { c::legacydesc_shutdownHelper(d.ptr()) },
             };
         }
     }

--- a/src/main/host/descriptor/epoll.h
+++ b/src/main/host/descriptor/epoll.h
@@ -15,7 +15,7 @@
 
 typedef struct _Epoll Epoll;
 
-/* free this with descriptor_free() */
+/* free this with legacydesc_free() */
 Epoll* epoll_new();
 
 gint epoll_control(Epoll* epoll, gint operation, int fd, const CompatDescriptor* descriptor,

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -670,7 +670,7 @@ impl CountedLegacyDescriptorRef {
 impl Drop for CountedLegacyDescriptorRef {
     fn drop(&mut self) {
         // unref the legacy descriptor object
-        unsafe { c::descriptor_unref(self.0.ptr() as *mut core::ffi::c_void) };
+        unsafe { c::legacydesc_unref(self.0.ptr() as *mut core::ffi::c_void) };
     }
 }
 
@@ -707,7 +707,7 @@ impl CompatDescriptor {
         match self {
             Self::New(desc) => desc.close(event_queue),
             Self::Legacy(desc) => {
-                unsafe { c::descriptor_close(desc.ptr(), host) };
+                unsafe { c::legacydesc_close(desc.ptr(), host) };
                 Some(Ok(()))
             }
         }

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -80,7 +80,7 @@ int regularfile_getShadowFlags(RegularFile* file) {
 }
 
 static inline RegularFile* _regularfile_descriptorToFile(LegacyDescriptor* desc) {
-    utility_assert(descriptor_getType(desc) == DT_FILE);
+    utility_assert(legacydesc_getType(desc) == DT_FILE);
     RegularFile* file = (RegularFile*)desc;
     MAGIC_ASSERT(file);
     return file;
@@ -100,7 +100,7 @@ static void _regularfile_closeHelper(RegularFile* file) {
         file->osfile.fd = OSFILE_INVALID;
 
         /* The os-backed file is no longer ready. */
-        descriptor_adjustStatus(&file->super, STATUS_DESCRIPTOR_ACTIVE, FALSE);
+        legacydesc_adjustStatus(&file->super, STATUS_DESCRIPTOR_ACTIVE, FALSE);
     }
 }
 
@@ -124,7 +124,7 @@ static void _regularfile_free(LegacyDescriptor* desc) {
         free(file->osfile.absPathAtOpen);
     }
 
-    descriptor_clear((LegacyDescriptor*)file);
+    legacydesc_clear((LegacyDescriptor*)file);
     MAGIC_CLEAR(file);
     free(file);
 
@@ -142,7 +142,7 @@ RegularFile* regularfile_new() {
 
     *file = (RegularFile){0};
 
-    descriptor_init(&(file->super), DT_FILE, &_fileFunctions);
+    legacydesc_init(&(file->super), DT_FILE, &_fileFunctions);
     MAGIC_INIT(file);
     file->osfile.fd = OSFILE_INVALID; // negative means uninitialized (0 is a valid fd)
 
@@ -331,7 +331,7 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
           _regularfile_getOSBackedFD(file), file->osfile.absPathAtOpen);
 
     /* The os-backed file is now ready. */
-    descriptor_adjustStatus(&file->super, STATUS_DESCRIPTOR_ACTIVE, TRUE);
+    legacydesc_adjustStatus(&file->super, STATUS_DESCRIPTOR_ACTIVE, TRUE);
 
     return 0;
 }

--- a/src/main/host/descriptor/regular_file.h
+++ b/src/main/host/descriptor/regular_file.h
@@ -44,7 +44,7 @@ typedef struct _RegularFile RegularFile;
 // Initialization and setup
 // ************************
 
-RegularFile* regularfile_new(); // Close the file with descriptor_close()
+RegularFile* regularfile_new(); // Close the file with legacydesc_close()
 RegularFile* regularfile_dup(RegularFile* file, int* dupError);
 int regularfile_open(RegularFile* file, const char* pathname, int flags, mode_t mode,
                      const char* workingDir);

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -24,8 +24,8 @@
 #include "main/utility/utility.h"
 
 static LegacySocket* _legacysocket_fromLegacyDescriptor(LegacyDescriptor* descriptor) {
-    utility_assert(descriptor_getType(descriptor) == DT_TCPSOCKET ||
-                   descriptor_getType(descriptor) == DT_UDPSOCKET);
+    utility_assert(legacydesc_getType(descriptor) == DT_TCPSOCKET ||
+                   legacydesc_getType(descriptor) == DT_UDPSOCKET);
     return (LegacySocket*)descriptor;
 }
 
@@ -369,7 +369,7 @@ gboolean legacysocket_addToInputBuffer(LegacySocket* socket, Host* host, Packet*
 
     /* we just added a packet, so we are readable */
     if(socket->inputBufferLength > 0) {
-        descriptor_adjustStatus((LegacyDescriptor*)socket, STATUS_DESCRIPTOR_READABLE, TRUE);
+        legacydesc_adjustStatus((LegacyDescriptor*)socket, STATUS_DESCRIPTOR_READABLE, TRUE);
     }
 
     return TRUE;
@@ -399,7 +399,7 @@ Packet* legacysocket_removeFromInputBuffer(LegacySocket* socket, Host* host) {
 
         /* we are not readable if we are now empty */
         if(socket->inputBufferLength <= 0) {
-            descriptor_adjustStatus((LegacyDescriptor*)socket, STATUS_DESCRIPTOR_READABLE, FALSE);
+            legacydesc_adjustStatus((LegacyDescriptor*)socket, STATUS_DESCRIPTOR_READABLE, FALSE);
         }
     }
 
@@ -448,7 +448,7 @@ gboolean legacysocket_addToOutputBuffer(LegacySocket* socket, Host* host, Packet
 
     /* we just added a packet, we are no longer writable if full */
     if(_legacysocket_getOutputBufferSpaceIncludingTCP(socket) <= 0) {
-        descriptor_adjustStatus((LegacyDescriptor*)socket, STATUS_DESCRIPTOR_WRITABLE, FALSE);
+        legacydesc_adjustStatus((LegacyDescriptor*)socket, STATUS_DESCRIPTOR_WRITABLE, FALSE);
     }
 
     /* tell the interface to include us when sending out to the network */
@@ -486,7 +486,7 @@ Packet* legacysocket_removeFromOutputBuffer(LegacySocket* socket, Host* host) {
 
         /* we are writable if we now have space */
         if(_legacysocket_getOutputBufferSpaceIncludingTCP(socket) > 0) {
-            descriptor_adjustStatus((LegacyDescriptor*)socket, STATUS_DESCRIPTOR_WRITABLE, TRUE);
+            legacydesc_adjustStatus((LegacyDescriptor*)socket, STATUS_DESCRIPTOR_WRITABLE, TRUE);
         }
     }
 

--- a/src/main/host/descriptor/timerfd.h
+++ b/src/main/host/descriptor/timerfd.h
@@ -14,7 +14,7 @@ typedef struct _TimerFd TimerFd;
 #include "main/bindings/c/bindings.h"
 #include "main/core/support/definitions.h"
 
-/* free this with descriptor_free() */
+/* free this with legacydesc_free() */
 TimerFd* timerfd_new(HostId hostId);
 gint timerfd_setTime(TimerFd* timer, Host* host, gint flags, const struct itimerspec* new_value,
                      struct itimerspec* old_value);

--- a/src/main/host/descriptor/transport.c
+++ b/src/main/host/descriptor/transport.c
@@ -14,8 +14,8 @@
 #include "main/utility/utility.h"
 
 static Transport* _transport_fromLegacyDescriptor(LegacyDescriptor* descriptor) {
-    utility_assert(descriptor_getType(descriptor) == DT_TCPSOCKET ||
-                   descriptor_getType(descriptor) == DT_UDPSOCKET);
+    utility_assert(legacydesc_getType(descriptor) == DT_TCPSOCKET ||
+                   legacydesc_getType(descriptor) == DT_UDPSOCKET);
     return (Transport*)descriptor;
 }
 
@@ -55,7 +55,7 @@ void transport_init(Transport* transport, TransportFunctionTable* vtable,
                     LegacyDescriptorType type) {
     utility_assert(transport && vtable);
 
-    descriptor_init(&(transport->super), type, &transport_functions);
+    legacydesc_init(&(transport->super), type, &transport_functions);
 
     MAGIC_INIT(transport);
     MAGIC_INIT(vtable);

--- a/src/main/host/descriptor/udp.c
+++ b/src/main/host/descriptor/udp.c
@@ -54,7 +54,7 @@ static void _udp_setState(UDP* udp, enum UDPState state) {
 }
 
 static UDP* _udp_fromLegacyDescriptor(LegacyDescriptor* descriptor) {
-    utility_assert(descriptor_getType(descriptor) == DT_UDPSOCKET);
+    utility_assert(legacydesc_getType(descriptor) == DT_UDPSOCKET);
     return (UDP*)descriptor;
 }
 
@@ -221,7 +221,7 @@ static void _udp_free(LegacyDescriptor* descriptor) {
     UDP* udp = _udp_fromLegacyDescriptor(descriptor);
     MAGIC_ASSERT(udp);
 
-    descriptor_clear(descriptor);
+    legacydesc_clear(descriptor);
     MAGIC_CLEAR(udp);
     g_free(udp);
 
@@ -270,7 +270,7 @@ UDP* udp_new(Host* host, guint receiveBufferSize, guint sendBufferSize) {
     udp->stateLast = UDPS_CLOSED;
 
     /* we are immediately active because UDP doesnt wait for accept or connect */
-    descriptor_adjustStatus(
+    legacydesc_adjustStatus(
         (LegacyDescriptor*)udp, STATUS_DESCRIPTOR_ACTIVE | STATUS_DESCRIPTOR_WRITABLE, TRUE);
 
     worker_count_allocation(UDP);

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -474,7 +474,7 @@ static void _networkinterface_updatePacketHeader(Host* host, const CompatSocket*
     if (socket->type == CST_LEGACY_SOCKET) {
         LegacyDescriptor* descriptor = (LegacyDescriptor*)socket->object.as_legacy_socket;
 
-        LegacyDescriptorType type = descriptor_getType(descriptor);
+        LegacyDescriptorType type = legacydesc_getType(descriptor);
         if (type == DT_TCPSOCKET) {
             TCP* tcp = (TCP*)descriptor;
             tcp_networkInterfaceIsAboutToSendPacket(tcp, host, packet);

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -499,7 +499,7 @@ static RegularFile* _process_openStdIOFileHelper(Process* proc, int fd, gchar* f
     utility_assert(fileName != NULL);
 
     RegularFile* stdfile = regularfile_new();
-    descriptor_setOwnerProcess((LegacyDescriptor*)stdfile, proc);
+    legacydesc_setOwnerProcess((LegacyDescriptor*)stdfile, proc);
 
     CompatDescriptor* compatDesc = compatdescriptor_fromLegacy((LegacyDescriptor*)stdfile);
     CompatDescriptor* replacedDesc = descriptortable_set(proc->descTable, fd, compatDesc);
@@ -540,13 +540,13 @@ static void _process_start(Process* proc) {
     // Set up stdout
     gchar* stdoutFileName = _process_outputFileName(proc, "stdout");
     proc->stdoutFile = _process_openStdIOFileHelper(proc, STDOUT_FILENO, stdoutFileName);
-    descriptor_ref((LegacyDescriptor*)proc->stdoutFile);
+    legacydesc_ref((LegacyDescriptor*)proc->stdoutFile);
     g_free(stdoutFileName);
 
     // Set up stderr
     gchar* stderrFileName = _process_outputFileName(proc, "stderr");
     proc->stderrFile = _process_openStdIOFileHelper(proc, STDERR_FILENO, stderrFileName);
-    descriptor_ref((LegacyDescriptor*)proc->stderrFile);
+    legacydesc_ref((LegacyDescriptor*)proc->stderrFile);
     g_free(stderrFileName);
 
     if (proc->straceLoggingMode != STRACE_FMT_MODE_OFF) {
@@ -946,10 +946,10 @@ static void _process_free(Process* proc) {
 #endif
 
     if (proc->stderrFile) {
-        descriptor_unref((LegacyDescriptor*)proc->stderrFile);
+        legacydesc_unref((LegacyDescriptor*)proc->stderrFile);
     }
     if (proc->stdoutFile) {
-        descriptor_unref((LegacyDescriptor*)proc->stdoutFile);
+        legacydesc_unref((LegacyDescriptor*)proc->stdoutFile);
     }
     if (proc->straceFd >= 0) {
         close(proc->straceFd);

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -91,7 +91,7 @@ impl Process {
 
         if let Some(CompatDescriptor::Legacy(ref replaced_desc)) = replaced_desc {
             unsafe {
-                cshadow::descriptor_setOwnerProcess(replaced_desc.ptr(), std::ptr::null_mut())
+                cshadow::legacydesc_setOwnerProcess(replaced_desc.ptr(), std::ptr::null_mut())
             };
         }
 
@@ -106,7 +106,7 @@ impl Process {
 
         if let Some(CompatDescriptor::Legacy(ref removed_desc)) = removed_desc {
             unsafe {
-                cshadow::descriptor_setOwnerProcess(removed_desc.ptr(), std::ptr::null_mut())
+                cshadow::legacydesc_setOwnerProcess(removed_desc.ptr(), std::ptr::null_mut())
             };
         }
 
@@ -243,7 +243,7 @@ mod export {
         let mut proc = unsafe { Process::borrow_from_c(proc) };
         assert!(!desc.is_null());
 
-        unsafe { cshadow::descriptor_setOwnerProcess(desc, proc.cprocess) };
+        unsafe { cshadow::legacydesc_setOwnerProcess(desc, proc.cprocess) };
         let desc =
             CompatDescriptor::Legacy(CountedLegacyDescriptorRef::new(HostTreePointer::new(desc)));
 

--- a/src/main/host/syscall/epoll.c
+++ b/src/main/host/syscall/epoll.c
@@ -31,7 +31,7 @@ static int _syscallhandler_createEpollHelper(SysCallHandler* sys, int64_t size,
     int handle = process_registerLegacyDescriptor(sys->process, (LegacyDescriptor*)epolld);
 
     if (flags & EPOLL_CLOEXEC) {
-        descriptor_addFlags((LegacyDescriptor*)epolld, EPOLL_CLOEXEC);
+        legacydesc_addFlags((LegacyDescriptor*)epolld, EPOLL_CLOEXEC);
     }
 
     return handle;

--- a/src/main/host/syscall/fcntl.c
+++ b/src/main/host/syscall/fcntl.c
@@ -180,17 +180,17 @@ SysCallReturn syscallhandler_fcntl(SysCallHandler* sys,
     }
 
     int result = 0;
-    if (descriptor_getType(desc) == DT_FILE) {
+    if (legacydesc_getType(desc) == DT_FILE) {
         result = _syscallhandler_fcntlHelper(sys, (RegularFile*)desc, fd, command, argReg);
     } else {
         /* TODO: add additional support for important operations. */
         switch (command) {
             case F_GETFL: {
-                result = descriptor_getFlags(desc);
+                result = legacydesc_getFlags(desc);
                 break;
             }
             case F_SETFL: {
-                descriptor_setFlags(desc, argReg.as_i64);
+                legacydesc_setFlags(desc, argReg.as_i64);
                 break;
             }
             default: {

--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -71,7 +71,7 @@ static SysCallReturn _syscallhandler_openHelper(SysCallHandler* sys,
     errcode = regularfile_open(filed, pathname, flags, mode, process_getWorkingDir(sys->process));
     if (errcode < 0) {
         /* This will remove the descriptor entry and unref/free the RegularFile. */
-        descriptor_close((LegacyDescriptor*)filed, sys->host);
+        legacydesc_close((LegacyDescriptor*)filed, sys->host);
 
         CompatDescriptor* removed_desc = process_deregisterCompatDescriptor(sys->process, handle);
         utility_assert(removed_desc != NULL);

--- a/src/main/host/syscall/fileat.c
+++ b/src/main/host/syscall/fileat.c
@@ -134,7 +134,7 @@ SysCallReturn syscallhandler_openat(SysCallHandler* sys,
         file_desc, dir_desc, pathname, flags, mode, process_getWorkingDir(sys->process));
     if (errcode < 0) {
         /* This will remove the descriptor entry and unref/free the RegularFile. */
-        descriptor_close((LegacyDescriptor*)file_desc, sys->host);
+        legacydesc_close((LegacyDescriptor*)file_desc, sys->host);
 
         CompatDescriptor* removed_desc = process_deregisterCompatDescriptor(sys->process, handle);
         utility_assert(removed_desc != NULL);

--- a/src/main/host/syscall/ioctl.c
+++ b/src/main/host/syscall/ioctl.c
@@ -114,9 +114,9 @@ static int _syscallhandler_ioctlTCPHelper(SysCallHandler* sys, TCP* tcp, int fd,
             }
 
             if (val == 0) {
-                descriptor_removeFlags((LegacyDescriptor*)tcp, O_NONBLOCK);
+                legacydesc_removeFlags((LegacyDescriptor*)tcp, O_NONBLOCK);
             } else {
-                descriptor_addFlags((LegacyDescriptor*)tcp, O_NONBLOCK);
+                legacydesc_addFlags((LegacyDescriptor*)tcp, O_NONBLOCK);
             }
 
             result = 0;
@@ -192,9 +192,9 @@ static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
             }
 
             if (val == 0) {
-                descriptor_removeFlags((LegacyDescriptor*)udp, O_NONBLOCK);
+                legacydesc_removeFlags((LegacyDescriptor*)udp, O_NONBLOCK);
             } else {
-                descriptor_addFlags((LegacyDescriptor*)udp, O_NONBLOCK);
+                legacydesc_addFlags((LegacyDescriptor*)udp, O_NONBLOCK);
             }
 
             result = 0;
@@ -244,7 +244,7 @@ SysCallReturn syscallhandler_ioctl(SysCallHandler* sys,
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
 
-    LegacyDescriptorType dtype = descriptor_getType(desc);
+    LegacyDescriptorType dtype = legacydesc_getType(desc);
 
     int result = 0;
     if (dtype == DT_FILE) {

--- a/src/main/host/syscall/mman.c
+++ b/src/main/host/syscall/mman.c
@@ -53,7 +53,7 @@ static int _syscallhandler_validateMmapArgsHelper(SysCallHandler* sys, int fd, s
             return errcode;
         }
 
-        if (descriptor_getType(desc) != DT_FILE) {
+        if (legacydesc_getType(desc) != DT_FILE) {
             debug("Descriptor exists for fd %i, but is not a file type", fd);
             return -EACCES;
         }

--- a/src/main/host/syscall/poll.c
+++ b/src/main/host/syscall/poll.c
@@ -32,8 +32,8 @@ static void _syscallhandler_getPollEventsHelper(const CompatDescriptor* cdesc, s
 
     // Some logic depends on the descriptor type. USE DT_NONE for non-legacy descriptors
     // TODO: when converted to rust, we'll need to match the RegularFile type instead
-    LegacyDescriptorType dType = ldesc ? descriptor_getType(ldesc) : DT_NONE;
-    Status dstat = ldesc ? descriptor_getStatus(ldesc)
+    LegacyDescriptorType dType = ldesc ? legacydesc_getType(ldesc) : DT_NONE;
+    Status dstat = ldesc ? legacydesc_getStatus(ldesc)
                          : openfile_getStatus(compatdescriptor_borrowOpenFile(cdesc));
 
     if (dType == DT_FILE) {

--- a/src/main/host/syscall/protected.c
+++ b/src/main/host/syscall/protected.c
@@ -47,14 +47,14 @@ bool _syscallhandler_wasBlocked(const SysCallHandler* sys) { return sys->blocked
 int _syscallhandler_validateDescriptor(LegacyDescriptor* descriptor,
                                        LegacyDescriptorType expectedType) {
     if (descriptor) {
-        Status status = descriptor_getStatus(descriptor);
+        Status status = legacydesc_getStatus(descriptor);
 
         if (status & STATUS_DESCRIPTOR_CLOSED) {
             warning("descriptor %p is closed", descriptor);
             return -EBADF;
         }
 
-        LegacyDescriptorType type = descriptor_getType(descriptor);
+        LegacyDescriptorType type = legacydesc_getType(descriptor);
 
         if (expectedType != DT_NONE && type != expectedType) {
             warning(

--- a/src/main/host/syscall/timerfd.c
+++ b/src/main/host/syscall/timerfd.c
@@ -80,10 +80,10 @@ SysCallReturn syscallhandler_timerfd_create(SysCallHandler* sys,
 
     /* Set any options that were given. */
     if (flags & TFD_NONBLOCK) {
-        descriptor_addFlags((LegacyDescriptor*)timer, O_NONBLOCK);
+        legacydesc_addFlags((LegacyDescriptor*)timer, O_NONBLOCK);
     }
     if (flags & TFD_CLOEXEC) {
-        descriptor_addFlags((LegacyDescriptor*)timer, O_CLOEXEC);
+        legacydesc_addFlags((LegacyDescriptor*)timer, O_CLOEXEC);
     }
 
     trace("timerfd_create() returning fd %i", tfd);

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -46,7 +46,7 @@ static int _syscallhandler_validateVecParams(SysCallHandler* sys, int fd,
     }
 
     /* We can only seek on files, otherwise its a pipe error. */
-    if (descriptor_getType(desc) != DT_FILE && offset != 0) {
+    if (legacydesc_getType(desc) != DT_FILE && offset != 0) {
         return -ESPIPE;
     }
 
@@ -102,7 +102,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
     }
 
     /* Some logic depends on the descriptor type. */
-    LegacyDescriptorType dType = descriptor_getType(desc);
+    LegacyDescriptorType dType = legacydesc_getType(desc);
 
     ssize_t result = 0;
 
@@ -176,7 +176,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
         }
     }
 
-    if (result == -EWOULDBLOCK && !(descriptor_getFlags(desc) & O_NONBLOCK)) {
+    if (result == -EWOULDBLOCK && !(legacydesc_getFlags(desc) & O_NONBLOCK)) {
         /* Blocking for file io will lock up the plugin because we don't
          * yet have a way to wait on file descriptors. */
         if (dType == DT_FILE) {
@@ -191,7 +191,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
 
         return (SysCallReturn){.state = SYSCALL_BLOCK,
                                .cond = syscallcondition_new(trigger),
-                               .restartable = descriptor_supportsSaRestart(desc)};
+                               .restartable = legacydesc_supportsSaRestart(desc)};
     }
 
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
@@ -217,7 +217,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
     }
 
     /* Some logic depends on the descriptor type. */
-    LegacyDescriptorType dType = descriptor_getType(desc);
+    LegacyDescriptorType dType = legacydesc_getType(desc);
 
     ssize_t result = 0;
 
@@ -289,7 +289,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
         }
     }
 
-    if (result == -EWOULDBLOCK && !(descriptor_getFlags(desc) & O_NONBLOCK)) {
+    if (result == -EWOULDBLOCK && !(legacydesc_getFlags(desc) & O_NONBLOCK)) {
         /* Blocking for file io will lock up the plugin because we don't
          * yet have a way to wait on file descriptors. */
         if (dType == DT_FILE) {
@@ -304,7 +304,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
 
         return (SysCallReturn){.state = SYSCALL_BLOCK,
                                .cond = syscallcondition_new(trigger),
-                               .restartable = descriptor_supportsSaRestart(desc)};
+                               .restartable = legacydesc_supportsSaRestart(desc)};
     }
 
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -42,7 +42,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, Plu
     }
 
     /* Some logic depends on the descriptor type. */
-    LegacyDescriptorType dType = descriptor_getType(desc);
+    LegacyDescriptorType dType = legacydesc_getType(desc);
 
     /* We can only seek on files, otherwise its a pipe error. */
     if (dType != DT_FILE && offset != 0) {
@@ -103,7 +103,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, Plu
             break;
     }
 
-    if (result == -EWOULDBLOCK && !(descriptor_getFlags(desc) & O_NONBLOCK)) {
+    if (result == -EWOULDBLOCK && !(legacydesc_getFlags(desc) & O_NONBLOCK)) {
         /* Blocking for file io will lock up the plugin because we don't
          * yet have a way to wait on file descriptors. */
         if (dType == DT_FILE) {
@@ -117,7 +117,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, Plu
             .type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_DESCRIPTOR_READABLE};
         return (SysCallReturn){.state = SYSCALL_BLOCK,
                                .cond = syscallcondition_new(trigger),
-                               .restartable = descriptor_supportsSaRestart(desc)};
+                               .restartable = legacydesc_supportsSaRestart(desc)};
     }
 
     return (SysCallReturn){
@@ -136,7 +136,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, Pl
     }
 
     /* Some logic depends on the descriptor type. */
-    LegacyDescriptorType dType = descriptor_getType(desc);
+    LegacyDescriptorType dType = legacydesc_getType(desc);
 
     /* We can only seek on files, otherwise its a pipe error. */
     if (dType != DT_FILE && offset != 0) {
@@ -188,7 +188,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, Pl
             break;
     }
 
-    if (result == -EWOULDBLOCK && !(descriptor_getFlags(desc) & O_NONBLOCK)) {
+    if (result == -EWOULDBLOCK && !(legacydesc_getFlags(desc) & O_NONBLOCK)) {
         /* Blocking for file io will lock up the plugin because we don't
          * yet have a way to wait on file descriptors. */
         if (dType == DT_FILE) {
@@ -202,7 +202,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, Pl
             .type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_DESCRIPTOR_WRITABLE};
         return (SysCallReturn){.state = SYSCALL_BLOCK,
                                .cond = syscallcondition_new(trigger),
-                               .restartable = descriptor_supportsSaRestart(desc)};
+                               .restartable = legacydesc_supportsSaRestart(desc)};
     }
 
     return (SysCallReturn){
@@ -224,7 +224,7 @@ SysCallReturn syscallhandler_dup(SysCallHandler* sys,
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EBADF};
     }
 
-    LegacyDescriptorType dType = descriptor_getType(desc);
+    LegacyDescriptorType dType = legacydesc_getType(desc);
 
     if (dType != DT_FILE) {
         warning("Cannot dup legacy non-regular-file descriptors");

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -59,7 +59,7 @@ SysCallCondition* syscallcondition_new(Trigger trigger) {
     if (cond->trigger.object.as_pointer) {
         switch (cond->trigger.type) {
             case TRIGGER_DESCRIPTOR: {
-                descriptor_ref(cond->trigger.object.as_descriptor);
+                legacydesc_ref(cond->trigger.object.as_descriptor);
                 return cond;
             }
             case TRIGGER_FILE: {
@@ -113,7 +113,7 @@ static void _syscallcondition_cleanupListeners(SysCallCondition* cond) {
     if (cond->trigger.object.as_pointer && cond->triggerListener) {
         switch (cond->trigger.type) {
             case TRIGGER_DESCRIPTOR: {
-                descriptor_removeListener(
+                legacydesc_removeListener(
                     cond->trigger.object.as_descriptor, cond->triggerListener);
                 break;
             }
@@ -177,7 +177,7 @@ static void _syscallcondition_free(SysCallCondition* cond) {
     if (cond->trigger.object.as_pointer) {
         switch (cond->trigger.type) {
             case TRIGGER_DESCRIPTOR: {
-                descriptor_unref(cond->trigger.object.as_descriptor);
+                legacydesc_unref(cond->trigger.object.as_descriptor);
                 break;
             }
             case TRIGGER_FILE: {
@@ -279,7 +279,7 @@ static bool _syscallcondition_statusIsValid(SysCallCondition* cond) {
 
     switch (cond->trigger.type) {
         case TRIGGER_DESCRIPTOR: {
-            if (descriptor_getStatus(cond->trigger.object.as_descriptor) & cond->trigger.status) {
+            if (legacydesc_getStatus(cond->trigger.object.as_descriptor) & cond->trigger.status) {
                 return true;
             }
             break;
@@ -454,7 +454,7 @@ void syscallcondition_waitNonblock(SysCallCondition* cond, Host* host, Process* 
                     cond->triggerListener, cond->trigger.status, SLF_OFF_TO_ON);
 
                 /* Attach the listener to the descriptor. */
-                descriptor_addListener(cond->trigger.object.as_descriptor, cond->triggerListener);
+                legacydesc_addListener(cond->trigger.object.as_descriptor, cond->triggerListener);
                 break;
             }
             case TRIGGER_FILE: {

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -130,7 +130,7 @@ static void _syscallhandler_free(SysCallHandler* sys) {
     }
 
     if (sys->epoll) {
-        descriptor_unref(sys->epoll);
+        legacydesc_unref(sys->epoll);
     }
 #ifdef USE_PERF_TIMERS
     if (sys->perfTimer) {


### PR DESCRIPTION
This better matches the type name `LegacyDescriptor`. The prefix was chosen since `legacydesc_` has the same length as `descriptor_`, and also has the same length as `legacyfile_` if we choose to rename this again in the future.