### PR TITLE
Don't warn if null pointer address isn't mapped into shadow

### DIFF
--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -964,7 +964,9 @@ impl MemoryMapper {
         let (interval, region) = match self.regions.get(usize::from(src.ptr())) {
             Some((i, r)) => (i, r),
             None => {
-                warn!("src {:?} isn't in any mapped region", src);
+                if !src.ptr().is_null() {
+                    warn!("src {:?} isn't in any mapped region", src);
+                }
                 return None;
             }
         };


### PR DESCRIPTION
This significantly reduces the number of warnings in tests, and I think it's expected that a null pointer address wouldn't be mapped into shadow.