### PR TITLE
Fix unsafe accesses of host objects from the manager

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -308,6 +308,10 @@ SimulationTime controller_getLatency(const struct Controller *controller,
 
 float controller_getReliability(const struct Controller *controller, in_addr_t src, in_addr_t dst);
 
+uint64_t controller_getBandwidthDownBytes(const struct Controller *controller, in_addr_t ip);
+
+uint64_t controller_getBandwidthUpBytes(const struct Controller *controller, in_addr_t ip);
+
 void controller_incrementPacketCount(const struct Controller *controller,
                                      in_addr_t src,
                                      in_addr_t dst);

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2911,16 +2911,10 @@ extern "C" {
     ) -> SimulationTime;
 }
 extern "C" {
-    pub fn worker_getLatency(sourceHostID: GQuark, destinationHostID: GQuark) -> SimulationTime;
-}
-extern "C" {
     pub fn worker_getReliabilityForAddresses(
         sourceAddress: *mut Address,
         destinationAddress: *mut Address,
     ) -> gdouble;
-}
-extern "C" {
-    pub fn worker_getReliability(sourceHostID: GQuark, destinationHostID: GQuark) -> gdouble;
 }
 extern "C" {
     pub fn worker_isRoutable(sourceAddress: *mut Address, destinationAddress: *mut Address)

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2896,10 +2896,10 @@ extern "C" {
     pub fn worker_isBootstrapActive() -> bool;
 }
 extern "C" {
-    pub fn worker_getNodeBandwidthUp(nodeID: GQuark, ip: in_addr_t) -> guint32;
+    pub fn worker_getNodeBandwidthUp(ip: in_addr_t) -> guint32;
 }
 extern "C" {
-    pub fn worker_getNodeBandwidthDown(nodeID: GQuark, ip: in_addr_t) -> guint32;
+    pub fn worker_getNodeBandwidthDown(ip: in_addr_t) -> guint32;
 }
 extern "C" {
     pub fn workerpool_updateMinHostRunahead(pool: *mut WorkerPool, time: SimulationTime);

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -593,17 +593,11 @@ DNS* manager_getDNS(Manager* manager) {
 }
 
 guint32 manager_getNodeBandwidthUp(Manager* manager, in_addr_t ip) {
-    // TODO: The `/ 1024 * 1024 / 1000 * 1000` is a workaround to keep the same networking
-    // performance/results. It should be removed in an isolated commit so that the performance
-    // change is caused by this small integer rounding change.
-    return controller_getBandwidthUpBytes(manager->controller, ip) / 1024 * 1024 / 1000 * 1000 / 1024;
+    return controller_getBandwidthUpBytes(manager->controller, ip) / 1024;
 }
 
 guint32 manager_getNodeBandwidthDown(Manager* manager, in_addr_t ip) {
-    // TODO: The `/ 1024 * 1024 / 1000 * 1000` is a workaround to keep the same networking
-    // performance/results. It should be removed in an isolated commit so that the performance
-    // change is caused by this small integer rounding change.
-    return controller_getBandwidthDownBytes(manager->controller, ip) / 1024 * 1024 / 1000 * 1000 / 1024;
+    return controller_getBandwidthDownBytes(manager->controller, ip) / 1024;
 }
 
 void manager_updateMinRunahead(Manager* manager, SimulationTime time) {

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -96,11 +96,6 @@ static void _manager_unlock(Manager* manager) {
     g_mutex_unlock(&(manager->lock));
 }
 
-static Host* _manager_getHost(Manager* manager, GQuark hostID) {
-    MAGIC_ASSERT(manager);
-    return scheduler_getHost(manager->scheduler, hostID);
-}
-
 static gchar* _manager_getRPath() {
     const ElfW(Dyn) *dyn = _DYNAMIC;
     const ElfW(Dyn) *rpath = NULL;
@@ -625,14 +620,6 @@ SimulationTime manager_getLatencyForAddresses(Manager* manager, Address* sourceA
     return controller_getLatency(manager->controller, src, dst);
 }
 
-SimulationTime manager_getLatency(Manager* manager, GQuark sourceHostID, GQuark destinationHostID) {
-    Host* sourceHost = _manager_getHost(manager, sourceHostID);
-    Host* destinationHost = _manager_getHost(manager, destinationHostID);
-    Address* sourceAddress = host_getDefaultAddress(sourceHost);
-    Address* destinationAddress = host_getDefaultAddress(destinationHost);
-    return manager_getLatencyForAddresses(manager, sourceAddress, destinationAddress);
-}
-
 gfloat manager_getReliabilityForAddresses(Manager* manager, Address* sourceAddress,
                                           Address* destinationAddress) {
     MAGIC_ASSERT(manager);
@@ -640,14 +627,6 @@ gfloat manager_getReliabilityForAddresses(Manager* manager, Address* sourceAddre
     in_addr_t src = htonl(address_toHostIP(sourceAddress));
     in_addr_t dst = htonl(address_toHostIP(destinationAddress));
     return controller_getReliability(manager->controller, src, dst);
-}
-
-gfloat manager_getReliability(Manager* manager, GQuark sourceHostID, GQuark destinationHostID) {
-    Host* sourceHost = _manager_getHost(manager, sourceHostID);
-    Host* destinationHost = _manager_getHost(manager, destinationHostID);
-    Address* sourceAddress = host_getDefaultAddress(sourceHost);
-    Address* destinationAddress = host_getDefaultAddress(destinationHost);
-    return manager_getReliabilityForAddresses(manager, sourceAddress, destinationAddress);
 }
 
 bool manager_isRoutable(Manager* manager, Address* sourceAddress, Address* destinationAddress) {

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -597,16 +597,18 @@ DNS* manager_getDNS(Manager* manager) {
     return controller_getDNS(manager->controller);
 }
 
-guint32 manager_getNodeBandwidthUp(Manager* manager, GQuark nodeID, in_addr_t ip) {
-    Host* host = _manager_getHost(manager, nodeID);
-    NetworkInterface* interface = host_lookupInterface(host, ip);
-    return networkinterface_getSpeedUpKiBps(interface);
+guint32 manager_getNodeBandwidthUp(Manager* manager, in_addr_t ip) {
+    // TODO: The `/ 1024 * 1024 / 1000 * 1000` is a workaround to keep the same networking
+    // performance/results. It should be removed in an isolated commit so that the performance
+    // change is caused by this small integer rounding change.
+    return controller_getBandwidthUpBytes(manager->controller, ip) / 1024 * 1024 / 1000 * 1000 / 1024;
 }
 
-guint32 manager_getNodeBandwidthDown(Manager* manager, GQuark nodeID, in_addr_t ip) {
-    Host* host = _manager_getHost(manager, nodeID);
-    NetworkInterface* interface = host_lookupInterface(host, ip);
-    return networkinterface_getSpeedDownKiBps(interface);
+guint32 manager_getNodeBandwidthDown(Manager* manager, in_addr_t ip) {
+    // TODO: The `/ 1024 * 1024 / 1000 * 1000` is a workaround to keep the same networking
+    // performance/results. It should be removed in an isolated commit so that the performance
+    // change is caused by this small integer rounding change.
+    return controller_getBandwidthDownBytes(manager->controller, ip) / 1024 * 1024 / 1000 * 1000 / 1024;
 }
 
 void manager_updateMinRunahead(Manager* manager, SimulationTime time) {

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -44,10 +44,8 @@ guint32 manager_getNodeBandwidthDown(Manager* manager, in_addr_t ip);
 void manager_updateMinRunahead(Manager* manager, SimulationTime time);
 SimulationTime manager_getLatencyForAddresses(Manager* manager, Address* sourceAddress,
                                               Address* destinationAddress);
-SimulationTime manager_getLatency(Manager* manager, GQuark sourceHostID, GQuark destinationHostID);
 gfloat manager_getReliabilityForAddresses(Manager* manager, Address* sourceAddress,
                                           Address* destinationAddress);
-gfloat manager_getReliability(Manager* manager, GQuark sourceHostID, GQuark destinationHostID);
 bool manager_isRoutable(Manager* manager, Address* sourceAddress, Address* destinationAddress);
 void manager_incrementPacketCount(Manager* manager, Address* sourceAddress,
                                   Address* destinationAddress);

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -39,8 +39,8 @@ ChildPidWatcher* manager_childpidwatcher(Manager* manager);
 
 guint manager_getRawCPUFrequency(Manager* manager);
 DNS* manager_getDNS(Manager* manager);
-guint32 manager_getNodeBandwidthUp(Manager* manager, GQuark nodeID, in_addr_t ip);
-guint32 manager_getNodeBandwidthDown(Manager* manager, GQuark nodeID, in_addr_t ip);
+guint32 manager_getNodeBandwidthUp(Manager* manager, in_addr_t ip);
+guint32 manager_getNodeBandwidthDown(Manager* manager, in_addr_t ip);
 void manager_updateMinRunahead(Manager* manager, SimulationTime time);
 SimulationTime manager_getLatencyForAddresses(Manager* manager, Address* sourceAddress,
                                               Address* destinationAddress);

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -623,12 +623,12 @@ static void _worker_shutdownHost(Host* host, void* _unused) {
     host_unref(host);
 }
 
-guint32 worker_getNodeBandwidthUp(GQuark nodeID, in_addr_t ip) {
-    return manager_getNodeBandwidthUp(_worker_pool()->manager, nodeID, ip);
+guint32 worker_getNodeBandwidthUp(in_addr_t ip) {
+    return manager_getNodeBandwidthUp(_worker_pool()->manager, ip);
 }
 
-guint32 worker_getNodeBandwidthDown(GQuark nodeID, in_addr_t ip) {
-    return manager_getNodeBandwidthDown(_worker_pool()->manager, nodeID, ip);
+guint32 worker_getNodeBandwidthDown(in_addr_t ip) {
+    return manager_getNodeBandwidthDown(_worker_pool()->manager, ip);
 }
 
 void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time) {

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -640,16 +640,8 @@ SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* de
         _worker_pool()->manager, sourceAddress, destinationAddress);
 }
 
-SimulationTime worker_getLatency(GQuark sourceHostID, GQuark destinationHostID) {
-    return manager_getLatency(_worker_pool()->manager, sourceHostID, destinationHostID);
-}
-
 gdouble worker_getReliabilityForAddresses(Address* sourceAddress, Address* destinationAddress) {
     return manager_getReliabilityForAddresses(_worker_pool()->manager, sourceAddress, destinationAddress);
-}
-
-gdouble worker_getReliability(GQuark sourceHostID, GQuark destinationHostID) {
-    return manager_getReliability(_worker_pool()->manager, sourceHostID, destinationHostID);
 }
 
 bool worker_isRoutable(Address* sourceAddress, Address* destinationAddress) {

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -90,8 +90,8 @@ SimulationTime worker_getCurrentSimulationTime();
 EmulatedTime worker_getCurrentEmulatedTime();
 
 bool worker_isBootstrapActive(void);
-guint32 worker_getNodeBandwidthUp(GQuark nodeID, in_addr_t ip);
-guint32 worker_getNodeBandwidthDown(GQuark nodeID, in_addr_t ip);
+guint32 worker_getNodeBandwidthUp(in_addr_t ip);
+guint32 worker_getNodeBandwidthDown(in_addr_t ip);
 
 void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time);
 SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress);

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -95,9 +95,7 @@ guint32 worker_getNodeBandwidthDown(in_addr_t ip);
 
 void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time);
 SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress);
-SimulationTime worker_getLatency(GQuark sourceHostID, GQuark destinationHostID);
 gdouble worker_getReliabilityForAddresses(Address* sourceAddress, Address* destinationAddress);
-gdouble worker_getReliability(GQuark sourceHostID, GQuark destinationHostID);
 bool worker_isRoutable(Address* sourceAddress, Address* destinationAddress);
 void worker_incrementPacketCount(Address* sourceAddress, Address* destinationAddress);
 

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -432,12 +432,9 @@ static guint _tcp_calculateRTT(TCP* tcp, Host* host) {
         Address* srcAddress = worker_resolveIPToAddress(sourceIP);
         Address* dstAddress = worker_resolveIPToAddress(destinationIP);
 
-        GQuark sourceID = (GQuark)address_getID(srcAddress);
-        GQuark destinationID = (GQuark)address_getID(dstAddress);
-
         /* these sim time values are a duration and not an absolute time */
-        SimulationTime srcLatency = worker_getLatency(sourceID, destinationID);
-        SimulationTime dstLatency = worker_getLatency(destinationID, sourceID);
+        SimulationTime srcLatency = worker_getLatencyForAddresses(srcAddress, dstAddress);
+        SimulationTime dstLatency = worker_getLatencyForAddresses(dstAddress, srcAddress);
 
         /* find latency in milliseconds */
         guint sendLatency = (guint)ceil((gdouble)srcLatency / SIMTIME_ONE_MILLISECOND);
@@ -445,9 +442,8 @@ static guint _tcp_calculateRTT(TCP* tcp, Host* host) {
 
         if(sendLatency == 0 || receiveLatency == 0) {
             utility_panic("need nonzero latency to set buffer sizes, "
-                          "source=%" G_GUINT32_FORMAT " dest=%" G_GUINT32_FORMAT
-                          " send=%" G_GUINT32_FORMAT " recv=%" G_GUINT32_FORMAT,
-                          sourceID, destinationID, sendLatency, receiveLatency);
+                          "send=%" G_GUINT32_FORMAT " recv=%" G_GUINT32_FORMAT,
+                          sendLatency, receiveLatency);
         }
         utility_assert(sendLatency > 0 && receiveLatency > 0);
 

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -538,16 +538,10 @@ static void _tcp_tuneInitialBufferSizes(TCP* tcp, Host* host) {
 
     guint32 rtt_milliseconds = (guint32)_tcp_calculateRTT(tcp, host);
 
-    Address* srcAddress = worker_resolveIPToAddress(sourceIP);
-    Address* dstAddress = worker_resolveIPToAddress(destinationIP);
-
-    GQuark sourceID = (GQuark)address_getID(srcAddress);
-    GQuark destinationID = (GQuark)address_getID(dstAddress);
-
     /* i got delay, now i need values for my send and receive buffer
      * sizes based on bandwidth in both directions. do my send size first. */
-    guint32 my_send_bw = worker_getNodeBandwidthUp(sourceID, sourceIP);
-    guint32 their_receive_bw = worker_getNodeBandwidthDown(destinationID, destinationIP);
+    guint32 my_send_bw = worker_getNodeBandwidthUp(sourceIP);
+    guint32 their_receive_bw = worker_getNodeBandwidthDown(destinationIP);
 
     /* KiBps is the same as Bpms, which works with our RTT calculation. */
     guint32 send_bottleneck_bw = my_send_bw < their_receive_bw ? my_send_bw : their_receive_bw;
@@ -556,8 +550,8 @@ static void _tcp_tuneInitialBufferSizes(TCP* tcp, Host* host) {
     guint64 sendbuf_size = (guint64) ((rtt_milliseconds * send_bottleneck_bw * 1024.0f * 1.25f) / 1000.0f);
 
     /* now the same thing for my receive buf */
-    guint32 my_receive_bw = worker_getNodeBandwidthDown(sourceID, sourceIP);
-    guint32 their_send_bw = worker_getNodeBandwidthUp(destinationID, destinationIP);
+    guint32 my_receive_bw = worker_getNodeBandwidthDown(sourceIP);
+    guint32 their_send_bw = worker_getNodeBandwidthUp(destinationIP);
 
     /* KiBps is the same as Bpms, which works with our RTT calculation. */
     guint32 receive_bottleneck_bw = my_receive_bw < their_send_bw ? my_receive_bw : their_send_bw;


### PR DESCRIPTION
The manager accesses `Host` objects without acquiring the hosts' locks, which is not safe.

Edit:

The simulation results have changed slightly in this PR, so I will try to investigate where this difference is from.

![1656599789_grim](https://user-images.githubusercontent.com/3708797/176704977-9476adb7-02a9-42f5-b2e0-bad903f6600f.png)

Edit 2:

With the workaround commit, the results are the same. We can revert that commit in a new PR.

![1656636436_grim](https://user-images.githubusercontent.com/3708797/176801112-1b12f1da-f597-4bb4-9ec2-fd51d3894e83.png)