### PR TITLE
Changes to controller, manager, and scheduler

### DIFF
--- a/src/main/bindings/c/bindings-opaque.h
+++ b/src/main/bindings/c/bindings-opaque.h
@@ -124,8 +124,6 @@ typedef struct Random Random;
 // Routing information for paths between nodes.
 typedef struct RoutingInfo_u32 RoutingInfo_u32;
 
-typedef struct StatusLogger_ShadowStatusBarState StatusLogger_ShadowStatusBarState;
-
 typedef struct SyscallHandler SyscallHandler;
 
 // Mostly for interoperability with C APIs.

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -127,8 +127,6 @@ typedef struct Random Random;
 // Routing information for paths between nodes.
 typedef struct RoutingInfo_u32 RoutingInfo_u32;
 
-typedef struct StatusLogger_ShadowStatusBarState StatusLogger_ShadowStatusBarState;
-
 typedef struct SyscallHandler SyscallHandler;
 
 // Mostly for interoperability with C APIs.
@@ -283,18 +281,6 @@ uint32_t random_nextU32(struct Random *rng);
 // Fills the buffer with pseudo-random bytes.
 void random_nextNBytes(struct Random *rng, uint8_t *buf, uintptr_t len);
 
-struct StatusLogger_ShadowStatusBarState *statusBar_new(uint64_t end);
-
-struct StatusLogger_ShadowStatusBarState *statusPrinter_new(uint64_t end);
-
-void statusLogger_free(struct StatusLogger_ShadowStatusBarState *status_logger);
-
-void statusLogger_updateEmuTime(const struct StatusLogger_ShadowStatusBarState *status_logger,
-                                uint64_t current);
-
-void statusLogger_updateNumFailedProcesses(const struct StatusLogger_ShadowStatusBarState *status_logger,
-                                           uint32_t num_failed_processes);
-
 // Get the backtrace. This function is slow. The string must be freed using `backtrace_free()`.
 char *backtrace(void);
 
@@ -325,6 +311,8 @@ bool controller_managerFinishedCurrentRound(const struct Controller *controller,
 
 void controller_updateMinRunahead(const struct Controller *controller,
                                   SimulationTime min_path_latency);
+
+void controller_incrementPluginErrors(const struct Controller *controller);
 
 // Flush Rust's log::logger().
 void rustlogger_flush(void);

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1633,7 +1633,7 @@ extern "C" {
     ) -> *mut Manager;
 }
 extern "C" {
-    pub fn manager_free(manager: *mut Manager) -> gint;
+    pub fn manager_free(manager: *mut Manager);
 }
 extern "C" {
     pub fn manager_run(arg1: *mut Manager);

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -643,11 +643,6 @@ const ConfigOptions* manager_getConfig(Manager* manager) {
     return manager->config;
 }
 
-gboolean manager_schedulerIsRunning(Manager* manager) {
-    MAGIC_ASSERT(manager);
-    return scheduler_isRunning(manager->scheduler);
-}
-
 static void _manager_heartbeat(Manager* manager, SimulationTime simClockNow) {
     MAGIC_ASSERT(manager);
 

--- a/src/main/core/manager.c
+++ b/src/main/core/manager.c
@@ -41,7 +41,6 @@ struct _Manager {
 
     /* simulation cli options */
     const ConfigOptions* config;
-    SimulationTime bootstrapEndTime;
 
     /* manager random source, init from controller random, used to init host randoms */
     Random* random;
@@ -192,7 +191,6 @@ Manager* manager_new(const Controller* controller, const ConfigOptions* config,
     manager->controller = controller;
     manager->config = config;
     manager->random = random_new(randomSeed);
-    manager->bootstrapEndTime = config_getBootstrapEndTime(config);
 
     manager->rawFrequencyKHz = utility_getRawCPUFrequency(CONFIG_CPU_MAX_FREQ_FILE);
     if (manager->rawFrequencyKHz == 0) {
@@ -825,9 +823,4 @@ void manager_add_syscall_counts(Manager* manager, const Counter* syscall_counts)
     }
     counter_add_counter(manager->syscall_counter, syscall_counts);
     _manager_unlock(manager);
-}
-
-SimulationTime manager_getBootstrapEndTime(Manager* manager) {
-    MAGIC_ASSERT(manager);
-    return manager->bootstrapEndTime;
 }

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -58,8 +58,6 @@ const gchar* manager_getHostsRootPath(Manager* manager);
 void manager_run(Manager*);
 
 /* info received from controller to set up the simulation */
-void manager_addNewProgram(Manager* manager, const gchar* name, const gchar* path,
-                           const gchar* startSymbol);
 int manager_addNewVirtualHost(Manager* manager, HostParameters* params);
 void manager_addNewVirtualProcess(Manager* manager, const gchar* hostName, const gchar* pluginName,
                                   SimulationTime startTime, SimulationTime stopTime,

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -56,7 +56,6 @@ void manager_incrementPluginError(Manager* manager);
 const gchar* manager_getHostsRootPath(Manager* manager);
 
 void manager_run(Manager*);
-gboolean manager_schedulerIsRunning(Manager* manager);
 
 /* info received from controller to set up the simulation */
 void manager_addNewProgram(Manager* manager, const gchar* name, const gchar* path,

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -33,7 +33,7 @@ typedef struct _Manager Manager;
 
 Manager* manager_new(const Controller* controller, const ConfigOptions* config,
                      SimulationTime endTime, guint randomSeed);
-gint manager_free(Manager* manager);
+void manager_free(Manager* manager);
 
 ChildPidWatcher* manager_childpidwatcher(Manager* manager);
 

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -51,7 +51,6 @@ void manager_incrementPacketCount(Manager* manager, Address* sourceAddress,
                                   Address* destinationAddress);
 
 const ConfigOptions* manager_getConfig(Manager* manager);
-SimulationTime manager_getBootstrapEndTime(Manager* manager);
 
 void manager_incrementPluginError(Manager* manager);
 const gchar* manager_getHostsRootPath(Manager* manager);

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -28,9 +28,6 @@ static int _parallelism;
 ADD_CONFIG_HANDLER(config_getParallelism, _parallelism)
 
 struct _Scheduler {
-    // Unowned back-pointer.
-    Manager* manager;
-
     WorkerPool* workerPool;
 
     /* global lock for all threads, hold this as little as possible */
@@ -121,9 +118,6 @@ Scheduler* scheduler_new(Manager* manager, SchedulerPolicyType policyType,
 
     /* global lock */
     g_mutex_init(&(scheduler->globalLock));
-
-    // Unowned back-pointer
-    scheduler->manager = manager;
 
     scheduler->workerPool = workerpool_new(manager, scheduler, /*nThreads=*/nWorkers,
                                            /*nParallel=*/_parallelism);

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -412,7 +412,9 @@ void* _worker_run(void* voidWorkerThreadInfo) {
     workerPool->workerNativeThreadIDs[threadID] = syscall(SYS_gettid);
 
     // Create the thread-local Worker object.
-    worker_newForThisThread(workerPool, threadID, manager_getBootstrapEndTime(workerPool->manager));
+    SimulationTime bootstrapEndTime =
+        config_getBootstrapEndTime(manager_getConfig(workerPool->manager));
+    worker_newForThisThread(workerPool, threadID, bootstrapEndTime);
 
     // Signal parent thread that we've set the nativeThreadID.
     countdownlatch_countDown(workerPool->finishLatch);

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -495,7 +495,7 @@ gboolean worker_scheduleTaskAtEmulatedTime(TaskRef* task, Host* host, EmulatedTi
     utility_assert(task);
     utility_assert(host);
 
-    if (!manager_schedulerIsRunning(_worker_pool()->manager)) {
+    if (!scheduler_isRunning(_worker_pool()->scheduler)) {
         return FALSE;
     }
 
@@ -536,7 +536,7 @@ static void _worker_runDeliverPacketTask(Host* host, gpointer voidPacket, gpoint
 void worker_sendPacket(Host* srcHost, Packet* packet) {
     utility_assert(packet != NULL);
 
-    if (!manager_schedulerIsRunning(_worker_pool()->manager)) {
+    if (!scheduler_isRunning(_worker_pool()->scheduler)) {
         /* the simulation is over, don't bother */
         return;
     }


### PR DESCRIPTION
Main changes:

- removed unnecessary complexity from the manager and scheduler
- removed `manager` field from the scheduler
- moved the status bar and plugin error count to the controller (the intended design is that the simulation may have multiple managers and a single controller, so the controller seems like a better place for these)