### PR TITLE
More organization changs to the manager / worker pool

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -390,6 +390,8 @@ bool config_getUseSeccomp(const struct ConfigOptions *config);
 
 bool config_getUseSyscallCounters(const struct ConfigOptions *config);
 
+bool config_getUseObjectCounters(const struct ConfigOptions *config);
+
 bool config_getUseLibcPreload(const struct ConfigOptions *config);
 
 bool config_getUseOpensslRNGPreload(const struct ConfigOptions *config);
@@ -575,8 +577,19 @@ WorkerPool *_worker_pool(void);
 
 bool worker_isAlive(void);
 
-void worker_addAndClearGlobalAllocCounters(struct Counter *alloc_counter,
-                                           struct Counter *dealloc_counter);
+// Add the global counters to the provided counters, and clear the global counters.
+void worker_addFromGlobalAllocCounters(struct Counter *alloc_counter,
+                                       struct Counter *dealloc_counter);
+
+// Add the counters to their global counterparts, and clear the provided counters.
+void worker_addToGlobalAllocCounters(struct Counter *alloc_counter,
+                                     struct Counter *dealloc_counter);
+
+// Add the global counter to the provided counter, and clear the global counter.
+void worker_addFromGlobalSyscallCounter(struct Counter *syscall_counter);
+
+// Add the counters to their global counterparts, and clear the provided counters.
+void worker_addToGlobalSyscallCounter(struct Counter *syscall_counter);
 
 // Create an object that can be used to store all descriptors created by a
 // process. When the table is no longer required, use descriptortable_free

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2896,10 +2896,10 @@ extern "C" {
     pub fn worker_isBootstrapActive() -> bool;
 }
 extern "C" {
-    pub fn worker_getNodeBandwidthUp(ip: in_addr_t) -> guint32;
+    pub fn worker_getNodeBandwidthUpKiBps(ip: in_addr_t) -> guint32;
 }
 extern "C" {
-    pub fn worker_getNodeBandwidthDown(ip: in_addr_t) -> guint32;
+    pub fn worker_getNodeBandwidthDownKiBps(ip: in_addr_t) -> guint32;
 }
 extern "C" {
     pub fn workerpool_updateMinHostRunahead(pool: *mut WorkerPool, time: SimulationTime);

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2858,7 +2858,7 @@ extern "C" {
     pub fn worker_getDNS() -> *mut DNS;
 }
 extern "C" {
-    pub fn worker_getChildPidWatcher() -> *mut ChildPidWatcher;
+    pub fn worker_getChildPidWatcher() -> *const ChildPidWatcher;
 }
 extern "C" {
     pub fn worker_getConfig() -> *const ConfigOptions;

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -64,12 +64,4 @@ void manager_addNewVirtualProcess(Manager* manager, const gchar* hostName, const
                                   const gchar* const* argv, const char* environment,
                                   bool pause_for_debugging);
 
-// Add the given allocated-object counts into a global manager counter.
-void manager_add_alloc_object_counts(Manager* manager, Counter* alloc_obj_counts);
-// Add the given deallocated-object counts into a global manager counter.
-void manager_add_dealloc_object_counts(Manager* manager, Counter* dealloc_obj_counts);
-
-// Add the given syscall counts into a global manager counter.
-void manager_add_syscall_counts(Manager* manager, const Counter* syscall_counts);
-
 #endif /* SHD_MANAGER_H_ */

--- a/src/main/core/manager.h
+++ b/src/main/core/manager.h
@@ -35,26 +35,6 @@ Manager* manager_new(const Controller* controller, const ConfigOptions* config,
                      SimulationTime endTime, guint randomSeed);
 void manager_free(Manager* manager);
 
-ChildPidWatcher* manager_childpidwatcher(Manager* manager);
-
-guint manager_getRawCPUFrequency(Manager* manager);
-DNS* manager_getDNS(Manager* manager);
-guint32 manager_getNodeBandwidthUp(Manager* manager, in_addr_t ip);
-guint32 manager_getNodeBandwidthDown(Manager* manager, in_addr_t ip);
-void manager_updateMinRunahead(Manager* manager, SimulationTime time);
-SimulationTime manager_getLatencyForAddresses(Manager* manager, Address* sourceAddress,
-                                              Address* destinationAddress);
-gfloat manager_getReliabilityForAddresses(Manager* manager, Address* sourceAddress,
-                                          Address* destinationAddress);
-bool manager_isRoutable(Manager* manager, Address* sourceAddress, Address* destinationAddress);
-void manager_incrementPacketCount(Manager* manager, Address* sourceAddress,
-                                  Address* destinationAddress);
-
-const ConfigOptions* manager_getConfig(Manager* manager);
-
-void manager_incrementPluginError(Manager* manager);
-const gchar* manager_getHostsRootPath(Manager* manager);
-
 void manager_run(Manager*);
 
 /* info received from controller to set up the simulation */

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -110,17 +110,18 @@ static void _scheduler_finishTaskFn(void* voidScheduler) {
     worker_finish(myHosts, scheduler->endTime);
 }
 
-Scheduler* scheduler_new(Manager* manager, SchedulerPolicyType policyType,
-                         guint nWorkers, guint schedulerSeed,
-                         SimulationTime endTime) {
+Scheduler* scheduler_new(const Controller* controller, const ChildPidWatcher* pidWatcher,
+                         const ConfigOptions* config, SchedulerPolicyType policyType,
+                         guint nWorkers, guint schedulerSeed, SimulationTime endTime) {
     Scheduler* scheduler = g_new0(Scheduler, 1);
     MAGIC_INIT(scheduler);
 
     /* global lock */
     g_mutex_init(&(scheduler->globalLock));
 
-    scheduler->workerPool = workerpool_new(manager, scheduler, /*nThreads=*/nWorkers,
-                                           /*nParallel=*/_parallelism);
+    scheduler->workerPool =
+        workerpool_new(controller, pidWatcher, scheduler, config, /*nThreads=*/nWorkers,
+                       /*nParallel=*/_parallelism);
 
     scheduler->endTime = endTime;
     scheduler->currentRound.endTime = scheduler->endTime;// default to one single round

--- a/src/main/core/scheduler/scheduler.h
+++ b/src/main/core/scheduler/scheduler.h
@@ -17,9 +17,9 @@ typedef struct _Scheduler Scheduler;
 #include "main/core/work/event.h"
 #include "main/host/host.h"
 
-Scheduler* scheduler_new(Manager* manager, SchedulerPolicyType policyType,
-                         guint nWorkers, guint schedulerSeed,
-                         SimulationTime endTime);
+Scheduler* scheduler_new(const Controller* controller, const ChildPidWatcher* pidWatcher,
+                         const ConfigOptions* config, SchedulerPolicyType policyType,
+                         guint nWorkers, guint schedulerSeed, SimulationTime endTime);
 void scheduler_ref(Scheduler*);
 void scheduler_unref(Scheduler*);
 void scheduler_shutdown(Scheduler* scheduler);

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -1409,6 +1409,13 @@ mod export {
     }
 
     #[no_mangle]
+    pub extern "C" fn config_getUseObjectCounters(config: *const ConfigOptions) -> bool {
+        assert!(!config.is_null());
+        let config = unsafe { &*config };
+        config.experimental.use_object_counters.unwrap()
+    }
+
+    #[no_mangle]
     pub extern "C" fn config_getUseLibcPreload(config: *const ConfigOptions) -> bool {
         assert!(!config.is_null());
         let config = unsafe { &*config };

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -628,11 +628,11 @@ static void _worker_shutdownHost(Host* host, void* _unused) {
     host_unref(host);
 }
 
-guint32 worker_getNodeBandwidthUp(in_addr_t ip) {
+guint32 worker_getNodeBandwidthUpKiBps(in_addr_t ip) {
     return controller_getBandwidthUpBytes(_worker_pool()->controller, ip) / 1024;
 }
 
-guint32 worker_getNodeBandwidthDown(in_addr_t ip) {
+guint32 worker_getNodeBandwidthDownKiBps(in_addr_t ip) {
     return controller_getBandwidthDownBytes(_worker_pool()->controller, ip) / 1024;
 }
 

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -480,15 +480,13 @@ void worker_finish(GQueue* hosts, SimulationTime time) {
     _worker_setLastEventTime(worker_getCurrentEmulatedTime());
     worker_clearCurrentTime();
 
-    /* cleanup is all done, send counters to manager */
     WorkerPool* pool = _worker_pool();
 
-    // Send object counts to manager
-    manager_add_alloc_object_counts(pool->manager, _worker_objectAllocCounter());
-    manager_add_dealloc_object_counts(pool->manager, _worker_objectDeallocCounter());
+    /* send object counts to global counters */
+    worker_addToGlobalAllocCounters(_worker_objectAllocCounter(), _worker_objectDeallocCounter());
 
-    // Send syscall counts to manager
-    manager_add_syscall_counts(pool->manager, _worker_syscallCounter());
+    /* send syscall counts to global counter */
+    worker_addToGlobalSyscallCounter(_worker_syscallCounter());
 }
 
 gboolean worker_scheduleTaskAtEmulatedTime(TaskRef* task, Host* host, EmulatedTime t) {

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -91,8 +91,8 @@ SimulationTime worker_getCurrentSimulationTime();
 EmulatedTime worker_getCurrentEmulatedTime();
 
 bool worker_isBootstrapActive(void);
-guint32 worker_getNodeBandwidthUp(in_addr_t ip);
-guint32 worker_getNodeBandwidthDown(in_addr_t ip);
+guint32 worker_getNodeBandwidthUpKiBps(in_addr_t ip);
+guint32 worker_getNodeBandwidthDownKiBps(in_addr_t ip);
 
 void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time);
 SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress);

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -37,8 +37,9 @@ void worker_finish(GQueue* hosts, SimulationTime time);
 
 // Create a workerpool with `nThreads` threads, allowing up to `nConcurrent` to
 // run at a time.
-WorkerPool* workerpool_new(Manager* manager, Scheduler* scheduler, int nThreads,
-                           int nConcurrent);
+WorkerPool* workerpool_new(const Controller* controller, const ChildPidWatcher* pidWatcher,
+                           Scheduler* scheduler, const ConfigOptions* config, int nWorkers,
+                           int nParallel);
 
 // Begin executing taskFn(data) on each worker thread in the pool.
 void workerpool_startTaskFn(WorkerPool* pool, WorkerPoolTaskFn taskFn,
@@ -70,7 +71,7 @@ void worker_setRoundEndTime(SimulationTime newRoundEndTime);
 
 int worker_getAffinity();
 DNS* worker_getDNS();
-ChildPidWatcher* worker_getChildPidWatcher();
+const ChildPidWatcher* worker_getChildPidWatcher();
 const ConfigOptions* worker_getConfig();
 gboolean worker_scheduleTaskWithDelay(TaskRef* task, Host* host, SimulationTime nanoDelay);
 gboolean worker_scheduleTaskAtEmulatedTime(TaskRef* task, Host* host, EmulatedTime t);

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -536,8 +536,8 @@ static void _tcp_tuneInitialBufferSizes(TCP* tcp, Host* host) {
 
     /* i got delay, now i need values for my send and receive buffer
      * sizes based on bandwidth in both directions. do my send size first. */
-    guint32 my_send_bw = worker_getNodeBandwidthUp(sourceIP);
-    guint32 their_receive_bw = worker_getNodeBandwidthDown(destinationIP);
+    guint32 my_send_bw = worker_getNodeBandwidthUpKiBps(sourceIP);
+    guint32 their_receive_bw = worker_getNodeBandwidthDownKiBps(destinationIP);
 
     /* KiBps is the same as Bpms, which works with our RTT calculation. */
     guint32 send_bottleneck_bw = my_send_bw < their_receive_bw ? my_send_bw : their_receive_bw;
@@ -546,8 +546,8 @@ static void _tcp_tuneInitialBufferSizes(TCP* tcp, Host* host) {
     guint64 sendbuf_size = (guint64) ((rtt_milliseconds * send_bottleneck_bw * 1024.0f * 1.25f) / 1000.0f);
 
     /* now the same thing for my receive buf */
-    guint32 my_receive_bw = worker_getNodeBandwidthDown(sourceIP);
-    guint32 their_send_bw = worker_getNodeBandwidthUp(destinationIP);
+    guint32 my_receive_bw = worker_getNodeBandwidthDownKiBps(sourceIP);
+    guint32 their_send_bw = worker_getNodeBandwidthUpKiBps(destinationIP);
 
     /* KiBps is the same as Bpms, which works with our RTT calculation. */
     guint32 receive_bottleneck_bw = my_receive_bw < their_send_bw ? my_receive_bw : their_send_bw;


### PR DESCRIPTION
These changes are to prepare for the rust migration of the `Manager`.

- Workers now add their local counters to the global counters --- Rather than having each worker add its counters to the manager through the global worker pool, each worker now adds its counters to the global counters and the manager then later reads from the global counters.
- Worker pool now accesses the controller, pid watcher, and config directly --- This is work towards making the controller/manager/scheduler/workerpool more composable and to limit parent references.