### PR TITLE
Pre-allocate space in shared memory files

### DIFF
--- a/src/main/shmem/shmem_allocator.c
+++ b/src/main/shmem/shmem_allocator.c
@@ -13,7 +13,7 @@
 #include "main/shmem/shmem_file.h"
 #include "main/shmem/shmem_util.h"
 
-#define SHD_SHMEM_ALLOCATOR_POOL_NBYTES SHD_BUDDY_POOL_MAX_NBYTES
+#define SHD_SHMEM_ALLOCATOR_POOL_NBYTES (1<<20)
 
 // when to change allocation strategies
 #define SHD_SHMEM_ALLOCATOR_CUTOVER_NBYTES                                     \

--- a/src/main/shmem/shmem_file.c
+++ b/src/main/shmem/shmem_file.c
@@ -73,7 +73,7 @@ int shmemfile_alloc(size_t nbytes, ShMemFile* shmf) {
     int fd = shm_open(shmf->name, O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, SHMEM_PERMISSION_BITS);
 
     if (fd >= 0) {
-        int rc = ftruncate(fd, nbytes);
+        int rc = posix_fallocate(fd, 0, nbytes);
         if (rc == 0) {
             void* p =
                 mmap(NULL, nbytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
@@ -86,8 +86,8 @@ int shmemfile_alloc(size_t nbytes, ShMemFile* shmf) {
                 bad = true;
             }
 
-        } else { // failed truncate
-            panic("error on truncate: %s", strerror(errno));
+        } else {
+            panic("error allocating %zu bytes in shared mem: %s", nbytes, strerror(rc));
             bad = true;
         }
 


### PR DESCRIPTION
Replace usage of `ftruncate` with `posix_fallocate`. `ftruncate` sets
the size of a file without actually allocating the backing storage,
which is allocated on-demand. While this allows the true allocation to
be "lazy", and thereby allows us to do large allocations without wasting
resources if the whole allocation isn't used, it can cause unpredictable
and confusing failure modes.

With `posix_fallocate`, the space is eagerly allocated. If the call
succeeds, we are guaranteed that the storage is actually available.
When we run out of storage, the call fails and we can fail with a clear
error message.

We were previously allocating quite-large chunks of memory at a time;
about 132 MB. While this probably wouldn't actually cause problems for a
single shadow simulation (which typically only needs one such
allocation), it ends up using a lot of space when running the shadow
tests in parallel. This changes the default allocation to 1 MB, instead.

Fixes https://github.com/shadow/shadow/issues/2266