### PR TITLE
Add support for smaller vdso trampolines

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,3 +14,6 @@ options. See https://github.com/shadow/shadow/issues/1945
 
 * Fixed a bug causing `timerfd_settime` to not reset the internal timer's
   expiration count. https://github.com/shadow/shadow/pull/2279
+
+* Fixed a panic when patching the VDSO in newer kernels, such as those in Ubuntu 22.04.
+  https://github.com/shadow/shadow/issues/2273


### PR DESCRIPTION
Add support for smaller VDSO trampolines (13 bytes -> 5 bytes). This fixes panics in Ubuntu 22.04, whose vdso functions are already just 5-byte trampolines into internal functions (#2273)

Also adds some tests with an Ubuntu 22.04 kernel to the CI.