### PR TITLE
Ensure timerfd_settime resets expiration count

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,3 +11,6 @@ options. See https://github.com/shadow/shadow/issues/1945
 
 * Fixed behavior when multiple threads are blocked in `epoll_wait` on the same epoll
   file description. https://github.com/shadow/shadow/issues/2260
+
+* Fixed a bug causing `timerfd_settime` to not reset the internal timer's
+  expiration count. https://github.com/shadow/shadow/pull/2279

--- a/src/main/host/timer.rs
+++ b/src/main/host/timer.rs
@@ -166,6 +166,7 @@ impl Timer {
         debug_assert!(expire_time >= Worker::current_time().unwrap());
         internal.next_expire_time = Some(expire_time);
         internal.expire_interval = expire_interval;
+        internal.expiration_count = 0;
         Self::schedule_new_expire_event(&mut *internal, Arc::downgrade(&self.internal), host);
     }
 }

--- a/src/test/timerfd/test_timerfd.c
+++ b/src/test/timerfd/test_timerfd.c
@@ -158,7 +158,7 @@ static void _test_disarm_timer() {
 
     /* wait for 2 seconds */
     struct epoll_event event = {0};
-    assert_nonneg_errno(epoll_wait(efd, &event, 1, 2));
+    assert_nonneg_errno(epoll_wait(efd, &event, 1, 2000));
 
     /* it should not have expired since we disarmed the 1 second timer */
     uint64_t num_expires = 0;
@@ -191,7 +191,7 @@ static void _test_rearm_timer() {
 
     /* wait for 2 seconds */
     struct epoll_event event = {0};
-    assert_nonneg_errno(epoll_wait(efd, &event, 1, 2));
+    assert_nonneg_errno(epoll_wait(efd, &event, 1, 2000));
 
     /* The timer should be ready, but calling timerfd_settime should make it
      * unready again */


### PR DESCRIPTION
Definitely a bug; might be the root cause of https://github.com/shadow/tgen/issues/35