### PR TITLE
shadow version string: get commit hash and dirty status more robustly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,11 @@ message(STATUS "SHADOW_VERSION_PATCH=${SHADOW_VERSION_PATCH}")
 
 if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
     ## current git commit version and hash
-    EXECUTE_PROCESS(COMMAND "git" "describe" "--long" "--dirty" OUTPUT_VARIABLE DESCRIBE)
+    ##
+    ## `--always` allows us to still get the commit hash and dirty status,
+    ## when tags aren't available, as sometimes happens when building from
+    ## a shallow clone.
+    EXECUTE_PROCESS(COMMAND "git" "describe" "--always" "--long" "--dirty" OUTPUT_VARIABLE DESCRIBE)
     if(DESCRIBE)
         string(REGEX REPLACE "\n" "" DESCRIBE ${DESCRIBE})
     endif(DESCRIBE)


### PR DESCRIPTION
Adding the `--always` tag allows `git describe` to succeed even if
a relevant tag can't be found. e.g. in the case of a shallow checkout
without tags it results in a version string like "5a6993e" instead of
the hard-coded version number "v2.1.0", which is misleading.