### PR TITLE
timerfd: ensure previously scheduled events are cancelled when re-arming

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,8 +12,9 @@ options. See https://github.com/shadow/shadow/issues/1945
 * Fixed behavior when multiple threads are blocked in `epoll_wait` on the same epoll
   file description. https://github.com/shadow/shadow/issues/2260
 
-* Fixed a bug causing `timerfd_settime` to not reset the internal timer's
-  expiration count. https://github.com/shadow/shadow/pull/2279
+* Fixed bugs causing `timerfd_settime` to not reset the internal timer's
+  expiration count (https://github.com/shadow/shadow/pull/2279), and not cancel
+  previously scheduled timer-fire events (https://github.com/shadow/shadow/pull/2282).
 
 * Fixed a panic when patching the VDSO in newer kernels, such as those in Ubuntu 22.04.
   https://github.com/shadow/shadow/issues/2273

--- a/src/main/host/timer.rs
+++ b/src/main/host/timer.rs
@@ -167,6 +167,7 @@ impl Timer {
         internal.next_expire_time = Some(expire_time);
         internal.expire_interval = expire_interval;
         internal.expiration_count = 0;
+        internal.min_valid_expire_id = internal.next_expire_id;
         Self::schedule_new_expire_event(&mut *internal, Arc::downgrade(&self.internal), host);
     }
 }


### PR DESCRIPTION
Fairly sure this will fix https://github.com/shadow/tgen/issues/35