### PR TITLE
Tweak shadow tests CI matrix

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -43,24 +43,29 @@ jobs:
           - 'fedora:36'
           # EOL May 2024 https://www.centos.org/centos-stream/
           - 'quay.io/centos/centos:stream8'
-        cc: ['gcc', 'clang']
+        cc: ['gcc']
         buildtype: ['debug', 'release']
-        exclude:
-          # https://github.com/shadow/shadow/issues/1741
-          - container: 'quay.io/centos/centos:stream8'
-            cc: clang
-          # https://github.com/shadow/shadow/issues/1741
-          - container: 'ubuntu:21.10'
-            cc: clang
-          # https://github.com/shadow/shadow/issues/1741
-          - container: 'fedora:35'
-            cc: clang
         include:
           # Run some tests on the newest-available base vm, and hence
           # newest-available kernel. https://github.com/actions/virtual-environments
           - vm: 'ubuntu-22.04'
             container: 'ubuntu:22.04'
             cc: 'gcc'
+            buildtype: 'release'
+          - vm: 'ubuntu-22.04'
+            container: 'ubuntu:22.04'
+            cc: 'gcc'
+            buildtype: 'debug'
+
+          # Run some tests on the newest-available clang.  Testing clang on
+          # *every* platform is a bit overkill, but testing on at least one
+          # gives decent "bang for the buck" of testing compatibility with
+          # clang's most recent diagnostics and optimizations.
+          #
+          # Also use the more-recent kernel here.
+          - vm: 'ubuntu-22.04'
+            container: 'ubuntu:22.04'
+            cc: 'clang'
             buildtype: 'release'
           - vm: 'ubuntu-22.04'
             container: 'ubuntu:22.04'

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,19 +19,12 @@ env:
 
 jobs:
   shadow:
-    # use the oldest kernel supported by github's CI (make sure to update the
-    # minimum supported kernel version in documentation when changing)
-    # https://github.com/actions/virtual-environments
-    runs-on: ubuntu-18.04
-    container:
-      image: ${{ matrix.container }}
-      # the default shm-size for ubuntu:18.04, but with the size increased from
-      # 65536k. github's default docker seccomp policy seems to disallow
-      # process_vm_readv and process_vm_writev; disable it altogether. See
-      # https://docs.docker.com/engine/security/seccomp/
-      options: '--shm-size="1g" --security-opt seccomp=unconfined'
     strategy:
       matrix:
+        vm:
+          # Oldest-available kernel from
+          # https://github.com/actions/virtual-environments
+          - ubuntu-18.04
         container:
           # End of standard support: April 2023 https://wiki.ubuntu.com/Releases
           - 'ubuntu:18.04'
@@ -62,6 +55,25 @@ jobs:
           # https://github.com/shadow/shadow/issues/1741
           - container: 'fedora:35'
             cc: clang
+        include:
+          # Run some tests on the newest-available base vm, and hence
+          # newest-available kernel. https://github.com/actions/virtual-environments
+          - vm: 'ubuntu-22.04'
+            container: 'ubuntu:22.04'
+            cc: 'gcc'
+            buildtype: 'release'
+          - vm: 'ubuntu-22.04'
+            container: 'ubuntu:22.04'
+            cc: 'clang'
+            buildtype: 'debug'
+    runs-on: ${{ matrix.vm }}
+    container:
+      image: ${{ matrix.container }}
+      # the default shm-size for ubuntu:18.04, but with the size increased from
+      # 65536k. github's default docker seccomp policy seems to disallow
+      # process_vm_readv and process_vm_writev; disable it altogether. See
+      # https://docs.docker.com/engine/security/seccomp/
+      options: '--shm-size="1g" --security-opt seccomp=unconfined'
     env:
       CC: ${{ matrix.cc }}
       CONTAINER: ${{ matrix.container }}


### PR DESCRIPTION
* Add some configurations that run with a newer kernel, to help catch kernel incompatibilities such as https://github.com/shadow/shadow/issues/2273

* Only test clang in a couple configurations, to cut down the CI matrix a bit.