### PR TITLE
Add shadow test workflow with incremental builds

### DIFF
--- a/.github/workflows/run_tests_incremental.yml
+++ b/.github/workflows/run_tests_incremental.yml
@@ -1,0 +1,152 @@
+# Syntax reference:
+# https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+
+name: Shadow Tests
+permissions: read-all
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  shadow:
+    strategy:
+      matrix:
+        vm:
+          # Oldest-available kernel from
+          # https://github.com/actions/virtual-environments
+          - ubuntu-18.04
+        container:
+          # End of standard support: April 2023 https://wiki.ubuntu.com/Releases
+          - 'ubuntu:18.04'
+          # End of standard support: April 2025 https://wiki.ubuntu.com/Releases
+          - 'ubuntu:20.04'
+          # End of standard support: April 2027 https://wiki.ubuntu.com/Releases
+          - 'ubuntu:22.04'
+          # EOL ~August 2022 https://wiki.debian.org/DebianReleases
+          - 'debian:10-slim'
+          - 'debian:11-slim'
+          # EOL June 7 2022 https://endoflife.date/fedora
+          - 'fedora:34'
+          - 'fedora:35'
+          - 'fedora:36'
+          # EOL May 2024 https://www.centos.org/centos-stream/
+          - 'quay.io/centos/centos:stream8'
+        cc: ['gcc']
+        buildtype: ['debug', 'release']
+        include:
+          # Run some tests on the newest-available base vm, and hence
+          # newest-available kernel. https://github.com/actions/virtual-environments
+          - vm: 'ubuntu-22.04'
+            container: 'ubuntu:22.04'
+            cc: 'gcc'
+            buildtype: 'release'
+          - vm: 'ubuntu-22.04'
+            container: 'ubuntu:22.04'
+            cc: 'gcc'
+            buildtype: 'debug'
+
+          # Run some tests on the newest-available clang.  Testing clang on
+          # *every* platform is a bit overkill, but testing on at least one
+          # gives decent "bang for the buck" of testing compatibility with
+          # clang's most recent diagnostics and optimizations.
+          #
+          # Also use the more-recent kernel here.
+          - vm: 'ubuntu-22.04'
+            container: 'ubuntu:22.04'
+            cc: 'clang'
+            buildtype: 'release'
+          - vm: 'ubuntu-22.04'
+            container: 'ubuntu:22.04'
+            cc: 'clang'
+            buildtype: 'debug'
+    runs-on: ${{ matrix.vm }}
+    container:
+      image: ${{ matrix.container }}
+      # the default shm-size for ubuntu:18.04, but with the size increased from
+      # 65536k. github's default docker seccomp policy seems to disallow
+      # process_vm_readv and process_vm_writev; disable it altogether. See
+      # https://docs.docker.com/engine/security/seccomp/
+      options: '--shm-size="1g" --security-opt seccomp=unconfined'
+    env:
+      CC: ${{ matrix.cc }}
+      CONTAINER: ${{ matrix.container }}
+      BUILDTYPE: ${{ matrix.buildtype }}
+      RUSTPROFILE: minimal
+
+    env:
+      # Assign these to env variables rather than using directly inline, to help
+      # prevent injection mistakes/attacks, e.g. by including a " character to
+      # terminate a bash string.
+      INPUTS_BUILD: "${{ github.event.inputs.build }}"
+      INPUTS_PUSH: "${{ github.event.inputs.push }}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          # Run on PR head instead of merge result. Running on the merge
+          # result can give confusing results, and we require PR to be up to
+          # date with target branch before merging, anyway.
+          # See https://github.com/shadow/shadow/issues/2166
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Get month
+        id: get-month
+        run: |
+          echo "::set-output name=month::$(/bin/date -u "+%Y%m")"
+
+      - name: Install dependencies
+        run: |
+          . ci/container_scripts/install_deps.sh
+          . ci/container_scripts/install_extra_deps.sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Restore cargo registry cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          # invalidate the cache once per month
+          key: cargo-registry-${{ steps.get-month.outputs.month }}
+          restore-keys: |
+            cargo-registry-
+
+      - name: Build
+        run: . ci/container_scripts/build_and_install.sh
+
+      - name: Test
+        run: . ci/container_scripts/test.sh
+
+      - name: Compress logs
+        if: failure()
+        run: |
+          shopt -s globstar
+          tar -cJf build/Testing/Temporary{.tar.xz,/}
+          for f in build/**/*.data; do tar -cJf "$f.tar.xz" "$f/"; done
+
+      - name: Upload shadow data directories
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: shadow-data-dirs
+          path: build/**/*.data.tar.xz
+
+      - name: Upload shadow log file
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: shadow-log-file
+          path: build/Testing/Temporary.tar.xz

--- a/.github/workflows/run_tests_incremental.yml
+++ b/.github/workflows/run_tests_incremental.yml
@@ -138,19 +138,19 @@ jobs:
         if: failure()
         run: |
           shopt -s globstar
-          tar -cJf build/Testing/Temporary{.tar.xz,/}
-          for f in build/**/*.data; do tar -cJf "$f.tar.xz" "$f/"; done
+          tar -cJf ci/build/Testing/Temporary{.tar.xz,/}
+          for f in ci/build/**/*.data; do tar -cJf "$f.tar.xz" "$f/"; done
 
       - name: Upload shadow data directories
         uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: shadow-data-dirs
-          path: build/**/*.data.tar.xz
+          path: ci/build/**/*.data.tar.xz
 
       - name: Upload shadow log file
         uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: shadow-log-file
-          path: build/Testing/Temporary.tar.xz
+          path: ci/build/Testing/Temporary.tar.xz

--- a/.github/workflows/run_tests_incremental.yml
+++ b/.github/workflows/run_tests_incremental.yml
@@ -1,7 +1,7 @@
 # Syntax reference:
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 
-name: Shadow Tests
+name: Shadow Tests Incremental
 permissions: read-all
 
 defaults:
@@ -13,9 +13,16 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize]
-
-env:
-  CARGO_TERM_COLOR: always
+  workflow_dispatch:
+    inputs:
+      build:
+        description: "Build new Docker images"
+        type: boolean
+        default: false
+      push:
+        description: "Push Docker images"
+        type: boolean
+        default: false
 
 jobs:
   shadow:
@@ -70,18 +77,6 @@ jobs:
             cc: 'clang'
             buildtype: 'debug'
     runs-on: ${{ matrix.vm }}
-    container:
-      image: ${{ matrix.container }}
-      # the default shm-size for ubuntu:18.04, but with the size increased from
-      # 65536k. github's default docker seccomp policy seems to disallow
-      # process_vm_readv and process_vm_writev; disable it altogether. See
-      # https://docs.docker.com/engine/security/seccomp/
-      options: '--shm-size="1g" --security-opt seccomp=unconfined'
-    env:
-      CC: ${{ matrix.cc }}
-      CONTAINER: ${{ matrix.container }}
-      BUILDTYPE: ${{ matrix.buildtype }}
-      RUSTPROFILE: minimal
 
     env:
       # Assign these to env variables rather than using directly inline, to help
@@ -101,34 +96,43 @@ jobs:
           # See https://github.com/shadow/shadow/issues/2166
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Get month
-        id: get-month
-        run: |
-          echo "::set-output name=month::$(/bin/date -u "+%Y%m")"
-
-      - name: Install dependencies
-        run: |
-          . ci/container_scripts/install_deps.sh
-          . ci/container_scripts/install_extra_deps.sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Restore cargo registry cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          # invalidate the cache once per month
-          key: cargo-registry-${{ steps.get-month.outputs.month }}
-          restore-keys: |
-            cargo-registry-
-
-      - name: Build
-        run: . ci/container_scripts/build_and_install.sh
-
       - name: Test
-        run: . ci/container_scripts/test.sh
+        run: |
+          FLAGS=()
+          FLAGS+=("-c" "${{ matrix.container }}")
+          FLAGS+=("-C" "${{ matrix.cc }}")
+          FLAGS+=("-b" "${{ matrix.buildtype }}")
+
+          # Get the generated tag for the image
+          IMAGETAG=`ci/run.sh -t ${FLAGS[@]}`
+
+          if [ "$INPUTS_BUILD" == "true" ]
+          then
+            # Build the image
+            FLAGS+=("-i")
+
+            # Fetch the base image for the build.
+            # Do this before logging in to avoid charging our account for the pull.
+            docker pull ${{ matrix.container }}
+          else
+            # Ensure the image is actually available
+            if ! docker pull "${IMAGETAG}"
+            then
+              echo "Couldn't pull image; building"
+              FLAGS+=("-i")
+            fi
+          fi
+
+          if [ "$INPUTS_PUSH" == "true" ]
+          then
+            FLAGS+=("-p")
+
+            # Log in so that we can push
+            docker login -u shadowsim --password "${{ secrets.DOCKERHUB_TOKEN }}"
+          fi
+
+          # Run
+          ci/run.sh ${FLAGS[@]}
 
       - name: Compress logs
         if: failure()

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -173,7 +173,7 @@ EOF
     CONTAINER_ID="$(docker create ${DOCKER_CREATE_FLAGS[@]} ${TAG} /bin/bash -c \
         "echo '' \
          && echo 'Changes (see https://stackoverflow.com/a/36851784 for details):' \
-         && rsync --delete --exclude-from=.dockerignore --itemize-changes -a --no-owner --no-group /mnt/shadow/ . \
+         && rsync --delete --exclude-from=.dockerignore --itemize-changes -c -rlpgoD --no-owner --no-group /mnt/shadow/ . \
          && echo '' \
          && ci/container_scripts/build_and_install.sh \
          && ci/container_scripts/test.sh")"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -143,6 +143,12 @@ EOF
     RV=0
     docker start --attach "${CONTAINER_ID}" || RV=$?
 
+    # On failure, copy build directory out of container
+    if [ "$RV" != 0 ]
+    then
+        docker cp "${CONTAINER_ID}":/root/shadow/build ./ci/
+    fi
+
     # Remove the container, even if it failed
     echo -n "Removing container: "
     docker rm -f "${CONTAINER_ID}"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -4,98 +4,50 @@
 
 set -euo pipefail
 
-BUILD_IMAGES=0
+BUILD_IMAGE=0
 PUSH=0
 NOCACHE=
 REPO=shadowsim/shadow-ci
 
-CONTAINERS=(
-    ubuntu:18.04
-    ubuntu:20.04
-    ubuntu:22.04
-    debian:10-slim
-    debian:11-slim
-    fedora:34
-    fedora:35
-    fedora:36
-    quay.io/centos/centos:stream8
-    )
-
-CCS=(
-    gcc
-    clang
-    )
-
-BUILDTYPES=(
-    debug
-    release
-    )
-
-EXTRAS=("ubuntu:18.04;clang;coverage")
-
-NOCACHE=
+CONTAINER=ubuntu:18.04
+CC=gcc
+BUILDTYPE=debug
 
 show_help () {
     cat <<EOF
 Usage: $0 ...
   -h
   -?             Show help
-  -i             Build images
-  -c CONTAINERS  Set containers used in test matrix
-  -C CCS         Set C compilers used in test matrix
-  -b BUILDTYPES  Set build-types used in test matrix
-  -e EXTRAS      Set extra configurations to run
-  -o             Set only configurations to run
+  -i             Build image
+  -c CONTAINER   Set container
+  -C CC          Set C compiler
+  -b BUILDTYPE   Set build-types
   -n             nocache when building Docker images
-  -p             pushes images to dockerhub if set
+  -p             push image to dockerhub
   -r             set Docker repository
 
-On the first run, you should use the '-i' flag to build the images.
+On the first run, you should use the '-i' flag to build the image.
 
-Run all default configurations:
+Run default configuration:
 
   $0
 
-Run all default configurations, but restrict C compilers to gcc:
-
-  $0 -C gcc
-
-Run all default configurations, but restrict C compilers to gcc,
-and containers to ubuntu:18.04 and fedora:35:
-
-  $0 -C gcc -c "ubuntu:18.04 fedora:35"
-
-Set "extra" configurations to ubuntu:18.04;clang;coverage
-and debian:11-slim;gcc;coverage
-
-  $0 -e "ubuntu:18.04;clang;coverage debian:11-slim;gcc;coverage"
-
-Set *only* configurations to run:
-
-  $0 -o "ubuntu:18.04;clang;coverage debian:11-slim;gcc;coverage"
 EOF
 }
 
-while getopts "h?ipc:C:b:e:o:nr:" opt; do
+while getopts "h?ipc:C:b:nr:" opt; do
     case "$opt" in
     h|\?)
         show_help
         exit 0
         ;;
-    i)  BUILD_IMAGES=1
+    i)  BUILD_IMAGE=1
         ;;
-    c)  read -ra CONTAINERS <<< "$OPTARG"
+    c)  CONTAINER="$OPTARG"
         ;;
-    C)  read -ra CCS <<< "$OPTARG"
+    C)  CC="$OPTARG"
         ;;
-    b)  read -ra BUILDTYPES <<< "$OPTARG"
-        ;;
-    e)  read -ra EXTRAS <<< "$OPTARG"
-        ;;
-    o)  CONTAINERS=()
-        CCS=()
-        BUILDTYPES=()
-        read -ra EXTRAS <<< "$OPTARG"
+    b)  BUILDTYPE="$OPTARG"
         ;;
     n)  NOCACHE=--no-cache
         ;;
@@ -106,10 +58,6 @@ while getopts "h?ipc:C:b:e:o:nr:" opt; do
 done
 
 run_one () {
-    CONTAINER="$1"
-    CC="$2"
-    BUILDTYPE="$3"
-
     # Replace the single ':' with a '-'
     CONTAINER_FOR_TAG=${CONTAINER/:/-}
     # Replace all forward slashes with '-'
@@ -117,7 +65,7 @@ run_one () {
 
     TAG="$REPO:$CONTAINER_FOR_TAG-$CC-$BUILDTYPE"
 
-    if [ "${BUILD_IMAGES}" == "1" ]; then
+    if [ "${BUILD_IMAGE}" == "1" ]; then
         echo "Building $TAG"
 
         # Build and tag a Docker image with the given configuration.
@@ -196,20 +144,4 @@ EOF
     fi
 }
 
-# Array indexing follows the syntax of:
-# https://stackoverflow.com/a/61551944
-# to handle potentially empty arrays
-
-for CONTAINER in ${CONTAINERS[@]+"${CONTAINERS[@]}"}; do
-for CC in ${CCS[@]+"${CCS[@]}"}; do
-for BUILDTYPE in ${BUILDTYPES[@]+"${BUILDTYPES[@]}"}; do
-    run_one "$CONTAINER" "$CC" "$BUILDTYPE"
-done
-done
-done
-
-for EXTRA in ${EXTRAS[@]+"${EXTRAS[@]}"}; do
-    # Split on ';'
-    IFS=';' read -ra args <<< "$EXTRA"
-    run_one "${args[0]}" "${args[1]}" "${args[2]}"
-done
+run_one

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -4,6 +4,7 @@
 
 set -euo pipefail
 
+DRYTAG=0
 BUILD_IMAGE=0
 PUSH=0
 NOCACHE=
@@ -25,6 +26,7 @@ Usage: $0 ...
   -n             nocache when building Docker images
   -p             push image to dockerhub
   -r             set Docker repository
+  -t             just get the image tag for the requested configuration
 
 On the first run, you should use the '-i' flag to build the image.
 
@@ -35,7 +37,7 @@ Run default configuration:
 EOF
 }
 
-while getopts "h?ipc:C:b:nr:" opt; do
+while getopts "h?ipc:C:b:nr:t" opt; do
     case "$opt" in
     h|\?)
         show_help
@@ -54,6 +56,9 @@ while getopts "h?ipc:C:b:nr:" opt; do
     p)  PUSH=1
         ;;
     r)  REPO="$OPTARG"
+        ;;
+    t)  DRYTAG=1
+        ;;
     esac
 done
 
@@ -64,6 +69,11 @@ run_one () {
     CONTAINER_FOR_TAG="${CONTAINER_FOR_TAG//\//-}"
 
     TAG="$REPO:$CONTAINER_FOR_TAG-$CC-$BUILDTYPE"
+
+    if [ "${DRYTAG}" == "1" ]; then
+        echo $TAG
+        return 0
+    fi
 
     if [ "${BUILD_IMAGE}" == "1" ]; then
         echo "Building $TAG"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -82,6 +82,9 @@ run_one () {
         docker build -t "$TAG" $NOCACHE -f- . <<EOF
         FROM $CONTAINER
 
+        ENV CARGO_TERM_COLOR=always
+        ENV RUSTPROFILE=minimal
+
         ENV CONTAINER "$CONTAINER"
         SHELL ["/bin/bash", "-c"]
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -31,6 +31,9 @@ with the clang compiler in debug mode:
 ci/run.sh -c ubuntu:18.04 -C clang -b debug"
 ```
 
+If the tests fail, shadow's build directory, including test outputs, will be copied
+from the ephemeral Docker container into `ci/build`.
+
 For additional options, run `ci/run.sh -h`.
 
 ## Debugging locally

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -51,7 +51,7 @@ run an interactive shell in a container built from that image.
 e.g.:
 
 ```{.bash}
-sudo docker run --shm-size=1g -it shadow:centos-8-clang-debug /bin/bash
+docker run --shm-size=1g --security-opt=seccomp=unconfined -it shadowsim/shadow-ci:centos-8-clang-debug /bin/bash
 ```
 
 If the failure happened in the middle of building the Docker image, you can do

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -14,28 +14,21 @@ We also have scripts for running the continuous integration tests locally,
 inside Docker containers. This can be useful for debugging and for quickly
 iterating on a test that's failing in GitHub's test runs.
 
-The [`run.sh`](../ci/run.sh) script builds a Docker images for all
-supported configurations, and runs our tests in them.
+The [`run.sh`](../ci/run.sh) script builds shadow inside a Docker image, and
+runs our tests in it.
 
-On the first invocation you should tell the `run.sh` script to build the images
-using `-i`:
+By default, the script will attempt to use a Docker image with already shadow
+built, perform an incremental build on top of that, and then run shadow's tests.
+If you don't already have a local image, the script will implicitly try to pull
+from the [shadowsim/shadow-ci](https://hub.docker.com/r/shadowsim/shadow-ci) on
+dockerhub. You can override this repo with `-r` or force the script to build a
+new image locally with `-i`.
 
-
-```{.bash}
-sudo ci/run.sh -i
-```
-
-If you wish to only check whether the tests pass or fail, future invocations
-can omit the `-i` option to use the existing image and build/test only the
-incremental changes. None of the test results will be saved in this case, but
-it is much quicker to build.
-
-Note that building all images locally typically takes hours. More often,
-you'll want to only run some smaller set of configurations locally.
-To run only the configurations you specify, use the `-o` flag:
+For example, to perform an incremental build and test on ubuntu 18.04,
+with the clang compiler in debug mode:
 
 ```{.bash}
-sudo ci/run.sh -i -o "ubuntu:18.04;clang;debug fedora:35;gcc;release"
+ci/run.sh -c ubuntu:18.04 -C clang -b debug"
 ```
 
 For additional options, run `ci/run.sh -h`.
@@ -59,7 +52,7 @@ the same with the last intermediate layer that was built successfully. e.g.
 given the output:
 
 ```{.bash}
-$ sudo ci/run.sh -i -o "centos:8;clang;debug"
+$ ci/run.sh -i -c centos:8 -C clang -b debug
 <snip>
 Step 13/13 : RUN . ci/container_scripts/build_and_install.sh
  ---> Running in a11c4a554ef8
@@ -71,5 +64,5 @@ You can start a container from the image where Docker tried (and failed) to run
 `ci/the build_and_install.sh` script was executed with:
 
 ```{.bash}
-sudo docker run --shm-size=1g -it a11c4a554ef8 /bin/bash
+docker run --shm-size=1g --security-opt=seccomp=unconfined -it a11c4a554ef8 /bin/bash
 ```


### PR DESCRIPTION
Adds a new workflow `run_tests_incremental.yml`, based on `run_tests.yml`.

When run manually, it gives the option of building and pushing Docker images with all dependencies installed, and a build of Shadow.

In other cases, it tries to *pull* such an image, and do an incremental build on top of the build baked into the image. In case the image can't be pulled, it falls back to building the image from scratch (but doesn't try to push to Dockerhub).

Note that no images exist yet in the `shadowsim:shadow-ci` repository, so in the runs on this PR it'll fall back to building images from scratch. We won't see the benefit until after merging this PR and doing a manual run that builds and pushes images.

The tentative plan is to *not* change the required tests when merging this PR. i.e. this adds a new set of tests "Shadow Tests Incremental", but it will run *in addition to* the current "Shadow Tests" workflow, and only the latter will be required.

After this PR is merged, we can kick off a workflow to build and push images.

After seeing how the new tests work for a bit, we can consider switching over to them - making the new tests required instead of the old ones, and disabling or deleting the old workflow.