### PR TITLE
Remove EOL distros from CI and docs

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,8 +30,6 @@ jobs:
           - 'ubuntu:18.04'
           # End of standard support: April 2025 https://wiki.ubuntu.com/Releases
           - 'ubuntu:20.04'
-          # End of standard support: July 2022 https://wiki.ubuntu.com/Releases
-          - 'ubuntu:21.10'
           # End of standard support: April 2027 https://wiki.ubuntu.com/Releases
           - 'ubuntu:22.04'
           # EOL ~August 2022 https://wiki.debian.org/DebianReleases

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,9 +35,9 @@ jobs:
           # EOL ~August 2022 https://wiki.debian.org/DebianReleases
           - 'debian:10-slim'
           - 'debian:11-slim'
-          # EOL June 7 2022 https://endoflife.date/fedora
-          - 'fedora:34'
+          # EOL November 15 2022 https://endoflife.date/fedora
           - 'fedora:35'
+          # EOL May 16 2023 https://endoflife.date/fedora
           - 'fedora:36'
           # EOL May 2024 https://www.centos.org/centos-stream/
           - 'quay.io/centos/centos:stream8'

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -12,7 +12,6 @@ CONTAINERS=(
     ubuntu:22.04
     debian:10-slim
     debian:11-slim
-    fedora:34
     fedora:35
     fedora:36
     quay.io/centos/centos:stream8

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -9,7 +9,6 @@ BUILD_IMAGES=0
 CONTAINERS=(
     ubuntu:18.04
     ubuntu:20.04
-    ubuntu:21.10
     ubuntu:22.04
     debian:10-slim
     debian:11-slim

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -6,7 +6,7 @@ We support the following Linux x86-64 distributions:
 
 - Ubuntu 18.04, 20.04, 22.04
 - Debian 10 and 11
-- Fedora 34, 35, 36
+- Fedora 35, 36
 - CentOS Stream 8
 
 We do not provide official support for other platforms. This means that we do


### PR DESCRIPTION
Ubuntu 21.10 is EOL. The upgrade path for Ubuntu 21.10 is to 22.04, which is already in the CI.
Ubuntu 22.10 is not scheduled to be released until October 20, 2022.
https://wiki.ubuntu.com/Releases

Fedora 34 is EOL. Fedora 35 and 36 are still supported.
https://docs.fedoraproject.org/en-US/releases/eol/

Closes #2307