### PR TITLE
Revert "Remove EOL Fedora 34"

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,9 +35,9 @@ jobs:
           # EOL ~August 2022 https://wiki.debian.org/DebianReleases
           - 'debian:10-slim'
           - 'debian:11-slim'
-          # EOL November 15 2022 https://endoflife.date/fedora
+          # EOL June 7 2022 https://endoflife.date/fedora
+          - 'fedora:34'
           - 'fedora:35'
-          # EOL May 16 2023 https://endoflife.date/fedora
           - 'fedora:36'
           # EOL May 2024 https://www.centos.org/centos-stream/
           - 'quay.io/centos/centos:stream8'

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -12,6 +12,7 @@ CONTAINERS=(
     ubuntu:22.04
     debian:10-slim
     debian:11-slim
+    fedora:34
     fedora:35
     fedora:36
     quay.io/centos/centos:stream8

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -6,7 +6,7 @@ We support the following Linux x86-64 distributions:
 
 - Ubuntu 18.04, 20.04, 22.04
 - Debian 10 and 11
-- Fedora 35, 36
+- Fedora 34, 35, 36
 - CentOS Stream 8
 
 We do not provide official support for other platforms. This means that we do


### PR DESCRIPTION
This reverts commit ea7336d7c4ba937656d56dd8cbac545b2470bfac.

We should try to keep supported versions between minor releases, see #2309