### PR TITLE
Remove the 'macro' feature for 'serde_with'

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -252,41 +252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,12 +277,6 @@ name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
@@ -369,12 +328,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -837,20 +790,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "serde_with_macros",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de337f322382fcdfbb21a014f7c224ee041a23785651db67b9827403178f698f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -37,7 +37,7 @@ rayon = "1.5.3"
 regex = "1"
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
-serde_with = "2.0.0"
+serde_with = { version = "2.0.0", default-features = false, features = ["std"] }
 serde_yaml = "0.8"
 syscall-logger = { path = "../lib/syscall-logger" }
 tempfile = "3.3"


### PR DESCRIPTION
We don't use the "macro" feature, so this removes some dependencies and probably slightly improves the build time.

```diff
diff --git a/tmp/tree-before b/tmp/tree-after
index f69469c..1a6846e 100644
--- a/tmp/tree-before
+++ b/tmp/tree-after
@@ -160,23 +160,7 @@ shadow-rs v2.2.0
 │       └── serde v1.0.140 (*)
 ├── serde v1.0.140 (*)
 ├── serde_with v2.0.0
-│   ├── serde v1.0.140 (*)
-│   └── serde_with_macros v2.0.0 (proc-macro)
-│       ├── darling v0.14.1
-│       │   ├── darling_core v0.14.1
-│       │   │   ├── fnv v1.0.7
-│       │   │   ├── ident_case v1.0.1
-│       │   │   ├── proc-macro2 v1.0.40 (*)
-│       │   │   ├── quote v1.0.20 (*)
-│       │   │   ├── strsim v0.10.0
-│       │   │   └── syn v1.0.98 (*)
-│       │   └── darling_macro v0.14.1 (proc-macro)
-│       │       ├── darling_core v0.14.1 (*)
-│       │       ├── quote v1.0.20 (*)
-│       │       └── syn v1.0.98 (*)
-│       ├── proc-macro2 v1.0.40 (*)
-│       ├── quote v1.0.20 (*)
-│       └── syn v1.0.98 (*)
+│   └── serde v1.0.140 (*)
 ├── serde_yaml v0.8.26
 │   ├── indexmap v1.8.2 (*)
 │   ├── ryu v1.0.10
```