### PR TITLE
Handle busy-loops that only use rdtsc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
 A list of user-facing changes since the latest Shadow release.
 
+* Added latency modeling and potential thread-yield to rdtsc emulation,
+  allowing managed code to avoid deadlock in busy-loops that use only the rdtsc
+  instruction and no syscalls. https://github.com/shadow/shadow/pull/2314
 * (add entry here)

--- a/src/test/regression/test_busy_wait.rs
+++ b/src/test/regression/test_busy_wait.rs
@@ -1,3 +1,4 @@
+use core::arch::x86_64::_rdtsc as rdtsc;
 use std::time::{Duration, Instant};
 
 // We've found several real-world examples where the process does a busy wait
@@ -17,6 +18,18 @@ fn test_wait_for_timeout() {
     }
 }
 
+// Same idea as `test_wait_for_timeout`, but for a loop that makes *no* syscalls, only checking the
+// time directly via rdtsc. Regression test for
+// https://github.com/shadow/shadow/discussions/2299#discussioncomment-3198368
+fn test_wait_for_rdtsc_timeout() {
+    let t0 = unsafe { rdtsc() };
+    let target = t0 + 1000;
+    while unsafe { rdtsc() } < target {
+        // wait
+    }
+}
+
 fn main() {
     test_wait_for_timeout();
+    test_wait_for_rdtsc_timeout();
 }


### PR DESCRIPTION
Previously the rdstc emulation code directly retrieved and returned the
simulated time.

This change uses an emulated syscall to get the time, ensuring that when
`model_unblocked_syscall_latency` is enabled, we correctly move
simulated time forward and yield if enough time has passed.

Fixes https://github.com/shadow/shadow/discussions/2299#discussioncomment-3198368