### PR TITLE
Support yaml merge keys and extension fields

### DIFF
--- a/docs/shadow_config_overview.md
+++ b/docs/shadow_config_overview.md
@@ -77,7 +77,10 @@ Acceptable unit *prefixes* are:
 
 Examples: `20 B`, `100 MB`, `100 megabyte`, `10 kibibytes`, `30 MiB`, `1024 Mbytes`
 
-## YAML Extensions
+## YAML Extensions (Experimental)
+
+Shadow has experimental support for extended YAML conventions. These can be
+enabled using the `--use-extended-yaml true` command line option.
 
 ### Merge/Override Mappings
 

--- a/docs/shadow_config_overview.md
+++ b/docs/shadow_config_overview.md
@@ -79,6 +79,8 @@ Examples: `20 B`, `100 MB`, `100 megabyte`, `10 kibibytes`, `30 MiB`, `1024 Mbyt
 
 ## YAML Extensions
 
+### Merge/Override Mappings
+
 To help reduce repeated configuration options, Shadow supports the YAML ["merge
 key (`<<`)"](https://yaml.org/type/merge.html) convention. This merges the keys
 of the child mapping into the parent mapping, and is useful when combined with
@@ -109,3 +111,37 @@ hosts:
 
 For a longer example, see
 https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/.
+
+### Extension Fields
+
+When using the "merge key" feature above, putting common options in a separate
+configuration fragment may help make the configuration more readable. Shadow
+supports the "extension field" convention used by [Docker
+Compose](https://docs.docker.com/compose/compose-file/compose-file-v3/). Any
+top-level field containing a key that begins with `x-` will be ignored by
+Shadow.
+
+Example:
+
+```yaml
+x-client: &client-defaults
+  processes:
+  - path: /usr/bin/curl
+    args: server --silent
+    start_time: 5
+
+general:
+  # --snip--
+
+network:
+  # --snip--
+
+hosts:
+  server:
+    # --snip--
+  client-uk:
+    network_node_id: 0
+    <<: *client-defaults
+  client-us:
+    network_node_id: 1
+    <<: *client-defaults

--- a/docs/shadow_config_overview.md
+++ b/docs/shadow_config_overview.md
@@ -76,3 +76,36 @@ Acceptable unit *prefixes* are:
 - tebi / Ti
 
 Examples: `20 B`, `100 MB`, `100 megabyte`, `10 kibibytes`, `30 MiB`, `1024 Mbytes`
+
+## YAML Extensions
+
+To help reduce repeated configuration options, Shadow supports the YAML ["merge
+key (`<<`)"](https://yaml.org/type/merge.html) convention. This merges the keys
+of the child mapping into the parent mapping, and is useful when combined with
+[YAML anchors (`&` and `*`)](https://yaml.org/spec/1.2.2/#692-node-anchors).
+
+Example:
+
+```yaml
+general:
+  # --snip--
+
+network:
+  # --snip--
+
+hosts:
+  server:
+    # --snip--
+  client-uk: &client
+    network_node_id: 0
+    processes:
+    - path: /usr/bin/curl
+      args: server --silent
+      start_time: 5
+  client-us:
+    network_node_id: 1
+    <<: *client
+```
+
+For a longer example, see
+https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/.

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -84,6 +84,7 @@ hosts:
 - [`experimental.use_cpu_pinning`](#experimentaluse_cpu_pinning)
 - [`experimental.use_dynamic_runahead`](#experimentaluse_dynamic_runahead)
 - [`experimental.use_explicit_block_message`](#experimentaluse_explicit_block_message)
+- [`experimental.use_extended_yaml`](#experimentaluse_extended_yaml)
 - [`experimental.use_legacy_working_dir`](#experimentaluse_legacy_working_dir)
 - [`experimental.use_libc_preload`](#experimentaluse_libc_preload)
 - [`experimental.use_memory_manager`](#experimentaluse_memory_manager)
@@ -479,6 +480,14 @@ Type: Bool
 
 Send message to managed process telling it to stop spinning when a syscall
 blocks.
+
+#### `experimental.use_extended_yaml`
+
+Default: false  
+Type: Bool
+
+Enable extended YAML conventions (merge keys and extension fields). Can only be
+enabled on the command line (enabling in the configuration file is a no-op).
 
 #### `experimental.use_legacy_working_dir`
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -331,9 +331,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -375,12 +375,6 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
@@ -795,14 +789,15 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "79b7c9017c64a49806c6e8df8ef99b92446d09c92457f85f91835b01a8064ae0"
 dependencies = [
  "indexmap",
+ "itoa",
  "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -958,6 +953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,12 +1063,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -74,12 +74,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,12 +84,6 @@ name = "build_const"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
-name = "bumpalo"
-version = "3.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"
@@ -119,19 +107,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "serde",
- "winapi",
-]
 
 [[package]]
 name = "clap"
@@ -324,12 +299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,7 +306,6 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
- "serde",
 ]
 
 [[package]]
@@ -354,15 +322,6 @@ name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
-
-[[package]]
-name = "js-sys"
-version = "0.3.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
-dependencies = [
- "wasm-bindgen",
-]
 
 [[package]]
 name = "lazy_static"
@@ -474,16 +433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,15 +448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -773,21 +713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89df7a26519371a3cce44fbb914c2819c84d9b897890987fa3ab096491cc0ea8"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap",
- "serde",
- "serde_json",
- "time",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,7 +753,6 @@ dependencies = [
  "regex",
  "schemars",
  "serde",
- "serde_with",
  "serde_yaml",
  "syscall-logger",
  "tempfile",
@@ -934,19 +858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
-dependencies = [
- "itoa",
- "js-sys",
- "libc",
- "num_threads",
- "serde",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,60 +889,6 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "winapi"

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -37,7 +37,6 @@ rayon = "1.5.3"
 regex = "1"
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
-serde_with = { version = "2.0.0", default-features = false, features = ["std"] }
 serde_yaml = "0.9"
 syscall-logger = { path = "../lib/syscall-logger" }
 tempfile = "3.3"

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -38,7 +38,7 @@ regex = "1"
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "2.0.0", default-features = false, features = ["std"] }
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 syscall-logger = { path = "../lib/syscall-logger" }
 tempfile = "3.3"
 # TODO: switch to upstream crate if/when they merge and release

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -62,10 +62,8 @@ pub fn run_shadow<'a>(args: Vec<&'a OsStr>) -> anyhow::Result<()> {
     .into();
 
     // load the configuration yaml
-    let file = std::fs::File::open(&config_filename)
-        .with_context(|| format!("Could not open config file {:?}", &config_filename))?;
-    let config_file: ConfigFileOptions = serde_yaml::from_reader(file)
-        .with_context(|| format!("Could not parse configuration file {:?}", &config_filename))?;
+    let config_file = load_config_file(&config_filename)
+        .with_context(|| format!("Failed to load configuration file {}", config_filename))?;
 
     // generate the final shadow configuration from the config file and cli options
     let shadow_config = ConfigOptions::new(config_file, options.clone());
@@ -179,6 +177,11 @@ pub fn run_shadow<'a>(args: Vec<&'a OsStr>) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn load_config_file(filename: impl AsRef<std::path::Path>) -> anyhow::Result<ConfigFileOptions> {
+    let file = std::fs::File::open(filename).context("Could not open config file")?;
+    Ok(serde_yaml::from_reader(file).context("Could not parse configuration file")?)
 }
 
 fn pause_for_gdb_attach() -> anyhow::Result<()> {

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -449,6 +449,13 @@ pub struct ExperimentalOptions {
     #[clap(long, value_name = "seconds")]
     #[clap(help = EXP_HELP.get("unblocked_vdso_latency").unwrap().as_str())]
     pub unblocked_vdso_latency: Option<units::Time<units::TimePrefix>>,
+
+    /// Enable extended YAML conventions (merge keys and extension fields). Can only be enabled on
+    /// the command line (enabling in the configuration file is a no-op).
+    #[clap(hide_short_help = true)]
+    #[clap(long, value_name = "bool")]
+    #[clap(help = EXP_HELP.get("use_extended_yaml").unwrap().as_str())]
+    pub use_extended_yaml: Option<bool>,
 }
 
 impl ExperimentalOptions {
@@ -500,6 +507,7 @@ impl Default for ExperimentalOptions {
             host_heartbeat_log_info: Some(IntoIterator::into_iter([LogInfoFlag::Node]).collect()),
             host_heartbeat_interval: None,
             strace_logging_mode: Some(StraceLoggingMode::Off),
+            use_extended_yaml: Some(false),
         }
     }
 }

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -85,8 +85,8 @@ pub struct ConfigFileOptions {
     pub experimental: ExperimentalOptions,
 
     // we use a BTreeMap so that the hosts are sorted by their hostname (useful for determinism)
-    // note: serde 'with' is incompatible with 'derive(JsonSchema)': https://github.com/GREsau/schemars/issues/89
-    #[serde(with = "serde_with::rust::maps_duplicate_key_is_error")]
+    // since shadow parses to a serde_yaml::Value initially, we don't need to worry about duplicate
+    // hostnames here
     pub hosts: BTreeMap<String, HostOptions>,
 }
 


### PR DESCRIPTION
- [merge keys](https://yaml.org/type/merge.html): not technically valid yaml 1.2, but is common enough that I don't think it hurts to support it
- [extension fields](https://docs.docker.com/compose/compose-file/#extension): fields beginning with "x-" that are ignored; this follows the convention of docker compose, but we only allow them at the top level of the document

This is technically a breaking change since "<<" was previously an allowed shadow hostname, but this isn't generally a valid hostname and I don't think is worth worrying about.

These are currently activated by a `--use-extended-yaml true` option.