### PR TITLE
run_tests_incremental: save most of the build directory on failure

### DIFF
--- a/.github/workflows/run_tests_incremental.yml
+++ b/.github/workflows/run_tests_incremental.yml
@@ -135,23 +135,24 @@ jobs:
           # Run
           ci/run.sh "${FLAGS[@]}"
 
-      - name: Compress logs
-        if: failure()
-        run: |
-          shopt -s globstar
-          tar -cJf ci/build/Testing/Temporary{.tar.xz,/}
-          for f in ci/build/**/*.data; do tar -cJf "$f.tar.xz" "$f/"; done
-
-      - name: Upload shadow data directories
+      - name: Upload build directory
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: shadow-data-dirs
-          path: ci/build/**/*.data.tar.xz
+          name: shadow-build
+          # Mainly we want the data directories, but occasionally
+          # it's useful to examine generated Makefiles, etc.
+          # We omit the Rust build directories (target), because
+          # they tend to be huge (~1 GB).
+          path: |
+            ci/build
+            !**/target
 
+      # Redundant with the build-directory, above, but provides
+      # convenient access.
       - name: Upload shadow log file
         uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: shadow-log-file
-          path: ci/build/Testing/Temporary.tar.xz
+          path: ci/build/Testing/Temporary/LastTest.log

--- a/.github/workflows/run_tests_incremental.yml
+++ b/.github/workflows/run_tests_incremental.yml
@@ -142,11 +142,13 @@ jobs:
           name: shadow-build
           # Mainly we want the data directories, but occasionally
           # it's useful to examine generated Makefiles, etc.
-          # We omit the Rust build directories (target), because
-          # they tend to be huge (~1 GB).
+          # We omit actual object files and executables, which can
+          # be quite large, especially in debug builds.
           path: |
             ci/build
             !**/target
+            !**/*.o
+            !ci/build/src/main/shadow
 
       # Redundant with the build-directory, above, but provides
       # convenient access.

--- a/.github/workflows/run_tests_incremental.yml
+++ b/.github/workflows/run_tests_incremental.yml
@@ -35,19 +35,6 @@ jobs:
         container:
           # End of standard support: April 2023 https://wiki.ubuntu.com/Releases
           - 'ubuntu:18.04'
-          # End of standard support: April 2025 https://wiki.ubuntu.com/Releases
-          - 'ubuntu:20.04'
-          # End of standard support: April 2027 https://wiki.ubuntu.com/Releases
-          - 'ubuntu:22.04'
-          # EOL ~August 2022 https://wiki.debian.org/DebianReleases
-          - 'debian:10-slim'
-          - 'debian:11-slim'
-          # EOL June 7 2022 https://endoflife.date/fedora
-          - 'fedora:34'
-          - 'fedora:35'
-          - 'fedora:36'
-          # EOL May 2024 https://www.centos.org/centos-stream/
-          - 'quay.io/centos/centos:stream8'
         cc: ['gcc']
         buildtype: ['debug', 'release']
         include:

--- a/.github/workflows/run_tests_incremental.yml
+++ b/.github/workflows/run_tests_incremental.yml
@@ -135,6 +135,16 @@ jobs:
           # Run
           ci/run.sh "${FLAGS[@]}"
 
+      # Useful to have the shadow log file as a separate artifact, since it's
+      # the most-frequently-useful, and the larger build-directory artifact can
+      # be a bit unwieldy or even fail to upload.
+      - name: Upload shadow log file
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: shadow-log-file
+          path: ci/build/Testing
+
       - name: Upload build directory
         uses: actions/upload-artifact@v3
         if: failure()
@@ -149,12 +159,4 @@ jobs:
             !**/target
             !**/*.o
             !ci/build/src/main/shadow
-
-      # Redundant with the build-directory, above, but provides
-      # convenient access.
-      - name: Upload shadow log file
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: shadow-log-file
-          path: ci/build/Testing/Temporary/LastTest.log
+            !ci/build/Testing

--- a/src/test/sleep/test_sleep.rs
+++ b/src/test/sleep/test_sleep.rs
@@ -31,7 +31,8 @@ fn duration_abs_diff(t1: Duration, t0: Duration) -> Duration {
 fn main() {
     sleep_and_test();
     sleep_and_signal_test();
-    println!("Success.");
+    // DO NOT MERGE
+    panic!("fail");
 }
 
 fn sleep_and_test() {


### PR DESCRIPTION
We currently have a heisenbug for which it'd be useful to inspect the
generated makefiles on failure.

More generally, we aren't charged for storage, and if we exclude the
Rust target directories, everything else is only ~50 MB.