### PR TITLE
Remove src/dst host pointers from `Event`, and reference counts from `Scheduler` and `SchedulerPolicy`

### DIFF
--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -54,7 +54,7 @@ add_custom_command(OUTPUT wrapper.rs
         --whitelist-function "main_.*"
         --whitelist-function "shmemcleanup_tryCleanup"
         --whitelist-function "scanRpathForLib"
-        --whitelist-function "scheduler_(new|unref|addHost|start|finish|shutdown)"
+        --whitelist-function "scheduler_(new|free|addHost|start|finish|shutdown)"
         --whitelist-function "scheduler_(continueNextRound|awaitNextRound)"
         --whitelist-function "runConfigHandlers"
         --whitelist-function "rustlogger_new"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2834,7 +2834,7 @@ extern "C" {
     ) -> *mut Scheduler;
 }
 extern "C" {
-    pub fn scheduler_unref(arg1: *mut Scheduler);
+    pub fn scheduler_free(arg1: *mut Scheduler);
 }
 extern "C" {
     pub fn scheduler_shutdown(scheduler: *mut Scheduler);

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -113,7 +113,6 @@ pub type gulong = ::std::os::raw::c_ulong;
 pub type guint = ::std::os::raw::c_uint;
 pub type gdouble = f64;
 pub type gpointer = *mut ::std::os::raw::c_void;
-pub type gconstpointer = *const ::std::os::raw::c_void;
 pub type GQuark = guint32;
 extern "C" {
     pub fn g_quark_from_string(string: *const gchar) -> GQuark;
@@ -2694,13 +2693,7 @@ extern "C" {
     pub fn host_freeAllApplications(host: *mut Host);
 }
 extern "C" {
-    pub fn host_compare(a: gconstpointer, b: gconstpointer, user_data: gpointer) -> gint;
-}
-extern "C" {
     pub fn host_getID(host: *mut Host) -> HostId;
-}
-extern "C" {
-    pub fn host_isEqual(a: *mut Host, b: *mut Host) -> gboolean;
 }
 extern "C" {
     pub fn host_getCPU(host: *mut Host) -> *mut CPU;
@@ -2859,7 +2852,7 @@ extern "C" {
     pub fn scheduler_addHost(arg1: *mut Scheduler, arg2: *mut Host) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn worker_runEvent(event: *mut Event);
+    pub fn worker_runEvent(event: *mut Event, host: *mut Host);
 }
 extern "C" {
     pub fn worker_setMinEventTimeNextRound(simtime: SimulationTime);

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -735,7 +735,7 @@ impl<'a> std::ops::Drop for SchedulerWrapper<'a> {
         self.finish();
         self.shutdown();
 
-        unsafe { c::scheduler_unref(self.ptr) };
+        unsafe { c::scheduler_free(self.ptr) };
     }
 }
 

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -77,7 +77,9 @@ static void _scheduler_runEventsWorkerTaskFn(void* voidScheduler) {
     Event* event = NULL;
     while ((event = scheduler->policy->pop(
                 scheduler->policy, scheduler->currentRound.endTime)) != NULL) {
-        worker_runEvent(event);
+        // get the host to run this event on
+        Host* host = scheduler_getHost(scheduler, event_getHostID(event));
+        worker_runEvent(event, host);
     }
 
     // Gets the time of the event at the head of the event queue right now.
@@ -182,7 +184,6 @@ gboolean scheduler_push(Scheduler* scheduler, Event* event, Host* sender, Host* 
     /* parties involved. sender may be NULL, receiver may not!
      * we MAY NOT OWN the receiver, so do not write to it! */
     utility_assert(receiver);
-    utility_assert(receiver == event_getHost(event));
 
     /* push to a queue based on the policy */
     scheduler->policy->push(scheduler->policy, event, sender, receiver, scheduler->currentRound.endTime);

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -79,7 +79,13 @@ static void _scheduler_runEventsWorkerTaskFn(void* voidScheduler) {
                 scheduler->policy, scheduler->currentRound.endTime)) != NULL) {
         // get the host to run this event on
         Host* host = scheduler_getHost(scheduler, event_getHostID(event));
+        host_lock(host);
+        host_lockShimShmemLock(host);
+
         worker_runEvent(event, host);
+
+        host_unlockShimShmemLock(host);
+        host_unlock(host);
     }
 
     // Gets the time of the event at the head of the event queue right now.

--- a/src/main/core/scheduler/scheduler.h
+++ b/src/main/core/scheduler/scheduler.h
@@ -19,8 +19,7 @@ typedef struct _Scheduler Scheduler;
 Scheduler* scheduler_new(const Controller* controller, const ChildPidWatcher* pidWatcher,
                          const ConfigOptions* config, guint nWorkers, guint schedulerSeed,
                          SimulationTime endTime);
-void scheduler_ref(Scheduler*);
-void scheduler_unref(Scheduler*);
+void scheduler_free(Scheduler*);
 void scheduler_shutdown(Scheduler* scheduler);
 
 void scheduler_awaitStart(Scheduler*);

--- a/src/main/core/scheduler/scheduler_policy.h
+++ b/src/main/core/scheduler/scheduler_policy.h
@@ -22,7 +22,6 @@ typedef void (*SchedulerPolicyFreeFunc)(SchedulerPolicy*);
 
 struct _SchedulerPolicy {
     gpointer data;
-    gint referenceCount;
     SchedulerPolicyAddHostFunc addHost;
     SchedulerPolicyGetHostsFunc getAssignedHosts;
     SchedulerPolicyPushFunc push;

--- a/src/main/core/scheduler/scheduler_policy_host_single.c
+++ b/src/main/core/scheduler/scheduler_policy_host_single.c
@@ -385,7 +385,6 @@ SchedulerPolicy* schedulerpolicyhostsingle_new() {
     policy->free = _schedulerpolicyhostsingle_free;
 
     policy->data = data;
-    policy->referenceCount = 1;
 
     return policy;
 }

--- a/src/main/core/scheduler/scheduler_policy_host_single.c
+++ b/src/main/core/scheduler/scheduler_policy_host_single.c
@@ -311,7 +311,6 @@ static EmulatedTime _schedulerpolicyhostsingle_nextHostEventTime(SchedulerPolicy
     EmulatedTime nextEventTime = 0;
     Event* nextEvent = priorityqueue_peek(qdata->pq);
     if (nextEvent) {
-        utility_assert(event_getHost(nextEvent) == host);
         nextEventTime = emutime_add_simtime(EMUTIME_SIMULATION_START, event_getTime(nextEvent));
         utility_assert(nextEventTime != EMUTIME_INVALID);
     }

--- a/src/main/core/work/event.c
+++ b/src/main/core/work/event.c
@@ -63,10 +63,6 @@ void event_unref(Event* event) {
 void event_execute(Event* event, Host* host) {
     MAGIC_ASSERT(event);
 
-    host_lock(host);
-    host_lockShimShmemLock(host);
-    worker_setActiveHost(host);
-
     utility_assert(event_getHostID(event) == host_getID(host));
 
     /* check if we are allowed to execute or have to wait for cpu delays */
@@ -91,10 +87,6 @@ void event_execute(Event* event, Host* host) {
         taskref_execute(event->task, host);
         host_stopExecutionTimer(host);
     }
-
-    worker_setActiveHost(NULL);
-    host_unlockShimShmemLock(host);
-    host_unlock(host);
 }
 
 SimulationTime event_getTime(Event* event) {

--- a/src/main/core/work/event.c
+++ b/src/main/core/work/event.c
@@ -15,8 +15,8 @@
 #include "main/utility/utility.h"
 
 struct _Event {
-    Host* srcHost;
-    Host* dstHost;
+    GQuark dstHostID;
+    GQuark srcHostID;
     TaskRef* task;
     SimulationTime time;
     guint64 srcHostEventID;
@@ -24,13 +24,13 @@ struct _Event {
     MAGIC_DECLARE;
 };
 
-Event* event_new_(TaskRef* task, SimulationTime time, gpointer srcHost, gpointer dstHost) {
+Event* event_new_(TaskRef* task, SimulationTime time, Host* srcHost, GQuark dstHostID) {
     utility_assert(task != NULL);
     Event* event = g_new0(Event, 1);
     MAGIC_INIT(event);
 
-    event->srcHost = (Host*)srcHost;
-    event->dstHost = (Host*)dstHost;
+    event->srcHostID = host_getID(srcHost);
+    event->dstHostID = dstHostID;
     event->task = taskref_clone(task);
     event->time = time;
     event->srcHostEventID = host_getNewEventID(srcHost);
@@ -60,15 +60,17 @@ void event_unref(Event* event) {
     }
 }
 
-void event_execute(Event* event) {
+void event_execute(Event* event, Host* host) {
     MAGIC_ASSERT(event);
 
-    host_lock(event->dstHost);
-    host_lockShimShmemLock(event->dstHost);
-    worker_setActiveHost(event->dstHost);
+    host_lock(host);
+    host_lockShimShmemLock(host);
+    worker_setActiveHost(host);
+
+    utility_assert(event_getHostID(event) == host_getID(host));
 
     /* check if we are allowed to execute or have to wait for cpu delays */
-    CPU* cpu = host_getCPU(event->dstHost);
+    CPU* cpu = host_getCPU(host);
     cpu_updateTime(cpu, event->time);
 
     if(cpu_isBlocked(cpu)) {
@@ -76,23 +78,23 @@ void event_execute(Event* event) {
         trace("event blocked on CPU, rescheduled for %"G_GUINT64_FORMAT" nanoseconds from now", cpuDelay);
 
         /* track the event delay time */
-        Tracker* tracker = host_getTracker(event->dstHost);
+        Tracker* tracker = host_getTracker(host);
         if (tracker != NULL) {
             tracker_addVirtualProcessingDelay(tracker, cpuDelay);
         }
 
         /* this event is delayed due to cpu, so reschedule it to ourselves */
-        worker_scheduleTaskWithDelay(event->task, event->dstHost, cpuDelay);
+        worker_scheduleTaskWithDelay(event->task, host, cpuDelay);
     } else {
         /* cpu is not blocked, its ok to execute the event */
-        host_continueExecutionTimer(event->dstHost);
-        taskref_execute(event->task, event->dstHost);
-        host_stopExecutionTimer(event->dstHost);
+        host_continueExecutionTimer(host);
+        taskref_execute(event->task, host);
+        host_stopExecutionTimer(host);
     }
 
     worker_setActiveHost(NULL);
-    host_unlockShimShmemLock(event->dstHost);
-    host_unlock(event->dstHost);
+    host_unlockShimShmemLock(host);
+    host_unlock(host);
 }
 
 SimulationTime event_getTime(Event* event) {
@@ -100,9 +102,9 @@ SimulationTime event_getTime(Event* event) {
     return event->time;
 }
 
-gpointer event_getHost(Event* event) {
+GQuark event_getHostID(Event* event) {
     MAGIC_ASSERT(event);
-    return event->dstHost;
+    return event->dstHostID;
 }
 
 void event_setTime(Event* event, SimulationTime time) {
@@ -127,16 +129,14 @@ gint event_compare(const Event* a, const Event* b, gpointer userData) {
     } else if (a->time < b->time) {
         return -1;
     } else {
-        gint cmpresult = host_compare(a->dstHost, b->dstHost, NULL);
-        if (cmpresult > 0) {
+        if (a->dstHostID > b->dstHostID) {
             return 1;
-        } else if (cmpresult < 0) {
+        } else if (a->dstHostID < b->dstHostID) {
             return -1;
         } else {
-            cmpresult = host_compare(a->srcHost, b->srcHost, NULL);
-            if (cmpresult > 0) {
+            if (a->srcHostID > b->srcHostID) {
                 return 1;
-            } else if (cmpresult < 0) {
+            } else if (a->srcHostID < b->srcHostID) {
                 return -1;
             } else {
                 /* src and dst host are the same. the event should be sorted in

--- a/src/main/core/work/event.h
+++ b/src/main/core/work/event.h
@@ -16,14 +16,14 @@ typedef struct _Event Event;
 #include "main/bindings/c/bindings.h"
 #include "main/core/support/definitions.h"
 
-Event* event_new_(TaskRef* task, SimulationTime time, gpointer srcHost, gpointer dstHost);
+Event* event_new_(TaskRef* task, SimulationTime time, Host* srcHost, GQuark dstHostID);
 void event_ref(Event* event);
 void event_unref(Event* event);
 
-void event_execute(Event* event);
+void event_execute(Event* event, Host* host);
 gint event_compare(const Event* a, const Event* b, gpointer userData);
 
-gpointer event_getHost(Event* event);
+GQuark event_getHostID(Event* event);
 SimulationTime event_getTime(Event* event);
 void event_setTime(Event* event, SimulationTime time);
 

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -455,14 +455,14 @@ void* _worker_run(void* voidWorkerThreadInfo) {
     return NULL;
 }
 
-void worker_runEvent(Event* event) {
+void worker_runEvent(Event* event, Host* host) {
 
     /* update cache, reset clocks */
     worker_setCurrentEmulatedTime(
         emutime_add_simtime(EMUTIME_SIMULATION_START, event_getTime(event)));
 
     /* process the local event */
-    event_execute(event);
+    event_execute(event, host);
     event_unref(event);
 
     /* update times */
@@ -501,7 +501,9 @@ gboolean worker_scheduleTaskAtEmulatedTime(TaskRef* task, Host* host, EmulatedTi
         return FALSE;
     }
 
-    Event* event = event_new_(task, emutime_sub_emutime(t, EMUTIME_SIMULATION_START), host, host);
+    GQuark hostID = host_getID(host);
+    Event* event = event_new_(task, emutime_sub_emutime(t, EMUTIME_SIMULATION_START), host, hostID);
+
     return scheduler_push(_worker_pool()->scheduler, event, host, host);
 }
 
@@ -576,8 +578,8 @@ void worker_sendPacket(Host* srcHost, Packet* packet) {
          * this is the only place where tasks are sent between separate hosts */
 
         Scheduler* scheduler = _worker_pool()->scheduler;
-        GQuark dstID = (GQuark)address_getID(dstAddress);
-        Host* dstHost = scheduler_getHost(scheduler, dstID);
+        GQuark dstHostID = (GQuark)address_getID(dstAddress);
+        Host* dstHost = scheduler_getHost(scheduler, dstHostID);
         utility_assert(dstHost);
 
         packet_addDeliveryStatus(packet, PDS_INET_SENT);
@@ -591,7 +593,9 @@ void worker_sendPacket(Host* srcHost, Packet* packet) {
          */
         TaskRef* packetTask = taskref_new_unbound(
             _worker_runDeliverPacketTask, packetCopy, NULL, (TaskObjectFreeFunc)packet_unref, NULL);
-        Event* packetEvent = event_new_(packetTask, deliverTime, srcHost, dstHost);
+
+        Event* packetEvent = event_new_(packetTask, deliverTime, srcHost, dstHostID);
+
         taskref_drop(packetTask);
 
         scheduler_push(scheduler, packetEvent, srcHost, dstHost);

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -461,9 +461,13 @@ void worker_runEvent(Event* event, Host* host) {
     worker_setCurrentEmulatedTime(
         emutime_add_simtime(EMUTIME_SIMULATION_START, event_getTime(event)));
 
+    worker_setActiveHost(host);
+
     /* process the local event */
     event_execute(event, host);
     event_unref(event);
+
+    worker_setActiveHost(NULL);
 
     /* update times */
     _worker_setLastEventTime(worker_getCurrentEmulatedTime());

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -30,7 +30,7 @@ typedef void (*WorkerPoolTaskFn)(void*);
 #include "main/bindings/c/bindings.h"
 
 // To be called by scheduler. Consumes `event`
-void worker_runEvent(Event* event);
+void worker_runEvent(Event* event, Host* host);
 // To be called by worker thread
 void worker_finish(GQueue* hosts, SimulationTime time);
 

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -466,24 +466,6 @@ void host_freeAllApplications(Host* host) {
     trace("done freeing application for host '%s'", host->params.hostname);
 }
 
-gint host_compare(gconstpointer a, gconstpointer b, gpointer user_data) {
-    const Host* na = a;
-    const Host* nb = b;
-    MAGIC_ASSERT(na);
-    MAGIC_ASSERT(nb);
-    return na->params.id > nb->params.id ? +1 : na->params.id < nb->params.id ? -1 : 0;
-}
-
-gboolean host_isEqual(Host* a, Host* b) {
-    if(a == NULL && b == NULL) {
-        return TRUE;
-    } else if(a == NULL || b == NULL) {
-        return FALSE;
-    } else {
-        return host_compare(a, b, NULL) == 0;
-    }
-}
-
 CPU* host_getCPU(Host* host) {
     MAGIC_ASSERT(host);
     return host->cpu;

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -56,9 +56,7 @@ void host_addApplication(Host* host, SimulationTime startTime, SimulationTime st
                          const gchar* const* argv, bool pause_for_debugging);
 void host_freeAllApplications(Host* host);
 
-gint host_compare(gconstpointer a, gconstpointer b, gpointer user_data);
 HostId host_getID(Host* host);
-gboolean host_isEqual(Host* a, Host* b);
 CPU* host_getCPU(Host* host);
 Tsc* host_getTsc(Host* host);
 const gchar* host_getName(Host* host);


### PR DESCRIPTION
I think it's better to pass the `Host` into the `Event` when running the event. The reference counts for `Scheduler` and `SchedulerPolicy` were unused.