### PR TITLE
Add compiler fence to `PerfTimer`

### DIFF
--- a/src/main/utility/perf_timer.rs
+++ b/src/main/utility/perf_timer.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{compiler_fence, Ordering};
 use std::time::{Duration, Instant};
 
 /// Intended as a drop-in-replacement for glib's GTimer.
@@ -17,16 +18,20 @@ impl PerfTimer {
 
     /// Start the timer, which must not already be running.
     pub fn start(&mut self) {
+        compiler_fence(Ordering::SeqCst);
         debug_assert!(self.start_time.is_none());
         self.start_time = Some(Instant::now());
+        compiler_fence(Ordering::SeqCst);
     }
 
     /// Stop the timer, which must already be running.
     pub fn stop(&mut self) {
+        compiler_fence(Ordering::SeqCst);
         debug_assert!(self.start_time.is_some());
         if let Some(t) = self.start_time.take() {
             self.elapsed += Instant::now().duration_since(t)
         }
+        compiler_fence(Ordering::SeqCst);
     }
 
     /// Total time elapsed while the timer has been running.


### PR DESCRIPTION
I think we should have this to help prevent the compiler from reordering the start and stop operations relative to the code that's being measured. I'm not sure if it's sufficient, but I think is better than not having it.