### PR TITLE
SysCallReturn: make a proper tagged union

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -82,6 +82,7 @@ set(shadow_srcs
     host/futex_table.c
     host/shimipc.c
     host/syscall_handler.c
+    host/syscall_types.c
     host/syscall/protected.c
     host/syscall/clone.c
     host/syscall/epoll.c

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1434,17 +1434,174 @@ pub struct _SysCallCondition {
 pub type SysCallCondition = _SysCallCondition;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct _SysCallReturn {
-    pub state: SysCallReturnState,
+pub struct SysCallReturnDone {
     pub retval: SysCallReg,
+    pub restartable: bool,
+}
+#[test]
+fn bindgen_test_layout_SysCallReturnDone() {
+    assert_eq!(
+        ::std::mem::size_of::<SysCallReturnDone>(),
+        16usize,
+        concat!("Size of: ", stringify!(SysCallReturnDone))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<SysCallReturnDone>(),
+        8usize,
+        concat!("Alignment of ", stringify!(SysCallReturnDone))
+    );
+    fn test_field_retval() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SysCallReturnDone>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).retval) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SysCallReturnDone),
+                "::",
+                stringify!(retval)
+            )
+        );
+    }
+    test_field_retval();
+    fn test_field_restartable() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SysCallReturnDone>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).restartable) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SysCallReturnDone),
+                "::",
+                stringify!(restartable)
+            )
+        );
+    }
+    test_field_restartable();
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SysCallReturnBlocked {
     pub cond: *mut SysCallCondition,
     pub restartable: bool,
+}
+#[test]
+fn bindgen_test_layout_SysCallReturnBlocked() {
+    assert_eq!(
+        ::std::mem::size_of::<SysCallReturnBlocked>(),
+        16usize,
+        concat!("Size of: ", stringify!(SysCallReturnBlocked))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<SysCallReturnBlocked>(),
+        8usize,
+        concat!("Alignment of ", stringify!(SysCallReturnBlocked))
+    );
+    fn test_field_cond() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SysCallReturnBlocked>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cond) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SysCallReturnBlocked),
+                "::",
+                stringify!(cond)
+            )
+        );
+    }
+    test_field_cond();
+    fn test_field_restartable() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SysCallReturnBlocked>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).restartable) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SysCallReturnBlocked),
+                "::",
+                stringify!(restartable)
+            )
+        );
+    }
+    test_field_restartable();
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union SysCallReturnBody {
+    pub done: SysCallReturnDone,
+    pub blocked: SysCallReturnBlocked,
+}
+#[test]
+fn bindgen_test_layout_SysCallReturnBody() {
+    assert_eq!(
+        ::std::mem::size_of::<SysCallReturnBody>(),
+        16usize,
+        concat!("Size of: ", stringify!(SysCallReturnBody))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<SysCallReturnBody>(),
+        8usize,
+        concat!("Alignment of ", stringify!(SysCallReturnBody))
+    );
+    fn test_field_done() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SysCallReturnBody>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).done) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SysCallReturnBody),
+                "::",
+                stringify!(done)
+            )
+        );
+    }
+    test_field_done();
+    fn test_field_blocked() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SysCallReturnBody>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).blocked) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SysCallReturnBody),
+                "::",
+                stringify!(blocked)
+            )
+        );
+    }
+    test_field_blocked();
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _SysCallReturn {
+    pub state: SysCallReturnState,
+    pub u: SysCallReturnBody,
 }
 #[test]
 fn bindgen_test_layout__SysCallReturn() {
     assert_eq!(
         ::std::mem::size_of::<_SysCallReturn>(),
-        32usize,
+        24usize,
         concat!("Size of: ", stringify!(_SysCallReturn))
     );
     assert_eq!(
@@ -1469,57 +1626,23 @@ fn bindgen_test_layout__SysCallReturn() {
         );
     }
     test_field_state();
-    fn test_field_retval() {
+    fn test_field_u() {
         assert_eq!(
             unsafe {
                 let uninit = ::std::mem::MaybeUninit::<_SysCallReturn>::uninit();
                 let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).retval) as usize - ptr as usize
+                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
             },
             8usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_SysCallReturn),
                 "::",
-                stringify!(retval)
+                stringify!(u)
             )
         );
     }
-    test_field_retval();
-    fn test_field_cond() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<_SysCallReturn>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cond) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(_SysCallReturn),
-                "::",
-                stringify!(cond)
-            )
-        );
-    }
-    test_field_cond();
-    fn test_field_restartable() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<_SysCallReturn>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).restartable) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(_SysCallReturn),
-                "::",
-                stringify!(restartable)
-            )
-        );
-    }
-    test_field_restartable();
+    test_field_u();
 }
 pub type SysCallReturn = _SysCallReturn;
 #[repr(C)]
@@ -3014,7 +3137,7 @@ pub struct _SysCallHandler {
 fn bindgen_test_layout__SysCallHandler() {
     assert_eq!(
         ::std::mem::size_of::<_SysCallHandler>(),
-        136usize,
+        128usize,
         concat!("Size of: ", stringify!(_SysCallHandler))
     );
     assert_eq!(
@@ -3250,7 +3373,7 @@ fn bindgen_test_layout__SysCallHandler() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).referenceCount) as usize - ptr as usize
             },
-            128usize,
+            120usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_SysCallHandler),
@@ -3267,7 +3390,7 @@ fn bindgen_test_layout__SysCallHandler() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).magic) as usize - ptr as usize
             },
-            132usize,
+            124usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_SysCallHandler),

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -133,11 +133,11 @@ Scheduler* scheduler_new(const Controller* controller, const ChildPidWatcher* pi
 
     scheduler->random = random_new(schedulerSeed);
 
-    utility_assert(nWorkers >= 1);
+    utility_debugAssert(nWorkers >= 1);
 
     /* create the configured policy to handle queues */
     scheduler->policy = schedulerpolicy_new();
-    utility_assert(scheduler->policy);
+    utility_debugAssert(scheduler->policy);
 
     info("main scheduler thread will operate with %u worker threads", nWorkers);
 
@@ -185,7 +185,7 @@ gboolean scheduler_push(Scheduler* scheduler, Event* event, Host* sender, Host* 
 
     /* parties involved. sender may be NULL, receiver may not!
      * we MAY NOT OWN the receiver, so do not write to it! */
-    utility_assert(receiver);
+    utility_debugAssert(receiver);
 
     /* push to a queue based on the policy */
     schedulerpolicy_push(
@@ -248,7 +248,7 @@ static void _scheduler_shuffleQueue(Scheduler* scheduler, GQueue* queue) {
     }
 
     /* we now should have moved all elements from the queue to the array */
-    utility_assert(g_queue_is_empty(queue));
+    utility_debugAssert(g_queue_is_empty(queue));
 
     /* shuffle array - Fisher-Yates shuffle */
     for(guint i = 0; i < length-1; i++) {
@@ -269,13 +269,13 @@ static void _scheduler_shuffleQueue(Scheduler* scheduler, GQueue* queue) {
 
 static void _scheduler_assignHostsToThread(Scheduler* scheduler, GQueue* hosts, pthread_t thread, uint maxAssignments) {
     MAGIC_ASSERT(scheduler);
-    utility_assert(hosts);
-    utility_assert(thread);
+    utility_debugAssert(hosts);
+    utility_debugAssert(thread);
 
     guint numAssignments = 0;
     while((maxAssignments == 0 || numAssignments < maxAssignments) && !g_queue_is_empty(hosts)) {
         Host* host = (Host*) g_queue_pop_head(hosts);
-        utility_assert(host);
+        utility_debugAssert(host);
         schedulerpolicy_addHost(scheduler->policy, host, thread);
         numAssignments++;
     }

--- a/src/main/core/scheduler/scheduler_policy.c
+++ b/src/main/core/scheduler/scheduler_policy.c
@@ -137,7 +137,7 @@ void schedulerpolicy_push(SchedulerPolicy* policy, Event* event, Host* srcHost, 
 
     /* get the queue for the destination */
     ThreadSafeEventQueue* qdata = g_hash_table_lookup(policy->hostToQueueDataMap, dstHost);
-    utility_assert(qdata);
+    utility_debugAssert(qdata);
 
     /* 'deliver' the event to the destination queue */
     eventqueue_push(qdata, event);
@@ -173,7 +173,7 @@ Event* schedulerpolicy_pop(SchedulerPolicy* policy, SimulationTime barrier) {
     while(!g_queue_is_empty(tdata->unprocessedHosts)) {
         Host* host = g_queue_peek_head(tdata->unprocessedHosts);
         ThreadSafeEventQueue* qdata = g_hash_table_lookup(policy->hostToQueueDataMap, host);
-        utility_assert(qdata);
+        utility_debugAssert(qdata);
 
         Event* nextEvent = NULL;
         SimulationTime eventTime = eventqueue_nextEventTime(qdata);
@@ -200,16 +200,16 @@ EmulatedTime schedulerpolicy_nextHostEventTime(SchedulerPolicy* policy, Host* ho
     /* figure out which hosts we should be checking */
     HostSingleThreadData* tdata =
         g_hash_table_lookup(policy->threadToThreadDataMap, GUINT_TO_POINTER(pthread_self()));
-    utility_assert(tdata);
+    utility_debugAssert(tdata);
 
     ThreadSafeEventQueue* qdata = g_hash_table_lookup(policy->hostToQueueDataMap, host);
-    utility_assert(qdata);
+    utility_debugAssert(qdata);
 
     SimulationTime nextEventSimTime = eventqueue_nextEventTime(qdata);
     EmulatedTime nextEventEmuTime = EMUTIME_INVALID;
     if (nextEventSimTime != SIMTIME_INVALID) {
         nextEventEmuTime = emutime_add_simtime(EMUTIME_SIMULATION_START, nextEventSimTime);
-        utility_assert(nextEventEmuTime != EMUTIME_INVALID);
+        utility_debugAssert(nextEventEmuTime != EMUTIME_INVALID);
     }
 
     return nextEventEmuTime;
@@ -217,7 +217,7 @@ EmulatedTime schedulerpolicy_nextHostEventTime(SchedulerPolicy* policy, Host* ho
 
 static void _schedulerpolicy_findMinTime(Host* host, HostSingleSearchState* state) {
     ThreadSafeEventQueue* qdata = g_hash_table_lookup(state->data->hostToQueueDataMap, host);
-    utility_assert(qdata);
+    utility_debugAssert(qdata);
 
     SimulationTime nextEventTime = eventqueue_nextEventTime(qdata);
     if (nextEventTime != SIMTIME_INVALID) {

--- a/src/main/host/cpu.c
+++ b/src/main/host/cpu.c
@@ -24,8 +24,8 @@ struct _CPU {
 };
 
 CPU* cpu_new(guint64 frequencyKHz, guint64 rawFrequencyKHz, guint64 threshold, guint64 precision) {
-    utility_assert(frequencyKHz > 0);
-    utility_assert(rawFrequencyKHz > 0);
+    utility_debugAssert(frequencyKHz > 0);
+    utility_debugAssert(rawFrequencyKHz > 0);
     CPU* cpu = g_new0(CPU, 1);
     MAGIC_INIT(cpu);
 

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -20,7 +20,7 @@
 
 void legacyfile_init(LegacyFile* descriptor, LegacyFileType type,
                      LegacyFileFunctionTable* funcTable) {
-    utility_assert(descriptor && funcTable);
+    utility_debugAssert(descriptor && funcTable);
 
     MAGIC_INIT(descriptor);
     MAGIC_INIT(funcTable);
@@ -69,7 +69,7 @@ void legacyfile_ref(gpointer data) {
     MAGIC_ASSERT(descriptor);
 
     // should not increment the strong count when there are only weak references left
-    utility_assert(descriptor->refCountStrong > 0);
+    utility_debugAssert(descriptor->refCountStrong > 0);
 
     (descriptor->refCountStrong)++;
     trace("Descriptor %p strong_ref++ to %i (weak_ref=%i)", descriptor, descriptor->refCountStrong,
@@ -84,7 +84,7 @@ void legacyfile_unref(gpointer data) {
     trace("Descriptor %p strong_ref-- to %i (weak_ref=%i)", descriptor, descriptor->refCountStrong,
           descriptor->refCountWeak);
 
-    utility_assert(descriptor->refCountStrong >= 0);
+    utility_debugAssert(descriptor->refCountStrong >= 0);
 
     if (descriptor->refCountStrong > 0) {
         // there are strong references, so do nothing
@@ -127,7 +127,7 @@ void legacyfile_unrefWeak(gpointer data) {
     trace("Descriptor %p weak_ref-- to %i (strong_ref=%i)", descriptor, descriptor->refCountWeak,
           descriptor->refCountStrong);
 
-    utility_assert(descriptor->refCountWeak >= 0);
+    utility_debugAssert(descriptor->refCountWeak >= 0);
 
     if (descriptor->refCountStrong > 0 || descriptor->refCountWeak > 0) {
         // there are references (strong or weak), so do nothing

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -119,7 +119,7 @@ struct _Epoll {
 
 static EpollKey* _epollkey_new(int fd, uintptr_t objectPtr) {
     EpollKey* key = g_new0(EpollKey, 1);
-    utility_assert(key);
+    utility_debugAssert(key);
 
     key->fd = fd;
     key->objectPtr = objectPtr;
@@ -164,7 +164,7 @@ static gint _epollwatch_compare(gconstpointer ptr_1, gconstpointer ptr_2) {
     } else {
         /* Both were previously reported at the same time (or never reported yet),
          * so now we fall back to the deterministic unique id ordering. */
-        utility_assert(watch_1->id != watch_2->id);
+        utility_debugAssert(watch_1->id != watch_2->id);
         return (watch_1->id < watch_2->id) ? -1 : 1;
     }
 }
@@ -177,8 +177,8 @@ static EpollWatch* _epollwatch_new(Epoll* epoll, int fd, EpollWatchTypes type,
                                    Host* host) {
     EpollWatch* watch = g_new0(EpollWatch, 1);
     MAGIC_INIT(watch);
-    utility_assert(event);
-    utility_assert(epoll);
+    utility_debugAssert(event);
+    utility_debugAssert(epoll);
 
     /* ref it for the EpollWatch, which also covers the listener reference
      * (which is freed below in _epollwatch_free) */
@@ -245,7 +245,7 @@ static void _epollwatch_unref(EpollWatch* watch) {
 }
 
 static Epoll* _epoll_fromLegacyFile(LegacyFile* descriptor) {
-    utility_assert(legacyfile_getType(descriptor) == DT_EPOLL);
+    utility_debugAssert(legacyfile_getType(descriptor) == DT_EPOLL);
     return (Epoll*)descriptor;
 }
 
@@ -522,7 +522,7 @@ gint epoll_control(Epoll* epoll, gint operation, int fd, const Descriptor* descr
             }
 
             MAGIC_ASSERT(watch);
-            utility_assert(event && (watch->flags & EWF_WATCHING));
+            utility_debugAssert(event && (watch->flags & EWF_WATCHING));
 
             /* the user set new events */
             watch->event = *event;
@@ -578,7 +578,7 @@ guint epoll_getNumReadyEvents(Epoll* epoll) {
 
 gint epoll_getEvents(Epoll* epoll, struct epoll_event* eventArray, gint eventArrayLength, gint* nEvents) {
     MAGIC_ASSERT(epoll);
-    utility_assert(nEvents);
+    utility_debugAssert(nEvents);
 
     /* return the available events in the eventArray, making sure not to
      * overflow. the number of actual events is returned in nEvents. */
@@ -637,7 +637,7 @@ gint epoll_getEvents(Epoll* epoll, struct epoll_event* eventArray, gint eventArr
             watch->flags &= ~EWF_WRITECHANGED;
 
             eventIndex++;
-            utility_assert(eventIndex <= eventArrayLength);
+            utility_debugAssert(eventIndex <= eventArrayLength);
 
             if(watch->flags & EWF_EDGETRIGGER) {
                 /* tag that an event was collected in ET mode */
@@ -724,7 +724,7 @@ static void _epoll_fileStatusChanged(Epoll* epoll, const EpollKey* key) {
                 /* unref gets called on the watch when it is removed from these tables */
                 g_hash_table_remove(epoll->watching, key);
                 /* we should have removed it from the ready list earlier */
-                utility_assert(!g_hash_table_contains(epoll->ready, key));
+                utility_debugAssert(!g_hash_table_contains(epoll->ready, key));
             }
         }
     }

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -80,7 +80,7 @@ int regularfile_getShadowFlags(RegularFile* file) {
 }
 
 static inline RegularFile* _regularfile_legacyFileToRegularFile(LegacyFile* desc) {
-    utility_assert(legacyfile_getType(desc) == DT_FILE);
+    utility_debugAssert(legacyfile_getType(desc) == DT_FILE);
     RegularFile* file = (RegularFile*)desc;
     MAGIC_ASSERT(file);
     return file;
@@ -161,9 +161,9 @@ static char* _regularfile_getConcatStr(const char* prefix, const char sep, const
 
 static char* _regularfile_getAbsolutePath(RegularFile* dir, const char* pathname,
                                           const char* workingDir) {
-    utility_assert(pathname);
-    utility_assert(workingDir);
-    utility_assert(workingDir[0] == '/');
+    utility_debugAssert(pathname);
+    utility_debugAssert(workingDir);
+    utility_debugAssert(workingDir[0] == '/');
 
     /* Compute the absolute path, which will allow us to reopen later. */
     if (pathname[0] == '/') {
@@ -225,7 +225,7 @@ static void _regularfile_print_flags(int flags) {
 int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname, int flags,
                        mode_t mode, const char* workingDir) {
     MAGIC_ASSERT(file);
-    utility_assert(file->osfile.fd == OSFILE_INVALID);
+    utility_debugAssert(file->osfile.fd == OSFILE_INVALID);
 
     trace("Attempting to open file with pathname=%s flags=%i mode=%i workingdir=%s", pathname,
           flags, (int)mode, workingDir);
@@ -311,9 +311,9 @@ int regularfile_open(RegularFile* file, const char* pathname, int flags, mode_t 
 
 static void _regularfile_readRandomBytes(RegularFile* file, Host* host, void* buf,
                                          size_t numBytes) {
-    utility_assert(file->type == FILE_TYPE_RANDOM);
+    utility_debugAssert(file->type == FILE_TYPE_RANDOM);
 
-    utility_assert(host != NULL);
+    utility_debugAssert(host != NULL);
 
     trace("RegularFile %p will read %zu bytes from random source for host %s", file, numBytes,
           host_getName(host));

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -24,8 +24,8 @@
 #include "main/utility/utility.h"
 
 static LegacySocket* _legacysocket_fromLegacyFile(LegacyFile* descriptor) {
-    utility_assert(legacyfile_getType(descriptor) == DT_TCPSOCKET ||
-                   legacyfile_getType(descriptor) == DT_UDPSOCKET);
+    utility_debugAssert(legacyfile_getType(descriptor) == DT_TCPSOCKET ||
+                        legacyfile_getType(descriptor) == DT_UDPSOCKET);
     return (LegacySocket*)descriptor;
 }
 
@@ -114,7 +114,7 @@ TransportFunctionTable socket_functions = {
 
 void legacysocket_init(LegacySocket* socket, Host* host, SocketFunctionTable* vtable,
                        LegacyFileType type, guint receiveBufferSize, guint sendBufferSize) {
-    utility_assert(socket && vtable);
+    utility_debugAssert(socket && vtable);
 
     transport_init(&(socket->super), &socket_functions, type);
 
@@ -281,7 +281,7 @@ gboolean legacysocket_isBound(LegacySocket* socket) {
 
 gsize legacysocket_getInputBufferSpace(LegacySocket* socket) {
     MAGIC_ASSERT(socket);
-    utility_assert(socket->inputBufferSize >= socket->inputBufferLength);
+    utility_debugAssert(socket->inputBufferSize >= socket->inputBufferLength);
     gsize bufferSize = legacysocket_getInputBufferSize(socket);
     if(bufferSize < socket->inputBufferLength) {
         return 0;
@@ -292,7 +292,7 @@ gsize legacysocket_getInputBufferSpace(LegacySocket* socket) {
 
 gsize legacysocket_getOutputBufferSpace(LegacySocket* socket) {
     MAGIC_ASSERT(socket);
-    utility_assert(socket->outputBufferSize >= socket->outputBufferLength);
+    utility_debugAssert(socket->outputBufferSize >= socket->outputBufferLength);
     gsize bufferSize = legacysocket_getOutputBufferSize(socket);
     if(bufferSize < socket->outputBufferLength) {
         return 0;

--- a/src/main/host/descriptor/timerfd.c
+++ b/src/main/host/descriptor/timerfd.c
@@ -28,7 +28,7 @@ struct _TimerFd {
 };
 
 static TimerFd* _timerfd_fromLegacyFile(LegacyFile* descriptor) {
-    utility_assert(legacyfile_getType(descriptor) == DT_TIMER);
+    utility_debugAssert(legacyfile_getType(descriptor) == DT_TIMER);
     return (TimerFd*)descriptor;
 }
 
@@ -90,10 +90,10 @@ TimerFd* timerfd_new(HostId hostId) {
 
 void timerfd_getTime(const TimerFd* timerfd, struct itimerspec* curr_value) {
     MAGIC_ASSERT(timerfd);
-    utility_assert(curr_value);
+    utility_debugAssert(curr_value);
 
     SimulationTime remainingTime = timer_getRemainingTime(timerfd->timer);
-    utility_assert(remainingTime != SIMTIME_INVALID);
+    utility_debugAssert(remainingTime != SIMTIME_INVALID);
     if (!simtime_to_timespec(remainingTime, &curr_value->it_value)) {
         panic("Couldn't convert %ld", remainingTime);
     }
@@ -116,10 +116,10 @@ static void _timerfd_expire(Host* host, gpointer voidTimerFd, gpointer data) {
 static void _timerfd_arm(TimerFd* timerfd, Host* host, const struct itimerspec* config,
                          gint flags) {
     MAGIC_ASSERT(timerfd);
-    utility_assert(config);
+    utility_debugAssert(config);
 
     SimulationTime configSimTime = simtime_from_timespec(config->it_value);
-    utility_assert(configSimTime != SIMTIME_INVALID);
+    utility_debugAssert(configSimTime != SIMTIME_INVALID);
 
     EmulatedTime now = worker_getCurrentEmulatedTime();
     EmulatedTime base = (flags == TFD_TIMER_ABSTIME) ? EMUTIME_UNIX_EPOCH : now;
@@ -140,7 +140,7 @@ static void _timerfd_arm(TimerFd* timerfd, Host* host, const struct itimerspec* 
 }
 
 static gboolean _timerfd_timeIsValid(const struct timespec* config) {
-    utility_assert(config);
+    utility_debugAssert(config);
     return (config->tv_nsec < 0 || config->tv_nsec >= SIMTIME_ONE_SECOND) ? FALSE : TRUE;
 }
 
@@ -148,7 +148,7 @@ gint timerfd_setTime(TimerFd* timerfd, Host* host, gint flags, const struct itim
                      struct itimerspec* old_value) {
     MAGIC_ASSERT(timerfd);
 
-    utility_assert(new_value);
+    utility_debugAssert(new_value);
 
     if (!_timerfd_timeIsValid(&(new_value->it_value)) ||
         !_timerfd_timeIsValid(&(new_value->it_interval))) {

--- a/src/main/host/descriptor/transport.c
+++ b/src/main/host/descriptor/transport.c
@@ -14,8 +14,8 @@
 #include "main/utility/utility.h"
 
 static Transport* _transport_fromLegacyFile(LegacyFile* descriptor) {
-    utility_assert(legacyfile_getType(descriptor) == DT_TCPSOCKET ||
-                   legacyfile_getType(descriptor) == DT_UDPSOCKET);
+    utility_debugAssert(legacyfile_getType(descriptor) == DT_TCPSOCKET ||
+                        legacyfile_getType(descriptor) == DT_UDPSOCKET);
     return (Transport*)descriptor;
 }
 
@@ -52,7 +52,7 @@ LegacyFileFunctionTable transport_functions = {
     _transport_close, _transport_cleanup, _transport_free, MAGIC_VALUE};
 
 void transport_init(Transport* transport, TransportFunctionTable* vtable, LegacyFileType type) {
-    utility_assert(transport && vtable);
+    utility_debugAssert(transport && vtable);
 
     legacyfile_init(&(transport->super), type, &transport_functions);
 

--- a/src/main/host/descriptor/udp.c
+++ b/src/main/host/descriptor/udp.c
@@ -54,7 +54,7 @@ static void _udp_setState(UDP* udp, enum UDPState state) {
 }
 
 static UDP* _udp_fromLegacyFile(LegacyFile* descriptor) {
-    utility_assert(legacyfile_getType(descriptor) == DT_UDPSOCKET);
+    utility_debugAssert(legacyfile_getType(descriptor) == DT_UDPSOCKET);
     return (UDP*)descriptor;
 }
 
@@ -140,7 +140,7 @@ static gssize _udp_sendUserData(Transport* transport, Thread* thread, PluginVirt
         }
     }
 
-    utility_assert(sourceIP && sourcePort && destinationIP && destinationPort);
+    utility_debugAssert(sourceIP && sourcePort && destinationIP && destinationPort);
 
     /* create the UDP packet */
     Packet* packet = packet_new(host);
@@ -198,7 +198,7 @@ static gssize _udp_receiveUserData(Transport* transport, Thread* thread, PluginV
 
     Packet* packet = legacysocket_removeFromInputBuffer((LegacySocket*)udp, thread_getHost(thread));
 
-    utility_assert(bytesCopied == copyLength);
+    utility_debugAssert(bytesCopied == copyLength);
     packet_addDeliveryStatus(packet, PDS_RCV_SOCKET_DELIVERED);
 
     /* fill in address info */

--- a/src/main/host/futex.c
+++ b/src/main/host/futex.c
@@ -57,7 +57,7 @@ void futex_ref(Futex* futex) {
 
 void futex_unref(Futex* futex) {
     MAGIC_ASSERT(futex);
-    utility_assert(futex->referenceCount > 0);
+    utility_debugAssert(futex->referenceCount > 0);
     if (--futex->referenceCount == 0) {
         _futex_free(futex);
     }
@@ -123,7 +123,7 @@ unsigned int futex_wake(Futex* futex, unsigned int numWakeups) {
 
 void futex_addListener(Futex* futex, StatusListener* listener) {
     MAGIC_ASSERT(futex);
-    utility_assert(listener);
+    utility_debugAssert(listener);
     statuslistener_ref(listener);
     g_hash_table_insert(futex->listeners, listener, GUINT_TO_POINTER(false));
 }

--- a/src/main/host/futex_table.c
+++ b/src/main/host/futex_table.c
@@ -54,7 +54,7 @@ void futextable_ref(FutexTable* table) {
 void futextable_unref(FutexTable* table) {
     MAGIC_ASSERT(table);
     table->referenceCount--;
-    utility_assert(table->referenceCount >= 0);
+    utility_debugAssert(table->referenceCount >= 0);
     if (table->referenceCount == 0) {
         _futextable_free(table);
     }

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -117,7 +117,7 @@ ADD_CONFIG_HANDLER(config_getMaxUnappliedCpuLatency, _maxUnappliedCpuLatencyConf
 
 /* this function is called by manager before the workers exist */
 Host* host_new(const HostParameters* params) {
-    utility_assert(params);
+    utility_debugAssert(params);
 
     Host* host = g_new0(Host, 1);
     MAGIC_INIT(host);
@@ -132,7 +132,7 @@ Host* host_new(const HostParameters* params) {
     host->params = *params;
 
     /* now dup the strings so we own them */
-    utility_assert(params->hostname);
+    utility_debugAssert(params->hostname);
     host->params.hostname = g_strdup(params->hostname);
     if(params->pcapDir) host->params.pcapDir = g_strdup(params->pcapDir);
 
@@ -329,7 +329,7 @@ void host_shutdown(Host* host) {
     if(host->defaultAddress) address_unref(host->defaultAddress);
     if(host->params.hostname) g_free((gchar*)host->params.hostname);
 
-    utility_assert(host_getSharedMem(host));
+    utility_debugAssert(host_getSharedMem(host));
     shimshmemhost_destroy(host_getSharedMem(host));
     shmemallocator_globalFree(&host->shimSharedMemBlock);
 }
@@ -342,7 +342,7 @@ void host_ref(Host* host) {
 void host_unref(Host* host) {
     MAGIC_ASSERT(host);
     (host->referenceCount)--;
-    utility_assert(host->referenceCount >= 0);
+    utility_debugAssert(host->referenceCount >= 0);
     if(host->referenceCount == 0) {
         _host_free(host);
     }
@@ -514,7 +514,7 @@ NetworkInterface* host_lookupInterface(Host* host, in_addr_t handle) {
 Router* host_getUpstreamRouter(Host* host, in_addr_t handle) {
     MAGIC_ASSERT(host);
     NetworkInterface* interface = g_hash_table_lookup(host->interfaces, GUINT_TO_POINTER(handle));
-    utility_assert(interface != NULL);
+    utility_debugAssert(interface != NULL);
     return networkinterface_getRouter(interface);
 }
 
@@ -640,7 +640,7 @@ static in_port_t _host_getRandomPort(Host* host) {
     /* make sure we don't assign any low privileged ports */
     randomHostPort += (in_port_t)MIN_RANDOM_PORT;
 
-    utility_assert(randomHostPort >= MIN_RANDOM_PORT);
+    utility_debugAssert(randomHostPort >= MIN_RANDOM_PORT);
     return htons(randomHostPort);
 }
 
@@ -770,7 +770,7 @@ pid_t host_getNativeTID(Host* host, pid_t virtualPID, pid_t virtualTID) {
 
 ShimShmemHost* host_getSharedMem(Host* host) {
     MAGIC_ASSERT(host);
-    utility_assert(host->shimSharedMemBlock.p);
+    utility_debugAssert(host->shimSharedMemBlock.p);
     return host->shimSharedMemBlock.p;
 }
 

--- a/src/main/host/managed_thread.c
+++ b/src/main/host/managed_thread.c
@@ -108,7 +108,7 @@ static gchar** _add_u64_to_env(gchar** envp, const char* var, uint64_t x) {
 
 static pid_t _managedthread_fork_exec(ManagedThread* thread, const char* file, char* const argv[],
                                       char* const envp[], const char* workingDir) {
-    utility_assert(file != NULL);
+    utility_debugAssert(file != NULL);
 
     // For childpidwatcher. We must create them O_CLOEXEC to prevent them from
     // "leaking" into a concurrently forked child.
@@ -185,7 +185,7 @@ void managedthread_run(ManagedThread* mthread, char* pluginPath, char** argv, ch
     gchar** myenvv = g_strdupv(envv);
 
     mthread->ipc_blk = shmemallocator_globalAlloc(ipcData_nbytes());
-    utility_assert(mthread->ipc_blk.p);
+    utility_debugAssert(mthread->ipc_blk.p);
     mthread->ipc_data = mthread->ipc_blk.p;
     ipcData_init(mthread->ipc_data, shimipc_spinMax());
 
@@ -230,7 +230,7 @@ void managedthread_run(ManagedThread* mthread, char* pluginPath, char** argv, ch
 }
 
 static inline void _managedthread_waitForNextEvent(ManagedThread* mthread, ShimEvent* e) {
-    utility_assert(mthread->ipc_data);
+    utility_debugAssert(mthread->ipc_data);
     shimevent_recvEventFromPlugin(mthread->ipc_data, e);
     // The managed mthread has yielded control back to us. Reacquire the shared
     // memory lock, which we released in `_managedthread_continuePlugin`.
@@ -250,8 +250,8 @@ static inline void _managedthread_waitForNextEvent(ManagedThread* mthread, ShimE
 ShMemBlock* managedthread_getIPCBlock(ManagedThread* mthread) { return &mthread->ipc_blk; }
 
 SysCallCondition* managedthread_resume(ManagedThread* mthread) {
-    utility_assert(mthread->isRunning);
-    utility_assert(mthread->currentEvent.event_id != SHD_SHIM_EVENT_NULL);
+    utility_debugAssert(mthread->isRunning);
+    utility_debugAssert(mthread->currentEvent.event_id != SHD_SHIM_EVENT_NULL);
 
     _managedthread_syncAffinityWithWorker(mthread);
 
@@ -350,7 +350,7 @@ SysCallCondition* managedthread_resume(ManagedThread* mthread) {
                 break;
             }
         }
-        utility_assert(mthread->isRunning);
+        utility_debugAssert(mthread->isRunning);
 
         /* previous event was handled, wait for next one */
         _managedthread_waitForNextEvent(mthread, &mthread->currentEvent);
@@ -368,7 +368,7 @@ void managedthread_handleProcessExit(ManagedThread* mthread) {
 
     int status = 0;
 
-    utility_assert(mthread->nativePid > 0);
+    utility_debugAssert(mthread->nativePid > 0);
 
     _managedthread_cleanup(mthread);
 }
@@ -381,7 +381,7 @@ pid_t managedthread_clone(ManagedThread* child, ManagedThread* parent, unsigned 
                           PluginPtr child_stack, PluginPtr ptid, PluginPtr ctid,
                           unsigned long newtls) {
     child->ipc_blk = shmemallocator_globalAlloc(ipcData_nbytes());
-    utility_assert(child->ipc_blk.p);
+    utility_debugAssert(child->ipc_blk.p);
     child->ipc_data = child->ipc_blk.p;
     ipcData_init(child->ipc_data, shimipc_spinMax());
     childpidwatcher_watch(
@@ -395,7 +395,7 @@ pid_t managedthread_clone(ManagedThread* child, ManagedThread* parent, unsigned 
                                                        }});
     ShimEvent response = {0};
     _managedthread_waitForNextEvent(parent, &response);
-    utility_assert(response.event_id == SHD_SHIM_EVENT_ADD_THREAD_PARENT_RES);
+    utility_debugAssert(response.event_id == SHD_SHIM_EVENT_ADD_THREAD_PARENT_RES);
 
     // Create the new managed thread.
     pid_t childNativeTid =
@@ -438,7 +438,7 @@ long managedthread_nativeSyscall(ManagedThread* mthread, long n, va_list args) {
         // We have to return *something* here. Probably doesn't matter much what.
         return -ESRCH;
     }
-    utility_assert(res.event_id == SHD_SHIM_EVENT_SYSCALL_COMPLETE);
+    utility_debugAssert(res.event_id == SHD_SHIM_EVENT_SYSCALL_COMPLETE);
     return res.event_data.syscall_complete.retval.as_i64;
 }
 

--- a/src/main/host/managed_thread.c
+++ b/src/main/host/managed_thread.c
@@ -319,17 +319,18 @@ SysCallCondition* managedthread_resume(ManagedThread* mthread) {
                         _managedthread_waitForNextEvent(mthread, &mthread->currentEvent);
                     }
 
-                    return result.cond;
+                    return syscallreturn_blocked(&result)->cond;
                 }
 
                 ShimEvent shim_result;
                 if (result.state == SYSCALL_DONE) {
                     // Now send the result of the syscall
+                    SysCallReturnDone* done = syscallreturn_done(&result);
                     shim_result =
                         (ShimEvent){.event_id = SHD_SHIM_EVENT_SYSCALL_COMPLETE,
                                     .event_data = {
-                                        .syscall_complete = {.retval = result.retval,
-                                                             .restartable = result.restartable},
+                                        .syscall_complete = {.retval = done->retval,
+                                                             .restartable = done->restartable},
 
                                     }};
                 } else if (result.state == SYSCALL_NATIVE) {

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -220,6 +220,10 @@ impl<'a, T: Debug + Pod> ProcessMemoryRefMut<'a, T> {
     /// overwritten, call `noflush` instead to avoid flushing back the
     /// unininitialized contents.
     pub fn flush(mut self) -> Result<(), Errno> {
+        // Whether the flush succeeds or not, the buffer is no longer considered
+        // dirty; the fact that it failed will be captured in an error result.
+        self.dirty = false;
+
         match &self.copied_or_mapped {
             CopiedOrMappedMut::Copied(copier, ptr, v) => {
                 trace!(
@@ -231,7 +235,6 @@ impl<'a, T: Debug + Pod> ProcessMemoryRefMut<'a, T> {
             }
             CopiedOrMappedMut::Mapped(_) => (),
         };
-        self.dirty = false;
         Ok(())
     }
 

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -70,7 +70,7 @@ struct _NetworkInterface {
 static void _networkinterface_sendPackets(NetworkInterface* interface, Host* src);
 
 static void _compatsocket_unrefTaggedVoid(void* taggedSocketPtr) {
-    utility_assert(taggedSocketPtr != NULL);
+    utility_debugAssert(taggedSocketPtr != NULL);
     if (taggedSocketPtr == NULL) {
         return;
     }
@@ -194,7 +194,7 @@ void networkinterface_associate(NetworkInterface* interface, const CompatSocket*
     gchar* key = _networkinterface_socketToAssociationKey(interface, socket);
 
     /* make sure there is no collision */
-    utility_assert(!g_hash_table_contains(interface->boundSockets, key));
+    utility_debugAssert(!g_hash_table_contains(interface->boundSockets, key));
 
     /* need to store our own reference to the socket object */
     CompatSocket newSocketRef = compatsocket_refAs(socket);
@@ -218,7 +218,7 @@ void networkinterface_disassociate(NetworkInterface* interface, const CompatSock
 }
 
 static void _networkinterface_capturePacket(NetworkInterface* interface, Packet* packet) {
-    utility_assert(interface->pcap != NULL);
+    utility_debugAssert(interface->pcap != NULL);
 
     /* get the current time that the packet is being sent/received */
     SimulationTime now = worker_getCurrentSimulationTime();
@@ -251,7 +251,7 @@ static void _networkinterface_process_packet_in(Host* host, NetworkInterface* in
     MAGIC_ASSERT(interface);
 
     /* get the next packet */
-    utility_assert(packet);
+    utility_debugAssert(packet);
 
     /* successfully received */
     packet_addDeliveryStatus(packet, PDS_RCV_INTERFACE_RECEIVED);
@@ -363,7 +363,7 @@ void networkinterface_receivePackets(NetworkInterface* interface, Host* host) {
         /* we are now the owner of the packet reference from the router */
         Packet* packet = router_dequeue(interface->router);
         // We already peeked it, so it better be here when we pop it.
-        utility_assert(packet);
+        utility_debugAssert(packet);
 
         _networkinterface_process_packet_in(host, interface, packet);
 
@@ -552,7 +552,7 @@ static void _networkinterface_sendPackets(NetworkInterface* interface, Host* src
         LegacySocket* legacySocket = NULL;
         Packet* packet = _networkinterface_pop_next_packet_out(interface, src, &legacySocket);
         // We already peeked it, so it better be here when we pop it.
-        utility_assert(packet);
+        utility_debugAssert(packet);
 
         packet_addDeliveryStatus(packet, PDS_SND_INTERFACE_SENT);
 
@@ -573,7 +573,7 @@ static void _networkinterface_sendPackets(NetworkInterface* interface, Host* src
         } else {
             /* let the upstream router send to remote with appropriate delays.
              * if we get here we are not loopback and should have been assigned a router. */
-            utility_assert(interface->router);
+            utility_debugAssert(interface->router);
             router_forward(interface->router, src, packet);
         }
 

--- a/src/main/host/network_queuing_disciplines.c
+++ b/src/main/host/network_queuing_disciplines.c
@@ -14,21 +14,21 @@
 #include "main/utility/utility.h"
 
 void rrsocketqueue_init(RrSocketQueue* self) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue == NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue == NULL);
     self->queue = g_queue_new();
 }
 
 void rrsocketqueue_destroy(RrSocketQueue* self, void (*fn_processItem)(const CompatSocket*)) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
 
     if (fn_processItem != NULL) {
         while (!rrsocketqueue_isEmpty(self)) {
             CompatSocket socket = {0};
             bool found = rrsocketqueue_pop(self, &socket);
 
-            utility_assert(found);
+            utility_debugAssert(found);
             if (!found) {
                 continue;
             }
@@ -42,14 +42,14 @@ void rrsocketqueue_destroy(RrSocketQueue* self, void (*fn_processItem)(const Com
 }
 
 bool rrsocketqueue_isEmpty(RrSocketQueue* self) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
     return g_queue_is_empty(self->queue);
 }
 
 bool rrsocketqueue_peek(RrSocketQueue* self, CompatSocket* socket) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
 
     uintptr_t taggedSocket = (uintptr_t)g_queue_peek_head(self->queue);
     if (taggedSocket == 0) {
@@ -61,8 +61,8 @@ bool rrsocketqueue_peek(RrSocketQueue* self, CompatSocket* socket) {
 }
 
 bool rrsocketqueue_pop(RrSocketQueue* self, CompatSocket* socket) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
 
     uintptr_t taggedSocket = (uintptr_t)g_queue_pop_head(self->queue);
     if (taggedSocket == 0) {
@@ -74,15 +74,15 @@ bool rrsocketqueue_pop(RrSocketQueue* self, CompatSocket* socket) {
 }
 
 void rrsocketqueue_push(RrSocketQueue* self, const CompatSocket* socket) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
-    utility_assert(socket->type != CST_NONE);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
+    utility_debugAssert(socket->type != CST_NONE);
     g_queue_push_tail(self->queue, (void*)compatsocket_toTagged(socket));
 }
 
 bool rrsocketqueue_find(RrSocketQueue* self, const CompatSocket* socket) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
     return g_queue_find(self->queue, (void*)compatsocket_toTagged(socket));
 }
 
@@ -90,8 +90,8 @@ static gint _compareSocket(const CompatSocket* sa, const CompatSocket* sb) {
     const Packet* pa = compatsocket_peekNextOutPacket(sa);
     const Packet* pb = compatsocket_peekNextOutPacket(sb);
 
-    utility_assert(pa != NULL);
-    utility_assert(pb != NULL);
+    utility_debugAssert(pa != NULL);
+    utility_debugAssert(pb != NULL);
 
     if (pa == NULL) {
         return -1;
@@ -112,21 +112,21 @@ static gint _compareSocketTagged(uintptr_t sa_tagged, uintptr_t sb_tagged, gpoin
 }
 
 void fifosocketqueue_init(FifoSocketQueue* self) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue == NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue == NULL);
     self->queue = priorityqueue_new((GCompareDataFunc)_compareSocketTagged, NULL, NULL);
 }
 
 void fifosocketqueue_destroy(FifoSocketQueue* self, void (*fn_processItem)(const CompatSocket*)) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
 
     if (fn_processItem != NULL) {
         while (!fifosocketqueue_isEmpty(self)) {
             CompatSocket socket = {0};
             bool found = fifosocketqueue_pop(self, &socket);
 
-            utility_assert(found);
+            utility_debugAssert(found);
             if (!found) {
                 continue;
             }
@@ -140,14 +140,14 @@ void fifosocketqueue_destroy(FifoSocketQueue* self, void (*fn_processItem)(const
 }
 
 bool fifosocketqueue_isEmpty(FifoSocketQueue* self) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
     return priorityqueue_isEmpty(self->queue);
 }
 
 bool fifosocketqueue_peek(FifoSocketQueue* self, CompatSocket* socket) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
 
     uintptr_t taggedSocket = (uintptr_t)priorityqueue_peek(self->queue);
     if (taggedSocket == 0) {
@@ -159,8 +159,8 @@ bool fifosocketqueue_peek(FifoSocketQueue* self, CompatSocket* socket) {
 }
 
 bool fifosocketqueue_pop(FifoSocketQueue* self, CompatSocket* socket) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
 
     uintptr_t taggedSocket = (uintptr_t)priorityqueue_pop(self->queue);
     if (taggedSocket == 0) {
@@ -172,14 +172,14 @@ bool fifosocketqueue_pop(FifoSocketQueue* self, CompatSocket* socket) {
 }
 
 void fifosocketqueue_push(FifoSocketQueue* self, const CompatSocket* socket) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
-    utility_assert(socket->type != CST_NONE);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
+    utility_debugAssert(socket->type != CST_NONE);
     priorityqueue_push(self->queue, (void*)compatsocket_toTagged(socket));
 }
 
 bool fifosocketqueue_find(FifoSocketQueue* self, const CompatSocket* socket) {
-    utility_assert(self != NULL);
-    utility_assert(self->queue != NULL);
+    utility_debugAssert(self != NULL);
+    utility_debugAssert(self->queue != NULL);
     return priorityqueue_find(self->queue, (void*)compatsocket_toTagged(socket));
 }

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -1182,7 +1182,10 @@ void process_flushPtrs(Process* proc) {
 
     // Flush and free any writers
     if (proc->memoryMutRef) {
-        memorymanager_freeMutRefWithFlush(proc->memoryMutRef);
+        int rv = memorymanager_freeMutRefWithFlush(proc->memoryMutRef);
+        if (rv) {
+            panic("Couldn't flush mutable reference");
+        }
         proc->memoryMutRef = NULL;
     }
 }

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -169,7 +169,7 @@ static Thread* _process_threadLeader(Process* proc) {
 
 ShimShmemProcess* process_getSharedMem(Process* proc) {
     MAGIC_ASSERT(proc);
-    utility_assert(proc->shimSharedMemBlock.p);
+    utility_debugAssert(proc->shimSharedMemBlock.p);
     return proc->shimSharedMemBlock.p;
 }
 
@@ -183,7 +183,7 @@ static void _process_setSharedTime(Process* proc) {
 
 const gchar* process_getName(Process* proc) {
     MAGIC_ASSERT(proc);
-    utility_assert(proc->processName->str);
+    utility_debugAssert(proc->processName->str);
     return proc->processName->str;
 }
 
@@ -199,7 +199,7 @@ int process_getStraceFd(Process* proc) {
 
 const gchar* process_getPluginName(Process* proc) {
     MAGIC_ASSERT(proc);
-    utility_assert(proc->plugin.exeName->str);
+    utility_debugAssert(proc->plugin.exeName->str);
     return proc->plugin.exeName->str;
 }
 
@@ -219,7 +219,7 @@ pid_t process_getNativePid(const Process* proc) {
 }
 
 static void _process_reapThread(Process* process, Thread* thread) {
-    utility_assert(!thread_isRunning(thread));
+    utility_debugAssert(!thread_isRunning(thread));
 
     // If the `clear_child_tid` attribute on the thread is set, and there are
     // any other threads left alive in the process, perform a futex wake on
@@ -290,7 +290,7 @@ static void _process_reapThread(Process* process, Thread* thread) {
         // flush.
 
         FutexTable* ftable = host_getFutexTable(process->host);
-        utility_assert(ftable);
+        utility_debugAssert(ftable);
         Futex* futex =
             futextable_get(ftable, process_getPhysicalAddress(process, clear_child_tid_pvp));
         if (futex) {
@@ -301,7 +301,7 @@ static void _process_reapThread(Process* process, Thread* thread) {
 
 static void _process_handleProcessExit(Process* proc) {
     trace("handleProcessExit");
-    utility_assert(!process_isRunning(proc));
+    utility_debugAssert(!process_isRunning(proc));
 
     GHashTableIter iter;
     gpointer key, value;
@@ -309,7 +309,7 @@ static void _process_handleProcessExit(Process* proc) {
     while (g_hash_table_iter_next(&iter, &key, &value)) {
         Thread* thread = value;
         thread_handleProcessExit(thread);
-        utility_assert(!thread_isRunning(thread));
+        utility_debugAssert(!thread_isRunning(thread));
         _process_reapThread(proc, thread);
 
         // Must be last, since it unrefs the thread.
@@ -496,14 +496,14 @@ static gchar* _process_outputFileName(Process* proc, const char* type) {
 
 static RegularFile* _process_openStdIOFileHelper(Process* proc, int fd, gchar* fileName) {
     MAGIC_ASSERT(proc);
-    utility_assert(fileName != NULL);
+    utility_debugAssert(fileName != NULL);
 
     RegularFile* stdfile = regularfile_new();
     Descriptor* desc = descriptor_fromLegacyFile((LegacyFile*)stdfile, /* flags= */ 0);
     Descriptor* replacedDesc = descriptortable_set(proc->descTable, fd, desc);
 
     // assume the fd was not previously in use
-    utility_assert(replacedDesc == NULL);
+    utility_debugAssert(replacedDesc == NULL);
 
     char* cwd = getcwd(NULL, 0);
     if (!cwd) {
@@ -814,8 +814,8 @@ Process* process_new(Host* host, guint processID, SimulationTime startTime, Simu
     proc->processID = processID;
 
     /* plugin name and path are required so we know what to execute */
-    utility_assert(pluginName);
-    utility_assert(pluginPath);
+    utility_debugAssert(pluginName);
+    utility_debugAssert(pluginPath);
     proc->plugin.exeName = g_string_new(pluginName);
     proc->plugin.exePath = g_string_new(pluginPath);
 
@@ -829,7 +829,7 @@ Process* process_new(Host* host, guint processID, SimulationTime startTime, Simu
     proc->cpuDelayTimer = g_timer_new();
 #endif
 
-    utility_assert(stopTime == 0 || stopTime > startTime);
+    utility_debugAssert(stopTime == 0 || stopTime > startTime);
     proc->startTime = emutime_add_simtime(EMUTIME_SIMULATION_START, startTime);
     proc->stopTime = emutime_add_simtime(EMUTIME_SIMULATION_START, stopTime);
 
@@ -986,7 +986,7 @@ void process_ref(Process* proc) {
 void process_unref(Process* proc) {
     MAGIC_ASSERT(proc);
     (proc->referenceCount)--;
-    utility_assert(proc->referenceCount >= 0);
+    utility_debugAssert(proc->referenceCount >= 0);
     if(proc->referenceCount == 0) {
         _process_free(proc);
     }
@@ -1007,7 +1007,7 @@ void process_setMemoryManager(Process* proc, MemoryManager* memoryManager) {
 
 uint32_t process_getHostId(const Process* proc) {
     MAGIC_ASSERT(proc);
-    utility_assert(proc->host);
+    utility_debugAssert(proc->host);
     return host_getID(proc->host);
 }
 
@@ -1037,10 +1037,10 @@ PluginPhysicalPtr process_getPhysicalAddress(Process* proc, PluginVirtualPtr vPt
     guint pid = process_getProcessID(proc);
     const int pid_shift = 64 - pid_bits;
     uint64_t high = (uint64_t)pid << pid_shift;
-    utility_assert(high >> pid_shift == pid);
+    utility_debugAssert(high >> pid_shift == pid);
 
     uint64_t low = vPtr.val;
-    utility_assert(low >> pid_shift == 0);
+    utility_debugAssert(low >> pid_shift == 0);
 
     return (PluginPhysicalPtr){.val = low | high};
 }
@@ -1049,7 +1049,7 @@ int process_readPtr(Process* proc, void* dst, PluginVirtualPtr src, size_t n) {
     MAGIC_ASSERT(proc);
 
     // Disallow additional references while there's a mutable reference.
-    utility_assert(!proc->memoryMutRef);
+    utility_debugAssert(!proc->memoryMutRef);
 
     return memorymanager_readPtr(proc->memoryManager, dst, src, n);
 }
@@ -1058,8 +1058,8 @@ int process_writePtr(Process* proc, PluginVirtualPtr dst, const void* src, size_
     MAGIC_ASSERT(proc);
 
     // Disallow additional references when trying to get a mutable reference.
-    utility_assert(!proc->memoryMutRef);
-    utility_assert(proc->memoryRefs->len == 0);
+    utility_debugAssert(!proc->memoryMutRef);
+    utility_debugAssert(proc->memoryRefs->len == 0);
 
     return memorymanager_writePtr(proc->memoryManager, dst, src, n);
 }
@@ -1068,7 +1068,7 @@ const void* process_getReadablePtr(Process* proc, PluginPtr plugin_src, size_t n
     MAGIC_ASSERT(proc);
 
     // Disallow additional references while there's a mutable reference.
-    utility_assert(!proc->memoryMutRef);
+    utility_debugAssert(!proc->memoryMutRef);
 
     ProcessMemoryRef_u8* ref = memorymanager_getReadablePtr(proc->memoryManager, plugin_src, n);
     if (!ref) {
@@ -1084,7 +1084,7 @@ int process_getReadableString(Process* proc, PluginPtr plugin_src, size_t n, con
     MAGIC_ASSERT(proc);
 
     // Disallow additional references while there's a mutable reference.
-    utility_assert(!proc->memoryMutRef);
+    utility_debugAssert(!proc->memoryMutRef);
 
     ProcessMemoryRef_u8* ref =
         memorymanager_getReadablePtrPrefix(proc->memoryManager, plugin_src, n);
@@ -1101,7 +1101,7 @@ int process_getReadableString(Process* proc, PluginPtr plugin_src, size_t n, con
         return -ENAMETOOLONG;
     }
 
-    utility_assert(out_str);
+    utility_debugAssert(out_str);
     *out_str = str;
     if (out_strlen) {
         *out_strlen = strlen;
@@ -1116,7 +1116,7 @@ ssize_t process_readString(Process* proc, char* str, PluginVirtualPtr src, size_
     MAGIC_ASSERT(proc);
 
     // Disallow additional references while there's a mutable reference.
-    utility_assert(!proc->memoryMutRef);
+    utility_debugAssert(!proc->memoryMutRef);
 
     return memorymanager_readString(proc->memoryManager, src, str, n);
 }
@@ -1129,8 +1129,8 @@ void* process_getWriteablePtr(Process* proc, PluginPtr plugin_src, size_t n) {
     MAGIC_ASSERT(proc);
 
     // Disallow additional references when trying to get a mutable reference.
-    utility_assert(!proc->memoryMutRef);
-    utility_assert(proc->memoryRefs->len == 0);
+    utility_debugAssert(!proc->memoryMutRef);
+    utility_debugAssert(proc->memoryRefs->len == 0);
 
     ProcessMemoryRefMut_u8* ref = memorymanager_getWritablePtr(proc->memoryManager, plugin_src, n);
     if (!ref) {
@@ -1149,8 +1149,8 @@ void* process_getMutablePtr(Process* proc, PluginPtr plugin_src, size_t n) {
     MAGIC_ASSERT(proc);
 
     // Disallow additional references when trying to get a mutable reference.
-    utility_assert(!proc->memoryMutRef);
-    utility_assert(proc->memoryRefs->len == 0);
+    utility_debugAssert(!proc->memoryMutRef);
+    utility_debugAssert(proc->memoryRefs->len == 0);
 
     ProcessMemoryRefMut_u8* ref = memorymanager_getMutablePtr(proc->memoryManager, plugin_src, n);
     if (!ref) {
@@ -1256,9 +1256,9 @@ static void _process_interruptWithSignal(Process* process, ShimShmemHostLock* ho
 
 void process_signal(Process* process, Thread* currentRunningThread, const siginfo_t* siginfo) {
     MAGIC_ASSERT(process);
-    utility_assert(siginfo->si_signo >= 0);
-    utility_assert(siginfo->si_signo <= SHD_SIGRT_MAX);
-    utility_assert(siginfo->si_signo <= SHD_STANDARD_SIGNAL_MAX_NO);
+    utility_debugAssert(siginfo->si_signo >= 0);
+    utility_debugAssert(siginfo->si_signo <= SHD_SIGRT_MAX);
+    utility_debugAssert(siginfo->si_signo <= SHD_STANDARD_SIGNAL_MAX_NO);
 
     if (siginfo->si_signo == 0) {
         return;

--- a/src/main/host/status_listener.c
+++ b/src/main/host/status_listener.c
@@ -95,7 +95,7 @@ void statuslistener_ref(StatusListener* listener) {
 void statuslistener_unref(StatusListener* listener) {
     MAGIC_ASSERT(listener);
     listener->referenceCount--;
-    utility_assert(listener->referenceCount >= 0);
+    utility_debugAssert(listener->referenceCount >= 0);
     if (listener->referenceCount == 0) {
         _statuslistener_free(listener);
     }

--- a/src/main/host/syscall/clone.c
+++ b/src/main/host/syscall/clone.c
@@ -29,7 +29,7 @@ SysCallReturn syscallhandler_clone(SysCallHandler* sys, const SysCallArgs* args)
         CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD | CLONE_SYSVSEM;
     if ((flags & required_flags) != required_flags) {
         warning("Missing a required clone flag in 0x%lx", flags);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOTSUP};
+        return syscallreturn_makeDoneErrno(ENOTSUP);
     }
 
     // Don't propagate flags to the real syscall that we'll handle ourselves.
@@ -40,7 +40,7 @@ SysCallReturn syscallhandler_clone(SysCallHandler* sys, const SysCallArgs* args)
         int res =
             thread_clone(sys->thread, filtered_flags, child_stack, ptid, ctid, newtls, &child);
         if (res < 0) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = res};
+            return syscallreturn_makeDoneI64(res);
         }
     }
     utility_debugAssert(child);
@@ -76,10 +76,10 @@ SysCallReturn syscallhandler_clone(SysCallHandler* sys, const SysCallArgs* args)
     // calling thread.
     process_addThread(sys->process, child);
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = thread_getID(child)};
+    return syscallreturn_makeDoneI64(thread_getID(child));
 }
 
 SysCallReturn syscallhandler_gettid(SysCallHandler* sys, const SysCallArgs* args) {
     utility_debugAssert(sys && args);
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = thread_getID(sys->thread)};
+    return syscallreturn_makeDoneI64(thread_getID(sys->thread));
 }

--- a/src/main/host/syscall/clone.c
+++ b/src/main/host/syscall/clone.c
@@ -15,7 +15,7 @@
 #include "main/utility/utility.h"
 
 SysCallReturn syscallhandler_clone(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
 
     // Note that the syscall args are different than the libc wrapper.
     // See "C library/kernel differences" in clone(2).
@@ -43,7 +43,7 @@ SysCallReturn syscallhandler_clone(SysCallHandler* sys, const SysCallArgs* args)
             return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = res};
         }
     }
-    utility_assert(child);
+    utility_debugAssert(child);
 
     unsigned long handled_flags = required_flags;
     if (flags & CLONE_PARENT_SETTID) {
@@ -80,6 +80,6 @@ SysCallReturn syscallhandler_clone(SysCallHandler* sys, const SysCallArgs* args)
 }
 
 SysCallReturn syscallhandler_gettid(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = thread_getID(sys->thread)};
 }

--- a/src/main/host/syscall/epoll.c
+++ b/src/main/host/syscall/epoll.c
@@ -50,7 +50,7 @@ SysCallReturn syscallhandler_epoll_create(SysCallHandler* sys,
 
     int result = _syscallhandler_createEpollHelper(sys, size, 0);
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
+    return syscallreturn_makeDoneI64(result);
 }
 
 SysCallReturn syscallhandler_epoll_create1(SysCallHandler* sys,
@@ -59,7 +59,7 @@ SysCallReturn syscallhandler_epoll_create1(SysCallHandler* sys,
 
     int result = _syscallhandler_createEpollHelper(sys, 1, flags);
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
+    return syscallreturn_makeDoneI64(result);
 }
 
 SysCallReturn syscallhandler_epoll_ctl(SysCallHandler* sys,
@@ -72,14 +72,14 @@ SysCallReturn syscallhandler_epoll_ctl(SysCallHandler* sys,
     /* Make sure they didn't pass a NULL pointer if EPOLL_CTL_DEL is not used. */
     if (!eventPtr.val && op != EPOLL_CTL_DEL) {
         trace("NULL event pointer passed for epoll %i", epfd);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        return syscallreturn_makeDoneErrno(EFAULT);
     }
 
     /* EINVAL if fd is the same as epfd, or the requested operation op is not
      * supported by this interface */
     if (epfd == fd) {
         trace("Epoll fd %i cannot be used to wait on itself.", epfd);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     /* Get and check the epoll descriptor. */
@@ -88,8 +88,7 @@ SysCallReturn syscallhandler_epoll_ctl(SysCallHandler* sys,
 
     if (errorCode) {
         trace("Error when trying to validate epoll %i", epfd);
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = errorCode};
+        return syscallreturn_makeDoneErrno(-errorCode);
     }
 
     /* It's now safe to cast. */
@@ -101,7 +100,7 @@ SysCallReturn syscallhandler_epoll_ctl(SysCallHandler* sys,
 
     if (descriptor == NULL) {
         debug("Child %i is not a shadow descriptor", fd);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EBADF};
+        return syscallreturn_makeDoneErrno(EBADF);
     }
 
     LegacyFile* legacyDescriptor = descriptor_asLegacyFile(descriptor);
@@ -117,7 +116,7 @@ SysCallReturn syscallhandler_epoll_ctl(SysCallHandler* sys,
 
         if (errorCode) {
             debug("Child %i of epoll %i is closed", fd, epfd);
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errorCode};
+            return syscallreturn_makeDoneErrno(-errorCode);
         }
     }
 
@@ -129,7 +128,7 @@ SysCallReturn syscallhandler_epoll_ctl(SysCallHandler* sys,
     trace("Calling epoll_control on epoll %i with child %i", epfd, fd);
     errorCode = epoll_control(epoll, op, fd, descriptor, event, sys->host);
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errorCode};
+    return syscallreturn_makeDoneI64(errorCode);
 }
 
 SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
@@ -142,13 +141,7 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
     /* Check input args. */
     if (maxevents <= 0) {
         trace("Maxevents %i is not greater than 0.", maxevents);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
-    }
-
-    /* Make sure they didn't pass a NULL pointer. */
-    if (!eventsPtr.val) {
-        trace("NULL event pointer passed for epoll %i", epfd);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     /* Get and check the epoll descriptor. */
@@ -157,8 +150,7 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
 
     if (errorCode) {
         trace("Error when trying to validate epoll %i", epfd);
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = errorCode};
+        return syscallreturn_makeDoneErrno(-errorCode);
     }
     utility_debugAssert(desc);
 
@@ -181,9 +173,9 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
                   epfd);
 
             /* Return 0; no events are ready. */
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+            return syscallreturn_makeDoneI64(0);
         } else if (thread_unblockedSignalPending(sys->thread, host_getShimShmemLock(sys->host))) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINTR};
+            return syscallreturn_makeInterrupted(false);
         } else {
             trace("No events are ready on epoll %i and we need to block", epfd);
 
@@ -201,7 +193,7 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
                     worker_getCurrentEmulatedTime() + timeout_ms * SIMTIME_ONE_MILLISECOND);
             }
 
-            return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = cond, .restartable = false};
+            return syscallreturn_makeBlocked(cond, false);
         }
     }
 
@@ -209,6 +201,9 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
     guint numEventsNeeded = MIN((guint)maxevents, numReadyEvents);
     size_t sizeNeeded = sizeof(struct epoll_event) * numEventsNeeded;
     struct epoll_event* events = process_getWriteablePtr(sys->process, eventsPtr, sizeNeeded);
+    if (!events) {
+        return syscallreturn_makeDoneErrno(EFAULT);
+    }
 
     /* Retrieve the events. */
     gint nEvents = 0;
@@ -218,7 +213,7 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
     trace("Found %i ready events on epoll %i.", nEvents, epfd);
 
     /* Return the number of events that are ready. */
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = nEvents};
+    return syscallreturn_makeDoneI64(nEvents);
 }
 
 SysCallReturn syscallhandler_epoll_pwait(SysCallHandler* sys, const SysCallArgs* args) {
@@ -227,7 +222,7 @@ SysCallReturn syscallhandler_epoll_pwait(SysCallHandler* sys, const SysCallArgs*
     if (sigmask.val != 0) {
         error("epoll_pwait called with non-null sigmask, which is not yet supported by shadow; "
               "returning ENOSYS");
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+        return syscallreturn_makeDoneErrno(ENOSYS);
     }
 
     return syscallhandler_epoll_wait(sys, args);

--- a/src/main/host/syscall/epoll.c
+++ b/src/main/host/syscall/epoll.c
@@ -94,7 +94,7 @@ SysCallReturn syscallhandler_epoll_ctl(SysCallHandler* sys,
 
     /* It's now safe to cast. */
     Epoll* epoll = (Epoll*)epollDescriptor;
-    utility_assert(epoll);
+    utility_debugAssert(epoll);
 
     /* Find the child descriptor that the epoll is monitoring. */
     const Descriptor* descriptor = process_getRegisteredDescriptor(sys->process, fd);
@@ -160,11 +160,11 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
         return (SysCallReturn){
             .state = SYSCALL_DONE, .retval.as_i64 = errorCode};
     }
-    utility_assert(desc);
+    utility_debugAssert(desc);
 
     /* It's now safe to cast. */
     Epoll* epoll = (Epoll*)desc;
-    utility_assert(epoll);
+    utility_debugAssert(epoll);
 
     /* figure out how many events we actually have so we can request
      * less memory than maxevents if possible. */
@@ -213,7 +213,7 @@ SysCallReturn syscallhandler_epoll_wait(SysCallHandler* sys,
     /* Retrieve the events. */
     gint nEvents = 0;
     gint result = epoll_getEvents(epoll, events, numEventsNeeded, &nEvents);
-    utility_assert(result == 0);
+    utility_debugAssert(result == 0);
 
     trace("Found %i ready events on epoll %i.", nEvents, epfd);
 

--- a/src/main/host/syscall/fcntl.c
+++ b/src/main/host/syscall/fcntl.c
@@ -179,7 +179,7 @@ SysCallReturn syscallhandler_fcntl(SysCallHandler* sys,
     LegacyFile* desc = process_getRegisteredLegacyFile(sys->process, fd);
     int errcode = _syscallhandler_validateLegacyFile(desc, DT_NONE);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
 
     int result = 0;
@@ -205,5 +205,5 @@ SysCallReturn syscallhandler_fcntl(SysCallHandler* sys,
         }
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
+    return syscallreturn_makeDoneI64(result);
 }

--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -75,7 +75,7 @@ static SysCallReturn _syscallhandler_openHelper(SysCallHandler* sys,
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
 
-    utility_assert(errcode == 0);
+    utility_debugAssert(errcode == 0);
     Descriptor* desc = descriptor_fromLegacyFile((LegacyFile*)filed, flags & O_CLOEXEC);
     int handle = process_registerDescriptor(sys->process, desc);
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = handle};

--- a/src/main/host/syscall/fileat.c
+++ b/src/main/host/syscall/fileat.c
@@ -136,7 +136,7 @@ SysCallReturn syscallhandler_openat(SysCallHandler* sys,
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
 
-    utility_assert(errcode == 0);
+    utility_debugAssert(errcode == 0);
     Descriptor* desc = descriptor_fromLegacyFile((LegacyFile*)file_desc, flags & O_CLOEXEC);
     int handle = process_registerDescriptor(sys->process, desc);
     return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = handle};

--- a/src/main/host/syscall/futex.c
+++ b/src/main/host/syscall/futex.c
@@ -65,7 +65,7 @@ static SysCallReturn _syscallhandler_futexWaitHelper(SysCallHandler* sys, Plugin
     Futex* futex = futextable_get(ftable, futexPPtr);
 
     if (_syscallhandler_wasBlocked(sys)) {
-        utility_assert(futex != NULL);
+        utility_debugAssert(futex != NULL);
         int result = 0;
 
         // We already blocked on wait, so this is either a timeout or wakeup
@@ -86,7 +86,7 @@ static SysCallReturn _syscallhandler_futexWaitHelper(SysCallHandler* sys, Plugin
         if (futex_getListenerCount(futex) == 0) {
             trace("Dynamically freed a futex object for futex addr %p", (void*)futexPPtr.val);
             bool success = futextable_remove(ftable, futex);
-            utility_assert(success);
+            utility_debugAssert(success);
         }
 
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
@@ -97,7 +97,7 @@ static SysCallReturn _syscallhandler_futexWaitHelper(SysCallHandler* sys, Plugin
         trace("Dynamically created a new futex object for futex addr %p", (void*)futexPPtr.val);
         futex = futex_new(futexPPtr);
         bool success = futextable_add(ftable, futex);
-        utility_assert(success);
+        utility_debugAssert(success);
     }
 
     // Now we need to block until another thread does a wake on the futex.
@@ -145,7 +145,7 @@ static SysCallReturn _syscallhandler_futexWakeHelper(SysCallHandler* sys, Plugin
 // hardware address (i.e., page table and offset). This is needed, e.g., when using
 // futexes across process boundaries.
 SysCallReturn syscallhandler_futex(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
 
     PluginPtr uaddrptr = args->args[0].as_ptr; // int*
     int futex_op = args->args[1].as_i64;
@@ -212,7 +212,7 @@ SysCallReturn syscallhandler_futex(SysCallHandler* sys, const SysCallArgs* args)
 }
 
 SysCallReturn syscallhandler_get_robust_list(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
 
     debug("get_robust_list was called but we don't yet support it");
 
@@ -220,7 +220,7 @@ SysCallReturn syscallhandler_get_robust_list(SysCallHandler* sys, const SysCallA
 }
 
 SysCallReturn syscallhandler_set_robust_list(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
 
     debug("set_robust_list was called but we don't yet support it");
 

--- a/src/main/host/syscall/ioctl.c
+++ b/src/main/host/syscall/ioctl.c
@@ -241,7 +241,7 @@ SysCallReturn syscallhandler_ioctl(SysCallHandler* sys,
     LegacyFile* desc = process_getRegisteredLegacyFile(sys->process, fd);
     int errcode = _syscallhandler_validateLegacyFile(desc, DT_NONE);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
 
     LegacyFileType dtype = legacyfile_getType(desc);
@@ -259,5 +259,5 @@ SysCallReturn syscallhandler_ioctl(SysCallHandler* sys,
         result = -ENOTTY;
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
+    return syscallreturn_makeDoneI64(result);
 }

--- a/src/main/host/syscall/ioctl.c
+++ b/src/main/host/syscall/ioctl.c
@@ -66,7 +66,7 @@ static int _syscallhandler_ioctlTCPHelper(SysCallHandler* sys, TCP* tcp, int fd,
             int rv = process_writePtr(sys->process, argPtr, &lenout, sizeof(int));
 
             if (rv != 0) {
-                utility_assert(rv < 0);
+                utility_debugAssert(rv < 0);
                 result = rv;
                 break;
             }
@@ -80,7 +80,7 @@ static int _syscallhandler_ioctlTCPHelper(SysCallHandler* sys, TCP* tcp, int fd,
             int rv = process_writePtr(sys->process, argPtr, &lenout, sizeof(int));
 
             if (rv != 0) {
-                utility_assert(rv < 0);
+                utility_debugAssert(rv < 0);
                 result = rv;
                 break;
             }
@@ -94,7 +94,7 @@ static int _syscallhandler_ioctlTCPHelper(SysCallHandler* sys, TCP* tcp, int fd,
             int rv = process_writePtr(sys->process, argPtr, &lenout, sizeof(int));
 
             if (rv != 0) {
-                utility_assert(rv < 0);
+                utility_debugAssert(rv < 0);
                 result = rv;
                 break;
             }
@@ -108,7 +108,7 @@ static int _syscallhandler_ioctlTCPHelper(SysCallHandler* sys, TCP* tcp, int fd,
             int rv = process_readPtr(sys->process, &val, argPtr, sizeof(int));
 
             if (rv != 0) {
-                utility_assert(rv < 0);
+                utility_debugAssert(rv < 0);
                 result = rv;
                 break;
             }
@@ -158,7 +158,7 @@ static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
             int rv = process_writePtr(sys->process, argPtr, &lenout, sizeof(int));
 
             if (rv != 0) {
-                utility_assert(rv < 0);
+                utility_debugAssert(rv < 0);
                 result = rv;
                 break;
             }
@@ -172,7 +172,7 @@ static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
             int rv = process_writePtr(sys->process, argPtr, &lenout, sizeof(int));
 
             if (rv != 0) {
-                utility_assert(rv < 0);
+                utility_debugAssert(rv < 0);
                 result = rv;
                 break;
             }
@@ -186,7 +186,7 @@ static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
             int rv = process_readPtr(sys->process, &val, argPtr, sizeof(int));
 
             if (rv != 0) {
-                utility_assert(rv < 0);
+                utility_debugAssert(rv < 0);
                 result = rv;
                 break;
             }

--- a/src/main/host/syscall/mman.c
+++ b/src/main/host/syscall/mman.c
@@ -113,7 +113,7 @@ static char* _file_createPersistentMMapPath(int file_fd, int osfile_fd) {
 }
 
 static int _syscallhandler_openPluginFile(SysCallHandler* sys, int fd, RegularFile* file) {
-    utility_assert(file);
+    utility_debugAssert(file);
 
     trace("Trying to open file %i in the plugin", fd);
 
@@ -129,7 +129,7 @@ static int _syscallhandler_openPluginFile(SysCallHandler* sys, int fd, RegularFi
 
     /* We need enough mem for the string, but no more than PATH_MAX. */
     size_t maplen = strnlen(mmap_path, PATH_MAX - 1) + 1; // an extra 1 for null
-    utility_assert(maplen > 1);
+    utility_debugAssert(maplen > 1);
 
     trace("Opening path '%s' in plugin.", mmap_path);
 
@@ -273,7 +273,7 @@ SysCallReturn syscallhandler_mmap2(SysCallHandler* sys, const SysCallArgs* args)
     int64_t pgoffset = args->args[5].as_i64;
 
     // As long as we're on a system where off_t is 64-bit, we can just remap to mmap.
-    utility_assert(sizeof(off_t) == sizeof(int64_t));
+    utility_debugAssert(sizeof(off_t) == sizeof(int64_t));
     return _syscallhandler_mmap(sys, addrPtr, len, prot, flags, fd, 4096 * pgoffset);
 }
 

--- a/src/main/host/syscall/mod.rs
+++ b/src/main/host/syscall/mod.rs
@@ -31,25 +31,3 @@ impl Trigger {
         })
     }
 }
-
-impl c::SysCallReturn {
-    pub fn from_errno(errno: nix::errno::Errno) -> Self {
-        Self {
-            state: c::SysCallReturnState_SYSCALL_DONE,
-            retval: c::SysCallReg {
-                as_i64: -(errno as i64),
-            },
-            cond: std::ptr::null_mut(),
-            restartable: false,
-        }
-    }
-
-    pub fn from_int(int: i64) -> Self {
-        Self {
-            state: c::SysCallReturnState_SYSCALL_DONE,
-            retval: c::SysCallReg { as_i64: int },
-            cond: std::ptr::null_mut(),
-            restartable: false,
-        }
-    }
-}

--- a/src/main/host/syscall/poll.c
+++ b/src/main/host/syscall/poll.c
@@ -155,7 +155,7 @@ SysCallReturn _syscallhandler_pollHelper(SysCallHandler* sys, struct pollfd* fds
             }
 
             // We either use our timer as a timeout, or no timeout
-            return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = cond, .restartable = false};
+            return syscallreturn_makeBlocked(cond, false);
         }
     }
 
@@ -164,7 +164,7 @@ SysCallReturn _syscallhandler_pollHelper(SysCallHandler* sys, struct pollfd* fds
 done:
     // Clear epoll for the next poll
     epoll_reset(sys->epoll);
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = num_ready};
+    return syscallreturn_makeDoneI64(num_ready);
 }
 
 static SysCallReturn _syscallhandler_pollHelperPluginPtr(SysCallHandler* sys, PluginPtr fds_ptr,
@@ -175,7 +175,7 @@ static SysCallReturn _syscallhandler_pollHelperPluginPtr(SysCallHandler* sys, Pl
     if (nfds > 0) {
         fds = process_getMutablePtr(sys->process, fds_ptr, nfds * sizeof(*fds));
         if (!fds) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+            return syscallreturn_makeDoneErrno(EFAULT);
         }
     }
 
@@ -204,7 +204,7 @@ SysCallReturn syscallhandler_poll(SysCallHandler* sys, const SysCallArgs* args) 
 
     int result = _syscallhandler_checkPollArgs(fds_ptr, nfds);
     if (result != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
+        return syscallreturn_makeDoneErrno(-result);
     } else {
         struct timespec timeout =
             (struct timespec){.tv_sec = timeout_millis / MILLIS_PER_SEC,
@@ -222,7 +222,7 @@ SysCallReturn syscallhandler_ppoll(SysCallHandler* sys, const SysCallArgs* args)
 
     int result = _syscallhandler_checkPollArgs(fds_ptr, nfds);
     if (result != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
+        return syscallreturn_makeDoneErrno(-result);
     }
 
     // We read the timeout struct into local memory to avoid holding a reference
@@ -234,13 +234,13 @@ SysCallReturn syscallhandler_ppoll(SysCallHandler* sys, const SysCallArgs* args)
     if (ts_timeout_ptr.val) {
         if (process_readPtr(
                 sys->process, &ts_timeout_val, ts_timeout_ptr, sizeof(ts_timeout_val)) != 0) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+            return syscallreturn_makeDoneErrno(EFAULT);
         }
 
         // Negative time values in the struct are invalid
         if (ts_timeout_val.tv_sec < 0 || ts_timeout_val.tv_nsec < 0) {
             trace("negative timeout given in timespec arg, returning EINVAL");
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+            return syscallreturn_makeDoneErrno(EINVAL);
         }
     }
 

--- a/src/main/host/syscall/poll.c
+++ b/src/main/host/syscall/poll.c
@@ -102,7 +102,7 @@ static void _syscallhandler_registerPollFDs(SysCallHandler* sys, struct pollfd* 
         }
 
         const Descriptor* desc = process_getRegisteredDescriptor(sys->process, pfd->fd);
-        utility_assert(desc); // we would have returned POLLNVAL in getPollEvents
+        utility_debugAssert(desc); // we would have returned POLLNVAL in getPollEvents
 
         struct epoll_event epev = {0};
         if (pfd->events & POLLIN) {

--- a/src/main/host/syscall/process.c
+++ b/src/main/host/syscall/process.c
@@ -36,7 +36,7 @@ static SysCallReturn _syscallhandler_prlimitHelper(SysCallHandler* sys, pid_t pi
 ///////////////////////////////////////////////////////////
 
 SysCallReturn syscallhandler_prctl(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
 
     int option = args->args[0].as_i64;
     trace("prctl called with option %i", option);
@@ -63,7 +63,7 @@ SysCallReturn syscallhandler_prctl(SysCallHandler* sys, const SysCallArgs* args)
 }
 
 SysCallReturn syscallhandler_prlimit(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
     pid_t pid = args->args[0].as_i64;
     int resource = args->args[1].as_i64;
     PluginPtr newlim = args->args[2].as_ptr; // const struct rlimit*
@@ -73,7 +73,7 @@ SysCallReturn syscallhandler_prlimit(SysCallHandler* sys, const SysCallArgs* arg
 }
 
 SysCallReturn syscallhandler_prlimit64(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
     pid_t pid = args->args[0].as_i64;
     int resource = args->args[1].as_i64;
     PluginPtr newlim = args->args[2].as_ptr; // const struct rlimit*

--- a/src/main/host/syscall/process.c
+++ b/src/main/host/syscall/process.c
@@ -22,12 +22,12 @@ static SysCallReturn _syscallhandler_prlimitHelper(SysCallHandler* sys, pid_t pi
     // RLIMIT_NOFILE. Some applications like Tor will change behavior depending on these limits.
     if (pid == 0) {
         // process is calling prlimit on itself
-        return (SysCallReturn){.state = SYSCALL_NATIVE};
+        return syscallreturn_makeNative();
     } else {
         // TODO: we do not currently support adjusting other processes limits.
         // To support it, we just need to find the native pid associated
         // with pid, and call prlimit on the native pid instead.
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+        return syscallreturn_makeDoneErrno(ENOSYS);
     }
 }
 
@@ -46,19 +46,13 @@ SysCallReturn syscallhandler_prctl(SysCallHandler* sys, const SysCallArgs* args)
 
         // Make sure we have somewhere to copy the output
         PluginPtr outptr = args->args[1].as_ptr;
-        if (!outptr.val) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        int res = process_writePtr(sys->process, outptr, &tid_addr.val, sizeof(tid_addr.val));
+        if (res) {
+            return syscallreturn_makeDoneErrno(-res);
         }
-
-        int** out = process_getWriteablePtr(sys->process, outptr, sizeof(*out));
-        if (!out) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
-        }
-
-        *out = (int*)tid_addr.val;
-        return (SysCallReturn){.state = SYSCALL_DONE};
+        return syscallreturn_makeDoneU64(0);
     } else {
-        return (SysCallReturn){.state = SYSCALL_NATIVE};
+        return syscallreturn_makeNative();
     }
 }
 
@@ -88,5 +82,5 @@ SysCallReturn syscallhandler_execve(SysCallHandler* sys, const SysCallArgs* args
     process_setMemoryManager(sys->process, NULL);
 
     // Have the plugin execute it natively.
-    return (SysCallReturn){.state = SYSCALL_NATIVE};
+    return syscallreturn_makeNative();
 }

--- a/src/main/host/syscall/shadow.c
+++ b/src/main/host/syscall/shadow.c
@@ -34,14 +34,14 @@ SysCallReturn syscallhandler_shadow_hostname_to_addr_ipv4(SysCallHandler* sys,
 
     if (!name_ptr.val || !addr_ptr.val || addr_len < sizeof(uint32_t)) {
         trace("Invalid argument detected, returning EINVAL");
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     const char* name;
     int rv = process_getReadableString(
         sys->process, name_ptr, name_len + 1 /* NULL byte */, &name, &name_len);
     if (rv != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = rv};
+        return syscallreturn_makeDoneErrno(-rv);
     }
 
     if (strcasecmp(name, "localhost") == 0) {
@@ -49,7 +49,7 @@ SysCallReturn syscallhandler_shadow_hostname_to_addr_ipv4(SysCallHandler* sys,
         uint32_t* addr = process_getWriteablePtr(sys->process, addr_ptr, addr_len);
         *addr = htonl(INADDR_LOOPBACK);
         trace("Returning loopback address for localhost");
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+        return syscallreturn_makeDoneI64(0);
     }
 
     Address* address;
@@ -73,18 +73,18 @@ SysCallReturn syscallhandler_shadow_hostname_to_addr_ipv4(SysCallHandler* sys,
         uint32_t* addr = process_getWriteablePtr(sys->process, addr_ptr, addr_len);
         *addr = ip;
 
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+        return syscallreturn_makeDoneI64(0);
     } else {
         trace("Unable to find address for name %s", name);
         // return EFAULT like gethostname
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        return syscallreturn_makeDoneErrno(EFAULT);
     }
 }
 
 static SysCallReturn _syscallhandler_get_shmem_block(SysCallHandler* sys, const SysCallArgs* args,
                                                      ShMemBlock* block) {
     if (!block) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENODEV};
+        return syscallreturn_makeDoneErrno(ENODEV);
     }
 
     PluginPtr shm_blk_pptr = args->args[0].as_ptr;
@@ -93,7 +93,7 @@ static SysCallReturn _syscallhandler_get_shmem_block(SysCallHandler* sys, const 
         process_getWriteablePtr(sys->process, shm_blk_pptr, sizeof(*shm_blk_ptr));
     *shm_blk_ptr = shmemallocator_globalBlockSerialize(block);
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+    return syscallreturn_makeDoneI64(0);
 }
 
 SysCallReturn syscallhandler_shadow_get_ipc_blk(SysCallHandler* sys, const SysCallArgs* args) {
@@ -116,9 +116,9 @@ SysCallReturn syscallhandler_shadow_init_memory_manager(SysCallHandler* sys, con
     } else {
         trace("Not initializing memory manager");
     }
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+    return syscallreturn_makeDoneI64(0);
 }
 
 SysCallReturn syscallhandler_shadow_yield(SysCallHandler* sys, const SysCallArgs* args) {
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+    return syscallreturn_makeDoneI64(0);
 }

--- a/src/main/host/syscall/shadow.c
+++ b/src/main/host/syscall/shadow.c
@@ -24,7 +24,7 @@ ADD_CONFIG_HANDLER(config_getUseMemoryManager, _useMM)
 
 SysCallReturn syscallhandler_shadow_hostname_to_addr_ipv4(SysCallHandler* sys,
                                                           const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
     PluginPtr name_ptr = args->args[0].as_ptr;
     size_t name_len = args->args[1].as_u64;
     PluginPtr addr_ptr = args->args[2].as_ptr;
@@ -97,19 +97,19 @@ static SysCallReturn _syscallhandler_get_shmem_block(SysCallHandler* sys, const 
 }
 
 SysCallReturn syscallhandler_shadow_get_ipc_blk(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
     trace("handling shadow_get_ipc_blk syscall");
     return _syscallhandler_get_shmem_block(sys, args, thread_getIPCBlock(sys->thread));
 }
 
 SysCallReturn syscallhandler_shadow_get_shm_blk(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
     trace("handling shadow_get_shm_blk syscall");
     return _syscallhandler_get_shmem_block(sys, args, thread_getShMBlock(sys->thread));
 }
 
 SysCallReturn syscallhandler_shadow_init_memory_manager(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
     if (_useMM) {
         trace("Initializing memory manager");
         memorymanager_initMapperIfNeeded(process_getMemoryManager(sys->process), sys->thread);

--- a/src/main/host/syscall/signal.c
+++ b/src/main/host/syscall/signal.c
@@ -135,7 +135,7 @@ static SysCallReturn _syscallhandler_signalThread(SysCallHandler* sys, Thread* t
 ///////////////////////////////////////////////////////////
 
 SysCallReturn syscallhandler_kill(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
     pid_t pid = args->args[0].as_i64;
     int sig = args->args[1].as_i64;
 
@@ -175,7 +175,7 @@ SysCallReturn syscallhandler_kill(SysCallHandler* sys, const SysCallArgs* args) 
 }
 
 SysCallReturn syscallhandler_tgkill(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
 
     pid_t tgid = args->args[0].as_i64;
     pid_t tid = args->args[1].as_i64;
@@ -198,7 +198,7 @@ SysCallReturn syscallhandler_tgkill(SysCallHandler* sys, const SysCallArgs* args
 }
 
 SysCallReturn syscallhandler_tkill(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
     pid_t tid = args->args[0].as_i64;
     int sig = args->args[1].as_i64;
 
@@ -215,7 +215,7 @@ SysCallReturn syscallhandler_tkill(SysCallHandler* sys, const SysCallArgs* args)
 
 static SysCallReturn _rt_sigaction(SysCallHandler* sys, int signum, PluginPtr actPtr,
                                    PluginPtr oldActPtr, size_t masksize) {
-    utility_assert(sys);
+    utility_debugAssert(sys);
 
     if (signum < 1 || signum > 64) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval = -EINVAL};
@@ -252,7 +252,7 @@ static SysCallReturn _rt_sigaction(SysCallHandler* sys, int signum, PluginPtr ac
 }
 
 SysCallReturn syscallhandler_rt_sigaction(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
     SysCallReturn ret =
         _rt_sigaction(sys, /*signum=*/(int)args->args[0].as_i64,
                       /*actPtr=*/args->args[1].as_ptr,
@@ -261,7 +261,7 @@ SysCallReturn syscallhandler_rt_sigaction(SysCallHandler* sys, const SysCallArgs
 }
 
 SysCallReturn syscallhandler_sigaltstack(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
     PluginPtr ss_ptr = args->args[0].as_ptr;
     PluginPtr old_ss_ptr = args->args[1].as_ptr;
     trace("sigaltstack(%p, %p)", (void*)ss_ptr.val, (void*)old_ss_ptr.val);
@@ -307,7 +307,7 @@ SysCallReturn syscallhandler_sigaltstack(SysCallHandler* sys, const SysCallArgs*
 
 static SysCallReturn _rt_sigprocmask(SysCallHandler* sys, int how, PluginPtr setPtr,
                                      PluginPtr oldSetPtr, size_t sigsetsize) {
-    utility_assert(sys);
+    utility_debugAssert(sys);
 
     // From sigprocmask(2): This argument is currently required to have a fixed architecture
     // specific value (equal to sizeof(kernel_sigset_t)).
@@ -360,7 +360,7 @@ static SysCallReturn _rt_sigprocmask(SysCallHandler* sys, int how, PluginPtr set
 }
 
 SysCallReturn syscallhandler_rt_sigprocmask(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_assert(sys && args);
+    utility_debugAssert(sys && args);
 
     SysCallReturn ret =
         _rt_sigprocmask(sys, /*how=*/(int)args->args[0].as_i64, /*setPtr=*/args->args[1].as_ptr,

--- a/src/main/host/syscall/signal.c
+++ b/src/main/host/syscall/signal.c
@@ -36,12 +36,12 @@ static int _shim_handled_signals[] = {SIGSYS, SIGSEGV};
 
 static SysCallReturn _syscallhandler_signalProcess(SysCallHandler* sys, Process* process, int sig) {
     if (sig < 0 || sig > SHD_SIGRT_MAX) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     if (sig > SHD_STANDARD_SIGNAL_MAX_NO) {
         warning("Unimplemented signal %d", sig);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+        return syscallreturn_makeDoneErrno(ENOSYS);
     }
 
     siginfo_t siginfo = {
@@ -54,21 +54,21 @@ static SysCallReturn _syscallhandler_signalProcess(SysCallHandler* sys, Process*
 
     process_signal(process, sys->thread, &siginfo);
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+    return syscallreturn_makeDoneI64(0);
 }
 
 static SysCallReturn _syscallhandler_signalThread(SysCallHandler* sys, Thread* thread, int sig) {
     if (sig < 0 || sig > SHD_SIGRT_MAX) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     if (sig > SHD_STANDARD_SIGNAL_MAX_NO) {
         warning("Unimplemented signal %d", sig);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+        return syscallreturn_makeDoneErrno(ENOSYS);
     }
 
     if (sig == 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+        return syscallreturn_makeDoneI64(0);
     }
 
     Process* process = thread_getProcess(thread);
@@ -77,7 +77,7 @@ static SysCallReturn _syscallhandler_signalThread(SysCallHandler* sys, Thread* t
     if (action.ksa_handler == SIG_IGN ||
         (action.ksa_handler == SIG_DFL && shd_defaultAction(sig) == SHD_DEFAULT_ACTION_IGN)) {
         // Don't deliver ignored an signal.
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+        return syscallreturn_makeDoneI64(0);
     }
 
     shd_kernel_sigset_t pending_signals = shimshmem_getThreadPendingSignals(
@@ -87,7 +87,7 @@ static SysCallReturn _syscallhandler_signalThread(SysCallHandler* sys, Thread* t
         // Signal is already pending. From signal(7):In the case where a standard signal is already
         // pending, the siginfo_t structure (see sigaction(2)) associated with  that  signal is not
         // overwritten on arrival of subsequent instances of the same signal.
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+        return syscallreturn_makeDoneI64(0);
     }
 
     shd_sigaddset(&pending_signals, sig);
@@ -105,7 +105,7 @@ static SysCallReturn _syscallhandler_signalThread(SysCallHandler* sys, Thread* t
     if (thread == sys->thread) {
         // Target is the current thread. It'll be handled synchronously when the
         // current syscall returns (if it's unblocked).
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+        return syscallreturn_makeDoneI64(0);
     }
 
     shd_kernel_sigset_t blocked_signals =
@@ -115,7 +115,7 @@ static SysCallReturn _syscallhandler_signalThread(SysCallHandler* sys, Thread* t
         // need to schedule an event to process the signal. It'll get processed
         // synchronously when the thread executes a syscall that would unblock
         // the signal.
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+        return syscallreturn_makeDoneI64(0);
     }
 
     SysCallCondition* cond = thread_getSysCallCondition(thread);
@@ -123,11 +123,11 @@ static SysCallReturn _syscallhandler_signalThread(SysCallHandler* sys, Thread* t
         // We may be able to get here if a thread is signalled before it runs
         // for the first time. Just return; the signal will be delivered when
         // the thread runs.
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+        return syscallreturn_makeDoneI64(0);
     }
     syscallcondition_wakeupForSignal(cond, host_getShimShmemLock(sys->host), sig);
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+    return syscallreturn_makeDoneI64(0);
 }
 
 ///////////////////////////////////////////////////////////
@@ -149,7 +149,7 @@ SysCallReturn syscallhandler_kill(SysCallHandler* sys, const SysCallArgs* args) 
         // Currently unimplemented, and unlikely to be needed in the context of
         // a shadow simulation.
         warning("kill with pid=-1 unimplemented");
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+        return syscallreturn_makeDoneErrno(ENOSYS);
     } else if (pid == 0) {
         // kill(2): If pid equals 0, then sig is sent to every process in the
         // process group of the calling process.
@@ -168,7 +168,7 @@ SysCallReturn syscallhandler_kill(SysCallHandler* sys, const SysCallArgs* args) 
     Process* process = host_getProcess(sys->host, pid);
     if (process == NULL) {
         debug("Process %d not found", pid);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ESRCH};
+        return syscallreturn_makeDoneErrno(ESRCH);
     }
 
     return _syscallhandler_signalProcess(sys, process, sig);
@@ -185,13 +185,13 @@ SysCallReturn syscallhandler_tgkill(SysCallHandler* sys, const SysCallArgs* args
 
     Thread* thread = host_getThread(sys->host, tid);
     if (thread == NULL) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ESRCH};
+        return syscallreturn_makeDoneErrno(ESRCH);
     }
 
     Process* process = thread_getProcess(thread);
 
     if (process_getProcessID(process) != tgid) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ESRCH};
+        return syscallreturn_makeDoneErrno(ESRCH);
     }
 
     return _syscallhandler_signalThread(sys, thread, sig);
@@ -206,7 +206,7 @@ SysCallReturn syscallhandler_tkill(SysCallHandler* sys, const SysCallArgs* args)
 
     Thread* thread = host_getThread(sys->host, tid);
     if (thread == NULL) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ESRCH};
+        return syscallreturn_makeDoneErrno(ESRCH);
     }
 
     SysCallReturn ret = _syscallhandler_signalThread(sys, thread, sig);
@@ -218,11 +218,11 @@ static SysCallReturn _rt_sigaction(SysCallHandler* sys, int signum, PluginPtr ac
     utility_debugAssert(sys);
 
     if (signum < 1 || signum > 64) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     if (masksize != 64 / 8) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     if (oldActPtr.val) {
@@ -230,25 +230,25 @@ static SysCallReturn _rt_sigaction(SysCallHandler* sys, int signum, PluginPtr ac
             host_getShimShmemLock(sys->host), process_getSharedMem(sys->process), signum);
         int rv = process_writePtr(sys->process, oldActPtr, &old_action, sizeof(old_action));
         if (rv != 0) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval = rv};
+            return syscallreturn_makeDoneErrno(-rv);
         }
     }
 
     if (actPtr.val) {
         if (signum == SIGKILL || signum == SIGSTOP) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval = -EINVAL};
+            return syscallreturn_makeDoneErrno(EINVAL);
         }
 
         struct shd_kernel_sigaction new_action;
         int rv = process_readPtr(sys->process, &new_action, actPtr, sizeof(new_action));
         if (rv != 0) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval = rv};
+            return syscallreturn_makeDoneErrno(-rv);
         }
         shimshmem_setSignalAction(host_getShimShmemLock(sys->host),
                                   process_getSharedMem(sys->process), signum, &new_action);
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval = 0};
+    return syscallreturn_makeDoneI64(0);
 }
 
 SysCallReturn syscallhandler_rt_sigaction(SysCallHandler* sys, const SysCallArgs* args) {
@@ -273,13 +273,13 @@ SysCallReturn syscallhandler_sigaltstack(SysCallHandler* sys, const SysCallArgs*
         if (old_ss.ss_flags & SS_ONSTACK) {
             // sigaltstack(2):  EPERM  An attempt was made to change the
             // alternate signal stack while it was active.
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval = -EPERM};
+            return syscallreturn_makeDoneErrno(EPERM);
         }
 
         stack_t new_ss;
         int rv = process_readPtr(sys->process, &new_ss, ss_ptr, sizeof(new_ss));
         if (rv != 0) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval = rv};
+            return syscallreturn_makeDoneErrno(-rv);
         }
         if (new_ss.ss_flags & SS_DISABLE) {
             // sigaltstack(2): To disable an existing stack, specify ss.ss_flags
@@ -289,7 +289,7 @@ SysCallReturn syscallhandler_sigaltstack(SysCallHandler* sys, const SysCallArgs*
         }
         if (new_ss.ss_flags & ~(SS_DISABLE | SS_AUTODISARM)) {
             // Unrecognized flag.
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval = -EINVAL};
+            return syscallreturn_makeDoneErrno(EINVAL);
         }
         shimshmem_setSigAltStack(
             host_getShimShmemLock(sys->host), thread_sharedMem(sys->thread), new_ss);
@@ -298,11 +298,11 @@ SysCallReturn syscallhandler_sigaltstack(SysCallHandler* sys, const SysCallArgs*
     if (old_ss_ptr.val) {
         int rv = process_writePtr(sys->process, old_ss_ptr, &old_ss, sizeof(old_ss));
         if (rv != 0) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval = rv};
+            return syscallreturn_makeDoneErrno(-rv);
         }
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval = 0};
+    return syscallreturn_makeDoneI64(0);
 }
 
 static SysCallReturn _rt_sigprocmask(SysCallHandler* sys, int how, PluginPtr setPtr,
@@ -313,7 +313,7 @@ static SysCallReturn _rt_sigprocmask(SysCallHandler* sys, int how, PluginPtr set
     // specific value (equal to sizeof(kernel_sigset_t)).
     if (sigsetsize != (64 / 8)) {
         warning("Bad sigsetsize %zu", sigsetsize);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     shd_kernel_sigset_t current_set = shimshmem_getBlockedSignals(
@@ -322,7 +322,7 @@ static SysCallReturn _rt_sigprocmask(SysCallHandler* sys, int how, PluginPtr set
     if (oldSetPtr.val) {
         int rv = process_writePtr(sys->process, oldSetPtr, &current_set, sizeof(current_set));
         if (rv < 0) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval = rv};
+            return syscallreturn_makeDoneErrno(-rv);
         }
     }
 
@@ -330,7 +330,7 @@ static SysCallReturn _rt_sigprocmask(SysCallHandler* sys, int how, PluginPtr set
         shd_kernel_sigset_t set;
         int rv = process_readPtr(sys->process, &set, setPtr, sizeof(set));
         if (rv < 0) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval = rv};
+            return syscallreturn_makeDoneErrno(-rv);
         }
 
         switch (how) {
@@ -348,7 +348,7 @@ static SysCallReturn _rt_sigprocmask(SysCallHandler* sys, int how, PluginPtr set
                 break;
             }
             default: {
-                return (SysCallReturn){.state = SYSCALL_DONE, .retval = -EINVAL};
+                return syscallreturn_makeDoneErrno(EINVAL);
             }
         }
 
@@ -356,7 +356,7 @@ static SysCallReturn _rt_sigprocmask(SysCallHandler* sys, int how, PluginPtr set
             host_getShimShmemLock(sys->host), thread_sharedMem(sys->thread), current_set);
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval = 0};
+    return syscallreturn_makeDoneI64(0);
 }
 
 SysCallReturn syscallhandler_rt_sigprocmask(SysCallHandler* sys, const SysCallArgs* args) {

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -176,7 +176,7 @@ static SysCallReturn _syscallhandler_acceptHelper(SysCallHandler* sys,
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
-    utility_assert(tcp_desc);
+    utility_debugAssert(tcp_desc);
 
     /* We must be listening in order to accept. */
     if (!tcp_isValidListener(tcp_desc)) {
@@ -213,11 +213,11 @@ static SysCallReturn _syscallhandler_acceptHelper(SysCallHandler* sys,
     }
 
     /* We accepted something! */
-    utility_assert(accepted_fd > 0);
+    utility_debugAssert(accepted_fd > 0);
     TCP* accepted_tcp_desc = NULL;
     errcode = _syscallhandler_validateTCPSocketHelper(
         sys, accepted_fd, &accepted_tcp_desc);
-    utility_assert(errcode == 0);
+    utility_debugAssert(errcode == 0);
 
     trace("listening socket %i accepted fd %i", sockfd, accepted_fd);
 
@@ -438,7 +438,8 @@ static int _syscallhandler_setTCPOptHelper(SysCallHandler* sys, TCP* tcp, int op
 
             // shadow doesn't support other congestion types, so do nothing
             const char* current_name = tcp_cong(tcp)->hooks->tcp_cong_name_str();
-            utility_assert(current_name != NULL && strcmp(current_name, TCP_CONG_RENO_NAME) == 0);
+            utility_debugAssert(current_name != NULL &&
+                                strcmp(current_name, TCP_CONG_RENO_NAME) == 0);
             return 0;
         }
         default: {
@@ -669,7 +670,7 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
     if (destAddrPtr.val) {
         const struct sockaddr* dest_addr =
             process_getReadablePtr(sys->process, destAddrPtr, addrlen);
-        utility_assert(dest_addr);
+        utility_debugAssert(dest_addr);
 
         /* TODO: we assume AF_INET here, change this when we support AF_UNIX */
         if (dest_addr->sa_family != AF_INET) {
@@ -820,7 +821,7 @@ SysCallReturn syscallhandler_bind(SysCallHandler* sys,
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
-    utility_assert(socket_desc);
+    utility_debugAssert(socket_desc);
 
     /* It's an error if it is already bound. */
     if (legacysocket_isBound(socket_desc)) {
@@ -874,7 +875,7 @@ SysCallReturn syscallhandler_connect(SysCallHandler* sys,
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
-    utility_assert(socket_desc);
+    utility_debugAssert(socket_desc);
 
     /* Make sure the addr PluginPtr is not NULL. */
     if (!addrPtr.val) {
@@ -890,7 +891,7 @@ SysCallReturn syscallhandler_connect(SysCallHandler* sys,
     }
 
     const struct sockaddr* addr = process_getReadablePtr(sys->process, addrPtr, addrlen);
-    utility_assert(addr);
+    utility_debugAssert(addr);
 
     /* TODO: we assume AF_INET here, change this when we support AF_UNIX */
     if (addr->sa_family != AF_INET && addr->sa_family != AF_UNSPEC) {
@@ -995,7 +996,7 @@ SysCallReturn syscallhandler_getpeername(SysCallHandler* sys,
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
-    utility_assert(socket_desc);
+    utility_debugAssert(socket_desc);
 
     // TODO I'm not sure if we should be able to get the peer name on UDP
     // sockets. If you call connect on it, then getpeername should probably
@@ -1045,7 +1046,7 @@ SysCallReturn syscallhandler_getsockname(SysCallHandler* sys,
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
-    utility_assert(socket_desc);
+    utility_debugAssert(socket_desc);
 
     /* Get the name of the socket.
      * TODO: Needs to be updated when we support AF_UNIX. */
@@ -1094,7 +1095,7 @@ SysCallReturn syscallhandler_getsockopt(SysCallHandler* sys,
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
-    utility_assert(socket_desc);
+    utility_debugAssert(socket_desc);
 
     /* The optlen pointer must be non-null. */
     if (!optlenPtr.val) {
@@ -1163,7 +1164,7 @@ SysCallReturn syscallhandler_listen(SysCallHandler* sys,
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
-    utility_assert(tcp_desc);
+    utility_debugAssert(tcp_desc);
 
     /* only listen on the socket if it is not used for other functions */
     if (!tcp_isListeningAllowed(tcp_desc)) {
@@ -1227,7 +1228,7 @@ SysCallReturn syscallhandler_setsockopt(SysCallHandler* sys,
     if (errcode < 0) {
         return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
     }
-    utility_assert(socket_desc);
+    utility_debugAssert(socket_desc);
 
     /* Return early if there is no data. */
     if (optlen == 0) {
@@ -1361,7 +1362,7 @@ SysCallReturn syscallhandler_socket(SysCallHandler* sys,
     if (errcode != 0) {
         utility_panic("Unable to find socket %i that we just created.", sockfd);
     }
-    utility_assert(errcode == 0);
+    utility_debugAssert(errcode == 0);
 
     /* Set any options that were given. */
     if (type & SOCK_NONBLOCK) {

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -123,17 +123,12 @@ static int _syscallhandler_validateUDPSocketHelper(SysCallHandler* sys,
     return 0;
 }
 
-static SysCallReturn _syscallhandler_getnameHelper(SysCallHandler* sys, struct sockaddr* saddr,
-                                                   size_t slen, PluginPtr addrPtr,
-                                                   PluginPtr addrlenPtr) {
-    if (!addrPtr.val || !addrlenPtr.val) {
-        debug("Cannot get name with NULL return address info.");
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
-    }
-
+static int _syscallhandler_getnameHelper(SysCallHandler* sys, struct sockaddr* saddr, size_t slen,
+                                         PluginPtr addrPtr, PluginPtr addrlenPtr) {
     socklen_t addrlen;
     if (process_readPtr(sys->process, &addrlen, addrlenPtr, sizeof(addrlen)) != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        debug("Couldn't read addrlenPtr %p", (void*)addrlenPtr.val);
+        return -EFAULT;
     }
 
     /* The result is truncated if they didn't give us enough space. */
@@ -141,17 +136,19 @@ static SysCallReturn _syscallhandler_getnameHelper(SysCallHandler* sys, struct s
 
     addrlen = slen;
     if (process_writePtr(sys->process, addrlenPtr, &addrlen, sizeof(addrlen)) != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        debug("Couldn't write addrlenPtr %p", (void*)addrlenPtr.val);
+        return -EFAULT;
     }
 
     if (retSize > 0) {
         /* Return the results */
         if (process_writePtr(sys->process, addrPtr, saddr, retSize) != 0) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+            debug("Couldn't write addrPtr %p", (void*)addrPtr.val);
+            return -EFAULT;
         }
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE};
+    return 0;
 }
 
 static SysCallReturn _syscallhandler_acceptHelper(SysCallHandler* sys,
@@ -165,7 +162,7 @@ static SysCallReturn _syscallhandler_acceptHelper(SysCallHandler* sys,
         debug("invalid flags \"%i\", only SOCK_NONBLOCK and SOCK_CLOEXEC are "
               "allowed",
               flags);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     /* Get and validate the TCP socket. */
@@ -174,20 +171,14 @@ static SysCallReturn _syscallhandler_acceptHelper(SysCallHandler* sys,
         _syscallhandler_validateTCPSocketHelper(sys, sockfd, &tcp_desc);
 
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
     utility_debugAssert(tcp_desc);
 
     /* We must be listening in order to accept. */
     if (!tcp_isValidListener(tcp_desc)) {
         debug("socket %i is not listening", sockfd);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
-    }
-
-    /* Make sure they supplied addrlen if they requested an addr. */
-    if (addrPtr.val && !addrlenPtr.val) {
-        debug("addrlen was NULL when addr was non-NULL");
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     /* OK, now we can check if we have anything to accept. */
@@ -204,12 +195,11 @@ static SysCallReturn _syscallhandler_acceptHelper(SysCallHandler* sys,
         trace("Listening socket %i waiting for acceptable connection.", sockfd);
         Trigger trigger = (Trigger){
             .type = TRIGGER_DESCRIPTOR, .object = legacyDesc, .status = STATUS_FILE_READABLE};
-        return (SysCallReturn){.state = SYSCALL_BLOCK,
-                               .cond = syscallcondition_new(trigger),
-                               .restartable = legacyfile_supportsSaRestart(legacyDesc)};
+        return syscallreturn_makeBlocked(
+            syscallcondition_new(trigger), legacyfile_supportsSaRestart(legacyDesc));
     } else if (errcode < 0) {
         trace("TCP error when accepting connection on socket %i", sockfd);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
 
     /* We accepted something! */
@@ -235,11 +225,14 @@ static SysCallReturn _syscallhandler_acceptHelper(SysCallHandler* sys,
 
     /* check if they wanted to know where we got the data from */
     if (addrPtr.val) {
-        _syscallhandler_getnameHelper(
+        errcode = _syscallhandler_getnameHelper(
             sys, (struct sockaddr*)&inet_addr, sizeof(inet_addr), addrPtr, addrlenPtr);
+        if (errcode != 0) {
+            return syscallreturn_makeDoneErrno(-errcode);
+        }
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = accepted_fd};
+    return syscallreturn_makeDoneI64(accepted_fd);
 }
 
 static int _syscallhandler_bindHelper(SysCallHandler* sys, LegacySocket* socket_desc,
@@ -460,6 +453,9 @@ static int _syscallhandler_setSocketOptHelper(SysCallHandler* sys, LegacySocket*
     switch (optname) {
         case SO_SNDBUF: {
             const unsigned int* val = process_getReadablePtr(sys->process, optvalPtr, sizeof(int));
+            if (!val) {
+                return -EFAULT;
+            }
             size_t newsize = (size_t)(*val) * 2; // Linux kernel doubles this value upon setting
 
             // Linux also has limits SOCK_MIN_SNDBUF (slightly greater than 4096) and the sysctl max
@@ -553,12 +549,7 @@ SysCallReturn _syscallhandler_recvfromHelper(SysCallHandler* sys, int sockfd,
     }
 
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
-    }
-
-    if (srcAddrPtr.val && !addrlenPtr.val) {
-        debug("Cannot get from address with NULL address length info.");
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
 
     if (flags & ~MSG_DONTWAIT) {
@@ -572,7 +563,7 @@ SysCallReturn _syscallhandler_recvfromHelper(SysCallHandler* sys, int sockfd,
 
         if (errcode > 0) {
             /* connect() was not called yet. */
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOTCONN};
+            return syscallreturn_makeDoneErrno(ENOTCONN);
         } else if (errcode == -EALREADY) {
             /* Connection in progress. */
             retval = -EWOULDBLOCK;
@@ -606,9 +597,8 @@ SysCallReturn _syscallhandler_recvfromHelper(SysCallHandler* sys, int sockfd,
         /* We need to block until the descriptor is ready to read. */
         Trigger trigger =
             (Trigger){.type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_FILE_READABLE};
-        return (SysCallReturn){.state = SYSCALL_BLOCK,
-                               .cond = syscallcondition_new(trigger),
-                               .restartable = legacyfile_supportsSaRestart(desc)};
+        return syscallreturn_makeBlocked(
+            syscallcondition_new(trigger), legacyfile_supportsSaRestart(desc));
     }
 
     /* check if they wanted to know where we got the data from */
@@ -617,19 +607,21 @@ SysCallReturn _syscallhandler_recvfromHelper(SysCallHandler* sys, int sockfd,
 
         /* only write an address for UDP sockets */
         if (legacyfile_getType(desc) == DT_UDPSOCKET) {
-            _syscallhandler_getnameHelper(
+            errcode = _syscallhandler_getnameHelper(
                 sys, (struct sockaddr*)&inet_addr, sizeof(inet_addr), srcAddrPtr, addrlenPtr);
+            if (errcode) {
+                return syscallreturn_makeDoneErrno(-errcode);
+            }
         } else {
             /* set the address length as 0 */
             socklen_t addrlen = 0;
             if (process_writePtr(sys->process, addrlenPtr, &addrlen, sizeof(addrlen)) != 0) {
-                return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+                return syscallreturn_makeDoneErrno(EFAULT);
             }
         }
     }
 
-    return (SysCallReturn){
-        .state = SYSCALL_DONE, .retval.as_i64 = (int64_t)retval};
+    return syscallreturn_makeDoneI64(retval);
 }
 
 SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
@@ -643,20 +635,24 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
     int errcode =
         _syscallhandler_validateSocketHelper(sys, sockfd, &socket_desc);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
 
     /* Need non-NULL buffer. */
+    /* FIXME: should push this check to the point the data is actually read,
+     * to correctly handle non-NULL pointers that aren't accessible.
+     * This is currently in the Payload code; need to bubble up errors from there.
+     */
     if (!bufPtr.val) {
         debug("Can't send from NULL buffer on socket %i", sockfd);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        return syscallreturn_makeDoneErrno(EFAULT);
     }
 
     /* TODO: when we support AF_UNIX this could be sockaddr_un */
     size_t inet_len = sizeof(struct sockaddr_in);
     if (destAddrPtr.val && addrlen < inet_len) {
         debug("Address length %ld is too small on socket %i", (long int)addrlen, sockfd);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     if (flags & ~MSG_DONTWAIT) {
@@ -676,8 +672,7 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
         if (dest_addr->sa_family != AF_INET) {
             warning(
                 "We only support address family AF_INET on socket %i", sockfd);
-            return (SysCallReturn){
-                .state = SYSCALL_DONE, .retval.as_i64 = -EAFNOSUPPORT};
+            return syscallreturn_makeDoneErrno(EAFNOSUPPORT);
         }
 
         dest_ip = ((struct sockaddr_in*)dest_addr)->sin_addr.s_addr;
@@ -694,8 +689,7 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
             legacysocket_getPeerName(socket_desc, &dest_ip, &dest_port);
             if (dest_ip == 0 || dest_port == 0) {
                 /* we have nowhere to send it */
-                return (SysCallReturn){
-                    .state = SYSCALL_DONE, .retval.as_i64 = -EDESTADDRREQ};
+                return syscallreturn_makeDoneErrno(EDESTADDRREQ);
             }
         }
 
@@ -712,8 +706,7 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
                 host_getRandomFreePort(sys->host, ptype, bindAddr, 0, 0);
 
             if (!bindPort) {
-                return (SysCallReturn){
-                    .state = SYSCALL_DONE, .retval.as_i64 = -EADDRNOTAVAIL};
+                return syscallreturn_makeDoneErrno(EADDRNOTAVAIL);
             }
 
             /* connect up socket layer */
@@ -733,8 +726,7 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
             /* connect() was not called yet.
              * TODO: Can they can piggy back a connect() on sendto() if they
              * provide an address for the connection? */
-            return (SysCallReturn){
-                .state = SYSCALL_DONE, .retval.as_i64 = -EPIPE};
+            return syscallreturn_makeDoneErrno(EPIPE);
         } else if (errcode == 0) {
             /* They connected, but never read the success code with a second
              * call to connect(). That's OK, proceed to send as usual. */
@@ -775,17 +767,15 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
             /* We need to block until the descriptor is ready to write. */
             Trigger trigger = (Trigger){
                 .type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_FILE_WRITABLE};
-            return (SysCallReturn){.state = SYSCALL_BLOCK,
-                                   .cond = syscallcondition_new(trigger),
-                                   .restartable = legacyfile_supportsSaRestart(desc)};
+            return syscallreturn_makeBlocked(
+                syscallcondition_new(trigger), legacyfile_supportsSaRestart(desc));
         } else {
             /* We attempted to write 0 bytes, so no need to block or return EWOULDBLOCK. */
             retval = 0;
         }
     }
 
-    return (SysCallReturn){
-        .state = SYSCALL_DONE, .retval.as_i64 = (int64_t)retval};
+    return syscallreturn_makeDoneI64(retval);
 }
 
 ///////////////////////////////////////////////////////////
@@ -819,20 +809,20 @@ SysCallReturn syscallhandler_bind(SysCallHandler* sys,
     int errcode =
         _syscallhandler_validateSocketHelper(sys, sockfd, &socket_desc);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
     utility_debugAssert(socket_desc);
 
     /* It's an error if it is already bound. */
     if (legacysocket_isBound(socket_desc)) {
         debug("socket descriptor %i is already bound to an address", sockfd);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     const struct sockaddr* addr = process_getReadablePtr(sys->process, addrPtr, addrlen);
     if (addr == NULL) {
         debug("Invalid bind address pointer");
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        return syscallreturn_makeDoneErrno(EFAULT);
     }
 
     /* TODO: we assume AF_INET here, change this when we support AF_UNIX */
@@ -840,14 +830,14 @@ SysCallReturn syscallhandler_bind(SysCallHandler* sys,
     size_t inet_len = sizeof(struct sockaddr_in);
     if (addrlen < inet_len) {
         debug("supplied address is not large enough for a inet address");
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     /* TODO: we assume AF_INET here, change this when we support AF_UNIX */
     if (addr->sa_family != AF_INET) {
         warning("binding to address family %i, but we only support AF_INET",
                 (int)addr->sa_family);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     /* Get the requested address and port. */
@@ -857,7 +847,7 @@ SysCallReturn syscallhandler_bind(SysCallHandler* sys,
 
     errcode =
         _syscallhandler_bindHelper(sys, socket_desc, bindAddr, bindPort, 0, 0);
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+    return syscallreturn_makeDoneI64(errcode);
 }
 
 SysCallReturn syscallhandler_connect(SysCallHandler* sys,
@@ -873,35 +863,31 @@ SysCallReturn syscallhandler_connect(SysCallHandler* sys,
     int errcode =
         _syscallhandler_validateSocketHelper(sys, sockfd, &socket_desc);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
     utility_debugAssert(socket_desc);
-
-    /* Make sure the addr PluginPtr is not NULL. */
-    if (!addrPtr.val) {
-        debug("connecting to a NULL address is invalid");
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
-    }
 
     /* TODO: we assume AF_INET here, change this when we support AF_UNIX */
     // size_t unix_len = sizeof(struct sockaddr_un); // if sa_family==AF_UNIX
     size_t inet_len = sizeof(struct sockaddr_in);
     if (addrlen < inet_len) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     const struct sockaddr* addr = process_getReadablePtr(sys->process, addrPtr, addrlen);
-    utility_debugAssert(addr);
+    if (!addr) {
+        debug("Couldn't read addr %p", (void*)addrPtr.val);
+        return syscallreturn_makeDoneErrno(EFAULT);
+    }
+
 
     /* TODO: we assume AF_INET here, change this when we support AF_UNIX */
     if (addr->sa_family != AF_INET && addr->sa_family != AF_UNSPEC) {
         warning("connecting to address family %i, but we only support AF_INET",
                 (int)addr->sa_family);
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = -EAFNOSUPPORT};
+        return syscallreturn_makeDoneErrno(EAFNOSUPPORT);
     } else if (!legacysocket_isFamilySupported(socket_desc, addr->sa_family)) {
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = -EAFNOSUPPORT};
+        return syscallreturn_makeDoneErrno(EAFNOSUPPORT);
     }
 
     /* TODO: update for AF_UNIX */
@@ -927,8 +913,7 @@ SysCallReturn syscallhandler_connect(SysCallHandler* sys,
                     "host exists",
                     peerAddressString, ntohs(peerPort));
             g_free(peerAddressString);
-            return (SysCallReturn){
-                .state = SYSCALL_DONE, .retval.as_i64 = -ECONNREFUSED};
+            return syscallreturn_makeDoneErrno(ECONNREFUSED);
         }
     }
 
@@ -941,8 +926,7 @@ SysCallReturn syscallhandler_connect(SysCallHandler* sys,
         errcode = _syscallhandler_bindHelper(
             sys, socket_desc, bindAddr, 0, peerAddr, peerPort);
         if (errcode < 0) {
-            return (SysCallReturn){
-                .state = SYSCALL_DONE, .retval.as_i64 = errcode};
+            return syscallreturn_makeDoneErrno(-errcode);
         }
     } else {
         legacysocket_setPeerName(socket_desc, peerAddr, peerPort);
@@ -961,9 +945,8 @@ SysCallReturn syscallhandler_connect(SysCallHandler* sys,
             Trigger trigger = (Trigger){.type = TRIGGER_DESCRIPTOR,
                                         .object = desc,
                                         .status = STATUS_FILE_ACTIVE | STATUS_FILE_WRITABLE};
-            return (SysCallReturn){.state = SYSCALL_BLOCK,
-                                   .cond = syscallcondition_new(trigger),
-                                   .restartable = legacyfile_supportsSaRestart(desc)};
+            return syscallreturn_makeBlocked(
+                syscallcondition_new(trigger), legacyfile_supportsSaRestart(desc));
         } else if (_syscallhandler_wasBlocked(sys) && errcode == -EISCONN) {
             /* It was EINPROGRESS, but is now a successful blocking connect. */
             errcode = 0;
@@ -980,7 +963,7 @@ SysCallReturn syscallhandler_connect(SysCallHandler* sys,
     }
 
     /* Return 0, -EINPROGRESS, etc. now. */
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+    return syscallreturn_makeDoneI64(errcode);
 }
 
 SysCallReturn syscallhandler_getpeername(SysCallHandler* sys,
@@ -994,7 +977,7 @@ SysCallReturn syscallhandler_getpeername(SysCallHandler* sys,
     int errcode =
         _syscallhandler_validateSocketHelper(sys, sockfd, &socket_desc);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
     utility_debugAssert(socket_desc);
 
@@ -1007,8 +990,7 @@ SysCallReturn syscallhandler_getpeername(SysCallHandler* sys,
     //    LegacyFileType type = legacyfile_getType((LegacyFile*)socket_desc);
     //    if(type != DT_TCPSOCKET) {
     //        info("descriptor %i is not a TCP socket", sockfd);
-    //        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 =
-    //        -ENOTCONN};
+    //        return syscallreturn_makeErrno(ENOTCONN);
     //    }
 
     /* Get the name of the connected peer.
@@ -1023,14 +1005,14 @@ SysCallReturn syscallhandler_getpeername(SysCallHandler* sys,
         legacysocket_getPeerName(socket_desc, &inet_addr->sin_addr.s_addr, &inet_addr->sin_port);
     if (!hasName) {
         debug("Socket %i has no peer name.", sockfd);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOTCONN};
+        return syscallreturn_makeDoneErrno(ENOTCONN);
     }
 
     slen = sizeof(*inet_addr);
 
     /* Use helper to write out the result. */
-    return _syscallhandler_getnameHelper(
-        sys, &saddr, slen, args->args[1].as_ptr, args->args[2].as_ptr);
+    return syscallreturn_makeDoneI64(_syscallhandler_getnameHelper(
+        sys, &saddr, slen, args->args[1].as_ptr, args->args[2].as_ptr));
 }
 
 SysCallReturn syscallhandler_getsockname(SysCallHandler* sys,
@@ -1044,7 +1026,7 @@ SysCallReturn syscallhandler_getsockname(SysCallHandler* sys,
     int errcode =
         _syscallhandler_validateSocketHelper(sys, sockfd, &socket_desc);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
     utility_debugAssert(socket_desc);
 
@@ -1073,8 +1055,8 @@ SysCallReturn syscallhandler_getsockname(SysCallHandler* sys,
     slen = sizeof(*inet_addr);
 
     /* Use helper to write out the result. */
-    return _syscallhandler_getnameHelper(
-        sys, &saddr, slen, args->args[1].as_ptr, args->args[2].as_ptr);
+    return syscallreturn_makeDoneI64(_syscallhandler_getnameHelper(
+        sys, &saddr, slen, args->args[1].as_ptr, args->args[2].as_ptr));
 }
 
 SysCallReturn syscallhandler_getsockopt(SysCallHandler* sys,
@@ -1093,31 +1075,31 @@ SysCallReturn syscallhandler_getsockopt(SysCallHandler* sys,
     int errcode =
         _syscallhandler_validateSocketHelper(sys, sockfd, &socket_desc);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
     utility_debugAssert(socket_desc);
 
-    /* The optlen pointer must be non-null. */
-    if (!optlenPtr.val) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
-    }
-
     socklen_t optlen;
     if (process_readPtr(sys->process, &optlen, optlenPtr, sizeof(optlen)) != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        return syscallreturn_makeDoneErrno(EFAULT);
     }
 
     /* Return early if there are no bytes to store data. */
     if (optlen == 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+        return syscallreturn_makeDoneI64(0);
     }
 
     /* The optval pointer must be non-null since optlen is non-zero. */
-    if (!optvalPtr.val) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
-    }
 
-    void* optval = process_getWriteablePtr(sys->process, optvalPtr, optlen);
+    MemoryManager* mm = process_getMemoryManager(sys->process);
+    ProcessMemoryRefMut_u8* optvalref = memorymanager_getWritablePtr(mm, optvalPtr, optlen);
+    if (!optvalref) {
+        return syscallreturn_makeDoneErrno(EFAULT);
+    }
+    void* optval = memorymanagermut_ptr(optvalref);
+    if (!optval) {
+        return syscallreturn_makeDoneErrno(EFAULT);
+    }
 
     errcode = 0;
     switch (level) {
@@ -1142,12 +1124,22 @@ SysCallReturn syscallhandler_getsockopt(SysCallHandler* sys,
             break;
     }
 
-    process_flushPtrs(sys->process);
-    if (process_writePtr(sys->process, optlenPtr, &optlen, sizeof(optlen)) != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+    if (errcode) {
+        memorymanager_freeMutRefWithoutFlush(optvalref);
+        return syscallreturn_makeDoneErrno(-errcode);
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+    errcode = memorymanager_freeMutRefWithFlush(optvalref);
+    if (errcode) {
+        return syscallreturn_makeDoneErrno(-errcode);
+    }
+
+    errcode = process_writePtr(sys->process, optlenPtr, &optlen, sizeof(optlen));
+    if (errcode) {
+        return syscallreturn_makeDoneErrno(-errcode);
+    }
+
+    return syscallreturn_makeDoneI64(0);
 }
 
 SysCallReturn syscallhandler_listen(SysCallHandler* sys,
@@ -1162,22 +1154,21 @@ SysCallReturn syscallhandler_listen(SysCallHandler* sys,
     int errcode =
         _syscallhandler_validateTCPSocketHelper(sys, sockfd, &tcp_desc);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
     utility_debugAssert(tcp_desc);
 
     /* only listen on the socket if it is not used for other functions */
     if (!tcp_isListeningAllowed(tcp_desc)) {
         debug("Cannot listen on previously used socket %i", sockfd);
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = -EOPNOTSUPP};
+        return syscallreturn_makeDoneErrno(EOPNOTSUPP);
     }
 
     /* if we are already listening, just update the backlog and return 0. */
     if (tcp_isValidListener(tcp_desc)) {
         trace("Socket %i already set up as a listener; updating backlog", sockfd);
         tcp_updateServerBacklog(tcp_desc, backlog);
-        return (SysCallReturn){.state = SYSCALL_DONE};
+        return syscallreturn_makeDoneU64(0);
     }
 
     /* We are allowed to listen but not already listening, start now. */
@@ -1187,13 +1178,12 @@ SysCallReturn syscallhandler_listen(SysCallHandler* sys,
         errcode =
             _syscallhandler_bindHelper(sys, (LegacySocket*)tcp_desc, htonl(INADDR_ANY), 0, 0, 0);
         if (errcode < 0) {
-            return (SysCallReturn){
-                .state = SYSCALL_DONE, .retval.as_i64 = errcode};
+            return syscallreturn_makeDoneErrno(-errcode);
         }
     }
 
     tcp_enterServerMode(tcp_desc, sys->host, sys->process, backlog);
-    return (SysCallReturn){.state = SYSCALL_DONE};
+    return syscallreturn_makeDoneU64(0);
 }
 
 SysCallReturn syscallhandler_recvfrom(SysCallHandler* sys,
@@ -1226,18 +1216,13 @@ SysCallReturn syscallhandler_setsockopt(SysCallHandler* sys,
     int errcode =
         _syscallhandler_validateSocketHelper(sys, sockfd, &socket_desc);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
     utility_debugAssert(socket_desc);
 
     /* Return early if there is no data. */
     if (optlen == 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
-    }
-
-    /* The pointer must be non-null. */
-    if (!optvalPtr.val) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     errcode = 0;
@@ -1262,7 +1247,7 @@ SysCallReturn syscallhandler_setsockopt(SysCallHandler* sys,
             errcode = -ENOPROTOOPT;
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+    return syscallreturn_makeDoneI64(errcode);
 }
 
 SysCallReturn syscallhandler_shutdown(SysCallHandler* sys,
@@ -1274,31 +1259,29 @@ SysCallReturn syscallhandler_shutdown(SysCallHandler* sys,
 
     if (how != SHUT_RD && how != SHUT_WR && how != SHUT_RDWR) {
         debug("invalid how %i", how);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     /* Get and validate the socket. */
     int errcode = _syscallhandler_validateSocketHelper(sys, sockfd, NULL);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
 
     TCP* tcp_desc = NULL;
     errcode = _syscallhandler_validateTCPSocketHelper(sys, sockfd, &tcp_desc);
     if (errcode >= 0) {
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = tcp_shutdown(tcp_desc, sys->host, how)};
+        return syscallreturn_makeDoneI64(tcp_shutdown(tcp_desc, sys->host, how));
     }
 
     UDP* udp_desc = NULL;
     errcode = _syscallhandler_validateUDPSocketHelper(sys, sockfd, &udp_desc);
     if (errcode >= 0) {
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = udp_shutdown(udp_desc, how)};
+        return syscallreturn_makeDoneI64(udp_shutdown(udp_desc, how));
     }
 
     warning("socket %d is neither a TCP nor UDP socket", sockfd);
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOTCONN};
+    return syscallreturn_makeDoneErrno(ENOTCONN);
 }
 
 SysCallReturn syscallhandler_socket(SysCallHandler* sys,
@@ -1318,24 +1301,20 @@ SysCallReturn syscallhandler_socket(SysCallHandler* sys,
     if (domain != AF_INET) {
         warning("unsupported socket domain \"%i\", we only support AF_INET",
                 domain);
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = -EAFNOSUPPORT};
+        return syscallreturn_makeDoneErrno(EAFNOSUPPORT);
     } else if (type_no_flags != SOCK_STREAM && type_no_flags != SOCK_DGRAM) {
         warning("unsupported socket type \"%i\", we only support SOCK_STREAM "
                 "and SOCK_DGRAM",
                 type_no_flags);
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = -ESOCKTNOSUPPORT};
+        return syscallreturn_makeDoneErrno(ESOCKTNOSUPPORT);
     } else if (type_no_flags == SOCK_STREAM && protocol != 0 && protocol != IPPROTO_TCP) {
         warning(
             "unsupported socket protocol \"%i\", we only support IPPROTO_TCP on sockets of type SOCK_STREAM", protocol);
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = -EPROTONOSUPPORT};
+        return syscallreturn_makeDoneErrno(EPROTONOSUPPORT);
     } else if (type_no_flags == SOCK_DGRAM && protocol != 0 && protocol != IPPROTO_UDP) {
         warning(
             "unsupported socket protocol \"%i\", we only support IPPROTO_UDP on sockets of type SOCK_DGRAM", protocol);
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = -EPROTONOSUPPORT};
+        return syscallreturn_makeDoneErrno(EPROTONOSUPPORT);
     }
 
     /* We are all set to create the socket. */
@@ -1371,5 +1350,5 @@ SysCallReturn syscallhandler_socket(SysCallHandler* sys,
 
     trace("socket() returning fd %i", sockfd);
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = sockfd};
+    return syscallreturn_makeDoneI64(sockfd);
 }

--- a/src/main/host/syscall/time.c
+++ b/src/main/host/syscall/time.c
@@ -28,28 +28,28 @@ static SysCallReturn _syscallhandler_nanosleep_helper(SysCallHandler* sys, clock
                                                       PluginPtr remainder) {
     if (clock_id == CLOCK_PROCESS_CPUTIME_ID || clock_id == CLOCK_THREAD_CPUTIME_ID) {
         warning("Unsupported clock ID %d during nanosleep", clock_id);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+        return syscallreturn_makeDoneErrno(ENOSYS);
     }
 
     if (flags != 0) {
         warning("Unsupported flag %d during nanosleep", flags);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+        return syscallreturn_makeDoneErrno(ENOSYS);
     }
 
     /* Grab the arg from the syscall register. */
     struct timespec req;
     int rv = process_readPtr(sys->process, &req, request, sizeof(req));
     if (rv < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = rv};
+        return syscallreturn_makeDoneErrno(-rv);
     }
     SimulationTime reqSimTime = simtime_from_timespec(req);
     if (reqSimTime == SIMTIME_INVALID) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     /* Does the timeout request require us to block? */
     if (reqSimTime == 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+        return syscallreturn_makeDoneI64(0);
     }
 
     /* Did we already block? */
@@ -60,7 +60,7 @@ static SysCallReturn _syscallhandler_nanosleep_helper(SysCallHandler* sys, clock
         syscallcondition_setTimeout(cond, sys->host, worker_getCurrentEmulatedTime() + reqSimTime);
 
         /* Block the thread, unblock when the timer expires. */
-        return (SysCallReturn){.state = SYSCALL_BLOCK, .cond = cond, .restartable = false};
+        return syscallreturn_makeBlocked(cond, false);
     }
 
     if (!_syscallhandler_didListenTimeoutExpire(sys)) {
@@ -79,14 +79,14 @@ static SysCallReturn _syscallhandler_nanosleep_helper(SysCallHandler* sys, clock
             }
             int rv = process_writePtr(sys->process, remainder, &timer_val, sizeof(timer_val));
             if (rv != 0) {
-                return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = rv};
+                return syscallreturn_makeDoneErrno(-rv);
             }
         }
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINTR};
+        return syscallreturn_makeInterrupted(false);
     }
 
     /* The syscall is now complete. */
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0, .restartable = false};
+    return syscallreturn_makeDoneI64(0);
 }
 
 ///////////////////////////////////////////////////////////
@@ -118,22 +118,20 @@ SysCallReturn syscallhandler_clock_gettime(SysCallHandler* sys,
 
     if (clk_id == CLOCK_PROCESS_CPUTIME_ID || clk_id == CLOCK_THREAD_CPUTIME_ID) {
         warning("Unsupported clock ID %d during gettime", clk_id);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
-    }
-
-    /* Make sure they didn't pass a NULL pointer. */
-    if (!args->args[1].as_ptr.val) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        return syscallreturn_makeDoneErrno(ENOSYS);
     }
 
     struct timespec* res_timespec =
         process_getWriteablePtr(sys->process, args->args[1].as_ptr, sizeof(*res_timespec));
+    if (!res_timespec) {
+        return syscallreturn_makeDoneErrno(EFAULT);
+    }
 
     EmulatedTime now = _syscallhandler_getEmulatedTime();
     res_timespec->tv_sec = now / SIMTIME_ONE_SECOND;
     res_timespec->tv_nsec = now % SIMTIME_ONE_SECOND;
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+    return syscallreturn_makeDoneI64(0);
 }
 
 SysCallReturn syscallhandler_time(SysCallHandler* sys, const SysCallArgs* args) {
@@ -143,10 +141,13 @@ SysCallReturn syscallhandler_time(SysCallHandler* sys, const SysCallArgs* args) 
 
     if (tlocPtr.val) {
         time_t* tloc = process_getWriteablePtr(sys->process, tlocPtr, sizeof(*tloc));
+        if (!tloc) {
+            return syscallreturn_makeDoneErrno(EFAULT);
+        }
         *tloc = seconds;
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_u64 = seconds};
+    return syscallreturn_makeDoneU64(seconds);
 }
 
 SysCallReturn syscallhandler_gettimeofday(SysCallHandler* sys, const SysCallArgs* args) {
@@ -159,5 +160,5 @@ SysCallReturn syscallhandler_gettimeofday(SysCallHandler* sys, const SysCallArgs
         tv->tv_usec = (now % SIMTIME_ONE_SECOND) / SIMTIME_ONE_MICROSECOND;
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+    return syscallreturn_makeDoneI64(0);
 }

--- a/src/main/host/syscall/time.c
+++ b/src/main/host/syscall/time.c
@@ -65,13 +65,13 @@ static SysCallReturn _syscallhandler_nanosleep_helper(SysCallHandler* sys, clock
 
     if (!_syscallhandler_didListenTimeoutExpire(sys)) {
         // Should only happen if we were interrupted by a signal.
-        utility_assert(
+        utility_debugAssert(
             thread_unblockedSignalPending(sys->thread, host_getShimShmemLock(sys->host)));
 
         if (remainder.val) {
             EmulatedTime nextExpireTime = _syscallhandler_getTimeout(sys);
-            utility_assert(nextExpireTime != EMUTIME_INVALID);
-            utility_assert(nextExpireTime >= worker_getCurrentEmulatedTime());
+            utility_debugAssert(nextExpireTime != EMUTIME_INVALID);
+            utility_debugAssert(nextExpireTime >= worker_getCurrentEmulatedTime());
             SimulationTime remainingTime = nextExpireTime - worker_getCurrentEmulatedTime();
             struct timespec timer_val = {0};
             if (!simtime_to_timespec(remainingTime, &timer_val)) {

--- a/src/main/host/syscall/timerfd.c
+++ b/src/main/host/syscall/timerfd.c
@@ -59,10 +59,10 @@ SysCallReturn syscallhandler_timerfd_create(SysCallHandler* sys,
         debug("Unsupported clockid %i, we support CLOCK_REALTIME and "
               "CLOCK_MONOTONIC.",
               clockid);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+        return syscallreturn_makeDoneErrno(ENOSYS);
     } else if (clockid != CLOCK_REALTIME && clockid != CLOCK_MONOTONIC) {
         debug("Unknown clockid %i.", clockid);
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     int descFlags = 0;
@@ -91,7 +91,7 @@ SysCallReturn syscallhandler_timerfd_create(SysCallHandler* sys,
 
     trace("timerfd_create() returning fd %i", tfd);
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = tfd};
+    return syscallreturn_makeDoneI64(tfd);
 }
 
 SysCallReturn syscallhandler_timerfd_settime(SysCallHandler* sys,
@@ -106,37 +106,37 @@ SysCallReturn syscallhandler_timerfd_settime(SysCallHandler* sys,
 #define TFD_TIMER_CANCEL_ON_SET 0
 #endif
     if (flags & ~(TFD_TIMER_ABSTIME | TFD_TIMER_CANCEL_ON_SET)) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EINVAL};
+        return syscallreturn_makeDoneErrno(EINVAL);
     }
 
     /* Get the corresponding descriptor. */
     TimerFd* timer = NULL;
     int errcode = _syscallhandler_validateTimerHelper(sys, tfd, &timer);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
 
     struct itimerspec newValue;
     if (process_readPtr(sys->process, &newValue, newValuePtr, sizeof(newValue)) != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
+        return syscallreturn_makeDoneErrno(EFAULT);
     };
 
     /* Service the call in the timer module. */
     struct itimerspec oldValue;
     errcode = timerfd_setTime(timer, sys->host, flags, &newValue, &oldValue);
     if (errcode < 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
 
     /* Old value is allowed to be null. */
     if (oldValuePtr.val) {
         errcode = process_writePtr(sys->process, oldValuePtr, &oldValue, sizeof(oldValue));
         if (errcode < 0) {
-            return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+            return syscallreturn_makeDoneErrno(-errcode);
         }
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+    return syscallreturn_makeDoneI64(0);
 }
 
 SysCallReturn syscallhandler_timerfd_gettime(SysCallHandler* sys,
@@ -148,7 +148,7 @@ SysCallReturn syscallhandler_timerfd_gettime(SysCallHandler* sys,
     TimerFd* timer = NULL;
     int errcode = _syscallhandler_validateTimerHelper(sys, tfd, &timer);
     if (errcode != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
 
     /* Get the timer value */
@@ -158,8 +158,8 @@ SysCallReturn syscallhandler_timerfd_gettime(SysCallHandler* sys,
     /* Write the timer value */
     errcode = process_writePtr(sys->process, currValuePtr, &currValue, sizeof(currValue));
     if (errcode != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneErrno(-errcode);
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+    return syscallreturn_makeDoneI64(0);
 }

--- a/src/main/host/syscall/timerfd.c
+++ b/src/main/host/syscall/timerfd.c
@@ -81,7 +81,7 @@ SysCallReturn syscallhandler_timerfd_create(SysCallHandler* sys,
     if (errcode != 0) {
         utility_panic("Unable to find timer %i that we just created.", tfd);
     }
-    utility_assert(errcode == 0);
+    utility_debugAssert(errcode == 0);
 #endif
 
     /* Set any options that were given. */

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -141,7 +141,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
             switch (dType) {
                 case DT_FILE: {
                     /* Handled above. */
-                    utility_assert(0);
+                    utility_debugAssert(0);
                     break;
                 }
                 case DT_TCPSOCKET:
@@ -255,7 +255,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
             switch (dType) {
                 case DT_FILE: {
                     /* Handled above. */
-                    utility_assert(0);
+                    utility_debugAssert(0);
                     break;
                 }
                 case DT_TCPSOCKET:

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -96,7 +96,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
     int errcode = _syscallhandler_validateVecParams(
         sys, fd, iovPtr, iovlen, offset, &desc, &iov);
     if (errcode < 0 || iovlen == 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneI64(errcode);
     }
 
     /* Some logic depends on the descriptor type. */
@@ -149,7 +149,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                     SysCallReturn scr = _syscallhandler_recvfromHelper(
                         sys, fd, bufPtr, bufSize, 0, (PluginPtr){0},
                         (PluginPtr){0});
-                    result = scr.retval.as_i64;
+                    result = syscallreturn_done(&scr)->retval.as_i64;
                     break;
                 }
                 case DT_TIMER:
@@ -187,12 +187,11 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
         Trigger trigger =
             (Trigger){.type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_FILE_READABLE};
 
-        return (SysCallReturn){.state = SYSCALL_BLOCK,
-                               .cond = syscallcondition_new(trigger),
-                               .restartable = legacyfile_supportsSaRestart(desc)};
+        return syscallreturn_makeBlocked(
+            syscallcondition_new(trigger), legacyfile_supportsSaRestart(desc));
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
+    return syscallreturn_makeDoneI64(result);
 }
 
 static SysCallReturn
@@ -211,7 +210,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
     int errcode = _syscallhandler_validateVecParams(
         sys, fd, iovPtr, iovlen, offset, &desc, &iov);
     if (errcode < 0 || iovlen == 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = errcode};
+        return syscallreturn_makeDoneI64(errcode);
     }
 
     /* Some logic depends on the descriptor type. */
@@ -262,7 +261,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                 case DT_UDPSOCKET: {
                     SysCallReturn scr = _syscallhandler_sendtoHelper(
                         sys, fd, bufPtr, bufSize, 0, (PluginPtr){0}, 0);
-                    result = scr.retval.as_i64;
+                    result = syscallreturn_done(&scr)->retval.as_i64;
                     break;
                 }
                 case DT_TIMER:
@@ -300,12 +299,11 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
         Trigger trigger =
             (Trigger){.type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_FILE_WRITABLE};
 
-        return (SysCallReturn){.state = SYSCALL_BLOCK,
-                               .cond = syscallcondition_new(trigger),
-                               .restartable = legacyfile_supportsSaRestart(desc)};
+        return syscallreturn_makeBlocked(
+            syscallcondition_new(trigger), legacyfile_supportsSaRestart(desc));
     }
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = result};
+    return syscallreturn_makeDoneI64(result);
 }
 
 ///////////////////////////////////////////////////////////

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -38,7 +38,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, Plu
     /* Get the descriptor. */
     LegacyFile* desc = process_getRegisteredLegacyFile(sys->process, fd);
     if (!desc) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EBADF};
+        return syscallreturn_makeDoneErrno(EBADF);
     }
 
     /* Some logic depends on the descriptor type. */
@@ -46,7 +46,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, Plu
 
     /* We can only seek on files, otherwise its a pipe error. */
     if (dType != DT_FILE && offset != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ESPIPE};
+        return syscallreturn_makeDoneErrno(ESPIPE);
     }
 
     /* Divert io on sockets to socket handler to pick up special checks. */
@@ -58,8 +58,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, Plu
     /* Now it's an error if the descriptor is closed. */
     int errorCode = _syscallhandler_validateLegacyFile(desc, DT_NONE);
     if (errorCode != 0) {
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = errorCode};
+        return syscallreturn_makeDoneErrno(-errorCode);
     }
     utility_debugAssert(desc);
 
@@ -115,13 +114,11 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, Plu
         /* We need to block until the descriptor is ready to read. */
         Trigger trigger =
             (Trigger){.type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_FILE_READABLE};
-        return (SysCallReturn){.state = SYSCALL_BLOCK,
-                               .cond = syscallcondition_new(trigger),
-                               .restartable = legacyfile_supportsSaRestart(desc)};
+        return syscallreturn_makeBlocked(
+            syscallcondition_new(trigger), legacyfile_supportsSaRestart(desc));
     }
 
-    return (SysCallReturn){
-        .state = SYSCALL_DONE, .retval.as_i64 = (int64_t)result};
+    return syscallreturn_makeDoneI64(result);
 }
 
 static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, PluginPtr bufPtr,
@@ -132,7 +129,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, Pl
     /* Get the descriptor. */
     LegacyFile* desc = process_getRegisteredLegacyFile(sys->process, fd);
     if (!desc) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EBADF};
+        return syscallreturn_makeDoneErrno(EBADF);
     }
 
     /* Some logic depends on the descriptor type. */
@@ -140,7 +137,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, Pl
 
     /* We can only seek on files, otherwise its a pipe error. */
     if (dType != DT_FILE && offset != 0) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ESPIPE};
+        return syscallreturn_makeDoneErrno(ESPIPE);
     }
 
     /* Divert io on sockets to socket handler to pick up special checks. */
@@ -152,8 +149,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, Pl
     /* Now it's an error if the descriptor is closed. */
     gint errorCode = _syscallhandler_validateLegacyFile(desc, DT_NONE);
     if (errorCode != 0) {
-        return (SysCallReturn){
-            .state = SYSCALL_DONE, .retval.as_i64 = errorCode};
+        return syscallreturn_makeDoneErrno(-errorCode);
     }
     utility_debugAssert(desc);
 
@@ -200,13 +196,11 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, Pl
         /* We need to block until the descriptor is ready to write. */
         Trigger trigger =
             (Trigger){.type = TRIGGER_DESCRIPTOR, .object = desc, .status = STATUS_FILE_WRITABLE};
-        return (SysCallReturn){.state = SYSCALL_BLOCK,
-                               .cond = syscallcondition_new(trigger),
-                               .restartable = legacyfile_supportsSaRestart(desc)};
+        return syscallreturn_makeBlocked(
+            syscallcondition_new(trigger), legacyfile_supportsSaRestart(desc));
     }
 
-    return (SysCallReturn){
-        .state = SYSCALL_DONE, .retval.as_i64 = (int64_t)result};
+    return syscallreturn_makeDoneI64(result);
 }
 
 ///////////////////////////////////////////////////////////
@@ -240,39 +234,36 @@ SysCallReturn syscallhandler_pwrite64(SysCallHandler* sys,
 SysCallReturn syscallhandler_exit_group(SysCallHandler* sys, const SysCallArgs* args) {
     trace("Exit group with exit code %ld", args->args[0].as_i64);
     process_markAsExiting(sys->process);
-    return (SysCallReturn){.state = SYSCALL_NATIVE};
+    return syscallreturn_makeNative();
 }
 
 SysCallReturn syscallhandler_getpid(SysCallHandler* sys,
                                     const SysCallArgs* args) {
     // We can't handle this natively in the plugin if we want determinism
-    guint pid = process_getProcessID(sys->process);
-    return (SysCallReturn){
-        .state = SYSCALL_DONE, .retval.as_i64 = (int64_t)pid};
+    pid_t pid = process_getProcessID(sys->process);
+    return syscallreturn_makeDoneI64(pid);
 }
 
 SysCallReturn syscallhandler_getppid(SysCallHandler* sys, const SysCallArgs* args) {
     // We can't handle this natively in the plugin if we want determinism
     // Just return a constant
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 1};
+    return syscallreturn_makeDoneI64(1);
 }
 
 SysCallReturn syscallhandler_set_tid_address(SysCallHandler* sys, const SysCallArgs* args) {
     PluginPtr tidptr = args->args[0].as_ptr; // int*
     thread_setTidAddress(sys->thread, tidptr);
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = thread_getID(sys->thread)};
+    return syscallreturn_makeDoneI64(thread_getID(sys->thread));
 }
 
 SysCallReturn syscallhandler_uname(SysCallHandler* sys,
                                    const SysCallArgs* args) {
     struct utsname* buf = NULL;
 
-    /* Make sure they didn't pass a NULL pointer. */
-    if (!args->args[0].as_ptr.val) {
-        return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -EFAULT};
-    }
-
     buf = process_getWriteablePtr(sys->process, args->args[0].as_ptr, sizeof(*buf));
+    if (!buf) {
+        return syscallreturn_makeDoneErrno(EFAULT);
+    }
 
     const gchar* hostname = host_getName(sys->host);
 
@@ -282,5 +273,5 @@ SysCallReturn syscallhandler_uname(SysCallHandler* sys,
     snprintf(buf->version, _UTSNAME_VERSION_LENGTH, "shadowversion");
     snprintf(buf->machine, _UTSNAME_MACHINE_LENGTH, "shadowmachine");
 
-    return (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = 0};
+    return syscallreturn_makeDoneI64(0);
 }

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -61,7 +61,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, Plu
         return (SysCallReturn){
             .state = SYSCALL_DONE, .retval.as_i64 = errorCode};
     }
-    utility_assert(desc);
+    utility_debugAssert(desc);
 
     /* TODO: Dynamically compute size based on how much data is actually
      * available in the descriptor. */
@@ -71,7 +71,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, Plu
     switch (dType) {
         case DT_FILE:
             if (!doPread) {
-                utility_assert(offset == 0);
+                utility_debugAssert(offset == 0);
                 result = regularfile_read((RegularFile*)desc, sys->host,
                                           process_getWriteablePtr(sys->process, bufPtr, sizeNeeded),
                                           sizeNeeded);
@@ -85,7 +85,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, Plu
             if (doPread) {
                 result = -ESPIPE;
             } else {
-                utility_assert(offset == 0);
+                utility_debugAssert(offset == 0);
                 result = timerfd_read((TimerFd*)desc,
                                       process_getWriteablePtr(sys->process, bufPtr, sizeNeeded),
                                       sizeNeeded);
@@ -94,7 +94,7 @@ static SysCallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, Plu
         case DT_TCPSOCKET:
         case DT_UDPSOCKET:
             // We already diverted these to the socket handler above.
-            utility_assert(0);
+            utility_debugAssert(0);
             break;
         case DT_EPOLL:
         default:
@@ -155,7 +155,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, Pl
         return (SysCallReturn){
             .state = SYSCALL_DONE, .retval.as_i64 = errorCode};
     }
-    utility_assert(desc);
+    utility_debugAssert(desc);
 
     /* TODO: Dynamically compute size based on how much data is actually
      * available in the descriptor. */
@@ -165,7 +165,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, Pl
     switch (dType) {
         case DT_FILE:
             if (!doPwrite) {
-                utility_assert(offset == 0);
+                utility_debugAssert(offset == 0);
                 result = regularfile_write((RegularFile*)desc,
                                            process_getReadablePtr(sys->process, bufPtr, sizeNeeded),
                                            sizeNeeded);
@@ -179,7 +179,7 @@ static SysCallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, Pl
         case DT_TCPSOCKET:
         case DT_UDPSOCKET:
             // We already diverted these to the socket handler above.
-            utility_assert(0);
+            utility_debugAssert(0);
             break;
         case DT_EPOLL:
         default:

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -211,7 +211,7 @@ void syscallcondition_ref(SysCallCondition* cond) {
 void syscallcondition_unref(SysCallCondition* cond) {
     MAGIC_ASSERT(cond);
     cond->referenceCount--;
-    utility_assert(cond->referenceCount >= 0);
+    utility_debugAssert(cond->referenceCount >= 0);
     if (cond->referenceCount == 0) {
         _syscallcondition_free(cond);
     }
@@ -261,7 +261,7 @@ static void _syscallcondition_logListeningState(SysCallCondition* cond,
     }
 
     if (cond->timeoutExpiration != EMUTIME_INVALID) {
-        utility_assert(cond->timeoutExpiration >= worker_getCurrentEmulatedTime());
+        utility_debugAssert(cond->timeoutExpiration >= worker_getCurrentEmulatedTime());
         SimulationTime remainingTime = cond->timeoutExpiration - worker_getCurrentEmulatedTime();
         g_string_append_printf(string, "a timeout with %lu.%09lu seconds remaining",
                                remainingTime / SIMTIME_ONE_SECOND,
@@ -337,9 +337,9 @@ static void _syscallcondition_trigger(Host* host, void* obj, void* arg) {
 #endif
 
     if (!cond->proc || !cond->thread) {
-        utility_assert(!cond->proc);
-        utility_assert(!cond->thread);
-        utility_assert(!cond->triggerListener);
+        utility_debugAssert(!cond->proc);
+        utility_debugAssert(!cond->thread);
+        utility_debugAssert(!cond->triggerListener);
 #ifdef DEBUG
         _syscallcondition_logListeningState(cond, "ignored (already cleaned up)");
 #endif
@@ -415,8 +415,8 @@ static void _syscallcondition_notifyTimeoutExpired(Host* host, void* obj, void* 
 void syscallcondition_waitNonblock(SysCallCondition* cond, Host* host, Process* proc,
                                    Thread* thread) {
     MAGIC_ASSERT(cond);
-    utility_assert(proc);
-    utility_assert(thread);
+    utility_debugAssert(proc);
+    utility_debugAssert(thread);
 
     /* Update the reference counts. */
     syscallcondition_cancel(cond);

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -183,16 +183,26 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number,
     /* Add the cumulative elapsed seconds and num syscalls. */
     sys->perfSecondsCurrent += g_timer_elapsed(sys->perfTimer, NULL);
 #endif
+    if (logger_isEnabled(logger_getDefault(), LOGLEVEL_TRACE)) {
+        const char* errstr = "n/a";
+        char errstrbuf[100];
 
-    trace("SYSCALL_HANDLER_POST(%s,pid=%u): syscall %ld %s result: state=%s%s "
-          "code=%d(%s)",
-          process_getPluginName(sys->process), thread_getID(sys->thread), number, name,
-          _syscallhandler_wasBlocked(sys) ? "BLOCK->" : "",
-          scr->state == SYSCALL_DONE
-              ? "DONE"
-              : scr->state == SYSCALL_BLOCK ? "BLOCK"
-                                            : scr->state == SYSCALL_NATIVE ? "NATIVE" : "UNKNOWN",
-          (int)scr->retval.as_i64, scr->retval.as_i64 < 0 ? strerror(-scr->retval.as_i64) : "n/a");
+        const char* valstr = "n/a";
+        char valbuf[100];
+        if (scr->state == SYSCALL_DONE) {
+            SysCallReturnDone* done = syscallreturn_done(scr);
+            if (done->retval.as_i64 < 0) {
+                errstr = strerror_r(-done->retval.as_i64, errstrbuf, sizeof(errstrbuf));
+            }
+            snprintf(valbuf, sizeof(valbuf), "%" PRIi64, done->retval.as_i64);
+            valstr = valbuf;
+        }
+        trace("SYSCALL_HANDLER_POST(%s,pid=%u): syscall %ld %s result: state=%s%s "
+              "val=%s(%s)",
+              process_getPluginName(sys->process), thread_getID(sys->thread), number, name,
+              _syscallhandler_wasBlocked(sys) ? "BLOCK->" : "", syscallreturnstate_str(scr->state),
+              valstr, errstr);
+    }
 
 #ifdef USE_PERF_TIMERS
     debug("handling syscall %ld %s took %f seconds", number, name, sys->perfSecondsCurrent);
@@ -225,7 +235,7 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number,
 #define NATIVE(s)                                                                                  \
     case SYS_##s:                                                                                  \
         trace("native syscall %ld " #s, args->number);                                             \
-        scr = (SysCallReturn){.state = SYSCALL_NATIVE};                                            \
+        scr = syscallreturn_makeNative();                                                          \
         if (straceLoggingMode != STRACE_FMT_MODE_OFF) {                                            \
             scr = log_syscall(                                                                     \
                 sys->process, straceLoggingMode, thread_getID(sys->thread), #s, "...", scr);       \
@@ -234,7 +244,7 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number,
 #define UNSUPPORTED(s)                                                                             \
     case SYS_##s:                                                                                  \
         error("Returning error ENOSYS for explicitly unsupported syscall %ld " #s, args->number);  \
-        scr = (SysCallReturn){.state = -ENOSYS};                                                   \
+        scr = syscallreturn_makeErrno(ENOSYS);                                                     \
         if (straceLoggingMode != STRACE_FMT_MODE_OFF) {                                            \
             scr = log_syscall(                                                                     \
                 sys->process, straceLoggingMode, thread_getID(sys->thread), #s, "...", scr);       \
@@ -531,7 +541,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
                 error("Returning error %i (ENOSYS) for unsupported syscall %li, which may result in "
                       "unusual behavior",
                       ENOSYS, args->number);
-                scr = (SysCallReturn){.state = SYSCALL_DONE, .retval.as_i64 = -ENOSYS};
+                scr = syscallreturn_makeDoneI64(-ENOSYS);
 
                 if (straceLoggingMode != STRACE_FMT_MODE_OFF) {
                     char arg_str[20] = {0};
@@ -567,14 +577,13 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
     // transferred)."
     if (scr.state == SYSCALL_BLOCK &&
         thread_unblockedSignalPending(sys->thread, host_getShimShmemLock(sys->host))) {
-        SysCallCondition* condition = scr.cond;
-        utility_assert(condition);
-        syscallcondition_unref(condition);
-        scr = (SysCallReturn){
-            .state = SYSCALL_DONE, .retval = -EINTR, .restartable = scr.restartable};
+        SysCallReturnBlocked* blocked = syscallreturn_blocked(&scr);
+        syscallcondition_unref(blocked->cond);
+        scr = syscallreturn_makeInterrupted(blocked->restartable);
     }
 
-    if (!(scr.state == SYSCALL_DONE && syscall_rawReturnValueToErrno(scr.retval.as_i64) == 0)) {
+    if (!(scr.state == SYSCALL_DONE &&
+          syscall_rawReturnValueToErrno(syscallreturn_done(&scr)->retval.as_i64) == 0)) {
         // The syscall didn't complete successfully; don't write back pointers.
         trace("Syscall didn't complete successfully; discarding plugin ptrs without writing back.");
         process_freePtrsWithoutFlushing(sys->process);
@@ -610,10 +619,9 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
                 utility_debugAssert(!sys->havePendingResult);
                 sys->havePendingResult = true;
                 sys->pendingResult = scr;
-                utility_assert(scr.cond == NULL);
-                scr.cond = syscallcondition_new((Trigger){.type = TRIGGER_NONE});
-                syscallcondition_setTimeout(scr.cond, sys->host, newTime);
-                scr.state = SYSCALL_BLOCK;
+                SysCallCondition* cond = syscallcondition_new((Trigger){.type = TRIGGER_NONE});
+                syscallcondition_setTimeout(cond, sys->host, newTime);
+                scr = syscallreturn_makeBlocked(cond, false);
             }
         }
     }

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -57,9 +57,9 @@ ADD_CONFIG_HANDLER(config_getUseSyscallCounters, _countSyscalls)
 
 SysCallHandler* syscallhandler_new(Host* host, Process* process,
                                    Thread* thread) {
-    utility_assert(host);
-    utility_assert(process);
-    utility_assert(thread);
+    utility_debugAssert(host);
+    utility_debugAssert(process);
+    utility_debugAssert(thread);
 
     SysCallHandler* sys = malloc(sizeof(SysCallHandler));
 
@@ -151,7 +151,7 @@ void syscallhandler_ref(SysCallHandler* sys) {
 void syscallhandler_unref(SysCallHandler* sys) {
     MAGIC_ASSERT(sys);
     (sys->referenceCount)--;
-    utility_assert(sys->referenceCount >= 0);
+    utility_debugAssert(sys->referenceCount >= 0);
     if(sys->referenceCount == 0) {
         _syscallhandler_free(sys);
     }
@@ -272,7 +272,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
         // Return that response now.
         trace("Returning delayed result");
         sys->havePendingResult = false;
-        utility_assert(sys->pendingResult.state != SYSCALL_BLOCK);
+        utility_debugAssert(sys->pendingResult.state != SYSCALL_BLOCK);
         sys->blockedSyscallNR = -1;
         return sys->pendingResult;
     } else {
@@ -607,7 +607,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
                 trace("Reached unblocked syscall limit. Yielding.");
                 // Block instead, but save the result so that we can return it
                 // later instead of re-executing the syscall.
-                utility_assert(!sys->havePendingResult);
+                utility_debugAssert(!sys->havePendingResult);
                 sys->havePendingResult = true;
                 sys->pendingResult = scr;
                 utility_assert(scr.cond == NULL);

--- a/src/main/host/syscall_types.c
+++ b/src/main/host/syscall_types.c
@@ -1,0 +1,81 @@
+#include "main/host/syscall_types.h"
+
+#include "main/utility/utility.h"
+
+SysCallReturn syscallreturn_makeDone(SysCallReg retval) {
+    return (SysCallReturn){
+        .state = SYSCALL_DONE,
+        .u.done =
+            {
+                .retval = retval,
+            },
+    };
+}
+
+SysCallReturn syscallreturn_makeDoneI64(int64_t retval) {
+    return syscallreturn_makeDone((SysCallReg){.as_i64 = retval});
+}
+
+SysCallReturn syscallreturn_makeDoneU64(uint64_t retval) {
+    return syscallreturn_makeDone((SysCallReg){.as_u64 = retval});
+}
+
+SysCallReturn syscallreturn_makeDonePtr(PluginPtr retval) {
+    return syscallreturn_makeDone((SysCallReg){.as_ptr = retval});
+}
+
+SysCallReturn syscallreturn_makeDoneErrno(int err) {
+    // Should be a *positive* error value.
+    utility_debugAssert(err > 0);
+    // Should use `syscallreturn_makeInterrupted` for EINTR
+    utility_debugAssert(err != EINTR);
+
+    return syscallreturn_makeDoneI64(-err);
+}
+
+SysCallReturn syscallreturn_makeInterrupted(bool restartable) {
+    return (SysCallReturn){
+        .state = SYSCALL_DONE,
+        .u.done =
+            {
+                .retval.as_i64 = -EINTR,
+                .restartable = restartable,
+            },
+    };
+}
+
+SysCallReturn syscallreturn_makeBlocked(SysCallCondition* cond, bool restartable) {
+    return (SysCallReturn){
+        .state = SYSCALL_BLOCK,
+        .u.blocked =
+            {
+                .cond = cond,
+                .restartable = restartable,
+            },
+    };
+}
+
+SysCallReturn syscallreturn_makeNative() {
+    return (SysCallReturn){
+        .state = SYSCALL_NATIVE,
+    };
+}
+
+SysCallReturnBlocked* syscallreturn_blocked(SysCallReturn* ret) {
+    utility_alwaysAssert(ret->state == SYSCALL_BLOCK);
+    return &ret->u.blocked;
+}
+
+SysCallReturnDone* syscallreturn_done(SysCallReturn* ret) {
+    utility_alwaysAssert(ret->state == SYSCALL_DONE);
+    return &ret->u.done;
+}
+
+const char* syscallreturnstate_str(SysCallReturnState s) {
+    switch (s) {
+        case SYSCALL_DONE: return "DONE";
+        case SYSCALL_BLOCK: return "BLOCK";
+        case SYSCALL_NATIVE: return "NATIVE";
+    }
+    return "UNKNOWN";
+}

--- a/src/main/host/syscall_types.h
+++ b/src/main/host/syscall_types.h
@@ -1,6 +1,7 @@
 #ifndef SHD_SYSCALL_TYPES_H_
 #define SHD_SYSCALL_TYPES_H_
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -43,25 +44,52 @@ typedef enum {
     SYSCALL_NATIVE
 } SysCallReturnState;
 
+const char* syscallreturnstate_str(SysCallReturnState s);
+
 /* This is an opaque structure holding the state needed to resume a thread
  * previously blocked by a syscall. Any syscall that returns SYSCALL_BLOCK
  * should include a SysCallCondition by which the thread should be unblocked. */
 typedef struct _SysCallCondition SysCallCondition;
 
-typedef struct _SysCallReturn {
-    SysCallReturnState state;
-    // Only valid for state SYSCALL_DONE.
+typedef struct {
     SysCallReg retval;
-    // Only valid for state SYSCALL_BLOCK.
+    // Only meaningful when `retval` is -EINTR.
+    //
+    // Whether the interrupted syscall is restartable.
+    bool restartable;
+} SysCallReturnDone;
+
+typedef struct {
     SysCallCondition* cond;
     // True if the syscall is restartable in the case that it was interrupted by
     // a signal. e.g. if the syscall was a `read` operation on a socket without
     // a configured timeout. See socket(7).
-    //
-    // syscall handlers returning `state` SYSCALL_BLOCK should set this. It is
-    // also valid to *read* this field when `state` is SYSCALL_DONE and `retval`
-    // is `-EINTR` - i.e. a blocked syscall has been interrupted by a signal.
     bool restartable;
+} SysCallReturnBlocked;
+
+union SysCallReturnBody {
+    SysCallReturnDone done;
+    SysCallReturnBlocked blocked;
+};
+
+typedef struct _SysCallReturn {
+    SysCallReturnState state;
+    // We need to name both the union type and the field for the Rust bindings
+    // to work well.
+    //
+    // Avoid accessing directly; use the helper functions below instead.
+    union SysCallReturnBody u;
 } SysCallReturn;
 
+SysCallReturn syscallreturn_makeDone(SysCallReg retval);
+SysCallReturn syscallreturn_makeDoneI64(int64_t retval);
+SysCallReturn syscallreturn_makeDoneU64(uint64_t retval);
+SysCallReturn syscallreturn_makeDonePtr(PluginPtr retval);
+SysCallReturn syscallreturn_makeDoneErrno(int err);
+SysCallReturn syscallreturn_makeInterrupted(bool restartable);
+SysCallReturn syscallreturn_makeBlocked(SysCallCondition* cond, bool restartable);
+SysCallReturn syscallreturn_makeNative();
+
+SysCallReturnBlocked* syscallreturn_blocked(SysCallReturn* ret);
+SysCallReturnDone* syscallreturn_done(SysCallReturn* ret);
 #endif

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -85,7 +85,7 @@ void thread_ref(Thread* thread) {
 void thread_unref(Thread* thread) {
     MAGIC_ASSERT(thread);
     (thread->referenceCount)--;
-    utility_assert(thread->referenceCount >= 0);
+    utility_debugAssert(thread->referenceCount >= 0);
     if(thread->referenceCount == 0) {
         _thread_cleanupSysCallCondition(thread);
         managedthread_free(thread->mthread);
@@ -135,7 +135,7 @@ void thread_resume(Thread* thread) {
     if (thread->cond) {
         syscallcondition_waitNonblock(thread->cond, thread->host, thread->process, thread);
     } else {
-        utility_assert(!managedthread_isRunning(thread->mthread));
+        utility_debugAssert(!managedthread_isRunning(thread->mthread));
         if (thread->sys) {
             syscallhandler_unref(thread->sys);
             thread->sys = NULL;
@@ -175,7 +175,7 @@ ShMemBlock* thread_getShMBlock(Thread* thread) {
 
 ShimShmemThread* thread_sharedMem(Thread* thread) {
     MAGIC_ASSERT(thread);
-    utility_assert(thread->shimSharedMemBlock.p);
+    utility_debugAssert(thread->shimSharedMemBlock.p);
     return thread->shimSharedMemBlock.p;
 }
 

--- a/src/main/host/tracker.c
+++ b/src/main/host/tracker.c
@@ -298,7 +298,7 @@ void tracker_removeAllocatedBytes(Tracker* tracker, gpointer location) {
         gboolean exists = g_hash_table_lookup_extended(tracker->allocatedLocations, location, NULL, &value);
         if(exists) {
             gboolean b = g_hash_table_remove(tracker->allocatedLocations, location);
-            utility_assert(b);
+            utility_debugAssert(b);
             gsize allocatedBytes = GPOINTER_TO_SIZE(value);
             tracker->allocatedBytesTotal -= allocatedBytes;
             tracker->deallocatedBytesLastInterval += allocatedBytes;
@@ -394,7 +394,7 @@ void tracker_removeSocket(Tracker* tracker, LegacySocket* socket) {
 }
 
 static gsize _tracker_sumBytes(ByteCounter* bytes) {
-    utility_assert(bytes);
+    utility_debugAssert(bytes);
     return bytes->controlHeader + bytes->controlHeaderRetransmit +
             bytes->dataHeader + bytes->dataHeaderRetransmit +
             bytes->dataPayload + bytes->dataPayloadRetransmit;
@@ -409,7 +409,7 @@ static const gchar* _tracker_getCounterHeaderString() {
 }
 
 static gchar* _tracker_getCounterString(Counters* c) {
-    utility_assert(c);
+    utility_debugAssert(c);
 
     gsize totalPackets = c->packets.control + c->packets.controlRetransmit +
             c->packets.data + c->packets.dataRetransmit;

--- a/src/main/routing/dns.c
+++ b/src/main/routing/dns.c
@@ -39,12 +39,12 @@ struct _DNS {
 };
 
 static gboolean _dns_isIPInRange(const in_addr_t netIP, const gchar* cidrStr) {
-    utility_assert(cidrStr);
+    utility_debugAssert(cidrStr);
 
     gchar** cidrParts = g_strsplit(cidrStr, "/", 0);
     gchar* cidrIPStr = cidrParts[0];
     gint cidrBits = atoi(cidrParts[1]);
-    utility_assert(cidrBits >= 0 && cidrBits <= 32);
+    utility_debugAssert(cidrBits >= 0 && cidrBits <= 32);
 
     /* first create the mask in host order */
     in_addr_t netmask = 0;
@@ -112,7 +112,7 @@ static gboolean _dns_isIPUnique(DNS* dns, in_addr_t ip) {
 
 Address* dns_register(DNS* dns, GQuark id, const gchar* name, in_addr_t requestedIP) {
     MAGIC_ASSERT(dns);
-    utility_assert(name);
+    utility_debugAssert(name);
 
     g_mutex_lock(&dns->lock);
 
@@ -223,7 +223,7 @@ static void _dns_writeHostLine(gpointer key, gpointer value, gpointer data) {
 
 static bool _dns_writeNewHostsFile(DNS* dns) {
     MAGIC_ASSERT(dns);
-    utility_assert(!dns->hosts.path);
+    utility_debugAssert(!dns->hosts.path);
 
     dns->hosts.path = _dns_getHostsPath(dns);
     dns->hosts.filenum = mkstemp(dns->hosts.path);

--- a/src/main/routing/packet.c
+++ b/src/main/routing/packet.c
@@ -104,9 +104,9 @@ Packet* packet_new(Host* host) {
 void packet_setPayload(Packet* packet, Thread* thread, PluginVirtualPtr payload,
                        gsize payloadLength) {
     MAGIC_ASSERT(packet);
-    utility_assert(thread);
-    utility_assert(payload.val);
-    utility_assert(!packet->payload);
+    utility_debugAssert(thread);
+    utility_debugAssert(payload.val);
+    utility_debugAssert(!packet->payload);
 
     /* the payload starts with 1 ref, which we hold */
     packet->payload = payload_new(thread, payload, payloadLength);
@@ -232,10 +232,10 @@ gint packet_compareTCPSequence(Packet* packet1, Packet* packet2, gpointer user_d
      * at once or a deadlock will occur */
     guint sequence1 = 0, sequence2 = 0;
 
-    utility_assert(packet1->protocol == PTCP);
+    utility_debugAssert(packet1->protocol == PTCP);
     sequence1 = ((PacketTCPHeader*)(packet1->header))->sequence;
 
-    utility_assert(packet2->protocol == PTCP);
+    utility_debugAssert(packet2->protocol == PTCP);
     sequence2 = ((PacketTCPHeader*)(packet2->header))->sequence;
 
     return sequence1 < sequence2 ? -1 : sequence1 > sequence2 ? 1 : 0;
@@ -244,8 +244,8 @@ gint packet_compareTCPSequence(Packet* packet1, Packet* packet2, gpointer user_d
 void packet_setLocal(Packet* packet, enum ProtocolLocalFlags flags,
         gint sourceDescriptorHandle, gint destinationDescriptorHandle, in_port_t port) {
     MAGIC_ASSERT(packet);
-    utility_assert(!(packet->header) && packet->protocol == PNONE);
-    utility_assert(port > 0);
+    utility_debugAssert(!(packet->header) && packet->protocol == PNONE);
+    utility_debugAssert(port > 0);
 
     PacketLocalHeader* header = g_new0(PacketLocalHeader, 1);
 
@@ -262,8 +262,8 @@ void packet_setUDP(Packet* packet, enum ProtocolUDPFlags flags,
         in_addr_t sourceIP, in_port_t sourcePort,
         in_addr_t destinationIP, in_port_t destinationPort) {
     MAGIC_ASSERT(packet);
-    utility_assert(!(packet->header) && packet->protocol == PNONE);
-    utility_assert(sourceIP && sourcePort && destinationIP && destinationPort);
+    utility_debugAssert(!(packet->header) && packet->protocol == PNONE);
+    utility_debugAssert(sourceIP && sourcePort && destinationIP && destinationPort);
 
     PacketUDPHeader* header = g_new0(PacketUDPHeader, 1);
 
@@ -281,8 +281,8 @@ void packet_setTCP(Packet* packet, enum ProtocolTCPFlags flags,
         in_addr_t sourceIP, in_port_t sourcePort,
         in_addr_t destinationIP, in_port_t destinationPort, guint sequence) {
     MAGIC_ASSERT(packet);
-    utility_assert(!(packet->header) && packet->protocol == PNONE);
-    utility_assert(sourceIP && sourcePort && destinationIP && destinationPort);
+    utility_debugAssert(!(packet->header) && packet->protocol == PNONE);
+    utility_debugAssert(sourceIP && sourcePort && destinationIP && destinationPort);
 
     PacketTCPHeader* header = g_new0(PacketTCPHeader, 1);
 
@@ -300,7 +300,7 @@ void packet_setTCP(Packet* packet, enum ProtocolTCPFlags flags,
 void packet_updateTCP(Packet* packet, guint acknowledgement, GList* selectiveACKs,
         guint window, SimulationTime timestampValue, SimulationTime timestampEcho) {
     MAGIC_ASSERT(packet);
-    utility_assert(packet->header && (packet->protocol == PTCP));
+    utility_debugAssert(packet->header && (packet->protocol == PTCP));
 
     PacketTCPHeader* header = (PacketTCPHeader*) packet->header;
 
@@ -507,7 +507,7 @@ guint packet_copyPayloadShadow(const Packet* packet, gsize payloadOffset, void* 
 
 GList* packet_copyTCPSelectiveACKs(Packet* packet) {
     MAGIC_ASSERT(packet);
-    utility_assert(packet->protocol == PTCP);
+    utility_debugAssert(packet->protocol == PTCP);
 
     PacketTCPHeader* packetHeader = (PacketTCPHeader*)packet->header;
 
@@ -523,7 +523,7 @@ GList* packet_copyTCPSelectiveACKs(Packet* packet) {
 
 PacketTCPHeader* packet_getTCPHeader(const Packet* packet) {
     MAGIC_ASSERT(packet);
-    utility_assert(packet->protocol == PTCP);
+    utility_debugAssert(packet->protocol == PTCP);
     return (PacketTCPHeader*)packet->header;
 }
 

--- a/src/main/routing/payload.c
+++ b/src/main/routing/payload.c
@@ -33,7 +33,7 @@ Payload* payload_new(Thread* thread, PluginVirtualPtr data, gsize dataLength) {
             g_free(payload);
             return NULL;
         }
-        utility_assert(payload->data != NULL);
+        utility_debugAssert(payload->data != NULL);
         payload->length = dataLength;
     }
 
@@ -102,7 +102,7 @@ gssize payload_getData(Payload* payload, Thread* thread, gsize offset, PluginVir
 
     _payload_lock(payload);
 
-    utility_assert(offset <= payload->length);
+    utility_debugAssert(offset <= payload->length);
 
     gssize targetLength = payload->length - offset;
     gssize copyLength = MIN(targetLength, destBufferLength);
@@ -126,7 +126,7 @@ gsize payload_getDataShadow(Payload* payload, gsize offset, void* destBuffer,
 
     _payload_lock(payload);
 
-    utility_assert(offset <= payload->length);
+    utility_debugAssert(offset <= payload->length);
 
     gsize targetLength = payload->length - offset;
     gsize copyLength = MIN(targetLength, destBufferLength);

--- a/src/main/routing/router.c
+++ b/src/main/routing/router.c
@@ -36,7 +36,7 @@ struct _Router {
 };
 
 Router* router_new(QueueManagerMode queueMode, void* interface) {
-    utility_assert(interface);
+    utility_debugAssert(interface);
 
     Router* router = g_new0(Router, 1);
     MAGIC_INIT(router);
@@ -56,11 +56,11 @@ Router* router_new(QueueManagerMode queueMode, void* interface) {
         utility_panic("Queue manager mode %i is undefined", (int)queueMode);
     }
 
-    utility_assert(router->queueHooks->new);
-    utility_assert(router->queueHooks->free);
-    utility_assert(router->queueHooks->enqueue);
-    utility_assert(router->queueHooks->dequeue);
-    utility_assert(router->queueHooks->peek);
+    utility_debugAssert(router->queueHooks->new);
+    utility_debugAssert(router->queueHooks->free);
+    utility_debugAssert(router->queueHooks->enqueue);
+    utility_debugAssert(router->queueHooks->dequeue);
+    utility_debugAssert(router->queueHooks->peek);
 
     router->queueManager = router->queueHooks->new();
 
@@ -86,7 +86,7 @@ void router_ref(Router* router) {
 void router_unref(Router* router) {
     MAGIC_ASSERT(router);
     (router->referenceCount)--;
-    utility_assert(router->referenceCount >= 0);
+    utility_debugAssert(router->referenceCount >= 0);
     if(router->referenceCount == 0) {
         _router_free(router);
     }
@@ -102,7 +102,7 @@ void router_forward(Router* router, Host* src, Packet* packet) {
 
 void router_enqueue(Router* router, Host* host, Packet* packet) {
     MAGIC_ASSERT(router);
-    utility_assert(packet);
+    utility_debugAssert(packet);
 
     Packet* bufferedPacket = router->queueHooks->peek(router->queueManager);
 

--- a/src/main/routing/router_queue_codel.c
+++ b/src/main/routing/router_queue_codel.c
@@ -88,7 +88,7 @@ static QueueManagerCoDel* _routerqueuecodel_new() {
 }
 
 static void _routerqueuecodel_free(QueueManagerCoDel* queueManager) {
-    utility_assert(queueManager);
+    utility_debugAssert(queueManager);
 
     if(queueManager->entries) {
         while(!g_queue_is_empty(queueManager->entries)) {
@@ -111,8 +111,8 @@ static inline guint64 _routerqueuecodel_getPacketLength(Packet* packet) {
 }
 
 static gboolean _routerqueuecodel_enqueue(QueueManagerCoDel* queueManager, Packet* packet) {
-    utility_assert(queueManager);
-    utility_assert(packet);
+    utility_debugAssert(queueManager);
+    utility_debugAssert(packet);
 
     if(g_queue_get_length(queueManager->entries) < CODEL_PARAM_QUEUE_SIZE_LIMIT) {
         /* we will store the packet */
@@ -166,10 +166,10 @@ static Packet* _routerqueuecodel_dequeueHelper(QueueManagerCoDel* queueManager,
     }
 
     guint64 length = _routerqueuecodel_getPacketLength(packet);
-    utility_assert(length <= queueManager->totalSize);
+    utility_debugAssert(length <= queueManager->totalSize);
     queueManager->totalSize -= length;
 
-    utility_assert(now >= ts);
+    utility_debugAssert(now >= ts);
     SimulationTime sojournTime = now - ts;
 
     if(sojournTime < CODEL_PARAM_TARGET_DELAY_SIMTIME || queueManager->totalSize < CONFIG_MTU) {
@@ -205,7 +205,7 @@ static SimulationTime _routerqueuecodel_controlLaw(guint count, SimulationTime t
 }
 
 static Packet* _routerqueuecodel_dequeue(QueueManagerCoDel* queueManager) {
-    utility_assert(queueManager);
+    utility_debugAssert(queueManager);
 
     SimulationTime now = worker_getCurrentSimulationTime();
 
@@ -267,7 +267,7 @@ static Packet* _routerqueuecodel_dequeue(QueueManagerCoDel* queueManager) {
 }
 
 static Packet* _routerqueuecodel_peek(QueueManagerCoDel* queueManager) {
-    utility_assert(queueManager);
+    utility_debugAssert(queueManager);
 
     CoDelEntry* entry = g_queue_peek_head(queueManager->entries);
 

--- a/src/main/routing/router_queue_single.c
+++ b/src/main/routing/router_queue_single.c
@@ -23,7 +23,7 @@ static QueueManagerSingle* _routerqueuesingle_new() {
 }
 
 static void _routerqueuesingle_free(QueueManagerSingle* queueManager) {
-    utility_assert(queueManager);
+    utility_debugAssert(queueManager);
     if(queueManager->currentPacket) {
         packet_unref(queueManager->currentPacket);
     }
@@ -31,7 +31,7 @@ static void _routerqueuesingle_free(QueueManagerSingle* queueManager) {
 }
 
 static gboolean _routerqueuesingle_enqueue(QueueManagerSingle* queueManager, Packet* packet) {
-    utility_assert(queueManager);
+    utility_debugAssert(queueManager);
 
     if(!queueManager->currentPacket) {
         /* we will queue the packet */
@@ -45,7 +45,7 @@ static gboolean _routerqueuesingle_enqueue(QueueManagerSingle* queueManager, Pac
 }
 
 static Packet* _routerqueuesingle_dequeue(QueueManagerSingle* queueManager) {
-    utility_assert(queueManager);
+    utility_debugAssert(queueManager);
     /* this call transfers the reference that we were holding to the caller */
     Packet* packet = queueManager->currentPacket;
     queueManager->currentPacket = NULL;
@@ -53,7 +53,7 @@ static Packet* _routerqueuesingle_dequeue(QueueManagerSingle* queueManager) {
 }
 
 static Packet* _routerqueuesingle_peek(QueueManagerSingle* queueManager) {
-    utility_assert(queueManager);
+    utility_debugAssert(queueManager);
     return queueManager->currentPacket;
 }
 

--- a/src/main/routing/router_queue_static.c
+++ b/src/main/routing/router_queue_static.c
@@ -28,7 +28,7 @@ static QueueManagerStatic* _routerqueuestatic_new() {
 }
 
 static void _routerqueuestatic_free(QueueManagerStatic* queueManager) {
-    utility_assert(queueManager);
+    utility_debugAssert(queueManager);
 
     if(queueManager->packets) {
         g_queue_free_full(queueManager->packets, (GDestroyNotify)packet_unref);
@@ -42,8 +42,8 @@ static inline guint64 _routerqueuestatic_getPacketLength(Packet* packet) {
 }
 
 static gboolean _routerqueuestatic_enqueue(QueueManagerStatic* queueManager, Packet* packet) {
-    utility_assert(queueManager);
-    utility_assert(packet);
+    utility_debugAssert(queueManager);
+    utility_debugAssert(packet);
 
     guint64 length = _routerqueuestatic_getPacketLength(packet);
 
@@ -60,14 +60,14 @@ static gboolean _routerqueuestatic_enqueue(QueueManagerStatic* queueManager, Pac
 }
 
 static Packet* _routerqueuestatic_dequeue(QueueManagerStatic* queueManager) {
-    utility_assert(queueManager);
+    utility_debugAssert(queueManager);
 
     /* this call transfers the reference that we were holding to the caller */
     Packet* packet = g_queue_pop_head(queueManager->packets);
 
     if(packet) {
         guint64 length = _routerqueuestatic_getPacketLength(packet);
-        utility_assert(length <= queueManager->totalSize);
+        utility_debugAssert(length <= queueManager->totalSize);
         queueManager->totalSize -= length;
     }
 
@@ -75,7 +75,7 @@ static Packet* _routerqueuestatic_dequeue(QueueManagerStatic* queueManager) {
 }
 
 static Packet* _routerqueuestatic_peek(QueueManagerStatic* queueManager) {
-    utility_assert(queueManager);
+    utility_debugAssert(queueManager);
     return g_queue_peek_head(queueManager->packets);
 }
 

--- a/src/main/utility/async_priority_queue.c
+++ b/src/main/utility/async_priority_queue.c
@@ -25,14 +25,14 @@ AsyncPriorityQueue* asyncpriorityqueue_new(GCompareDataFunc compareFunc,
 }
 
 void asyncpriorityqueue_clear(AsyncPriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     g_mutex_lock(&(q->lock));
     priorityqueue_clear(q->pq);
     g_mutex_unlock(&(q->lock));
 }
 
 void asyncpriorityqueue_free(AsyncPriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     g_mutex_lock(&(q->lock));
     priorityqueue_free(q->pq);
     q->pq = NULL;
@@ -42,7 +42,7 @@ void asyncpriorityqueue_free(AsyncPriorityQueue *q) {
 }
 
 gsize asyncpriorityqueue_getLength(AsyncPriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     g_mutex_lock(&(q->lock));
     gsize returnVal = priorityqueue_getLength(q->pq);
     g_mutex_unlock(&(q->lock));
@@ -50,7 +50,7 @@ gsize asyncpriorityqueue_getLength(AsyncPriorityQueue *q) {
 }
 
 gboolean asyncpriorityqueue_isEmpty(AsyncPriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     g_mutex_lock(&(q->lock));
     gboolean returnVal = priorityqueue_isEmpty(q->pq);
     g_mutex_unlock(&(q->lock));
@@ -58,7 +58,7 @@ gboolean asyncpriorityqueue_isEmpty(AsyncPriorityQueue *q) {
 }
 
 gboolean asyncpriorityqueue_push(AsyncPriorityQueue *q, gpointer data) {
-    utility_assert(q);
+    utility_debugAssert(q);
     g_mutex_lock(&(q->lock));
     gboolean returnVal = priorityqueue_push(q->pq, data);
     g_mutex_unlock(&(q->lock));
@@ -66,7 +66,7 @@ gboolean asyncpriorityqueue_push(AsyncPriorityQueue *q, gpointer data) {
 }
 
 gpointer asyncpriorityqueue_peek(AsyncPriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     g_mutex_lock(&(q->lock));
     gpointer returnData = priorityqueue_peek(q->pq);
     g_mutex_unlock(&(q->lock));
@@ -74,7 +74,7 @@ gpointer asyncpriorityqueue_peek(AsyncPriorityQueue *q) {
 }
 
 gpointer asyncpriorityqueue_find(AsyncPriorityQueue *q, gpointer data) {
-    utility_assert(q);
+    utility_debugAssert(q);
     g_mutex_lock(&(q->lock));
     gpointer returnData = priorityqueue_find(q->pq, data);
     g_mutex_unlock(&(q->lock));
@@ -82,7 +82,7 @@ gpointer asyncpriorityqueue_find(AsyncPriorityQueue *q, gpointer data) {
 }
 
 gpointer asyncpriorityqueue_pop(AsyncPriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     g_mutex_lock(&(q->lock));
     gpointer returnData = priorityqueue_pop(q->pq);
     g_mutex_unlock(&(q->lock));

--- a/src/main/utility/count_down_latch.c
+++ b/src/main/utility/count_down_latch.c
@@ -26,14 +26,14 @@ CountDownLatch* countdownlatch_new(guint count) {
 }
 
 void countdownlatch_free(CountDownLatch* latch) {
-    utility_assert(latch);
+    utility_debugAssert(latch);
     g_cond_clear(&(latch->waiters));
     g_mutex_clear(&(latch->lock));
     g_free(latch);
 }
 
 void countdownlatch_await(CountDownLatch* latch) {
-    utility_assert(latch);
+    utility_debugAssert(latch);
     g_mutex_lock(&(latch->lock));
     while(latch->count > 0) {
         g_cond_wait(&(latch->waiters), &(latch->lock));
@@ -42,9 +42,9 @@ void countdownlatch_await(CountDownLatch* latch) {
 }
 
 void countdownlatch_countDown(CountDownLatch* latch) {
-    utility_assert(latch);
+    utility_debugAssert(latch);
     g_mutex_lock(&(latch->lock));
-    utility_assert(latch->count > 0);
+    utility_debugAssert(latch->count > 0);
     (latch->count)--;
     if(latch->count == 0) {
         g_cond_broadcast(&(latch->waiters));
@@ -53,9 +53,9 @@ void countdownlatch_countDown(CountDownLatch* latch) {
 }
 
 void countdownlatch_countDownAwait(CountDownLatch* latch) {
-    utility_assert(latch);
+    utility_debugAssert(latch);
     g_mutex_lock(&(latch->lock));
-    utility_assert(latch->count > 0);
+    utility_debugAssert(latch->count > 0);
     (latch->count)--;
     if(latch->count == 0) {
         g_cond_broadcast(&(latch->waiters));
@@ -66,9 +66,9 @@ void countdownlatch_countDownAwait(CountDownLatch* latch) {
 }
 
 void countdownlatch_reset(CountDownLatch* latch) {
-    utility_assert(latch);
+    utility_debugAssert(latch);
     g_mutex_lock(&(latch->lock));
-    utility_assert(latch->count == 0);
+    utility_debugAssert(latch->count == 0);
     latch->count = latch->initialCount;
     g_mutex_unlock(&(latch->lock));
 }

--- a/src/main/utility/priority_queue.c
+++ b/src/main/utility/priority_queue.c
@@ -26,7 +26,7 @@ struct _PriorityQueue {
 
 PriorityQueue* priorityqueue_new(GCompareDataFunc compareFunc,
         gpointer compareData, GDestroyNotify freeFunc) {
-    utility_assert(compareFunc);
+    utility_debugAssert(compareFunc);
     PriorityQueue *q = g_slice_new(PriorityQueue);
     q->heap = g_new(gpointer, INITIAL_SIZE);
     q->map = g_hash_table_new(NULL, NULL);
@@ -39,7 +39,7 @@ PriorityQueue* priorityqueue_new(GCompareDataFunc compareFunc,
 }
 
 void priorityqueue_clear(PriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     if(q->freeFunc) {
         for (guint i = 0; i < q->size; i++) {
             q->freeFunc(q->heap[i]);
@@ -51,7 +51,7 @@ void priorityqueue_clear(PriorityQueue *q) {
 }
 
 void priorityqueue_free(PriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     priorityqueue_clear(q);
     g_hash_table_destroy(q->map);
     g_free(q->heap);
@@ -59,12 +59,12 @@ void priorityqueue_free(PriorityQueue *q) {
 }
 
 gsize priorityqueue_getLength(PriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     return q->size;
 }
 
 gboolean priorityqueue_isEmpty(PriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     return q->size == 0;
 }
 
@@ -113,7 +113,7 @@ static guint _priorityqueue_heapify_down(PriorityQueue *q, guint index) {
 }
 
 gboolean priorityqueue_push(PriorityQueue *q, gpointer data) {
-    utility_assert(q);
+    utility_debugAssert(q);
     if (q->size >= q->heapSize) {
         q->heapSize *= 2;
         gpointer *oldheap = q->heap;
@@ -140,7 +140,7 @@ gboolean priorityqueue_push(PriorityQueue *q, gpointer data) {
 }
 
 gpointer priorityqueue_peek(PriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     if (q->size > 0) {
         return q->heap[0];
     }
@@ -148,13 +148,13 @@ gpointer priorityqueue_peek(PriorityQueue *q) {
 }
 
 gpointer priorityqueue_find(PriorityQueue *q, gpointer data) {
-    utility_assert(q);
+    utility_debugAssert(q);
     gpointer *entry = g_hash_table_lookup(q->map, data);
     return (entry == NULL) ? NULL : *entry;
 }
 
 gpointer priorityqueue_pop(PriorityQueue *q) {
-    utility_assert(q);
+    utility_debugAssert(q);
     if (q->size > 0) {
         gpointer data = q->heap[0];
         _priorityqueue_swap_entries(q, 0, q->size - 1);

--- a/src/main/utility/utility.c
+++ b/src/main/utility/utility.c
@@ -27,7 +27,7 @@ guint utility_ipPortHash(in_addr_t ip, in_port_t port) {
 }
 
 guint utility_int16Hash(gconstpointer value) {
-    utility_assert(value);
+    utility_debugAssert(value);
     /* make sure upper bits are zero */
     gint key = 0;
     key = (gint) *((gint16*)value);
@@ -35,7 +35,7 @@ guint utility_int16Hash(gconstpointer value) {
 }
 
 gboolean utility_int16Equal(gconstpointer value1, gconstpointer value2) {
-    utility_assert(value1 && value2);
+    utility_debugAssert(value1 && value2);
     /* make sure upper bits are zero */
     gint key1 = 0, key2 = 0;
     key1 = (gint) *((gint16*)value1);
@@ -44,14 +44,14 @@ gboolean utility_int16Equal(gconstpointer value1, gconstpointer value2) {
 }
 
 gint utility_doubleCompare(const gdouble* value1, const gdouble* value2, gpointer userData) {
-    utility_assert(value1 && value2);
+    utility_debugAssert(value1 && value2);
     /* return neg if first before second, pos if second before first, 0 if equal */
     return (*value1) == (*value2) ? 0 : (*value1) < (*value2) ? -1 : +1;
 }
 
 gint utility_simulationTimeCompare(const SimulationTime* value1, const SimulationTime* value2,
         gpointer userData) {
-    utility_assert(value1 && value2);
+    utility_debugAssert(value1 && value2);
     /* return neg if first before second, pos if second before first, 0 if equal */
     return (*value1) == (*value2) ? 0 : (*value1) < (*value2) ? -1 : +1;
 }
@@ -75,7 +75,7 @@ guint utility_getRawCPUFrequency(const gchar* freqFilename) {
     gsize length = 0;
     GError* error = NULL;
     if(freqFilename && g_file_get_contents(freqFilename, &contents, &length, &error)) {
-        utility_assert(contents);
+        utility_debugAssert(contents);
         rawFrequencyKHz = (guint)atoi(contents);
         g_free(contents);
     }

--- a/src/main/utility/utility.h
+++ b/src/main/utility/utility.h
@@ -13,8 +13,7 @@
 
 #include "main/core/support/definitions.h"
 
-#ifdef DEBUG
-#define utility_assert(expr)                                                                       \
+#define utility_alwaysAssert(expr)                                                                 \
     do {                                                                                           \
         if G_LIKELY (expr) {                                                                       \
             ;                                                                                      \
@@ -22,8 +21,11 @@
             utility_handleError(__FILE__, __LINE__, G_STRFUNC, "Assertion failed: %s", #expr);     \
         }                                                                                          \
     } while (0)
+
+#ifdef DEBUG
+#define utility_debugAssert(expr) utility_alwaysAssert(expr)
 #else
-#define utility_assert(expr)
+#define utility_debugAssert(expr)
 #endif
 
 #define utility_panic(...) utility_handleError(__FILE__, __LINE__, G_STRFUNC, __VA_ARGS__);
@@ -70,8 +72,7 @@
  * Assert that a struct declared with MAGIC_DECLARE and initialized with
  * MAGIC_INIT still holds the value MAGIC_VALUE.
  */
-#define MAGIC_ASSERT(object)                                                   \
-    utility_assert((object) && ((object)->magic == MAGIC_VALUE))
+#define MAGIC_ASSERT(object) utility_debugAssert((object) && ((object)->magic == MAGIC_VALUE))
 
 /**
  * CLear a magic value. Future assertions with MAGIC_ASSERT will fail.

--- a/src/test/socket/connect/test_connect.rs
+++ b/src/test/socket/connect/test_connect.rs
@@ -318,7 +318,7 @@ fn test_null_addr() -> Result<(), String> {
     let args = ConnectArguments {
         fd: fd,
         addr: None,
-        addr_len: 5,
+        addr_len: std::mem::size_of::<libc::sockaddr_in>() as u32,
     };
 
     test_utils::run_and_close_fds(&[fd], || check_connect_call(&args, Some(libc::EFAULT)))


### PR DESCRIPTION
Adds interfaces to SysCallReturn to ensure that they are constructed
and accessed consistently with their type.

This also adds structs to represent each individual potential state of
the SysCallReturn, which will be helpful for a follow-on refactor to
move more of the syscallhandling code from ManagedThread to Thread.

While updating the syscall handlers I perhaps-ill-advisably fixed some
handlers to check the result of the actual memory access operation
instead of just checking whether the user-pointer was NULL, which led to needing to fix some
other minor bugs:

* In test_connect, when testing a NULL pointer, I ensured that other
arguments are consistent, to remove ambiguity over whether EINVAL or
EFAULT should be expected.
* In the memory manager, if we try and fail to flush a mutable
reference, still mark the buffer as non-dirty, so that we don't panic
when the buffer is dropped.