### PR TITLE
Add tasks to the host instead of the worker

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2822,6 +2822,20 @@ extern "C" {
     pub fn host_getNextDeterministicSequenceValue(host: *mut Host) -> guint64;
 }
 extern "C" {
+    pub fn host_scheduleTaskAtEmulatedTime(
+        host: *mut Host,
+        task: *mut TaskRef,
+        time: EmulatedTime,
+    ) -> gboolean;
+}
+extern "C" {
+    pub fn host_scheduleTaskWithDelay(
+        host: *mut Host,
+        task: *mut TaskRef,
+        nanoDelay: SimulationTime,
+    ) -> gboolean;
+}
+extern "C" {
     pub fn scheduler_new(
         controller: *const Controller,
         pidWatcher: *const ChildPidWatcher,

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -479,7 +479,7 @@ void worker_runEvent(Event* event, Host* host) {
 
         /* this event is delayed due to cpu, so reschedule it to ourselves */
         TaskRef* task = event_intoTask(event);
-        worker_scheduleTaskWithDelay(task, host, cpuDelay);
+        host_scheduleTaskWithDelay(host, task, cpuDelay);
         taskref_drop(task);
     } else {
         /* cpu is not blocked, its ok to execute the event */

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -1,7 +1,6 @@
 use nix::unistd::Pid;
 use once_cell::sync::Lazy;
 use once_cell::unsync::OnceCell;
-use std::sync::Mutex;
 
 use crate::core::support::emulated_time::EmulatedTime;
 use crate::core::support::simulation_time::SimulationTime;
@@ -14,11 +13,11 @@ use crate::host::thread::ThreadId;
 use crate::host::thread::{CThread, Thread};
 use crate::utility::counter::Counter;
 use crate::utility::notnull::*;
+
 use std::cell::{Cell, RefCell};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-
-use super::work::task::TaskRef;
+use std::sync::Mutex;
 
 static USE_OBJECT_COUNTERS: AtomicBool = AtomicBool::new(false);
 
@@ -220,34 +219,6 @@ impl Worker {
 
     fn set_last_event_time(t: EmulatedTime) {
         Worker::with_mut(|w| w.clock.last.replace(t)).unwrap();
-    }
-
-    pub fn schedule_task_at_emulated_time(
-        mut task: TaskRef,
-        host: &mut Host,
-        t: EmulatedTime,
-    ) -> bool {
-        let res = unsafe {
-            cshadow::worker_scheduleTaskAtEmulatedTime(
-                &mut task,
-                host.chost(),
-                EmulatedTime::to_c_emutime(Some(t)),
-            )
-        };
-        // Intentionally drop `task`. worker_scheduleTaskAtEmulatedTime clones.
-        res != 0
-    }
-
-    pub fn schedule_task_with_delay(mut task: TaskRef, host: &mut Host, t: SimulationTime) -> bool {
-        let res = unsafe {
-            cshadow::worker_scheduleTaskWithDelay(
-                &mut task,
-                host.chost(),
-                SimulationTime::to_c_simtime(Some(t)),
-            )
-        };
-        // Intentionally drop `task`. worker_scheduleTaskAtEmulatedTime clones.
-        res != 0
     }
 
     pub fn update_min_host_runahead(t: SimulationTime) {

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -724,7 +724,7 @@ static void _tcp_setState(TCP* tcp, Host* host, enum TCPState state) {
                 delay = SIMTIME_ONE_SECOND;
             }
 
-            worker_scheduleTaskWithDelay(closeTask, host, delay);
+            host_scheduleTaskWithDelay(host, closeTask, delay);
             taskref_drop(closeTask);
             break;
         }
@@ -1030,7 +1030,7 @@ static void _tcp_scheduleRetransmitTimer(TCP* tcp, Host* host, SimulationTime no
         TaskRef* retexpTask =
             taskref_new_bound(host_getID(host), _tcp_runRetransmitTimerExpiredTask, tcp, NULL,
                               legacyfile_unref, NULL);
-        worker_scheduleTaskWithDelay(retexpTask, host, delay);
+        host_scheduleTaskWithDelay(host, retexpTask, delay);
         taskref_drop(retexpTask);
 
         trace("%s retransmit timer scheduled for %"G_GUINT64_FORMAT" ns",
@@ -2260,7 +2260,7 @@ static void _tcp_processPacket(LegacySocket* socket, Host* host, Packet* packet)
                     delay = 5*SIMTIME_ONE_MILLISECOND;
                 }
 
-                worker_scheduleTaskWithDelay(sendACKTask, host, delay);
+                host_scheduleTaskWithDelay(host, sendACKTask, delay);
                 taskref_drop(sendACKTask);
 
                 tcp->send.delayedACKIsScheduled = TRUE;
@@ -2530,7 +2530,7 @@ static gssize _tcp_receiveUserData(Transport* transport, Thread* thread, PluginV
 
         TaskRef* updateWindowTask = taskref_new_bound(
             host_getID(host), _tcp_sendWindowUpdate, tcp, NULL, legacyfile_unref, NULL);
-        worker_scheduleTaskWithDelay(updateWindowTask, thread_getHost(thread), 1);
+        host_scheduleTaskWithDelay(thread_getHost(thread), updateWindowTask, 1);
         taskref_drop(updateWindowTask);
 
         tcp->receive.windowUpdatePending = TRUE;

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -793,3 +793,11 @@ guint64 host_getNextDeterministicSequenceValue(Host* host) {
     MAGIC_ASSERT(host);
     return host->determinismSequenceCounter++;
 }
+
+gboolean host_scheduleTaskAtEmulatedTime(Host* host, TaskRef* task, EmulatedTime time) {
+    return worker_scheduleTaskAtEmulatedTime(task, host, time);
+}
+
+gboolean host_scheduleTaskWithDelay(Host* host, TaskRef* task, SimulationTime nanoDelay) {
+    return worker_scheduleTaskWithDelay(task, host, nanoDelay);
+}

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -132,4 +132,9 @@ void host_unlockShimShmemLock(Host* host);
 // items that are otherwise inconsistently ordered (e.g. hash table iterators).
 guint64 host_getNextDeterministicSequenceValue(Host* host);
 
+// Schedule a task for this host at time 'time'.
+gboolean host_scheduleTaskAtEmulatedTime(Host* host, TaskRef* task, EmulatedTime time);
+// Schedule a task for this host at a time 'nanoDelay' from now,.
+gboolean host_scheduleTaskWithDelay(Host* host, TaskRef* task, SimulationTime nanoDelay);
+
 #endif /* SHD_HOST_H_ */

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -352,8 +352,7 @@ void networkinterface_receivePackets(NetworkInterface* interface, Host* host) {
                     TaskRef* recv_again =
                         taskref_new_bound(host_getID(host), _networkinterface_continue_receiving_CB,
                                           interface, NULL, NULL, NULL);
-                    worker_scheduleTaskWithDelay(
-                        recv_again, host, (SimulationTime)next_refill_nanos);
+                    host_scheduleTaskWithDelay(host, recv_again, (SimulationTime)next_refill_nanos);
                     taskref_drop(recv_again);
                     interface->tb_receive_refill_pending = true;
                 }
@@ -541,8 +540,7 @@ static void _networkinterface_sendPackets(NetworkInterface* interface, Host* src
                     TaskRef* send_again =
                         taskref_new_bound(host_getID(src), _networkinterface_continue_sending_CB,
                                           interface, NULL, NULL, NULL);
-                    worker_scheduleTaskWithDelay(
-                        send_again, src, (SimulationTime)next_refill_nanos);
+                    host_scheduleTaskWithDelay(src, send_again, (SimulationTime)next_refill_nanos);
                     taskref_drop(send_again);
                     interface->tb_send_refill_pending = true;
                 }
@@ -570,7 +568,7 @@ static void _networkinterface_sendPackets(NetworkInterface* interface, Host* src
             TaskRef* packetTask =
                 taskref_new_bound(host_getID(src), _networkinterface_local_packet_arrived_CB,
                                   interface, packet, NULL, packet_unrefTaskFreeFunc);
-            worker_scheduleTaskWithDelay(packetTask, src, 1);
+            host_scheduleTaskWithDelay(src, packetTask, 1);
             taskref_drop(packetTask);
         } else {
             /* let the upstream router send to remote with appropriate delays.

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -650,7 +650,7 @@ void process_addThread(Process* proc, Thread* thread) {
     process_ref(proc);
     TaskRef* task = taskref_new_bound(host_getID(proc->host), _start_thread_task, proc, thread,
                                       _unref_process_cb, _unref_thread_cb);
-    worker_scheduleTaskWithDelay(task, proc->host, 0);
+    host_scheduleTaskWithDelay(proc->host, task, 0);
     taskref_drop(task);
 }
 
@@ -759,7 +759,7 @@ void process_schedule(Process* proc, gpointer nothing) {
         TaskRef* startProcessTask =
             taskref_new_bound(host_getID(proc->host), _process_runStartTask, proc, NULL,
                               (TaskObjectFreeFunc)process_unref, NULL);
-        worker_scheduleTaskAtEmulatedTime(startProcessTask, proc->host, proc->startTime);
+        host_scheduleTaskAtEmulatedTime(proc->host, startProcessTask, proc->startTime);
         taskref_drop(startProcessTask);
     }
 
@@ -768,7 +768,7 @@ void process_schedule(Process* proc, gpointer nothing) {
         TaskRef* stopProcessTask =
             taskref_new_bound(host_getID(proc->host), _process_runStopTask, proc, NULL,
                               (TaskObjectFreeFunc)process_unref, NULL);
-        worker_scheduleTaskAtEmulatedTime(stopProcessTask, proc->host, proc->stopTime);
+        host_scheduleTaskAtEmulatedTime(proc->host, stopProcessTask, proc->stopTime);
         taskref_drop(stopProcessTask);
     }
 }

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -381,8 +381,8 @@ static void _syscallcondition_scheduleWakeupTask(SysCallCondition* cond) {
     TaskRef* wakeupTask =
         taskref_new_bound(thread_getHostId(cond->thread), _syscallcondition_trigger, cond, NULL,
                           _syscallcondition_unrefcb, NULL);
-    worker_scheduleTaskWithDelay(
-        wakeupTask, thread_getHost(cond->thread), 0); // Call without moving time forward
+    host_scheduleTaskWithDelay(
+        thread_getHost(cond->thread), wakeupTask, 0); // Call without moving time forward
 
     syscallcondition_ref(cond);
     taskref_drop(wakeupTask);

--- a/src/main/host/timer.rs
+++ b/src/main/host/timer.rs
@@ -157,7 +157,7 @@ impl Timer {
         let expire_id = internal_ref.next_expire_id;
         internal_ref.next_expire_id += 1;
         let task = TaskRef::new(move |host| Self::timer_expire(&internal_ptr, host, expire_id));
-        Worker::schedule_task_with_delay(task, host, delay);
+        host.schedule_task_with_delay(task, delay);
     }
 
     pub fn arm(

--- a/src/main/host/tracker.c
+++ b/src/main/host/tracker.c
@@ -618,6 +618,6 @@ void tracker_heartbeat(Tracker* tracker, Host* host) {
     tracker->lastHeartbeat = worker_getCurrentEmulatedTime();
     TaskRef* heartbeatTask =
         taskref_new_bound(host_getID(host), tracker_heartbeatTask, tracker, NULL, NULL, NULL);
-    worker_scheduleTaskWithDelay(heartbeatTask, host, tracker->interval);
+    host_scheduleTaskWithDelay(host, heartbeatTask, tracker->interval);
     taskref_drop(heartbeatTask);
 }


### PR DESCRIPTION
New tasks should be added to the host rather than the worker. In this PR the host simply passes the tasks on to the worker, but in the future the host may want to handle these tasks internally without involving the global worker. The current plan is to move the event queue into the host itself.