### PR TITLE
Fix use-after-free in scheduler

### DIFF
--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -188,13 +188,13 @@ gboolean scheduler_push(Scheduler* scheduler, Event* event, Host* sender, Host* 
     utility_debugAssert(receiver);
 
     /* push to a queue based on the policy */
-    schedulerpolicy_push(
+    eventTime = schedulerpolicy_push(
         scheduler->policy, event, sender, receiver, scheduler->currentRound.endTime);
 
     // Store the minimum time of events that we are pushing between hosts. The
     // push operation may adjust the event time, so make sure we call this after
     // the push.
-    worker_setMinEventTimeNextRound(event_getTime(event));
+    worker_setMinEventTimeNextRound(eventTime);
 
     return TRUE;
 }

--- a/src/main/core/scheduler/scheduler_policy.c
+++ b/src/main/core/scheduler/scheduler_policy.c
@@ -111,8 +111,8 @@ GQueue* schedulerpolicy_getAssignedHosts(SchedulerPolicy* policy) {
     return tdata->allHosts;
 }
 
-void schedulerpolicy_push(SchedulerPolicy* policy, Event* event, Host* srcHost, Host* dstHost,
-                          SimulationTime barrier) {
+SimulationTime schedulerpolicy_push(SchedulerPolicy* policy, Event* event, Host* srcHost,
+                                    Host* dstHost, SimulationTime barrier) {
     MAGIC_ASSERT(policy);
 
     /* non-local events must be properly delayed so the event wont show up at another host
@@ -139,8 +139,12 @@ void schedulerpolicy_push(SchedulerPolicy* policy, Event* event, Host* srcHost, 
     ThreadSafeEventQueue* qdata = g_hash_table_lookup(policy->hostToQueueDataMap, dstHost);
     utility_debugAssert(qdata);
 
+    eventTime = event_getTime(event);
+
     /* 'deliver' the event to the destination queue */
     eventqueue_push(qdata, event);
+
+    return eventTime;
 }
 
 Event* schedulerpolicy_pop(SchedulerPolicy* policy, SimulationTime barrier) {

--- a/src/main/core/scheduler/scheduler_policy.h
+++ b/src/main/core/scheduler/scheduler_policy.h
@@ -16,8 +16,8 @@ typedef struct _SchedulerPolicy SchedulerPolicy;
 
 void schedulerpolicy_addHost(SchedulerPolicy* policy, Host* host, pthread_t randomThread);
 GQueue* schedulerpolicy_getAssignedHosts(SchedulerPolicy* policy);
-void schedulerpolicy_push(SchedulerPolicy* policy, Event* event, Host* srcHost, Host* dstHost,
-                          SimulationTime barrier);
+SimulationTime schedulerpolicy_push(SchedulerPolicy* policy, Event* event, Host* srcHost,
+                                    Host* dstHost, SimulationTime barrier);
 Event* schedulerpolicy_pop(SchedulerPolicy* policy, SimulationTime barrier);
 EmulatedTime schedulerpolicy_nextHostEventTime(SchedulerPolicy* policy, Host* host);
 SimulationTime schedulerpolicy_getNextTime(SchedulerPolicy* policy);


### PR DESCRIPTION
Haven't seen any crashes caused by this, but it's definitely a bug.

**Edit:** The nightly benchmark failed, possibly due to this.

```
Progress: 44% — simulated: 00:08:00/00:18:00, realtime: 01:30:00, processes failed: 0
Progress: 45% — simulated: 00:08:01/00:18:00, realtime: 01:31:00, processes failed: 0
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', main/core/support/emulated_time.rs:62:46
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
2022-08-10 05:44:57 1660110297.418442 [tornettools] [INFO] Cleaning up
2022-08-10 05:44:58 1660110298.407282 [tornettools] [INFO] Done simulating; shadow returned code '-6'
Error: -10 05:44:58 1660110298.423163 [tornettools] [ERROR] Shadow simulation did not complete successfully
Error: Process completed with exit code 250.
```