### PR TITLE
Move the event queue into the host object

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -464,9 +464,11 @@ SimulationTime event_getTime(const struct Event *event);
 
 void event_setTime(struct Event *event, SimulationTime time);
 
-struct ThreadSafeEventQueue *eventqueue_new(void);
+const struct ThreadSafeEventQueue *eventqueue_new(void);
 
-void eventqueue_free(struct ThreadSafeEventQueue *queue);
+void eventqueue_drop(const struct ThreadSafeEventQueue *queue);
+
+const struct ThreadSafeEventQueue *eventqueue_cloneArc(const struct ThreadSafeEventQueue *queue_ptr);
 
 // Takes ownership of the event.
 void eventqueue_push(const struct ThreadSafeEventQueue *queue, struct Event *event);

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -574,8 +574,6 @@ EmulatedTime worker_getCurrentEmulatedTime(void);
 
 void worker_updateMinHostRunahead(SimulationTime t);
 
-void _worker_setLastEventTime(EmulatedTime t);
-
 bool worker_isBootstrapActive(void);
 
 WorkerPool *_worker_pool(void);

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -473,7 +473,7 @@ void eventqueue_push(const struct ThreadSafeEventQueue *queue, struct Event *eve
 
 struct Event *eventqueue_pop(const struct ThreadSafeEventQueue *queue);
 
-SimulationTime eventqueue_nextEventTime(const struct ThreadSafeEventQueue *queue);
+EmulatedTime eventqueue_nextEventTime(const struct ThreadSafeEventQueue *queue);
 
 // Create a new reference-counted task that can only be executed on the
 // given host. The callbacks can safely assume that they will only be called

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -454,10 +454,6 @@ void event_free(struct Event *event);
 // Execute the event. **This frees the event.**
 void event_executeAndFree(struct Event *event, Host *host);
 
-// Convert the event into its inner `TaskRef`. **This frees the event, and you must manually
-// free/drop the returned `TaskRef`.**
-struct TaskRef *event_intoTask(struct Event *event);
-
 HostId event_getHostID(struct Event *event);
 
 SimulationTime event_getTime(const struct Event *event);

--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -49,6 +49,7 @@ add_custom_command(OUTPUT wrapper.rs
         --whitelist-function "host_.*"
         # Needs CompatSocket
         --blacklist-function "host_.*Interface"
+        --blacklist-function "host_getOwnedEventQueue"
 
         # used by shadow's main function
         --whitelist-function "main_.*"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2357,6 +2357,7 @@ pub struct _HostParameters {
     pub hostname: *const gchar,
     pub nodeId: guint,
     pub ipAddr: in_addr_t,
+    pub simEndTime: EmulatedTime,
     pub requestedBwDownBits: guint64,
     pub requestedBwUpBits: guint64,
     pub cpuFrequency: guint64,
@@ -2379,7 +2380,7 @@ pub struct _HostParameters {
 fn bindgen_test_layout__HostParameters() {
     assert_eq!(
         ::std::mem::size_of::<_HostParameters>(),
-        144usize,
+        152usize,
         concat!("Size of: ", stringify!(_HostParameters))
     );
     assert_eq!(
@@ -2472,6 +2473,23 @@ fn bindgen_test_layout__HostParameters() {
         );
     }
     test_field_ipAddr();
+    fn test_field_simEndTime() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<_HostParameters>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).simEndTime) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(_HostParameters),
+                "::",
+                stringify!(simEndTime)
+            )
+        );
+    }
+    test_field_simEndTime();
     fn test_field_requestedBwDownBits() {
         assert_eq!(
             unsafe {
@@ -2479,7 +2497,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).requestedBwDownBits) as usize - ptr as usize
             },
-            24usize,
+            32usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2496,7 +2514,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).requestedBwUpBits) as usize - ptr as usize
             },
-            32usize,
+            40usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2513,7 +2531,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).cpuFrequency) as usize - ptr as usize
             },
-            40usize,
+            48usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2530,7 +2548,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).cpuThreshold) as usize - ptr as usize
             },
-            48usize,
+            56usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2547,7 +2565,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).cpuPrecision) as usize - ptr as usize
             },
-            56usize,
+            64usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2564,7 +2582,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).heartbeatInterval) as usize - ptr as usize
             },
-            64usize,
+            72usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2581,7 +2599,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).heartbeatLogLevel) as usize - ptr as usize
             },
-            72usize,
+            80usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2598,7 +2616,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).heartbeatLogInfo) as usize - ptr as usize
             },
-            76usize,
+            84usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2615,7 +2633,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).logLevel) as usize - ptr as usize
             },
-            80usize,
+            88usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2632,7 +2650,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).pcapDir) as usize - ptr as usize
             },
-            88usize,
+            96usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2649,7 +2667,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).pcapCaptureSize) as usize - ptr as usize
             },
-            96usize,
+            104usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2666,7 +2684,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).qdisc) as usize - ptr as usize
             },
-            100usize,
+            108usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2683,7 +2701,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).recvBufSize) as usize - ptr as usize
             },
-            104usize,
+            112usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2700,7 +2718,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).autotuneRecvBuf) as usize - ptr as usize
             },
-            112usize,
+            120usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2717,7 +2735,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).sendBufSize) as usize - ptr as usize
             },
-            120usize,
+            128usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2734,7 +2752,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).autotuneSendBuf) as usize - ptr as usize
             },
-            128usize,
+            136usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2751,7 +2769,7 @@ fn bindgen_test_layout__HostParameters() {
                 let ptr = uninit.as_ptr();
                 ::std::ptr::addr_of!((*ptr).interfaceBufSize) as usize - ptr as usize
             },
-            136usize,
+            144usize,
             concat!(
                 "Offset of field: ",
                 stringify!(_HostParameters),
@@ -2782,6 +2800,15 @@ extern "C" {
 }
 extern "C" {
     pub fn host_unref(host: *mut Host);
+}
+extern "C" {
+    pub fn host_pushLocalEvent(host: *mut Host, event: *mut Event) -> bool;
+}
+extern "C" {
+    pub fn host_execute(host: *mut Host, until: EmulatedTime);
+}
+extern "C" {
+    pub fn host_nextEventTime(host: *mut Host) -> EmulatedTime;
 }
 extern "C" {
     pub fn host_lock(host: *mut Host);
@@ -2994,7 +3021,7 @@ extern "C" {
     pub fn scheduler_addHost(arg1: *mut Scheduler, arg2: *mut Host) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn worker_runEvent(event: *mut Event, host: *mut Host);
+    pub fn worker_runHost(host: *mut Host, until: EmulatedTime);
 }
 extern "C" {
     pub fn worker_setMinEventTimeNextRound(simtime: SimulationTime);

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -327,6 +327,7 @@ impl<'a> Manager<'a> {
                     // the config only allows ipv4 addresses, so this shouldn't happen
                     std::net::IpAddr::V6(_) => unreachable!("IPv6 not supported"),
                 },
+                simEndTime: EmulatedTime::to_c_emutime(Some(self.end_time)),
                 requestedBwDownBits: host.bandwidth_down_bits.unwrap(),
                 requestedBwUpBits: host.bandwidth_up_bits.unwrap(),
                 cpuThreshold: host.cpu_threshold,
@@ -366,6 +367,7 @@ impl<'a> Manager<'a> {
 
             let c_host = unsafe { c::host_new(&params) };
             assert!(!c_host.is_null());
+
             unsafe {
                 c::host_setup(
                     c_host,

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -38,6 +38,10 @@ struct _Scheduler {
     /* we store the hosts here */
     GHashTable* hostIDToHostMap;
 
+    /* we store the host queues here (this is read-only once the simulation starts and is read by
+     * multiple threads) */
+    GHashTable* hostIDToHostQueueMap;
+
     /* used to randomize host-to-thread assignment */
     Random* random;
 
@@ -72,25 +76,37 @@ static void _scheduler_runEventsWorkerTaskFn(void* voidScheduler) {
     // Reset the round end time before starting the new round.
     worker_setRoundEndTime(scheduler->currentRound.endTime);
 
-    Event* event = NULL;
-    while ((event = schedulerpolicy_pop(scheduler->policy, scheduler->currentRound.endTime)) !=
-           NULL) {
-        // get the host to run this event on
-        Host* host = scheduler_getHost(scheduler, event_getHostID(event));
+    EmulatedTime minEventTime = EMUTIME_INVALID;
+    EmulatedTime barrier =
+        emutime_add_simtime(EMUTIME_SIMULATION_START, scheduler->currentRound.endTime);
+
+    GList* nextHost = schedulerpolicy_getAssignedHosts(scheduler->policy)->head;
+
+    while (nextHost != NULL) {
+        Host* host = nextHost->data;
+
         host_lock(host);
         host_lockShimShmemLock(host);
 
-        worker_runEvent(event, host);
+        worker_runHost(host, barrier);
+        EmulatedTime nextEventTime = host_nextEventTime(host);
 
         host_unlockShimShmemLock(host);
         host_unlock(host);
+
+        if (minEventTime == EMUTIME_INVALID || nextEventTime < minEventTime) {
+            minEventTime = nextEventTime;
+        }
+
+        nextHost = nextHost->next;
     }
 
-    // Gets the time of the event at the head of the event queue right now.
-    SimulationTime minQTime = schedulerpolicy_getNextTime(scheduler->policy);
-
-    // We'll compute the global min time across all workers.
-    worker_setMinEventTimeNextRound(minQTime);
+    if (minEventTime != EMUTIME_INVALID) {
+        // this min event time will contain all local events, and some packet events
+        SimulationTime minEventSimTime =
+            emutime_sub_emutime(minEventTime, EMUTIME_SIMULATION_START);
+        worker_setMinEventTimeNextRound(minEventSimTime);
+    }
 }
 
 static void _scheduler_finishTaskFn(void* voidScheduler) {
@@ -130,6 +146,8 @@ Scheduler* scheduler_new(const Controller* controller, const ChildPidWatcher* pi
     scheduler->currentRound.minNextEventTime = SIMTIME_MAX;
 
     scheduler->hostIDToHostMap = g_hash_table_new(g_direct_hash, g_direct_equal);
+    scheduler->hostIDToHostQueueMap =
+        g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, (GDestroyNotify)eventqueue_drop);
 
     scheduler->random = random_new(schedulerSeed);
 
@@ -153,6 +171,7 @@ void scheduler_shutdown(Scheduler* scheduler) {
      * the engine is marked "killed" and workers are destroyed, so that
      * each plug-in is able to destroy/free its virtual nodes properly */
     g_hash_table_destroy(scheduler->hostIDToHostMap);
+    g_hash_table_destroy(scheduler->hostIDToHostQueueMap);
 
     info("waiting for %d worker threads to finish", workerpool_getNWorkers(scheduler->workerPool));
     workerpool_joinAll(scheduler->workerPool);
@@ -174,37 +193,6 @@ void scheduler_free(Scheduler* scheduler) {
     g_free(scheduler);
 }
 
-gboolean scheduler_push(Scheduler* scheduler, Event* event, Host* sender, Host* receiver) {
-    MAGIC_ASSERT(scheduler);
-
-    SimulationTime eventTime = event_getTime(event);
-    if(eventTime >= scheduler->endTime) {
-        event_free(event);
-        return FALSE;
-    }
-
-    /* parties involved. sender may be NULL, receiver may not!
-     * we MAY NOT OWN the receiver, so do not write to it! */
-    utility_debugAssert(receiver);
-
-    /* push to a queue based on the policy */
-    eventTime = schedulerpolicy_push(
-        scheduler->policy, event, sender, receiver, scheduler->currentRound.endTime);
-
-    // Store the minimum time of events that we are pushing between hosts. The
-    // push operation may adjust the event time, so make sure we call this after
-    // the push.
-    worker_setMinEventTimeNextRound(eventTime);
-
-    return TRUE;
-}
-
-EmulatedTime scheduler_nextHostEventTime(Scheduler* scheduler, Host* host) {
-    MAGIC_ASSERT(scheduler);
-
-    return schedulerpolicy_nextHostEventTime(scheduler->policy, host);
-}
-
 int scheduler_addHost(Scheduler* scheduler, Host* host) {
     MAGIC_ASSERT(scheduler);
 
@@ -222,12 +210,17 @@ int scheduler_addHost(Scheduler* scheduler, Host* host) {
     }
 
     g_hash_table_replace(scheduler->hostIDToHostMap, hostIDKey, host);
+
+    // casts const pointer to non-const
+    g_hash_table_replace(
+        scheduler->hostIDToHostQueueMap, hostIDKey, (void*)host_getOwnedEventQueue(host));
     return 0;
 }
 
-Host* scheduler_getHost(Scheduler* scheduler, GQuark hostID) {
+const ThreadSafeEventQueue* scheduler_getEventQueue(Scheduler* scheduler, HostId host) {
     MAGIC_ASSERT(scheduler);
-    return (Host*) g_hash_table_lookup(scheduler->hostIDToHostMap, GUINT_TO_POINTER((guint)hostID));
+    // cast back to const pointer
+    return g_hash_table_lookup(scheduler->hostIDToHostQueueMap, GUINT_TO_POINTER(host));
 }
 
 static void _scheduler_appendHostToQueue(gpointer uintKey, Host* host, GQueue* allHosts) {

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -307,37 +307,6 @@ static void _scheduler_assignHosts(Scheduler* scheduler) {
     g_mutex_unlock(&scheduler->globalLock);
 }
 
-__attribute__((unused)) static void _scheduler_rebalanceHosts(Scheduler* scheduler) {
-    MAGIC_ASSERT(scheduler);
-    utility_panic("Unimplemented");
-
-    // WARNING if this is run, then all existing eventSequenceCounters
-    // need to get set to the max of all existing counters to ensure order correctness
-
-    /* get queue of all hosts */
-    GQueue* hosts = g_queue_new();
-    g_hash_table_foreach(scheduler->hostIDToHostMap, (GHFunc)_scheduler_appendHostToQueue, hosts);
-
-    _scheduler_shuffleQueue(scheduler, hosts);
-
-    /* now that our host order has been randomized, assign them evenly to worker threads */
-    while(!g_queue_is_empty(hosts)) {
-        Host* host = g_queue_pop_head(hosts);
-        // SchedulerThreadItem* item = g_queue_pop_head(scheduler->threadItems);
-        // pthread_t newThread = item->thread;
-
-        //        TODO this needs to get uncommented/updated when migration code
-        //        is added schedulerpolicy_migrateHost(scheduler->policy,
-        //        host, newThread);
-
-        // g_queue_push_tail(scheduler->threadItems, item);
-    }
-
-    if(hosts) {
-        g_queue_free(hosts);
-    }
-}
-
 gboolean scheduler_isRunning(Scheduler* scheduler) {
     MAGIC_ASSERT(scheduler);
     return scheduler->isRunning;

--- a/src/main/core/scheduler/scheduler.h
+++ b/src/main/core/scheduler/scheduler.h
@@ -34,7 +34,7 @@ Event* scheduler_pop(Scheduler*);
 EmulatedTime scheduler_nextHostEventTime(Scheduler*, Host* host);
 
 int scheduler_addHost(Scheduler*, Host*);
-Host* scheduler_getHost(Scheduler*, GQuark);
+const ThreadSafeEventQueue* scheduler_getEventQueue(Scheduler* scheduler, HostId host);
 gboolean scheduler_isRunning(Scheduler* scheduler);
 
 #endif /* SHD_SCHEDULER_H_ */

--- a/src/main/core/scheduler/scheduler_policy.c
+++ b/src/main/core/scheduler/scheduler_policy.c
@@ -62,8 +62,9 @@ static void _threaddata_free(HostSingleThreadData* tdata) {
 }
 
 /* this must be run synchronously, or the call must be protected by locks */
-void schedulerpolicy_addHost(SchedulerPolicy* policy, Host* host, pthread_t randomThread) {
+void schedulerpolicy_addHost(SchedulerPolicy* policy, Host* host, pthread_t assignedThread) {
     MAGIC_ASSERT(policy);
+    utility_alwaysAssert(assignedThread != 0);
 
     /* each host has its own queue */
     if (!g_hash_table_lookup(policy->hostToQueueDataMap, host)) {
@@ -71,7 +72,6 @@ void schedulerpolicy_addHost(SchedulerPolicy* policy, Host* host, pthread_t rand
     }
 
     /* each thread keeps track of the hosts it needs to run */
-    pthread_t assignedThread = (randomThread != 0) ? randomThread : pthread_self();
     HostSingleThreadData* tdata =
         g_hash_table_lookup(policy->threadToThreadDataMap, GUINT_TO_POINTER(assignedThread));
     if(!tdata) {

--- a/src/main/core/scheduler/scheduler_policy.c
+++ b/src/main/core/scheduler/scheduler_policy.c
@@ -18,30 +18,17 @@ typedef struct _HostSingleThreadData HostSingleThreadData;
 struct _HostSingleThreadData {
     /* used to cache getHosts() result for memory management as needed */
     GQueue* allHosts;
-    /* all hosts that have been assigned to this worker for event processing but not yet processed this round */
-    GQueue* unprocessedHosts;
-    /* during each round, hosts whose events have been processed are moved from unprocessedHosts to here */
-    GQueue* processedHosts;
-    SimulationTime currentBarrier;
 };
 
 struct _SchedulerPolicy {
-    GHashTable* hostToQueueDataMap;
     GHashTable* threadToThreadDataMap;
     MAGIC_DECLARE;
-};
-
-typedef struct _HostSingleSearchState HostSingleSearchState;
-struct _HostSingleSearchState {
-    SchedulerPolicy* data;
-    SimulationTime nextEventTime;
 };
 
 static HostSingleThreadData* _threaddata_new() {
     HostSingleThreadData* tdata = g_new0(HostSingleThreadData, 1);
 
-    tdata->unprocessedHosts = g_queue_new();
-    tdata->processedHosts = g_queue_new();
+    tdata->allHosts = g_queue_new();
 
     return tdata;
 }
@@ -50,12 +37,6 @@ static void _threaddata_free(HostSingleThreadData* tdata) {
     if(tdata) {
         if(tdata->allHosts) {
             g_queue_free(tdata->allHosts);
-        }
-        if(tdata->unprocessedHosts) {
-            g_queue_free(tdata->unprocessedHosts);
-        }
-        if(tdata->processedHosts) {
-            g_queue_free(tdata->processedHosts);
         }
         g_free(tdata);
     }
@@ -66,180 +47,34 @@ void schedulerpolicy_addHost(SchedulerPolicy* policy, Host* host, pthread_t assi
     MAGIC_ASSERT(policy);
     utility_alwaysAssert(assignedThread != 0);
 
-    /* each host has its own queue */
-    if (!g_hash_table_contains(policy->hostToQueueDataMap, host)) {
-        // cast from const pointer to non-const pointer; we should always cast it back to a const
-        // pointer when using the queue
-        g_hash_table_replace(policy->hostToQueueDataMap, host, (void*)eventqueue_new());
-    }
-
     /* each thread keeps track of the hosts it needs to run */
     HostSingleThreadData* tdata =
         g_hash_table_lookup(policy->threadToThreadDataMap, GUINT_TO_POINTER(assignedThread));
+
     if(!tdata) {
         tdata = _threaddata_new();
         g_hash_table_replace(
             policy->threadToThreadDataMap, GUINT_TO_POINTER(assignedThread), tdata);
     }
-    g_queue_push_tail(tdata->unprocessedHosts, host);
-}
 
-static void concat_queue_iter(Host* hostItem, GQueue* userQueue) {
-    g_queue_push_tail(userQueue, hostItem);
+    g_queue_push_tail(tdata->allHosts, host);
 }
 
 GQueue* schedulerpolicy_getAssignedHosts(SchedulerPolicy* policy) {
     MAGIC_ASSERT(policy);
     HostSingleThreadData* tdata =
         g_hash_table_lookup(policy->threadToThreadDataMap, GUINT_TO_POINTER(pthread_self()));
+
     if(!tdata) {
         return NULL;
     }
-    if(g_queue_is_empty(tdata->unprocessedHosts)) {
-        return tdata->processedHosts;
-    }
-    if(g_queue_is_empty(tdata->processedHosts)) {
-        return tdata->unprocessedHosts;
-    }
-    if(tdata->allHosts) {
-        g_queue_free(tdata->allHosts);
-    }
-    tdata->allHosts = g_queue_copy(tdata->processedHosts);
-    g_queue_foreach(tdata->unprocessedHosts, (GFunc)concat_queue_iter, tdata->allHosts);
+
     return tdata->allHosts;
-}
-
-SimulationTime schedulerpolicy_push(SchedulerPolicy* policy, Event* event, Host* srcHost,
-                                    Host* dstHost, SimulationTime barrier) {
-    MAGIC_ASSERT(policy);
-
-    /* non-local events must be properly delayed so the event wont show up at another host
-     * before the next scheduling interval. if the thread scheduler guaranteed to always run
-     * the minimum time event accross all of its assigned hosts, then we would only need to
-     * do the time adjustment if the srcThread and dstThread are not identical. however,
-     * the logic of this policy allows a thread to run all events from a given host before
-     * moving on to the next host, so we must adjust the time whenever the srcHost and
-     * dstHost are not the same. */
-    SimulationTime eventTime = event_getTime(event);
-
-    if(srcHost != dstHost && eventTime < barrier) {
-        event_setTime(event, barrier);
-        debug("Inter-host event time %" G_GUINT64_FORMAT " changed to %" G_GUINT64_FORMAT " "
-              "to ensure event causality",
-              eventTime, barrier);
-    }
-
-    /* get the queue for the destination */
-    const ThreadSafeEventQueue* qdata = g_hash_table_lookup(policy->hostToQueueDataMap, dstHost);
-    utility_debugAssert(qdata);
-
-    eventTime = event_getTime(event);
-
-    /* 'deliver' the event to the destination queue */
-    eventqueue_push(qdata, event);
-
-    return eventTime;
-}
-
-Event* schedulerpolicy_pop(SchedulerPolicy* policy, SimulationTime barrier) {
-    MAGIC_ASSERT(policy);
-
-    /* figure out which hosts we should be checking */
-    HostSingleThreadData* tdata =
-        g_hash_table_lookup(policy->threadToThreadDataMap, GUINT_TO_POINTER(pthread_self()));
-    /* if there is no tdata, that means this thread didn't get any hosts assigned to it */
-    if(!tdata) {
-        /* this thread will remain idle */
-        return NULL;
-    }
-
-    if(barrier > tdata->currentBarrier) {
-        tdata->currentBarrier = barrier;
-
-        /* make sure all of the hosts that were processed last time get processed in the next round */
-        if(g_queue_is_empty(tdata->unprocessedHosts) && !g_queue_is_empty(tdata->processedHosts)) {
-            GQueue* swap = tdata->unprocessedHosts;
-            tdata->unprocessedHosts = tdata->processedHosts;
-            tdata->processedHosts = swap;
-        } else {
-            while(!g_queue_is_empty(tdata->processedHosts)) {
-                g_queue_push_tail(tdata->unprocessedHosts, g_queue_pop_head(tdata->processedHosts));
-            }
-        }
-    }
-
-    EmulatedTime barrierEmuTime = emutime_add_simtime(EMUTIME_SIMULATION_START, barrier);
-
-    while(!g_queue_is_empty(tdata->unprocessedHosts)) {
-        Host* host = g_queue_peek_head(tdata->unprocessedHosts);
-        const ThreadSafeEventQueue* qdata = g_hash_table_lookup(policy->hostToQueueDataMap, host);
-        utility_debugAssert(qdata);
-
-        Event* nextEvent = NULL;
-        EmulatedTime eventTime = eventqueue_nextEventTime(qdata);
-
-        if(eventTime != EMUTIME_INVALID && eventTime < barrierEmuTime) {
-            nextEvent = eventqueue_pop(qdata);
-        }
-
-        if(nextEvent != NULL) {
-            return nextEvent;
-        }
-        /* this host is done, store it in the processed queue and then
-         * try the next host if we still have more */
-        g_queue_push_tail(tdata->processedHosts, g_queue_pop_head(tdata->unprocessedHosts));
-    }
-
-    /* if we make it here, all hosts for this thread have no more events before barrier */
-    return NULL;
-}
-
-EmulatedTime schedulerpolicy_nextHostEventTime(SchedulerPolicy* policy, Host* host) {
-    MAGIC_ASSERT(policy);
-
-    const ThreadSafeEventQueue* qdata = g_hash_table_lookup(policy->hostToQueueDataMap, host);
-    utility_debugAssert(qdata);
-
-    return eventqueue_nextEventTime(qdata);
-}
-
-static void _schedulerpolicy_findMinTime(Host* host, HostSingleSearchState* state) {
-    const ThreadSafeEventQueue* qdata = g_hash_table_lookup(state->data->hostToQueueDataMap, host);
-    utility_debugAssert(qdata);
-
-    EmulatedTime nextEventTime = eventqueue_nextEventTime(qdata);
-    if (nextEventTime != EMUTIME_INVALID) {
-        SimulationTime nextEventSimTime =
-            emutime_sub_emutime(nextEventTime, EMUTIME_SIMULATION_START);
-        state->nextEventTime = MIN(state->nextEventTime, nextEventSimTime);
-    }
-}
-
-SimulationTime schedulerpolicy_getNextTime(SchedulerPolicy* policy) {
-    MAGIC_ASSERT(policy);
-
-    /* set up state that we need for the foreach queue iterator */
-    HostSingleSearchState searchState;
-    memset(&searchState, 0, sizeof(HostSingleSearchState));
-    searchState.data = policy;
-    searchState.nextEventTime = SIMTIME_MAX;
-
-    HostSingleThreadData* tdata =
-        g_hash_table_lookup(policy->threadToThreadDataMap, GUINT_TO_POINTER(pthread_self()));
-    if(tdata) {
-        /* make sure we get all hosts, which are probably held in the processedHosts queue between rounds */
-        g_queue_foreach(tdata->unprocessedHosts, (GFunc)_schedulerpolicy_findMinTime, &searchState);
-        g_queue_foreach(tdata->processedHosts, (GFunc)_schedulerpolicy_findMinTime, &searchState);
-    }
-    debug("next event at time %" G_GUINT64_FORMAT, searchState.nextEventTime);
-
-    return searchState.nextEventTime;
 }
 
 void schedulerpolicy_free(SchedulerPolicy* policy) {
     MAGIC_ASSERT(policy);
 
-    g_hash_table_destroy(policy->hostToQueueDataMap);
     g_hash_table_destroy(policy->threadToThreadDataMap);
 
     MAGIC_CLEAR(policy);
@@ -250,8 +85,6 @@ SchedulerPolicy* schedulerpolicy_new() {
     SchedulerPolicy* policy = g_new0(SchedulerPolicy, 1);
     MAGIC_INIT(policy);
 
-    policy->hostToQueueDataMap =
-        g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, (GDestroyNotify)eventqueue_drop);
     policy->threadToThreadDataMap = g_hash_table_new_full(
         g_direct_hash, g_direct_equal, NULL, (GDestroyNotify)_threaddata_free);
 

--- a/src/main/core/scheduler/scheduler_policy.c
+++ b/src/main/core/scheduler/scheduler_policy.c
@@ -127,10 +127,6 @@ SimulationTime schedulerpolicy_push(SchedulerPolicy* policy, Event* event, Host*
               eventTime, barrier);
     }
 
-    /* we want to track how long this thread spends idle waiting to push the event */
-    HostSingleThreadData* tdata =
-        g_hash_table_lookup(policy->threadToThreadDataMap, GUINT_TO_POINTER(pthread_self()));
-
     /* get the queue for the destination */
     ThreadSafeEventQueue* qdata = g_hash_table_lookup(policy->hostToQueueDataMap, dstHost);
     utility_debugAssert(qdata);
@@ -196,11 +192,6 @@ Event* schedulerpolicy_pop(SchedulerPolicy* policy, SimulationTime barrier) {
 
 EmulatedTime schedulerpolicy_nextHostEventTime(SchedulerPolicy* policy, Host* host) {
     MAGIC_ASSERT(policy);
-
-    /* figure out which hosts we should be checking */
-    HostSingleThreadData* tdata =
-        g_hash_table_lookup(policy->threadToThreadDataMap, GUINT_TO_POINTER(pthread_self()));
-    utility_debugAssert(tdata);
 
     ThreadSafeEventQueue* qdata = g_hash_table_lookup(policy->hostToQueueDataMap, host);
     utility_debugAssert(qdata);

--- a/src/main/core/scheduler/scheduler_policy.c
+++ b/src/main/core/scheduler/scheduler_policy.c
@@ -28,7 +28,6 @@ struct _HostSingleThreadData {
 struct _SchedulerPolicy {
     GHashTable* hostToQueueDataMap;
     GHashTable* threadToThreadDataMap;
-    GHashTable* hostToThreadMap;
     MAGIC_DECLARE;
 };
 
@@ -81,9 +80,6 @@ void schedulerpolicy_addHost(SchedulerPolicy* policy, Host* host, pthread_t rand
             policy->threadToThreadDataMap, GUINT_TO_POINTER(assignedThread), tdata);
     }
     g_queue_push_tail(tdata->unprocessedHosts, host);
-
-    /* finally, store the host-to-thread mapping */
-    g_hash_table_replace(policy->hostToThreadMap, host, GUINT_TO_POINTER(assignedThread));
 }
 
 static void concat_queue_iter(Host* hostItem, GQueue* userQueue) {
@@ -255,7 +251,6 @@ void schedulerpolicy_free(SchedulerPolicy* policy) {
 
     g_hash_table_destroy(policy->hostToQueueDataMap);
     g_hash_table_destroy(policy->threadToThreadDataMap);
-    g_hash_table_destroy(policy->hostToThreadMap);
 
     MAGIC_CLEAR(policy);
     g_free(policy);
@@ -269,7 +264,6 @@ SchedulerPolicy* schedulerpolicy_new() {
         g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, (GDestroyNotify)eventqueue_free);
     policy->threadToThreadDataMap = g_hash_table_new_full(
         g_direct_hash, g_direct_equal, NULL, (GDestroyNotify)_threaddata_free);
-    policy->hostToThreadMap = g_hash_table_new(g_direct_hash, g_direct_equal);
 
     return policy;
 }

--- a/src/main/core/scheduler/scheduler_policy.h
+++ b/src/main/core/scheduler/scheduler_policy.h
@@ -14,7 +14,7 @@
 
 typedef struct _SchedulerPolicy SchedulerPolicy;
 
-void schedulerpolicy_addHost(SchedulerPolicy* policy, Host* host, pthread_t randomThread);
+void schedulerpolicy_addHost(SchedulerPolicy* policy, Host* host, pthread_t assignedThread);
 GQueue* schedulerpolicy_getAssignedHosts(SchedulerPolicy* policy);
 SimulationTime schedulerpolicy_push(SchedulerPolicy* policy, Event* event, Host* srcHost,
                                     Host* dstHost, SimulationTime barrier);

--- a/src/main/core/scheduler/scheduler_policy.h
+++ b/src/main/core/scheduler/scheduler_policy.h
@@ -16,11 +16,6 @@ typedef struct _SchedulerPolicy SchedulerPolicy;
 
 void schedulerpolicy_addHost(SchedulerPolicy* policy, Host* host, pthread_t assignedThread);
 GQueue* schedulerpolicy_getAssignedHosts(SchedulerPolicy* policy);
-SimulationTime schedulerpolicy_push(SchedulerPolicy* policy, Event* event, Host* srcHost,
-                                    Host* dstHost, SimulationTime barrier);
-Event* schedulerpolicy_pop(SchedulerPolicy* policy, SimulationTime barrier);
-EmulatedTime schedulerpolicy_nextHostEventTime(SchedulerPolicy* policy, Host* host);
-SimulationTime schedulerpolicy_getNextTime(SchedulerPolicy* policy);
 void schedulerpolicy_free(SchedulerPolicy* policy);
 SchedulerPolicy* schedulerpolicy_new();
 

--- a/src/main/core/work/event.rs
+++ b/src/main/core/work/event.rs
@@ -148,16 +148,6 @@ mod export {
         event.execute(&mut host);
     }
 
-    /// Convert the event into its inner `TaskRef`. **This frees the event, and you must manually
-    /// free/drop the returned `TaskRef`.**
-    #[no_mangle]
-    pub unsafe extern "C" fn event_intoTask(event: *mut Event) -> *mut TaskRef {
-        assert!(!event.is_null());
-        let event = unsafe { Box::from_raw(event) };
-
-        Box::into_raw(Box::new(event.task))
-    }
-
     #[no_mangle]
     pub unsafe extern "C" fn event_getHostID(event: *mut Event) -> c::HostId {
         let event = unsafe { event.as_ref() }.unwrap();

--- a/src/main/core/work/event_queue.rs
+++ b/src/main/core/work/event_queue.rs
@@ -97,6 +97,8 @@ mod export {
     use super::*;
     use crate::cshadow as c;
 
+    use std::sync::Arc;
+
     /// A wrapper for [`EventQueue`] that uses interior mutability to make the ffi simpler.
     pub struct ThreadSafeEventQueue {
         event_queue: Mutex<EventQueue>,
@@ -123,14 +125,27 @@ mod export {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn eventqueue_new() -> *mut ThreadSafeEventQueue {
-        Box::into_raw(Box::new(ThreadSafeEventQueue::new()))
+    pub unsafe extern "C" fn eventqueue_new() -> *const ThreadSafeEventQueue {
+        Arc::into_raw(Arc::new(ThreadSafeEventQueue::new()))
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn eventqueue_free(queue: *mut ThreadSafeEventQueue) {
+    pub unsafe extern "C" fn eventqueue_drop(queue: *const ThreadSafeEventQueue) {
         assert!(!queue.is_null());
-        unsafe { Box::from_raw(queue) };
+        unsafe { Arc::from_raw(queue) };
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn eventqueue_cloneArc(
+        queue_ptr: *const ThreadSafeEventQueue,
+    ) -> *const ThreadSafeEventQueue {
+        assert!(!queue_ptr.is_null());
+
+        let queue_arc = unsafe { Arc::from_raw(queue_ptr) };
+        let queue_dup = Arc::clone(&queue_arc);
+
+        assert_eq!(Arc::into_raw(queue_arc), queue_ptr);
+        Arc::into_raw(queue_dup)
     }
 
     /// Takes ownership of the event.

--- a/src/main/core/work/event_queue.rs
+++ b/src/main/core/work/event_queue.rs
@@ -95,7 +95,6 @@ impl<T: PartialOrd + Eq> std::ops::DerefMut for PanickingOrd<T> {
 
 mod export {
     use super::*;
-    use crate::core::support::simulation_time::SimulationTime;
     use crate::cshadow as c;
 
     /// A wrapper for [`EventQueue`] that uses interior mutability to make the ffi simpler.
@@ -159,9 +158,8 @@ mod export {
     #[no_mangle]
     pub unsafe extern "C" fn eventqueue_nextEventTime(
         queue: *const ThreadSafeEventQueue,
-    ) -> c::SimulationTime {
+    ) -> c::EmulatedTime {
         let queue = unsafe { queue.as_ref() }.unwrap();
-        let time = queue.next_event_time().map(EmulatedTime::to_abs_simtime);
-        SimulationTime::to_c_simtime(time)
+        EmulatedTime::to_c_emutime(queue.next_event_time())
     }
 }

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -489,7 +489,6 @@ void worker_runEvent(Event* event, Host* host) {
     worker_setActiveHost(NULL);
 
     /* update times */
-    _worker_setLastEventTime(worker_getCurrentEmulatedTime());
     worker_clearCurrentTime();
 }
 
@@ -504,7 +503,6 @@ void worker_finish(GQueue* hosts, SimulationTime time) {
         info("%u hosts are shut down", nHosts);
     }
 
-    _worker_setLastEventTime(worker_getCurrentEmulatedTime());
     worker_clearCurrentTime();
 
     WorkerPool* pool = _worker_pool();

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -30,7 +30,7 @@ typedef void (*WorkerPoolTaskFn)(void*);
 #include "main/bindings/c/bindings.h"
 
 // To be called by scheduler. Consumes `event`
-void worker_runEvent(Event* event, Host* host);
+void worker_runHost(Host* host, EmulatedTime until);
 // To be called by worker thread
 void worker_finish(GQueue* hosts, SimulationTime time);
 
@@ -76,7 +76,8 @@ gboolean worker_scheduleTaskWithDelay(TaskRef* task, Host* host, SimulationTime 
 gboolean worker_scheduleTaskAtEmulatedTime(TaskRef* task, Host* host, EmulatedTime t);
 void worker_sendPacket(Host* src, Packet* packet);
 bool worker_isAlive(void);
-// Maximum time that the current event may run ahead to.
+// Maximum time that the current event may run ahead to. Must only be called if we hold the host
+// lock.
 EmulatedTime worker_maxEventRunaheadTime(Host* host);
 
 /* Time from the  beginning of the simulation.

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -42,7 +42,6 @@ struct ThreadInfo {
 
 struct Clock {
     now: Option<EmulatedTime>,
-    last: Option<EmulatedTime>,
     barrier: Option<EmulatedTime>,
 }
 
@@ -99,7 +98,6 @@ impl Worker {
                 active_thread_info: None,
                 clock: Clock {
                     now: None,
-                    last: None,
                     barrier: None,
                 },
                 bootstrap_end_time,
@@ -215,10 +213,6 @@ impl Worker {
 
     pub fn current_time() -> Option<EmulatedTime> {
         Worker::with(|w| w.clock.now).flatten()
-    }
-
-    fn set_last_event_time(t: EmulatedTime) {
-        Worker::with_mut(|w| w.clock.last.replace(t)).unwrap();
     }
 
     pub fn update_min_host_runahead(t: SimulationTime) {
@@ -466,11 +460,6 @@ mod export {
     #[no_mangle]
     pub extern "C" fn worker_updateMinHostRunahead(t: cshadow::SimulationTime) {
         Worker::update_min_host_runahead(SimulationTime::from_c_simtime(t).unwrap());
-    }
-
-    #[no_mangle]
-    pub extern "C" fn _worker_setLastEventTime(t: cshadow::EmulatedTime) {
-        Worker::set_last_event_time(EmulatedTime::from_c_emutime(t).unwrap())
     }
 
     #[no_mangle]

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -39,6 +39,11 @@ Host* host_new(const HostParameters* params);
 void host_ref(Host* host);
 void host_unref(Host* host);
 
+bool host_pushLocalEvent(Host* host, Event* event);
+void host_execute(Host* host, EmulatedTime until);
+EmulatedTime host_nextEventTime(Host* host);
+const ThreadSafeEventQueue* host_getOwnedEventQueue(Host* host);
+
 void host_lock(Host* host);
 void host_unlock(Host* host);
 

--- a/src/main/host/host_parameters.h
+++ b/src/main/host/host_parameters.h
@@ -21,6 +21,7 @@ struct _HostParameters {
     const gchar* hostname;
     guint nodeId;
     in_addr_t ipAddr;
+    EmulatedTime simEndTime;
     guint64 requestedBwDownBits;
     guint64 requestedBwUpBits;
     guint64 cpuFrequency;


### PR DESCRIPTION
In this PR the event processing has been simplified and moved into the host object. Each host's event queue is reference counted and stored by both the host and the global scheduler. This allows the host to access the event queue when adding local events or when processing/iterating events, and allows other hosts to add packet events through the global worker without needing to acquire the destination host's lock.

The future plan is:
1. Rather than having the worker add packet events directly to a host's event queue, the worker will store pending packet events in separate per-host queues, and once the current scheduling round completes, those packet events will be popped from the queues and added to their respective host event queues. This will allow us to remove both reference counting and locks from the host's event queue.
2. Have two separate event queues in the host rather than just one; one for local events and one for packet events. This will allow shadow to alternate between packet events and local events and is intended to solve #1341.

There does not seem to be any significant change to the performance or simulation results. (The performance does seem slightly better for the two benchmark runs I've done, but I don't think it's really significant.)

![ram_simtime](https://user-images.githubusercontent.com/3708797/184062815-e9162ae2-3c11-4f51-ad3b-9741d053ee1a.png)

![run_time](https://user-images.githubusercontent.com/3708797/184062816-f05691ea-c5bd-4cde-ad2e-7c4e61acaa24.png)

![transfer_time_1048576 exit](https://user-images.githubusercontent.com/3708797/184062817-ff3bb1f3-acea-4f18-820c-93119cbf5e47.png)