### PR TITLE
networkinterface_new: don't take Host*

### DIFF
--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -227,10 +227,10 @@ void host_setup(Host* host, DNS* dns, gulong rawCPUFreq, const gchar* hostRootPa
 
     /* virtual addresses and interfaces for managing network I/O */
     NetworkInterface* loopback =
-        networkinterface_new(host, loopbackAddress, pcapDir, host->params.pcapCaptureSize,
+        networkinterface_new(loopbackAddress, pcapDir, host->params.pcapCaptureSize,
                              host->params.qdisc, host->params.interfaceBufSize);
     NetworkInterface* ethernet =
-        networkinterface_new(host, ethernetAddress, pcapDir, host->params.pcapCaptureSize,
+        networkinterface_new(ethernetAddress, pcapDir, host->params.pcapCaptureSize,
                              host->params.qdisc, host->params.interfaceBufSize);
 
     g_free(pcapDir);

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -635,7 +635,7 @@ Router* networkinterface_getRouter(NetworkInterface* interface) {
     return interface->router;
 }
 
-NetworkInterface* networkinterface_new(Host* host, Address* address, gchar* pcapDir,
+NetworkInterface* networkinterface_new(Address* address, const gchar* pcapDir,
                                        guint32 pcapCaptureSize, QDiscMode qdisc,
                                        guint64 interfaceReceiveLength) {
     NetworkInterface* interface = g_new0(NetworkInterface, 1);

--- a/src/main/host/network_interface.h
+++ b/src/main/host/network_interface.h
@@ -19,7 +19,7 @@ typedef struct _NetworkInterface NetworkInterface;
 #include "main/routing/address.h"
 #include "main/routing/router.h"
 
-NetworkInterface* networkinterface_new(Host* host, Address* address, gchar* pcapDir,
+NetworkInterface* networkinterface_new(Address* address, const gchar* pcapDir,
                                        guint32 pcapCaptureSize, QDiscMode qdisc,
                                        guint64 interfaceReceiveLength);
 void networkinterface_free(NetworkInterface* interface);


### PR DESCRIPTION
Cleanup while working on migrating Host to Rust.