### PR TITLE
router_new: take NetworkInterface* instead of void*

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2764,16 +2764,16 @@ fn bindgen_test_layout__HostParameters() {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _Router {
-    _unused: [u8; 0],
-}
-pub type Router = _Router;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct _NetworkInterface {
     _unused: [u8; 0],
 }
 pub type NetworkInterface = _NetworkInterface;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _Router {
+    _unused: [u8; 0],
+}
+pub type Router = _Router;
 extern "C" {
     pub fn host_new(params: *const HostParameters) -> *mut Host;
 }

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -28,6 +28,7 @@ typedef GQuark HostId;
 #include "main/host/futex_table.h"
 #include "main/host/host_parameters.h"
 #include "main/host/network_interface.h"
+#include "main/host/protocol.h"
 #include "main/host/thread.h"
 #include "main/host/tracker_types.h"
 #include "main/routing/address.h"

--- a/src/main/host/network_interface.h
+++ b/src/main/host/network_interface.h
@@ -10,14 +10,14 @@
 #include <glib.h>
 #include <netinet/in.h>
 
+typedef struct _NetworkInterface NetworkInterface;
+
 #include "main/core/support/definitions.h"
 #include "main/host/descriptor/compat_socket.h"
 #include "main/host/descriptor/socket.h"
 #include "main/host/protocol.h"
 #include "main/routing/address.h"
 #include "main/routing/router.h"
-
-typedef struct _NetworkInterface NetworkInterface;
 
 NetworkInterface* networkinterface_new(Host* host, Address* address, gchar* pcapDir,
                                        guint32 pcapCaptureSize, QDiscMode qdisc,

--- a/src/main/routing/router.c
+++ b/src/main/routing/router.c
@@ -35,7 +35,7 @@ struct _Router {
     MAGIC_DECLARE;
 };
 
-Router* router_new(QueueManagerMode queueMode, void* interface) {
+Router* router_new(QueueManagerMode queueMode, NetworkInterface* interface) {
     utility_debugAssert(interface);
 
     Router* router = g_new0(Router, 1);

--- a/src/main/routing/router.h
+++ b/src/main/routing/router.h
@@ -17,6 +17,8 @@ typedef struct _Router Router;
 typedef enum _QueueManagerMode QueueManagerMode;
 typedef struct _QueueManagerHooks QueueManagerHooks;
 
+#include "main/host/network_interface.h"
+
 enum _QueueManagerMode {
     QUEUE_MANAGER_SINGLE, // buffers only a single packet
     QUEUE_MANAGER_STATIC, // a FIFO queue with a static size
@@ -37,7 +39,7 @@ struct _QueueManagerHooks {
     QueueManagerPeek peek;
 };
 
-Router* router_new(QueueManagerMode queueMode, void* interface);
+Router* router_new(QueueManagerMode queueMode, NetworkInterface* interface);
 void router_ref(Router* router);
 void router_unref(Router* router);
 

--- a/src/main/routing/router_queue_codel.c
+++ b/src/main/routing/router_queue_codel.c
@@ -26,6 +26,7 @@
 #include "lib/logger/logger.h"
 #include "main/core/support/definitions.h"
 #include "main/core/worker.h"
+#include "main/host/protocol.h"
 #include "main/routing/packet.h"
 #include "main/routing/router.h"
 #include "main/utility/utility.h"


### PR DESCRIPTION
Cleanup while migrating Host to Rust.