### PR TITLE
Remove O_NOFOLLOW flag when mmap file in plugin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,4 +9,6 @@ A list of user-facing changes since the latest Shadow release.
   as in a [guix](https://guix.gnu.org/) environment.
 * The `setup` script now has a `--search` option, which can be used to add additional directories
   to search for pkg-config files, C headers, and libraries. It obsoletes the options `--library` and `--include`.
+* Fixed a bug causing `mmap` to fail when called on a file descriptor that was
+opened with `O_NOFOLLOW`. https://github.com/shadow/shadow/pull/2353
 * (add entry here)

--- a/src/main/host/syscall/mman.c
+++ b/src/main/host/syscall/mman.c
@@ -163,6 +163,9 @@ static int _syscallhandler_openPluginFile(SysCallHandler* sys, int fd, RegularFi
     flags |= regularfile_getShadowFlags(file);
     /* Be careful not to try re-creating or truncating it. */
     flags &= ~(O_CREAT | O_EXCL | O_TMPFILE | O_TRUNC);
+    /* Don't use O_NOFOLLOW since it will prevent the plugin from
+     * opening the /proc/<shadow-pid>/fd/<linux-fd> file, which is a symbolic link. */
+    flags &= ~O_NOFOLLOW;
 
     /* Instruct the plugin to open the file at the path we sent. */
     int result = thread_nativeSyscall(

--- a/src/test/memory/test_mmap.rs
+++ b/src/test/memory/test_mmap.rs
@@ -346,20 +346,21 @@ fn test_mmap_nofollow_file() -> Result<(), Box<dyn Error>> {
     nix::fcntl::posix_fallocate(temp_fd, 0, MAPLEN as i64)?;
 
     nix::unistd::close(temp_fd)?;
-    
+
     /* Open the file with O_NOFOLLOW flag. */
     let nofollow_fd = nix::fcntl::open(
         &path,
-        nix::fcntl::OFlag::O_RDWR|nix::fcntl::OFlag::O_NOFOLLOW,
+        nix::fcntl::OFlag::O_RDWR | nix::fcntl::OFlag::O_NOFOLLOW,
         nix::sys::stat::Mode::empty(),
-    ).unwrap();
+    )
+    .unwrap();
 
     /* Do the mmap. */
     let mapbuf = unsafe {
         libc::mmap(
             std::ptr::null_mut(),
             MAPLEN,
-            libc::PROT_READ|libc::PROT_WRITE,
+            libc::PROT_READ | libc::PROT_WRITE,
             libc::MAP_SHARED,
             nofollow_fd,
             0,
@@ -367,7 +368,7 @@ fn test_mmap_nofollow_file() -> Result<(), Box<dyn Error>> {
     };
 
     assert!(mapbuf != libc::MAP_FAILED);
-   
+
     nix::unistd::close(nofollow_fd)?;
     nix::unistd::unlink(&path)?;
 


### PR DESCRIPTION
When the plugin mmaps a file opened with `O_NOFOLLOW`, shadow cannot open the file for plugin and return error for mmap.

example.c:

```c
#include <sys/mman.h>
#include <stdio.h>
#include <sys/types.h>
#include <sys/stat.h>
#include <fcntl.h>
#include <stdlib.h>
#include <unistd.h>
#define errExit(msg)    do { perror(msg); exit(EXIT_FAILURE); \
                                   } while (0)
int main() {
        int fd = open("file", O_CREAT|O_NOFOLLOW|O_RDWR, 0666);
        if (fd == -1) {
                errExit("open");
        }
        int size = 32;
        if (ftruncate(fd, size) == -1) {
                errExit("ftruncate");
        }
        void *addr = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
        if (addr == MAP_FAILED) {
                errExit("mmap");
        }
        return 0;
}
```

Running the above code will produce shadow log:

```
[memory_mapper.rs:499] [shadow_rs::host::memory_manager::memory_mapper] Handling mmap result for 7ffff7ffb000..+20
[managed_thread.c:238] [_managedthread_waitForNextEvent] received shim_event 3
[managed_thread.c:238] [_managedthread_waitForNextEvent] received shim_event 3
[mman.c:175] [_syscallhandler_openPluginFile] Failed to open path '/proc/2488142/fd/10' in plugin, error 40: Too many levels of symbolic links.
```

The error 40 (`ELOOP`) is caused by the `O_NOFOLLOW` flag, which prevents the plugin opening the path where the base name is a symbolic link. So reset `O_NOFOLLOW` since plugin is opening a symbolic link file in procfs. This flag is also unnecessary at this stage since it was already enforced when shadow opening the file.