### PR TITLE
Change host shuffle method to rust

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -3040,11 +3040,7 @@ extern "C" {
     ) -> gboolean;
 }
 extern "C" {
-    pub fn scheduler_new(
-        nWorkers: guint,
-        schedulerSeed: guint,
-        endTime: SimulationTime,
-    ) -> *mut Scheduler;
+    pub fn scheduler_new(nWorkers: guint, endTime: SimulationTime) -> *mut Scheduler;
 }
 extern "C" {
     pub fn scheduler_free(arg1: *mut Scheduler);

--- a/src/main/core/controller.rs
+++ b/src/main/core/controller.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use rand::{Rng, SeedableRng};
+use rand::SeedableRng;
 use rand_xoshiro::Xoshiro256PlusPlus;
 
 use crate::core::manager::{Manager, ManagerConfig};
@@ -51,7 +51,7 @@ impl<'a> Controller<'a> {
         });
 
         let manager_config = ManagerConfig {
-            random: Xoshiro256PlusPlus::seed_from_u64(sim_config.random.gen()),
+            random: Xoshiro256PlusPlus::from_rng(&mut sim_config.random).unwrap(),
             ip_assignment: sim_config.ip_assignment,
             routing_info: sim_config.routing_info,
             host_bandwidths: sim_config.host_bandwidths,

--- a/src/main/core/scheduler/scheduler.h
+++ b/src/main/core/scheduler/scheduler.h
@@ -15,7 +15,7 @@ typedef struct _Scheduler Scheduler;
 #include "main/core/support/definitions.h"
 #include "main/host/host.h"
 
-Scheduler* scheduler_new(guint nWorkers, guint schedulerSeed, SimulationTime endTime);
+Scheduler* scheduler_new(guint nWorkers, SimulationTime endTime);
 void scheduler_free(Scheduler*);
 void scheduler_shutdown(Scheduler* scheduler);
 


### PR DESCRIPTION
We'll want to change the shuffle method to a rust method at some point, and by changing only the shuffle method now (the shuffle is changed from C to rust), we can isolate simulation performance changes due to the different host order and not conflate it with other changes.

I also think shuffling in the manager makes more sense anyways.