### PR TITLE
Move some of `Controller`'s global state to the worker module

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -294,24 +294,6 @@ char *backtrace(void);
 
 void backtrace_free(char *backtrace);
 
-DNS *controller_getDNS(const struct Controller *controller);
-
-SimulationTime controller_getLatency(const struct Controller *controller,
-                                     in_addr_t src,
-                                     in_addr_t dst);
-
-float controller_getReliability(const struct Controller *controller, in_addr_t src, in_addr_t dst);
-
-uint64_t controller_getBandwidthDownBytes(const struct Controller *controller, in_addr_t ip);
-
-uint64_t controller_getBandwidthUpBytes(const struct Controller *controller, in_addr_t ip);
-
-void controller_incrementPacketCount(const struct Controller *controller,
-                                     in_addr_t src,
-                                     in_addr_t dst);
-
-bool controller_isRoutable(const struct Controller *controller, in_addr_t src, in_addr_t dst);
-
 bool controller_managerFinishedCurrentRound(const struct Controller *controller,
                                             SimulationTime min_next_event_time,
                                             SimulationTime *execute_window_start,
@@ -523,6 +505,20 @@ struct TaskRef *taskref_new_unbound(TaskCallbackFunc callback,
 //
 // SAFETY: `task` must be legally dereferencable.
 void taskref_drop(struct TaskRef *task);
+
+DNS *worker_getDNS(void);
+
+SimulationTime worker_getLatency(in_addr_t src, in_addr_t dst);
+
+float worker_getReliability(in_addr_t src, in_addr_t dst);
+
+uint64_t worker_getBandwidthDownBytes(in_addr_t ip);
+
+uint64_t worker_getBandwidthUpBytes(in_addr_t ip);
+
+bool worker_isRoutable(in_addr_t src, in_addr_t dst);
+
+void worker_incrementPacketCount(in_addr_t src, in_addr_t dst);
 
 // Initialize a Worker for this thread.
 void worker_newForThisThread(WorkerPool *worker_pool,

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -3030,9 +3030,6 @@ extern "C" {
     pub fn worker_getAffinity() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn worker_getDNS() -> *mut DNS;
-}
-extern "C" {
     pub fn worker_getChildPidWatcher() -> *const ChildPidWatcher;
 }
 extern "C" {

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -3068,37 +3068,7 @@ extern "C" {
     pub fn worker_isBootstrapActive() -> bool;
 }
 extern "C" {
-    pub fn worker_getNodeBandwidthUpKiBps(ip: in_addr_t) -> guint32;
-}
-extern "C" {
-    pub fn worker_getNodeBandwidthDownKiBps(ip: in_addr_t) -> guint32;
-}
-extern "C" {
     pub fn workerpool_updateMinHostRunahead(pool: *mut WorkerPool, time: SimulationTime);
-}
-extern "C" {
-    pub fn worker_getLatencyForAddresses(
-        sourceAddress: *mut Address,
-        destinationAddress: *mut Address,
-    ) -> SimulationTime;
-}
-extern "C" {
-    pub fn worker_getReliabilityForAddresses(
-        sourceAddress: *mut Address,
-        destinationAddress: *mut Address,
-    ) -> gdouble;
-}
-extern "C" {
-    pub fn worker_isRoutableForAddresses(
-        sourceAddress: *mut Address,
-        destinationAddress: *mut Address,
-    ) -> bool;
-}
-extern "C" {
-    pub fn worker_incrementPacketCountForAddresses(
-        sourceAddress: *mut Address,
-        destinationAddress: *mut Address,
-    );
 }
 extern "C" {
     pub fn worker_clearCurrentTime();

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -3092,11 +3092,13 @@ extern "C" {
     ) -> gdouble;
 }
 extern "C" {
-    pub fn worker_isRoutable(sourceAddress: *mut Address, destinationAddress: *mut Address)
-        -> bool;
+    pub fn worker_isRoutableForAddresses(
+        sourceAddress: *mut Address,
+        destinationAddress: *mut Address,
+    ) -> bool;
 }
 extern "C" {
-    pub fn worker_incrementPacketCount(
+    pub fn worker_incrementPacketCountForAddresses(
         sourceAddress: *mut Address,
         destinationAddress: *mut Address,
     );

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -371,7 +371,7 @@ impl<'a> Manager<'a> {
             unsafe {
                 c::host_setup(
                     c_host,
-                    self.controller.get_dns(),
+                    worker::WORKER_SHARED.get().unwrap().dns(),
                     self.raw_frequency_khz,
                     hosts_path.as_ptr(),
                 )

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -532,7 +532,7 @@ void worker_sendPacket(Host* srcHost, Packet* packet) {
         worker_updateMinHostRunahead(delay);
         SimulationTime deliverTime = worker_getCurrentSimulationTime() + delay;
 
-        worker_incrementPacketCount(srcAddress, dstAddress);
+        worker_incrementPacketCountForAddresses(srcAddress, dstAddress);
 
         /* TODO this should change for sending to remote manager (on a different machine)
          * this is the only place where tasks are sent between separate hosts */
@@ -625,13 +625,13 @@ gdouble worker_getReliabilityForAddresses(Address* sourceAddress, Address* desti
     return controller_getReliability(_worker_pool()->controller, src, dst);
 }
 
-bool worker_isRoutable(Address* sourceAddress, Address* destinationAddress) {
+bool worker_isRoutableForAddresses(Address* sourceAddress, Address* destinationAddress) {
     in_addr_t src = htonl(address_toHostIP(sourceAddress));
     in_addr_t dst = htonl(address_toHostIP(destinationAddress));
     return controller_isRoutable(_worker_pool()->controller, src, dst);
 }
 
-void worker_incrementPacketCount(Address* sourceAddress, Address* destinationAddress) {
+void worker_incrementPacketCountForAddresses(Address* sourceAddress, Address* destinationAddress) {
     in_addr_t src = htonl(address_toHostIP(sourceAddress));
     in_addr_t dst = htonl(address_toHostIP(destinationAddress));
     controller_incrementPacketCount(_worker_pool()->controller, src, dst);

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -367,8 +367,6 @@ int worker_getAffinity() {
     return lps_cpuId(pool->logicalProcessors, pool->workerLogicalProcessorIdxs[worker_threadID()]);
 }
 
-DNS* worker_getDNS() { return controller_getDNS(_worker_pool()->controller); }
-
 Address* worker_resolveIPToAddress(in_addr_t ip) {
     DNS* dns = worker_getDNS();
     return dns_resolveIPToAddress(dns, ip);
@@ -602,11 +600,11 @@ static void _worker_shutdownHost(Host* host, void* _unused) {
 }
 
 guint32 worker_getNodeBandwidthUpKiBps(in_addr_t ip) {
-    return controller_getBandwidthUpBytes(_worker_pool()->controller, ip) / 1024;
+    return worker_getBandwidthUpBytes(ip) / 1024;
 }
 
 guint32 worker_getNodeBandwidthDownKiBps(in_addr_t ip) {
-    return controller_getBandwidthDownBytes(_worker_pool()->controller, ip) / 1024;
+    return worker_getBandwidthDownBytes(ip) / 1024;
 }
 
 void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time) {
@@ -616,25 +614,25 @@ void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time) {
 SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress) {
     in_addr_t src = htonl(address_toHostIP(sourceAddress));
     in_addr_t dst = htonl(address_toHostIP(destinationAddress));
-    return controller_getLatency(_worker_pool()->controller, src, dst);
+    return worker_getLatency(src, dst);
 }
 
 gdouble worker_getReliabilityForAddresses(Address* sourceAddress, Address* destinationAddress) {
     in_addr_t src = htonl(address_toHostIP(sourceAddress));
     in_addr_t dst = htonl(address_toHostIP(destinationAddress));
-    return controller_getReliability(_worker_pool()->controller, src, dst);
+    return worker_getReliability(src, dst);
 }
 
 bool worker_isRoutableForAddresses(Address* sourceAddress, Address* destinationAddress) {
     in_addr_t src = htonl(address_toHostIP(sourceAddress));
     in_addr_t dst = htonl(address_toHostIP(destinationAddress));
-    return controller_isRoutable(_worker_pool()->controller, src, dst);
+    return worker_isRoutable(src, dst);
 }
 
 void worker_incrementPacketCountForAddresses(Address* sourceAddress, Address* destinationAddress) {
     in_addr_t src = htonl(address_toHostIP(sourceAddress));
     in_addr_t dst = htonl(address_toHostIP(destinationAddress));
-    controller_incrementPacketCount(_worker_pool()->controller, src, dst);
+    worker_incrementPacketCount(src, dst);
 }
 
 gboolean worker_isFiltered(LogLevel level) { return !logger_isEnabled(logger_getDefault(), level); }

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -95,8 +95,8 @@ guint32 worker_getNodeBandwidthDownKiBps(in_addr_t ip);
 void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time);
 SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress);
 gdouble worker_getReliabilityForAddresses(Address* sourceAddress, Address* destinationAddress);
-bool worker_isRoutable(Address* sourceAddress, Address* destinationAddress);
-void worker_incrementPacketCount(Address* sourceAddress, Address* destinationAddress);
+bool worker_isRoutableForAddresses(Address* sourceAddress, Address* destinationAddress);
+void worker_incrementPacketCountForAddresses(Address* sourceAddress, Address* destinationAddress);
 
 void worker_clearCurrentTime();
 void worker_setCurrentEmulatedTime(EmulatedTime time);

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -88,14 +88,8 @@ SimulationTime worker_getCurrentSimulationTime();
 EmulatedTime worker_getCurrentEmulatedTime();
 
 bool worker_isBootstrapActive(void);
-guint32 worker_getNodeBandwidthUpKiBps(in_addr_t ip);
-guint32 worker_getNodeBandwidthDownKiBps(in_addr_t ip);
 
 void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time);
-SimulationTime worker_getLatencyForAddresses(Address* sourceAddress, Address* destinationAddress);
-gdouble worker_getReliabilityForAddresses(Address* sourceAddress, Address* destinationAddress);
-bool worker_isRoutableForAddresses(Address* sourceAddress, Address* destinationAddress);
-void worker_incrementPacketCountForAddresses(Address* sourceAddress, Address* destinationAddress);
 
 void worker_clearCurrentTime();
 void worker_setCurrentEmulatedTime(EmulatedTime time);

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -67,7 +67,6 @@ void worker_setMinEventTimeNextRound(SimulationTime simtime);
 void worker_setRoundEndTime(SimulationTime newRoundEndTime);
 
 int worker_getAffinity();
-DNS* worker_getDNS();
 const ChildPidWatcher* worker_getChildPidWatcher();
 const ConfigOptions* worker_getConfig();
 gboolean worker_scheduleTaskWithDelay(TaskRef* task, Host* host, SimulationTime nanoDelay);

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -26,6 +26,12 @@ static ALLOC_COUNTER: Lazy<Mutex<Counter>> = Lazy::new(|| Mutex::new(Counter::ne
 static DEALLOC_COUNTER: Lazy<Mutex<Counter>> = Lazy::new(|| Mutex::new(Counter::new()));
 static SYSCALL_COUNTER: Lazy<Mutex<Counter>> = Lazy::new(|| Mutex::new(Counter::new()));
 
+std::thread_local! {
+    // Initialized when the worker thread starts running. No shared ownership
+    // or access from outside of the current thread.
+    static WORKER: OnceCell<RefCell<Worker>> = OnceCell::new();
+}
+
 #[derive(Copy, Clone, Debug)]
 pub struct WorkerThreadID(u32);
 
@@ -75,12 +81,6 @@ pub struct Worker {
     object_dealloc_counter: Counter,
 
     worker_pool: *mut cshadow::WorkerPool,
-}
-
-std::thread_local! {
-    // Initialized when the worker thread starts running. No shared ownership
-    // or access from outside of the current thread.
-    static WORKER: OnceCell<RefCell<Worker>> = OnceCell::new();
 }
 
 impl Worker {

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -1,7 +1,7 @@
 use nix::unistd::Pid;
 use once_cell::sync::Lazy;
-use once_cell::unsync::OnceCell;
 
+use crate::core::sim_config::Bandwidth;
 use crate::core::support::emulated_time::EmulatedTime;
 use crate::core::support::simulation_time::SimulationTime;
 use crate::cshadow;
@@ -11,25 +11,87 @@ use crate::host::process::Process;
 use crate::host::process::ProcessId;
 use crate::host::thread::ThreadId;
 use crate::host::thread::{CThread, Thread};
+use crate::network::network_graph::{IpAssignment, RoutingInfo};
 use crate::utility::counter::Counter;
 use crate::utility::notnull::*;
+use crate::utility::SyncSendPointer;
 
 use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 static USE_OBJECT_COUNTERS: AtomicBool = AtomicBool::new(false);
 
-// counters to be used when there is no worker active
+// global counters to be used when there is no worker active
 static ALLOC_COUNTER: Lazy<Mutex<Counter>> = Lazy::new(|| Mutex::new(Counter::new()));
 static DEALLOC_COUNTER: Lazy<Mutex<Counter>> = Lazy::new(|| Mutex::new(Counter::new()));
 static SYSCALL_COUNTER: Lazy<Mutex<Counter>> = Lazy::new(|| Mutex::new(Counter::new()));
 
+// thread-local global state
 std::thread_local! {
     // Initialized when the worker thread starts running. No shared ownership
     // or access from outside of the current thread.
-    static WORKER: OnceCell<RefCell<Worker>> = OnceCell::new();
+    static WORKER: once_cell::unsync::OnceCell<RefCell<Worker>> = once_cell::unsync::OnceCell::new();
+}
+
+// shared global state
+pub static WORKER_SHARED: once_cell::sync::OnceCell<WorkerShared> =
+    once_cell::sync::OnceCell::new();
+
+#[derive(Debug)]
+pub struct WorkerShared {
+    pub ip_assignment: IpAssignment<u32>,
+    pub routing_info: RoutingInfo<u32>,
+    pub host_bandwidths: HashMap<std::net::IpAddr, Bandwidth>,
+    pub dns: SyncSendPointer<cshadow::DNS>,
+}
+
+impl WorkerShared {
+    pub fn dns(&self) -> *mut cshadow::DNS {
+        self.dns.ptr()
+    }
+
+    pub fn latency(&self, src: std::net::IpAddr, dst: std::net::IpAddr) -> Option<SimulationTime> {
+        let src = self.ip_assignment.get_node(src)?;
+        let dst = self.ip_assignment.get_node(dst)?;
+
+        Some(SimulationTime::from_nanos(
+            self.routing_info.path(src, dst)?.latency_ns,
+        ))
+    }
+
+    pub fn reliability(&self, src: std::net::IpAddr, dst: std::net::IpAddr) -> Option<f32> {
+        let src = self.ip_assignment.get_node(src)?;
+        let dst = self.ip_assignment.get_node(dst)?;
+
+        Some(1.0 - self.routing_info.path(src, dst)?.packet_loss)
+    }
+
+    pub fn bandwidth(&self, ip: std::net::IpAddr) -> Option<&Bandwidth> {
+        self.host_bandwidths.get(&ip)
+    }
+
+    pub fn increment_packet_count(&self, src: std::net::IpAddr, dst: std::net::IpAddr) {
+        let src = self.ip_assignment.get_node(src).unwrap();
+        let dst = self.ip_assignment.get_node(dst).unwrap();
+
+        self.routing_info.increment_packet_count(src, dst)
+    }
+
+    pub fn is_routable(&self, src: std::net::IpAddr, dst: std::net::IpAddr) -> bool {
+        if self.ip_assignment.get_node(src).is_none() {
+            return false;
+        }
+
+        if self.ip_assignment.get_node(dst).is_none() {
+            return false;
+        }
+
+        // the network graph is required to be a connected graph, so they must be routable
+        true
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -320,6 +382,69 @@ pub fn with_global_object_counters<T>(f: impl FnOnce(&Counter, &Counter) -> T) -
 
 mod export {
     use super::*;
+
+    #[no_mangle]
+    pub extern "C" fn worker_getDNS() -> *mut cshadow::DNS {
+        unsafe { WORKER_SHARED.get().unwrap().dns() }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn worker_getLatency(
+        src: libc::in_addr_t,
+        dst: libc::in_addr_t,
+    ) -> cshadow::SimulationTime {
+        let src = std::net::IpAddr::V4(u32::from_be(src).into());
+        let dst = std::net::IpAddr::V4(u32::from_be(dst).into());
+
+        SimulationTime::to_c_simtime(WORKER_SHARED.get().unwrap().latency(src, dst))
+    }
+
+    #[no_mangle]
+    pub extern "C" fn worker_getReliability(
+        src: libc::in_addr_t,
+        dst: libc::in_addr_t,
+    ) -> libc::c_float {
+        let src = std::net::IpAddr::V4(u32::from_be(src).into());
+        let dst = std::net::IpAddr::V4(u32::from_be(dst).into());
+
+        WORKER_SHARED.get().unwrap().reliability(src, dst).unwrap()
+    }
+
+    #[no_mangle]
+    pub extern "C" fn worker_getBandwidthDownBytes(ip: libc::in_addr_t) -> u64 {
+        let ip = std::net::IpAddr::V4(u32::from_be(ip).into());
+        WORKER_SHARED
+            .get()
+            .unwrap()
+            .bandwidth(ip)
+            .unwrap()
+            .down_bytes
+    }
+
+    #[no_mangle]
+    pub extern "C" fn worker_getBandwidthUpBytes(ip: libc::in_addr_t) -> u64 {
+        let ip = std::net::IpAddr::V4(u32::from_be(ip).into());
+        WORKER_SHARED.get().unwrap().bandwidth(ip).unwrap().up_bytes
+    }
+
+    #[no_mangle]
+    pub extern "C" fn worker_isRoutable(src: libc::in_addr_t, dst: libc::in_addr_t) -> bool {
+        let src = std::net::IpAddr::V4(u32::from_be(src).into());
+        let dst = std::net::IpAddr::V4(u32::from_be(dst).into());
+
+        WORKER_SHARED.get().unwrap().is_routable(src, dst)
+    }
+
+    #[no_mangle]
+    pub extern "C" fn worker_incrementPacketCount(src: libc::in_addr_t, dst: libc::in_addr_t) {
+        let src = std::net::IpAddr::V4(u32::from_be(src).into());
+        let dst = std::net::IpAddr::V4(u32::from_be(dst).into());
+
+        WORKER_SHARED
+            .get()
+            .unwrap()
+            .increment_packet_count(src, dst)
+    }
 
     /// Initialize a Worker for this thread.
     #[no_mangle]

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -430,12 +430,9 @@ static guint _tcp_calculateRTT(TCP* tcp, Host* host) {
     guint rtt = 1;
 
     if(sourceIP != destinationIP) {
-        Address* srcAddress = worker_resolveIPToAddress(sourceIP);
-        Address* dstAddress = worker_resolveIPToAddress(destinationIP);
-
         /* these sim time values are a duration and not an absolute time */
-        SimulationTime srcLatency = worker_getLatencyForAddresses(srcAddress, dstAddress);
-        SimulationTime dstLatency = worker_getLatencyForAddresses(dstAddress, srcAddress);
+        SimulationTime srcLatency = worker_getLatency(sourceIP, destinationIP);
+        SimulationTime dstLatency = worker_getLatency(destinationIP, sourceIP);
 
         /* find latency in milliseconds */
         guint sendLatency = (guint)ceil((gdouble)srcLatency / SIMTIME_ONE_MILLISECOND);
@@ -531,8 +528,8 @@ static void _tcp_tuneInitialBufferSizes(TCP* tcp, Host* host) {
 
     /* i got delay, now i need values for my send and receive buffer
      * sizes based on bandwidth in both directions. do my send size first. */
-    guint32 my_send_bw = worker_getNodeBandwidthUpKiBps(sourceIP);
-    guint32 their_receive_bw = worker_getNodeBandwidthDownKiBps(destinationIP);
+    guint32 my_send_bw = worker_getBandwidthUpBytes(sourceIP) / 1024;
+    guint32 their_receive_bw = worker_getBandwidthDownBytes(destinationIP) / 1024;
 
     /* KiBps is the same as Bpms, which works with our RTT calculation. */
     guint32 send_bottleneck_bw = my_send_bw < their_receive_bw ? my_send_bw : their_receive_bw;
@@ -541,8 +538,8 @@ static void _tcp_tuneInitialBufferSizes(TCP* tcp, Host* host) {
     guint64 sendbuf_size = (guint64) ((rtt_milliseconds * send_bottleneck_bw * 1024.0f * 1.25f) / 1000.0f);
 
     /* now the same thing for my receive buf */
-    guint32 my_receive_bw = worker_getNodeBandwidthDownKiBps(sourceIP);
-    guint32 their_send_bw = worker_getNodeBandwidthUpKiBps(destinationIP);
+    guint32 my_receive_bw = worker_getBandwidthDownBytes(sourceIP) / 1024;
+    guint32 their_send_bw = worker_getBandwidthUpBytes(destinationIP) / 1024;
 
     /* KiBps is the same as Bpms, which works with our RTT calculation. */
     guint32 receive_bottleneck_bw = my_receive_bw < their_send_bw ? my_receive_bw : their_send_bw;

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -906,7 +906,8 @@ SysCallReturn syscallhandler_connect(SysCallHandler* sys,
     if (peerAddr != loopbackAddr) {
         Address* myAddress = host_getDefaultAddress(sys->host);
         Address* peerAddress = worker_resolveIPToAddress(peerAddr);
-        if (!peerAddress || !worker_isRoutableForAddresses(myAddress, peerAddress)) {
+        in_addr_t myAddr = htonl(address_toHostIP(myAddress));
+        if (!peerAddress || !worker_isRoutable(myAddr, peerAddr)) {
             /* can't route it - there is no node with this address */
             gchar* peerAddressString = address_ipToNewString(peerAddr);
             warning("attempting to connect to address '%s:%u' for which no "

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -906,7 +906,7 @@ SysCallReturn syscallhandler_connect(SysCallHandler* sys,
     if (peerAddr != loopbackAddr) {
         Address* myAddress = host_getDefaultAddress(sys->host);
         Address* peerAddress = worker_resolveIPToAddress(peerAddr);
-        if (!peerAddress || !worker_isRoutable(myAddress, peerAddress)) {
+        if (!peerAddress || !worker_isRoutableForAddresses(myAddress, peerAddress)) {
             /* can't route it - there is no node with this address */
             gchar* peerAddressString = address_ipToNewString(peerAddr);
             warning("attempting to connect to address '%s:%u' for which no "

--- a/src/main/network/network_graph.rs
+++ b/src/main/network/network_graph.rs
@@ -420,6 +420,7 @@ impl<T: Copy + Eq + Hash + std::fmt::Display> IpAssignment<T> {
 }
 
 /// Routing information for paths between nodes.
+#[derive(Debug)]
 pub struct RoutingInfo<T: Eq + Hash + std::fmt::Display + Clone + Copy> {
     paths: HashMap<(T, T), PathProperties>,
     packet_counters: std::sync::RwLock<HashMap<(T, T), u64>>,


### PR DESCRIPTION
The `Controller` is currently globally accessible through the global worker pool, but since the controller exists on the stack, this is not allowed in rust (unless we use `Box::leak`). This breaks out some of the global state into a new global object. Accesses to this global state is made explicit through a `worker::WORKER_SHARED` static variable.