### PR TITLE
Fixed warning about unneeded `unsafe` from #2361

### DIFF
--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -385,7 +385,7 @@ mod export {
 
     #[no_mangle]
     pub extern "C" fn worker_getDNS() -> *mut cshadow::DNS {
-        unsafe { WORKER_SHARED.get().unwrap().dns() }
+        WORKER_SHARED.get().unwrap().dns()
     }
 
     #[no_mangle]


### PR DESCRIPTION
When I fixed #2361 after the comments I didn't check code warnings before merging.