### PR TITLE
Fix UB in the controller, and move the plugin error count to the worker module

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -297,8 +297,6 @@ void backtrace_free(char *backtrace);
 void controller_updateMinRunahead(const struct Controller *controller,
                                   SimulationTime min_path_latency);
 
-void controller_incrementPluginErrors(const struct Controller *controller);
-
 // Flush Rust's log::logger().
 void rustlogger_flush(void);
 
@@ -514,6 +512,8 @@ uint64_t worker_getBandwidthUpBytes(in_addr_t ip);
 bool worker_isRoutable(in_addr_t src, in_addr_t dst);
 
 void worker_incrementPacketCount(in_addr_t src, in_addr_t dst);
+
+void worker_incrementPluginErrors(void);
 
 // Initialize a Worker for this thread.
 void worker_newForThisThread(WorkerPool *worker_pool,

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -3080,9 +3080,6 @@ extern "C" {
     pub fn worker_isFiltered(level: LogLevel) -> gboolean;
 }
 extern "C" {
-    pub fn worker_incrementPluginError();
-}
-extern "C" {
     pub fn worker_resolveIPToAddress(ip: in_addr_t) -> *mut Address;
 }
 extern "C" {

--- a/src/main/core/controller.rs
+++ b/src/main/core/controller.rs
@@ -131,15 +131,6 @@ impl SimController for Controller<'_> {
         let scheduling_data = self.scheduling_data.read().unwrap();
         let (new_start, new_end) = scheduling_data.next_interval_window(min_next_event_time);
 
-        // update the status logger
-        let display_time = std::cmp::min(new_start, new_end);
-        worker::WORKER_SHARED
-            .get()
-            .unwrap()
-            .update_status_logger(|state| {
-                state.current = display_time;
-            });
-
         let continue_running = new_start < new_end;
         continue_running.then(|| (new_start, new_end))
     }

--- a/src/main/core/controller.rs
+++ b/src/main/core/controller.rs
@@ -93,6 +93,8 @@ impl<'a> Controller<'a> {
                 // safe since the DNS type has an internal mutex, and since global memory is leaked
                 // we don't ever need to free this
                 dns: unsafe { SyncSendPointer::new(dns) },
+                // allow the status logger's state to be updated from anywhere
+                status_logger_state: self.status_logger.as_ref().map(|x| Arc::clone(x.status())),
             })
             .expect("The global state has already been set during the program's execution");
 

--- a/src/main/core/controller.rs
+++ b/src/main/core/controller.rs
@@ -115,13 +115,6 @@ impl<'a> Controller<'a> {
     }
 }
 
-impl std::ops::Drop for Controller<'_> {
-    fn drop(&mut self) {
-        // stop and clear the status logger
-        self.status_logger.as_mut().map(|x| x.stop());
-    }
-}
-
 /// Controller methods that are accessed by the manager.
 pub trait SimController {
     fn manager_finished_current_round(
@@ -293,7 +286,7 @@ impl ShadowStatusBarState {
     }
 }
 
-enum StatusLogger<T: status_bar::StatusBarState> {
+enum StatusLogger<T: 'static + status_bar::StatusBarState> {
     Printer(StatusPrinter<T>),
     Bar(StatusBar<T>),
 }
@@ -303,13 +296,6 @@ impl<T: 'static + status_bar::StatusBarState> StatusLogger<T> {
         match self {
             Self::Printer(x) => x.status(),
             Self::Bar(x) => x.status(),
-        }
-    }
-
-    pub fn stop(&mut self) {
-        match self {
-            Self::Printer(x) => x.stop(),
-            Self::Bar(x) => x.stop(),
         }
     }
 }

--- a/src/main/core/controller.rs
+++ b/src/main/core/controller.rs
@@ -254,7 +254,7 @@ impl std::fmt::Display for ShadowStatusBarState {
             f,
             "{}% — simulated: {}/{}, realtime: {}, processes failed: {}",
             (frac * 100.0).round() as i8,
-            sim_current.fmt_hr_min_sec(),
+            sim_current.fmt_hr_min_sec_milli(),
             sim_end.fmt_hr_min_sec(),
             realtime.fmt_hr_min_sec(),
             self.num_failed_processes,

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -241,6 +241,15 @@ impl<'a> Manager<'a> {
                 // release the workers and run next round
                 scheduler.continue_next_round(window_start, window_end);
 
+                // update the status logger
+                let display_time = std::cmp::min(window_start, window_end);
+                worker::WORKER_SHARED
+                    .get()
+                    .unwrap()
+                    .update_status_logger(|state| {
+                        state.current = display_time;
+                    });
+
                 // log a heartbeat message every 'heartbeat_interval' amount of simulated time
                 if let Some(heartbeat_interval) = heartbeat_interval {
                     if window_start > last_heartbeat + heartbeat_interval {
@@ -275,6 +284,14 @@ impl<'a> Manager<'a> {
                     .manager_finished_current_round(min_next_event_time);
             }
         }
+
+        // simulation is finished, so update the status logger
+        worker::WORKER_SHARED
+            .get()
+            .unwrap()
+            .update_status_logger(|state| {
+                state.current = self.end_time;
+            });
 
         // since the scheduler was dropped, all workers should have completed and the global object
         // and syscall counters should have been updated

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -603,5 +603,3 @@ void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time) {
 }
 
 gboolean worker_isFiltered(LogLevel level) { return !logger_isEnabled(logger_getDefault(), level); }
-
-void worker_incrementPluginError() { controller_incrementPluginErrors(_worker_pool()->controller); }

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -99,8 +99,6 @@ gboolean worker_isFiltered(LogLevel level);
 void worker_bootHosts(GQueue* hosts);
 void worker_freeHosts(GQueue* hosts);
 
-void worker_incrementPluginError();
-
 Address* worker_resolveIPToAddress(in_addr_t ip);
 Address* worker_resolveNameToAddress(const gchar* name);
 

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -422,7 +422,7 @@ static void _process_getAndLogReturnCode(Process* proc) {
         info("%s", mainResultString->str);
     } else {
         warning("%s", mainResultString->str);
-        worker_incrementPluginError();
+        worker_incrementPluginErrors();
     }
 
     g_string_free(mainResultString, TRUE);


### PR DESCRIPTION
The status logger is globally accessible through the controller, which is UB because the `StatusLogger` is not `Sync`. This PR makes the status logger's state global so that we can make the status logger itself non-global.

Also moves the plugin error count to `worker::WORKER_SHARED` to be more explicit that this is intended to be used as a global.