### PR TITLE
Move the runahead data from `Controller` to `WorkerShared`

### DIFF
--- a/src/main/bindings/c/bindings-opaque.h
+++ b/src/main/bindings/c/bindings-opaque.h
@@ -48,8 +48,6 @@ typedef struct CliOptions CliOptions;
 // Shadow configuration options after processing command-line and configuration file options.
 typedef struct ConfigOptions ConfigOptions;
 
-typedef struct Controller Controller;
-
 // The main counter object that maps individual keys to count values.
 typedef struct Counter Counter;
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -52,8 +52,6 @@ typedef struct CliOptions CliOptions;
 // Shadow configuration options after processing command-line and configuration file options.
 typedef struct ConfigOptions ConfigOptions;
 
-typedef struct Controller Controller;
-
 // The main counter object that maps individual keys to count values.
 typedef struct Counter Counter;
 
@@ -293,9 +291,6 @@ void random_nextNBytes(struct Random *rng, uint8_t *buf, uintptr_t len);
 char *backtrace(void);
 
 void backtrace_free(char *backtrace);
-
-void controller_updateMinRunahead(const struct Controller *controller,
-                                  SimulationTime min_path_latency);
 
 // Flush Rust's log::logger().
 void rustlogger_flush(void);
@@ -561,7 +556,7 @@ SimulationTime worker_getCurrentSimulationTime(void);
 
 EmulatedTime worker_getCurrentEmulatedTime(void);
 
-void worker_updateMinHostRunahead(SimulationTime t);
+void worker_updateLowestUsedLatency(SimulationTime min_path_latency);
 
 bool worker_isBootstrapActive(void);
 

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2987,7 +2987,6 @@ extern "C" {
 }
 extern "C" {
     pub fn scheduler_new(
-        controller: *const Controller,
         pidWatcher: *const ChildPidWatcher,
         config: *const ConfigOptions,
         nWorkers: guint,
@@ -3066,9 +3065,6 @@ extern "C" {
 }
 extern "C" {
     pub fn worker_isBootstrapActive() -> bool;
-}
-extern "C" {
-    pub fn workerpool_updateMinHostRunahead(pool: *mut WorkerPool, time: SimulationTime);
 }
 extern "C" {
     pub fn worker_clearCurrentTime();

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -202,7 +202,6 @@ impl<'a> Manager<'a> {
         {
             let pid_watcher = ChildPidWatcher::new();
             let mut scheduler = SchedulerWrapper::new(
-                self.controller,
                 &pid_watcher,
                 self.config,
                 num_workers,
@@ -677,14 +676,12 @@ impl<'a> Manager<'a> {
 
 struct SchedulerWrapper<'a> {
     pub ptr: *mut c::Scheduler,
-    _phantom_controller: PhantomData<&'a Controller<'a>>,
     _phantom_pid_watcher: PhantomData<&'a ChildPidWatcher>,
     _phantom_config: PhantomData<&'a ConfigOptions>,
 }
 
 impl<'a> SchedulerWrapper<'a> {
     pub fn new(
-        controller: &'a Controller,
         pid_watcher: &'a ChildPidWatcher,
         config: &'a ConfigOptions,
         num_workers: u32,
@@ -694,7 +691,6 @@ impl<'a> SchedulerWrapper<'a> {
         Self {
             ptr: unsafe {
                 c::scheduler_new(
-                    controller,
                     pid_watcher,
                     config,
                     num_workers,
@@ -702,7 +698,6 @@ impl<'a> SchedulerWrapper<'a> {
                     EmulatedTime::to_abs_simtime(end_time).into(),
                 )
             },
-            _phantom_controller: Default::default(),
             _phantom_pid_watcher: Default::default(),
             _phantom_config: Default::default(),
         }

--- a/src/main/core/mod.rs
+++ b/src/main/core/mod.rs
@@ -3,6 +3,7 @@ pub mod logger;
 pub mod logical_processor;
 pub mod main;
 pub mod manager;
+pub mod scheduler;
 pub mod sim_config;
 pub mod support;
 pub mod work;

--- a/src/main/core/scheduler/mod.rs
+++ b/src/main/core/scheduler/mod.rs
@@ -1,0 +1,1 @@
+pub mod runahead;

--- a/src/main/core/scheduler/runahead.rs
+++ b/src/main/core/scheduler/runahead.rs
@@ -9,6 +9,7 @@ use crate::core::support::simulation_time::SimulationTime;
 /// the provided minimum possible latency when dynamic runahead is disabled, and otherwise uses a
 /// dynamic runahead of the minimum used latency. Both runahead calculations have a static lower
 /// bound.
+#[derive(Debug)]
 pub struct Runahead {
     /// The lowest packet latency that shadow has used so far in the simulation. For performance, is
     /// only updated if dynamic runahead is enabled for the simulation.

--- a/src/main/core/scheduler/runahead.rs
+++ b/src/main/core/scheduler/runahead.rs
@@ -1,0 +1,115 @@
+use std::sync::RwLock;
+
+use crate::core::support::simulation_time::SimulationTime;
+
+/// Decides on the runahead for the next simulation round (the duration of the round). Having a
+/// larger runahead improves performance since more hosts and more events can be run in parallel
+/// during a simulation round, but if the runahead is too large then packets will be delayed until
+/// the next simulation round which is beyond their intended latency. This uses a fixed runahead of
+/// the provided minimum possible latency when dynamic runahead is disabled, and otherwise uses a
+/// dynamic runahead of the minimum used latency. Both runahead calculations have a static lower
+/// bound.
+pub struct Runahead {
+    /// The lowest packet latency that shadow has used so far in the simulation. For performance, is
+    /// only updated if dynamic runahead is enabled for the simulation.
+    min_used_latency: RwLock<Option<SimulationTime>>,
+    /// The lowest latency that's possible in the simulation (the graph edge with the lowest
+    /// latency).
+    min_possible_latency: SimulationTime,
+    /// A lower bound for the runahead as specified by the user.
+    min_runahead_config: Option<SimulationTime>,
+    /// Is dynamic runahead enabled?
+    is_runahead_dynamic: bool,
+}
+
+impl Runahead {
+    pub fn new(
+        is_runahead_dynamic: bool,
+        min_possible_latency: SimulationTime,
+        min_runahead_config: Option<SimulationTime>,
+    ) -> Self {
+        assert!(!min_possible_latency.is_zero());
+
+        Self {
+            min_used_latency: RwLock::new(None),
+            min_possible_latency,
+            min_runahead_config,
+            is_runahead_dynamic,
+        }
+    }
+
+    /// Get the runahead for the next round.
+    pub fn get(&self) -> SimulationTime {
+        // If the 'min_used_latency' is None, we haven't yet been given a latency value to base our
+        // runahead off of (or dynamic runahead is disabled). We use the smallest possible latency
+        // to start.
+        let runahead = self
+            .min_used_latency
+            .read()
+            .unwrap()
+            .unwrap_or(self.min_possible_latency);
+
+        // the 'runahead' config option sets a lower bound for the runahead
+        let runahead_config = self.min_runahead_config.unwrap_or(SimulationTime::ZERO);
+        std::cmp::max(runahead, runahead_config)
+    }
+
+    /// If dynamic runahead is enabled, will compare and update the stored lowest packet latency.
+    /// This may shorten the runahead for future rounds.
+    pub fn update_lowest_used_latency(&self, latency: SimulationTime) {
+        assert!(latency > SimulationTime::ZERO);
+
+        // if dynamic runahead is disabled, we don't update 'min_used_latency'
+        if !self.is_runahead_dynamic {
+            return;
+        }
+
+        // helper function for checking if we should update the min_used_latency
+        let should_update = |min_used_latency: &Option<SimulationTime>| {
+            if let Some(min_used_latency) = min_used_latency {
+                if latency >= *min_used_latency {
+                    return false;
+                }
+            }
+            // true if runahead was never set before, or new latency is smaller than the old latency
+            true
+        };
+
+        // an initial check with only a read lock
+        {
+            let min_used_latency = self.min_used_latency.read().unwrap();
+
+            if !should_update(&min_used_latency) {
+                return;
+            }
+        }
+
+        let old_runahead;
+        let min_runahead_config;
+
+        // check the same condition again, but with a write lock
+        {
+            let mut min_used_latency = self.min_used_latency.write().unwrap();
+
+            if !should_update(&min_used_latency) {
+                return;
+            }
+
+            // cache the values for logging
+            old_runahead = *min_used_latency;
+            min_runahead_config = self.min_runahead_config;
+
+            // update the min runahead
+            *min_used_latency = Some(latency);
+        }
+
+        // these info messages may appear out-of-order in the log
+        log::info!(
+            "Minimum time runahead for next scheduling round updated from {:?} \
+             to {} ns; the minimum config override is {:?} ns",
+            old_runahead.map(|x| x.as_nanos()),
+            latency.as_nanos(),
+            min_runahead_config.map(|x| x.as_nanos())
+        );
+    }
+}

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -131,18 +131,16 @@ static void _scheduler_finishTaskFn(void* voidScheduler) {
     worker_finish(myHosts, scheduler->endTime);
 }
 
-Scheduler* scheduler_new(const Controller* controller, const ChildPidWatcher* pidWatcher,
-                         const ConfigOptions* config, guint nWorkers, guint schedulerSeed,
-                         SimulationTime endTime) {
+Scheduler* scheduler_new(const ChildPidWatcher* pidWatcher, const ConfigOptions* config,
+                         guint nWorkers, guint schedulerSeed, SimulationTime endTime) {
     Scheduler* scheduler = g_new0(Scheduler, 1);
     MAGIC_INIT(scheduler);
 
     /* global lock */
     g_mutex_init(&(scheduler->globalLock));
 
-    scheduler->workerPool =
-        workerpool_new(controller, pidWatcher, scheduler, config, /*nThreads=*/nWorkers,
-                       /*nParallel=*/_parallelism);
+    scheduler->workerPool = workerpool_new(pidWatcher, scheduler, config, /*nThreads=*/nWorkers,
+                                           /*nParallel=*/_parallelism);
 
     scheduler->endTime = endTime;
     scheduler->currentRound.endTime = scheduler->endTime;// default to one single round

--- a/src/main/core/scheduler/scheduler.h
+++ b/src/main/core/scheduler/scheduler.h
@@ -15,9 +15,8 @@ typedef struct _Scheduler Scheduler;
 #include "main/core/support/definitions.h"
 #include "main/host/host.h"
 
-Scheduler* scheduler_new(const Controller* controller, const ChildPidWatcher* pidWatcher,
-                         const ConfigOptions* config, guint nWorkers, guint schedulerSeed,
-                         SimulationTime endTime);
+Scheduler* scheduler_new(const ChildPidWatcher* pidWatcher, const ConfigOptions* config,
+                         guint nWorkers, guint schedulerSeed, SimulationTime endTime);
 void scheduler_free(Scheduler*);
 void scheduler_shutdown(Scheduler* scheduler);
 

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -34,9 +34,8 @@ void worker_finish(GQueue* hosts, SimulationTime time);
 
 // Create a workerpool with `nThreads` threads, allowing up to `nConcurrent` to
 // run at a time.
-WorkerPool* workerpool_new(const Controller* controller, const ChildPidWatcher* pidWatcher,
-                           Scheduler* scheduler, const ConfigOptions* config, int nWorkers,
-                           int nParallel);
+WorkerPool* workerpool_new(const ChildPidWatcher* pidWatcher, Scheduler* scheduler,
+                           const ConfigOptions* config, int nWorkers, int nParallel);
 
 // Begin executing taskFn(data) on each worker thread in the pool.
 void workerpool_startTaskFn(WorkerPool* pool, WorkerPoolTaskFn taskFn,
@@ -88,8 +87,6 @@ SimulationTime worker_getCurrentSimulationTime();
 EmulatedTime worker_getCurrentEmulatedTime();
 
 bool worker_isBootstrapActive(void);
-
-void workerpool_updateMinHostRunahead(WorkerPool* pool, SimulationTime time);
 
 void worker_clearCurrentTime();
 void worker_setCurrentEmulatedTime(EmulatedTime time);


### PR DESCRIPTION
This is the last part of the controller that is accessed globally, and lets us remove the controller pointer from the global worker pool.