### PR TITLE
Protect `CountDownLatch` against spurious wakeups

### DIFF
--- a/src/main/utility/count_down_latch.c
+++ b/src/main/utility/count_down_latch.c
@@ -60,7 +60,9 @@ void countdownlatch_countDownAwait(CountDownLatch* latch) {
     if(latch->count == 0) {
         g_cond_broadcast(&(latch->waiters));
     } else {
-        g_cond_wait(&(latch->waiters), &(latch->lock));
+        while (latch->count > 0) {
+            g_cond_wait(&(latch->waiters), &(latch->lock));
+        }
     }
     g_mutex_unlock(&(latch->lock));
 }


### PR DESCRIPTION
From the documentation:

> When using condition variables, it is possible that a spurious wakeup may occur (ie: g_cond_wait() returns even though g_cond_signal() was not called). It’s also possible that a stolen wakeup may occur. [...] For this reason, g_cond_wait() must always be used in a loop.