### PR TITLE
Emulate PR_SET_DUMPABLE and misc improvements

### DIFF
--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -2051,6 +2051,12 @@ extern "C" {
 extern "C" {
     pub fn process_getRealtimeTimer(process: *mut Process) -> *mut Timer;
 }
+extern "C" {
+    pub fn process_getDumpable(process: *mut Process) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn process_setDumpable(process: *mut Process, dumpable: ::std::os::raw::c_int);
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _Tsc {

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -152,6 +152,11 @@ struct _Process {
      */
     Timer* itimerReal;
 
+    /* "dumpable" state, as manipulated via the prctl operations PR_SET_DUMPABLE
+     * and PR_GET_DUMPABLE.
+     */
+    int dumpable;
+
     /* Pause shadow after launching this process, to give the user time to attach gdb */
     bool pause_for_debugging;
 
@@ -894,6 +899,8 @@ Process* process_new(Host* host, guint processID, SimulationTime startTime, Simu
 
     proc->pause_for_debugging = pause_for_debugging;
 
+    proc->dumpable = SUID_DUMP_USER;
+
     process_ref(proc);
     TaskRef* task = taskref_new_bound(
         host_getID(host), _process_itimer_real_expiration, proc, NULL, _unref_process_cb, NULL);
@@ -1308,4 +1315,13 @@ void process_signal(Process* process, Thread* currentRunningThread, const siginf
 Timer* process_getRealtimeTimer(Process* process) {
     MAGIC_ASSERT(process);
     return process->itimerReal;
+}
+
+int process_getDumpable(Process* process) {
+    return process->dumpable;
+}
+
+void process_setDumpable(Process* process, int dumpable) {
+    utility_alwaysAssert(dumpable == SUID_DUMP_DISABLE || dumpable == SUID_DUMP_USER);
+    process->dumpable = dumpable;
 }

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -190,4 +190,9 @@ void process_signal(Process* process, Thread* currentRunningThread, const siginf
 // Access the process's realtime timer; e.g. corresponding to ITIMER_REAL.
 Timer* process_getRealtimeTimer(Process* process);
 
+// Process's "dumpable" state, as manipulated by the prctl operations
+// PR_SET_DUMPABLE and PR_GET_DUMPABLE.
+int process_getDumpable(Process* process);
+void process_setDumpable(Process* process, int dumpable);
+
 #endif /* SHD_PROCESS_H_ */

--- a/src/main/host/syscall/kernel_types.h
+++ b/src/main/host/syscall/kernel_types.h
@@ -19,11 +19,20 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
 #include "shd-config.h"
+
+#ifndef SUID_DUMP_DISABLE
+#define SUID_DUMP_DISABLE 0
+#endif
+
+#ifndef SUID_DUMP_USER
+#define SUID_DUMP_USER 1
+#endif
 
 #if HAVE_STRUCT_LINUX_DIRENT == 0
 struct linux_dirent {

--- a/src/main/host/syscall/process.c
+++ b/src/main/host/syscall/process.c
@@ -39,32 +39,92 @@ SysCallReturn syscallhandler_prctl(SysCallHandler* sys, const SysCallArgs* args)
     utility_debugAssert(sys && args);
 
     int option = args->args[0].as_i64;
-    trace("prctl called with option %i", option);
 
-    if (option == PR_GET_TID_ADDRESS) {
-        PluginVirtualPtr tid_addr = thread_getTidAddress(sys->thread);
+    switch (option) {
+        case PR_CAP_AMBIENT:
+        case PR_CAPBSET_READ:
+        case PR_CAPBSET_DROP:
+        case PR_SET_CHILD_SUBREAPER:
+        case PR_GET_CHILD_SUBREAPER:
+        case PR_SET_ENDIAN:
+        case PR_GET_ENDIAN:
+        case PR_SET_FP_MODE:
+        case PR_GET_FP_MODE:
+        case PR_SET_FPEMU:
+        case PR_GET_FPEMU:
+        case PR_SET_FPEXC:
+        case PR_GET_FPEXC:
+        case PR_SET_KEEPCAPS:
+        case PR_GET_KEEPCAPS:
+        case PR_MCE_KILL:
+        case PR_MCE_KILL_GET:
+        case PR_MPX_ENABLE_MANAGEMENT:
+        case PR_MPX_DISABLE_MANAGEMENT:
+        case PR_SET_NAME:
+        case PR_GET_NAME:
+        case PR_SET_NO_NEW_PRIVS:
+        case PR_GET_NO_NEW_PRIVS:
+        case PR_SET_MM:
+        case PR_SET_PTRACER:
+        case PR_SET_SECCOMP:
+        case PR_GET_SECCOMP:
+        case PR_SET_SECUREBITS:
+        case PR_GET_SECUREBITS:
+        case PR_GET_SPECULATION_CTRL:
+        case PR_SET_THP_DISABLE:
+        case PR_TASK_PERF_EVENTS_DISABLE:
+        case PR_TASK_PERF_EVENTS_ENABLE:
+        case PR_GET_THP_DISABLE:
+        case PR_GET_TIMERSLACK:
+        case PR_SET_TIMING:
+        case PR_GET_TIMING:
+        case PR_GET_TSC:
+        case PR_GET_UNALIGN:
+            trace("prctl %i executing natively", option);
+            return syscallreturn_makeNative();
+        // Needs emulation to have the desired effect, but also N/A on x86_64.
+        case PR_SET_UNALIGN:
+        // Executing natively could interfere with shadow's interception of
+        // rdtsc. Needs emulation.
+        case PR_SET_TSC:
+        // Executing natively wouldn't directly hurt anything, but wouldn't
+        // have the desired effect.
+        case PR_SET_TIMERSLACK:
+        // Wouldn't actually hurt correctness, but could significantly hurt
+        // performance.
+        case PR_SET_SPECULATION_CTRL:
+        // We use this signal to ensure managed processes die when Shadow does.
+        // Allowing the process to override it could end up allowing orphaned
+        // managed processes to live on after shadow exits.
+        case PR_SET_PDEATHSIG:
+            warning("Not allowing unimplemented prctl %d", option);
+            return syscallreturn_makeDoneErrno(ENOSYS);
+        case PR_GET_TID_ADDRESS: {
+            PluginVirtualPtr tid_addr = thread_getTidAddress(sys->thread);
 
-        // Make sure we have somewhere to copy the output
-        PluginPtr outptr = args->args[1].as_ptr;
-        int res = process_writePtr(sys->process, outptr, &tid_addr.val, sizeof(tid_addr.val));
-        if (res) {
-            return syscallreturn_makeDoneErrno(-res);
+            // Make sure we have somewhere to copy the output
+            PluginPtr outptr = args->args[1].as_ptr;
+            int res = process_writePtr(sys->process, outptr, &tid_addr.val, sizeof(tid_addr.val));
+            if (res) {
+                return syscallreturn_makeDoneErrno(-res);
+            }
+            return syscallreturn_makeDoneU64(0);
         }
-        return syscallreturn_makeDoneU64(0);
-    } else if (option == PR_SET_DUMPABLE) {
-        int arg = args->args[1].as_i64;
-        switch (arg) {
-            case SUID_DUMP_DISABLE:
-            case SUID_DUMP_USER:
-                process_setDumpable(sys->process, arg);
-                return syscallreturn_makeDoneU64(0);
-        };
-        return syscallreturn_makeDoneErrno(EINVAL);
-    } else if (option == PR_GET_DUMPABLE) {
-        return syscallreturn_makeDoneI64(process_getDumpable(sys->process));
-    } else {
-        return syscallreturn_makeNative();
+        case PR_SET_DUMPABLE: {
+            int arg = args->args[1].as_i64;
+            switch (arg) {
+                case SUID_DUMP_DISABLE:
+                case SUID_DUMP_USER:
+                    process_setDumpable(sys->process, arg);
+                    return syscallreturn_makeDoneU64(0);
+            };
+            return syscallreturn_makeDoneErrno(EINVAL);
+        }
+        case PR_GET_DUMPABLE: return syscallreturn_makeDoneI64(process_getDumpable(sys->process));
     }
+
+    warning("Unknown prctl operation %d", option);
+    return syscallreturn_makeDoneErrno(EINVAL);
 }
 
 SysCallReturn syscallhandler_prlimit(SysCallHandler* sys, const SysCallArgs* args) {

--- a/src/main/host/syscall/process.c
+++ b/src/main/host/syscall/process.c
@@ -51,6 +51,17 @@ SysCallReturn syscallhandler_prctl(SysCallHandler* sys, const SysCallArgs* args)
             return syscallreturn_makeDoneErrno(-res);
         }
         return syscallreturn_makeDoneU64(0);
+    } else if (option == PR_SET_DUMPABLE) {
+        int arg = args->args[1].as_i64;
+        switch (arg) {
+            case SUID_DUMP_DISABLE:
+            case SUID_DUMP_USER:
+                process_setDumpable(sys->process, arg);
+                return syscallreturn_makeDoneU64(0);
+        };
+        return syscallreturn_makeDoneErrno(EINVAL);
+    } else if (option == PR_GET_DUMPABLE) {
+        return syscallreturn_makeDoneI64(process_getDumpable(sys->process));
     } else {
         return syscallreturn_makeNative();
     }

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -491,6 +491,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
             NATIVE(geteuid);
             NATIVE(getegid);
             NATIVE(getgid);
+            NATIVE(getgroups);
             NATIVE(getresgid);
             NATIVE(getresuid);
             NATIVE(getrlimit);

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -244,7 +244,7 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number,
 #define UNSUPPORTED(s)                                                                             \
     case SYS_##s:                                                                                  \
         error("Returning error ENOSYS for explicitly unsupported syscall %ld " #s, args->number);  \
-        scr = syscallreturn_makeErrno(ENOSYS);                                                     \
+        scr = syscallreturn_makeDoneErrno(ENOSYS);                                                 \
         if (straceLoggingMode != STRACE_FMT_MODE_OFF) {                                            \
             scr = log_syscall(                                                                     \
                 sys->process, straceLoggingMode, thread_getID(sys->thread), #s, "...", scr);       \
@@ -532,6 +532,15 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
             NATIVE(unlink);
             NATIVE(utime);
             NATIVE(utimes);
+
+            // ***************************************
+            // Syscalls that aren't implemented yet. Listing them here gives the same behavior
+            // as the default case (returning ENOSYS), but allows the logging to include the
+            // syscall name instead of just the number.
+            // ***************************************
+
+            UNSUPPORTED(sched_getaffinity);
+            UNSUPPORTED(sched_setaffinity);
 
             default: {
                 warning(


### PR DESCRIPTION
This is primarily to fix https://github.com/shadow/shadow/issues/2368

* Emulate PR_SET_DUMPABLE instead of allowing it to execute natively, which interferes with Shadow's ability to access managed process memory.

Some other minor improvements:

* Return an error for some other prctl operations that would interfere with Shadow
* Add explicit cases for all known prctl operations, and return errors for any others.
* Enable the getgroups syscall to just execute natively.
* Add explicit cases for the unimplemented sched_getaffinity and sched_setaffinity syscalls, so that the logged warnings give the syscall names instead of just the numbers.
* Fix clock_gettime and futex syscalls to handle the cases where a bad user pointer is provided.