### PR TITLE
workflows: Replace usage of ubuntu 18.04 image with 20.04

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
     # use the oldest kernel supported by github's CI (make sure to update the
     # minimum supported kernel version in documentation when changing)
     # https://github.com/actions/virtual-environments
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
       image: 'ubuntu:22.04'
       # the default shm-size for ubuntu:18.04, but with the size increased from

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
     # use the oldest kernel supported by github's CI (make sure to update the
     # minimum supported kernel version in documentation when changing)
     # https://github.com/actions/virtual-environments
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,7 +24,7 @@ jobs:
         vm:
           # Oldest-available kernel from
           # https://github.com/actions/virtual-environments
-          - ubuntu-18.04
+          - ubuntu-20.04
         container:
           # End of standard support: April 2023 https://wiki.ubuntu.com/Releases
           - 'ubuntu:18.04'

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -69,7 +69,9 @@ jobs:
             container: 'ubuntu:22.04'
             cc: 'clang'
             buildtype: 'debug'
-    runs-on: ${{ matrix.vm }}
+    # Map "oldest" and "newest" to oldest and newest images currently available.
+    # https://github.com/actions/virtual-environments
+    runs-on: ${{ fromJSON('{"oldest": "ubuntu-20.04", "newest": "ubuntu-22.04"}')[ matrix.vm ] }}
     container:
       image: ${{ matrix.container }}
       # the default shm-size for ubuntu:18.04, but with the size increased from

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -69,9 +69,7 @@ jobs:
             container: 'ubuntu:22.04'
             cc: 'clang'
             buildtype: 'debug'
-    # Map "oldest" and "newest" to oldest and newest images currently available.
-    # https://github.com/actions/virtual-environments
-    runs-on: ${{ fromJSON('{"oldest": "ubuntu-20.04", "newest": "ubuntu-22.04"}')[ matrix.vm ] }}
+    runs-on: ${{ matrix.vm }}
     container:
       image: ${{ matrix.container }}
       # the default shm-size for ubuntu:18.04, but with the size increased from

--- a/.github/workflows/run_tests_incremental.yml
+++ b/.github/workflows/run_tests_incremental.yml
@@ -29,7 +29,9 @@ jobs:
     strategy:
       matrix:
         vm:
-          - oldest
+          # Oldest-available kernel from
+          # https://github.com/actions/virtual-environments
+          - ubuntu-20.04
         container:
           # End of standard support: April 2023 https://wiki.ubuntu.com/Releases
           - 'ubuntu:18.04'
@@ -51,11 +53,11 @@ jobs:
         include:
           # Run some tests on the newest-available base vm, and hence
           # newest-available kernel. https://github.com/actions/virtual-environments
-          - vm: newest
+          - vm: 'ubuntu-22.04'
             container: 'ubuntu:22.04'
             cc: 'gcc'
             buildtype: 'release'
-          - vm: newest
+          - vm: 'ubuntu-22.04'
             container: 'ubuntu:22.04'
             cc: 'gcc'
             buildtype: 'debug'
@@ -66,17 +68,15 @@ jobs:
           # clang's most recent diagnostics and optimizations.
           #
           # Also use the more-recent kernel here.
-          - vm: newest
+          - vm: 'ubuntu-22.04'
             container: 'ubuntu:22.04'
             cc: 'clang'
             buildtype: 'release'
-          - vm: newest
+          - vm: 'ubuntu-22.04'
             container: 'ubuntu:22.04'
             cc: 'clang'
             buildtype: 'debug'
-    # Map "oldest" and "newest" to oldest and newest images currently available.
-    # https://github.com/actions/virtual-environments
-    runs-on: ${{ fromJSON('{"oldest": "ubuntu-20.04", "newest": "ubuntu-22.04"}')[ matrix.vm ] }}
+    runs-on: ${{ matrix.vm }}
 
     env:
       # Assign these to env variables rather than using directly inline, to help

--- a/.github/workflows/run_tests_incremental.yml
+++ b/.github/workflows/run_tests_incremental.yml
@@ -31,7 +31,7 @@ jobs:
         vm:
           # Oldest-available kernel from
           # https://github.com/actions/virtual-environments
-          - ubuntu-18.04
+          - ubuntu-20.04
         container:
           # End of standard support: April 2023 https://wiki.ubuntu.com/Releases
           - 'ubuntu:18.04'

--- a/.github/workflows/run_tests_incremental.yml
+++ b/.github/workflows/run_tests_incremental.yml
@@ -29,9 +29,7 @@ jobs:
     strategy:
       matrix:
         vm:
-          # Oldest-available kernel from
-          # https://github.com/actions/virtual-environments
-          - ubuntu-20.04
+          - oldest
         container:
           # End of standard support: April 2023 https://wiki.ubuntu.com/Releases
           - 'ubuntu:18.04'
@@ -53,11 +51,11 @@ jobs:
         include:
           # Run some tests on the newest-available base vm, and hence
           # newest-available kernel. https://github.com/actions/virtual-environments
-          - vm: 'ubuntu-22.04'
+          - vm: newest
             container: 'ubuntu:22.04'
             cc: 'gcc'
             buildtype: 'release'
-          - vm: 'ubuntu-22.04'
+          - vm: newest
             container: 'ubuntu:22.04'
             cc: 'gcc'
             buildtype: 'debug'
@@ -68,15 +66,17 @@ jobs:
           # clang's most recent diagnostics and optimizations.
           #
           # Also use the more-recent kernel here.
-          - vm: 'ubuntu-22.04'
+          - vm: newest
             container: 'ubuntu:22.04'
             cc: 'clang'
             buildtype: 'release'
-          - vm: 'ubuntu-22.04'
+          - vm: newest
             container: 'ubuntu:22.04'
             cc: 'clang'
             buildtype: 'debug'
-    runs-on: ${{ matrix.vm }}
+    # Map "oldest" and "newest" to oldest and newest images currently available.
+    # https://github.com/actions/virtual-environments
+    runs-on: ${{ fromJSON('{"oldest": "ubuntu-20.04", "newest": "ubuntu-22.04"}')[ matrix.vm ] }}
 
     env:
       # Assign these to env variables rather than using directly inline, to help

--- a/.github/workflows/run_tor.yml
+++ b/.github/workflows/run_tor.yml
@@ -22,7 +22,7 @@ jobs:
     # use the oldest kernel supported by github's CI (make sure to update the
     # minimum supported kernel version in documentation when changing)
     # https://github.com/actions/virtual-environments
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     container:
       image: ${{ matrix.container }}


### PR DESCRIPTION
The 18.04 VM image is now deprecated.
https://github.com/actions/runner-images/issues/6002