### PR TITLE
Move more global state to the worker module

### DIFF
--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -508,6 +508,9 @@ void worker_incrementPacketCount(in_addr_t src, in_addr_t dst);
 
 void worker_incrementPluginErrors(void);
 
+// SAFETY: The returned pointer must not be accessed after this worker thread has exited.
+const struct ChildPidWatcher *worker_getChildPidWatcher(void);
+
 // Takes ownership of the event.
 void worker_pushToHost(HostId host, struct Event *event);
 

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -556,6 +556,8 @@ void worker_updateLowestUsedLatency(SimulationTime min_path_latency);
 
 bool worker_isBootstrapActive(void);
 
+bool worker_isSimCompleted(void);
+
 WorkerPool *_worker_pool(void);
 
 bool worker_isAlive(void);

--- a/src/main/bindings/c/bindings.h
+++ b/src/main/bindings/c/bindings.h
@@ -508,6 +508,9 @@ void worker_incrementPacketCount(in_addr_t src, in_addr_t dst);
 
 void worker_incrementPluginErrors(void);
 
+// Takes ownership of the event.
+void worker_pushToHost(HostId host, struct Event *event);
+
 // Initialize a Worker for this thread.
 void worker_newForThisThread(WorkerPool *worker_pool, int32_t worker_id);
 

--- a/src/main/bindings/rust/CMakeLists.txt
+++ b/src/main/bindings/rust/CMakeLists.txt
@@ -49,7 +49,6 @@ add_custom_command(OUTPUT wrapper.rs
         --whitelist-function "host_.*"
         # Needs CompatSocket
         --blacklist-function "host_.*Interface"
-        --blacklist-function "host_getOwnedEventQueue"
 
         # used by shadow's main function
         --whitelist-function "main_.*"
@@ -155,6 +154,7 @@ add_custom_command(OUTPUT wrapper.rs
         --raw-line "use crate::core::support::configuration::ConfigOptions;"
         --raw-line "use crate::core::support::configuration::QDiscMode;"
         --raw-line "use crate::core::work::event::Event;"
+        --raw-line "use crate::core::work::event_queue::ThreadSafeEventQueue;"
         --raw-line "use crate::core::work::task::TaskRef;"
         --raw-line "use crate::utility::childpid_watcher::ChildPidWatcher;"
         --raw-line "use crate::utility::counter::Counter;"

--- a/src/main/bindings/rust/wrapper.h
+++ b/src/main/bindings/rust/wrapper.h
@@ -7,6 +7,7 @@
 
 #include "main/core/logger/log_wrapper.h"
 #include "main/core/main.h"
+#include "main/core/scheduler/scheduler.h"
 #include "main/core/support/config_handlers.h"
 #include "main/core/worker.h"
 #include "main/host/affinity.h"
@@ -17,8 +18,8 @@
 #include "main/host/status_listener.h"
 #include "main/host/syscall/fcntl.h"
 #include "main/host/syscall/ioctl.h"
-#include "main/host/syscall/unistd.h"
 #include "main/host/syscall/socket.h"
+#include "main/host/syscall/unistd.h"
 #include "main/host/syscall_condition.h"
 #include "main/host/syscall_types.h"
 #include "main/host/thread.h"

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1829,9 +1829,6 @@ extern "C" {
     pub fn worker_getAffinity() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn worker_getChildPidWatcher() -> *const ChildPidWatcher;
-}
-extern "C" {
     pub fn worker_getConfig() -> *const ConfigOptions;
 }
 extern "C" {
@@ -3056,7 +3053,6 @@ extern "C" {
 }
 extern "C" {
     pub fn scheduler_new(
-        pidWatcher: *const ChildPidWatcher,
         config: *const ConfigOptions,
         nWorkers: guint,
         schedulerSeed: guint,

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -11,6 +11,7 @@ use crate::core::controller::Controller;
 use crate::core::support::configuration::ConfigOptions;
 use crate::core::support::configuration::QDiscMode;
 use crate::core::work::event::Event;
+use crate::core::work::event_queue::ThreadSafeEventQueue;
 use crate::core::work::task::TaskRef;
 use crate::utility::childpid_watcher::ChildPidWatcher;
 use crate::utility::counter::Counter;
@@ -2815,6 +2816,9 @@ extern "C" {
 }
 extern "C" {
     pub fn host_nextEventTime(host: *mut Host) -> EmulatedTime;
+}
+extern "C" {
+    pub fn host_getOwnedEventQueue(host: *mut Host) -> *const ThreadSafeEventQueue;
 }
 extern "C" {
     pub fn host_lock(host: *mut Host);

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -1829,9 +1829,6 @@ extern "C" {
     pub fn worker_getAffinity() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn worker_getConfig() -> *const ConfigOptions;
-}
-extern "C" {
     pub fn worker_scheduleTaskWithDelay(
         task: *mut TaskRef,
         host: *mut Host,
@@ -3053,7 +3050,6 @@ extern "C" {
 }
 extern "C" {
     pub fn scheduler_new(
-        config: *const ConfigOptions,
         nWorkers: guint,
         schedulerSeed: guint,
         endTime: SimulationTime,

--- a/src/main/bindings/rust/wrapper.rs
+++ b/src/main/bindings/rust/wrapper.rs
@@ -101,9 +101,6 @@ extern "C" {
 extern "C" {
     pub fn main_logBuildInfo();
 }
-extern "C" {
-    pub fn runConfigHandlers(config: *const ConfigOptions);
-}
 pub type guint32 = ::std::os::raw::c_uint;
 pub type guint64 = ::std::os::raw::c_ulong;
 pub type gssize = ::std::os::raw::c_long;
@@ -1134,11 +1131,10 @@ pub struct _GTimer {
     _unused: [u8; 0],
 }
 pub type GTimer = _GTimer;
+pub type Scheduler = u8;
 pub type sa_family_t = ::std::os::raw::c_ushort;
 pub type in_addr_t = u32;
 pub type in_port_t = u16;
-pub type WorkerPool = u8;
-pub type Scheduler = u8;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _Host {
@@ -1660,51 +1656,14 @@ pub type SimulationTime = guint64;
 #[doc = " plus the EMULATION_TIME_OFFSET. This type allows us to explicitly"]
 #[doc = " distinguish each type of time in the code.,"]
 pub type EmulatedTime = guint64;
-pub type LegacyFile = [u64; 5usize];
-pub use self::_Status as Status;
-pub const _Status_STATUS_NONE: _Status = 0;
-pub const _Status_STATUS_FILE_ACTIVE: _Status = 1;
-pub const _Status_STATUS_FILE_READABLE: _Status = 2;
-pub const _Status_STATUS_FILE_WRITABLE: _Status = 4;
-pub const _Status_STATUS_FILE_CLOSED: _Status = 8;
-pub const _Status_STATUS_FUTEX_WAKEUP: _Status = 16;
-pub const _Status_STATUS_SOCKET_ALLOWING_CONNECT: _Status = 32;
-pub type _Status = i32;
-extern "C" {
-    pub fn return_code_for_signal(signal: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-pub type LegacyFileCloseFunc =
-    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyFile, host: *mut Host)>;
-pub type LegacyFileCleanupFunc =
-    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyFile)>;
-pub type LegacyFileFreeFunc =
-    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyFile)>;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _StatusListener {
-    _unused: [u8; 0],
-}
-pub type StatusListener = _StatusListener;
-extern "C" {
-    pub fn statuslistener_ref(listener: *mut StatusListener);
-}
-extern "C" {
-    pub fn statuslistener_unref(listener: *mut StatusListener);
-}
-extern "C" {
-    pub fn statuslistener_onStatusChanged(
-        listener: *mut StatusListener,
-        currentStatus: Status,
-        transitions: Status,
-    );
-}
-pub type SysCallHandler = _SysCallHandler;
+pub type WorkerPool = u8;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _Thread {
     _unused: [u8; 0],
 }
 pub type Thread = _Thread;
+pub type SysCallHandler = _SysCallHandler;
 extern "C" {
     pub fn thread_new(
         host: *mut Host,
@@ -1813,18 +1772,6 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _Tracker {
-    _unused: [u8; 0],
-}
-pub type Tracker = _Tracker;
-pub use self::_LogInfoFlags as LogInfoFlags;
-pub const _LogInfoFlags_LOG_INFO_FLAGS_NONE: _LogInfoFlags = 0;
-pub const _LogInfoFlags_LOG_INFO_FLAGS_NODE: _LogInfoFlags = 1;
-pub const _LogInfoFlags_LOG_INFO_FLAGS_SOCKET: _LogInfoFlags = 2;
-pub const _LogInfoFlags_LOG_INFO_FLAGS_RAM: _LogInfoFlags = 4;
-pub type _LogInfoFlags = i32;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct _Address {
     _unused: [u8; 0],
 }
@@ -1872,6 +1819,118 @@ pub struct _Packet {
 }
 pub type Packet = _Packet;
 pub type PacketTCPHeader = _PacketTCPHeader;
+extern "C" {
+    pub fn worker_setMinEventTimeNextRound(simtime: SimulationTime);
+}
+extern "C" {
+    pub fn worker_setRoundEndTime(newRoundEndTime: SimulationTime);
+}
+extern "C" {
+    pub fn worker_getAffinity() -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn worker_getChildPidWatcher() -> *const ChildPidWatcher;
+}
+extern "C" {
+    pub fn worker_getConfig() -> *const ConfigOptions;
+}
+extern "C" {
+    pub fn worker_scheduleTaskWithDelay(
+        task: *mut TaskRef,
+        host: *mut Host,
+        nanoDelay: SimulationTime,
+    ) -> gboolean;
+}
+extern "C" {
+    pub fn worker_scheduleTaskAtEmulatedTime(
+        task: *mut TaskRef,
+        host: *mut Host,
+        t: EmulatedTime,
+    ) -> gboolean;
+}
+extern "C" {
+    pub fn worker_sendPacket(src: *mut Host, packet: *mut Packet);
+}
+extern "C" {
+    pub fn worker_isAlive() -> bool;
+}
+extern "C" {
+    pub fn worker_maxEventRunaheadTime(host: *mut Host) -> EmulatedTime;
+}
+extern "C" {
+    pub fn worker_getCurrentSimulationTime() -> SimulationTime;
+}
+extern "C" {
+    pub fn worker_getCurrentEmulatedTime() -> EmulatedTime;
+}
+extern "C" {
+    pub fn worker_isBootstrapActive() -> bool;
+}
+extern "C" {
+    pub fn worker_clearCurrentTime();
+}
+extern "C" {
+    pub fn worker_setCurrentEmulatedTime(time: EmulatedTime);
+}
+extern "C" {
+    pub fn worker_isFiltered(level: LogLevel) -> gboolean;
+}
+extern "C" {
+    pub fn worker_resolveIPToAddress(ip: in_addr_t) -> *mut Address;
+}
+extern "C" {
+    pub fn worker_resolveNameToAddress(name: *const gchar) -> *mut Address;
+}
+pub type LegacyFile = [u64; 5usize];
+pub use self::_Status as Status;
+pub const _Status_STATUS_NONE: _Status = 0;
+pub const _Status_STATUS_FILE_ACTIVE: _Status = 1;
+pub const _Status_STATUS_FILE_READABLE: _Status = 2;
+pub const _Status_STATUS_FILE_WRITABLE: _Status = 4;
+pub const _Status_STATUS_FILE_CLOSED: _Status = 8;
+pub const _Status_STATUS_FUTEX_WAKEUP: _Status = 16;
+pub const _Status_STATUS_SOCKET_ALLOWING_CONNECT: _Status = 32;
+pub type _Status = i32;
+extern "C" {
+    pub fn return_code_for_signal(signal: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+pub type LegacyFileCloseFunc =
+    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyFile, host: *mut Host)>;
+pub type LegacyFileCleanupFunc =
+    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyFile)>;
+pub type LegacyFileFreeFunc =
+    ::std::option::Option<unsafe extern "C" fn(descriptor: *mut LegacyFile)>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _StatusListener {
+    _unused: [u8; 0],
+}
+pub type StatusListener = _StatusListener;
+extern "C" {
+    pub fn statuslistener_ref(listener: *mut StatusListener);
+}
+extern "C" {
+    pub fn statuslistener_unref(listener: *mut StatusListener);
+}
+extern "C" {
+    pub fn statuslistener_onStatusChanged(
+        listener: *mut StatusListener,
+        currentStatus: Status,
+        transitions: Status,
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _Tracker {
+    _unused: [u8; 0],
+}
+pub type Tracker = _Tracker;
+pub use self::_LogInfoFlags as LogInfoFlags;
+pub const _LogInfoFlags_LOG_INFO_FLAGS_NONE: _LogInfoFlags = 0;
+pub const _LogInfoFlags_LOG_INFO_FLAGS_NODE: _LogInfoFlags = 1;
+pub const _LogInfoFlags_LOG_INFO_FLAGS_SOCKET: _LogInfoFlags = 2;
+pub const _LogInfoFlags_LOG_INFO_FLAGS_RAM: _LogInfoFlags = 4;
+pub type _LogInfoFlags = i32;
 extern "C" {
     pub fn process_new(
         host: *mut Host,
@@ -3030,66 +3089,7 @@ extern "C" {
     pub fn scheduler_addHost(arg1: *mut Scheduler, arg2: *mut Host) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn worker_setMinEventTimeNextRound(simtime: SimulationTime);
-}
-extern "C" {
-    pub fn worker_setRoundEndTime(newRoundEndTime: SimulationTime);
-}
-extern "C" {
-    pub fn worker_getAffinity() -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn worker_getChildPidWatcher() -> *const ChildPidWatcher;
-}
-extern "C" {
-    pub fn worker_getConfig() -> *const ConfigOptions;
-}
-extern "C" {
-    pub fn worker_scheduleTaskWithDelay(
-        task: *mut TaskRef,
-        host: *mut Host,
-        nanoDelay: SimulationTime,
-    ) -> gboolean;
-}
-extern "C" {
-    pub fn worker_scheduleTaskAtEmulatedTime(
-        task: *mut TaskRef,
-        host: *mut Host,
-        t: EmulatedTime,
-    ) -> gboolean;
-}
-extern "C" {
-    pub fn worker_sendPacket(src: *mut Host, packet: *mut Packet);
-}
-extern "C" {
-    pub fn worker_isAlive() -> bool;
-}
-extern "C" {
-    pub fn worker_maxEventRunaheadTime(host: *mut Host) -> EmulatedTime;
-}
-extern "C" {
-    pub fn worker_getCurrentSimulationTime() -> SimulationTime;
-}
-extern "C" {
-    pub fn worker_getCurrentEmulatedTime() -> EmulatedTime;
-}
-extern "C" {
-    pub fn worker_isBootstrapActive() -> bool;
-}
-extern "C" {
-    pub fn worker_clearCurrentTime();
-}
-extern "C" {
-    pub fn worker_setCurrentEmulatedTime(time: EmulatedTime);
-}
-extern "C" {
-    pub fn worker_isFiltered(level: LogLevel) -> gboolean;
-}
-extern "C" {
-    pub fn worker_resolveIPToAddress(ip: in_addr_t) -> *mut Address;
-}
-extern "C" {
-    pub fn worker_resolveNameToAddress(name: *const gchar) -> *mut Address;
+    pub fn runConfigHandlers(config: *const ConfigOptions);
 }
 extern "C" {
     pub fn affinity_getGoodWorkerAffinity() -> ::std::os::raw::c_int;
@@ -3410,58 +3410,6 @@ extern "C" {
     ) -> SysCallReturn;
 }
 extern "C" {
-    pub fn syscallhandler_exit_group(
-        sys: *mut SysCallHandler,
-        args: *const SysCallArgs,
-    ) -> SysCallReturn;
-}
-extern "C" {
-    pub fn syscallhandler_getpid(
-        sys: *mut SysCallHandler,
-        args: *const SysCallArgs,
-    ) -> SysCallReturn;
-}
-extern "C" {
-    pub fn syscallhandler_getppid(
-        sys: *mut SysCallHandler,
-        args: *const SysCallArgs,
-    ) -> SysCallReturn;
-}
-extern "C" {
-    pub fn syscallhandler_pread64(
-        sys: *mut SysCallHandler,
-        args: *const SysCallArgs,
-    ) -> SysCallReturn;
-}
-extern "C" {
-    pub fn syscallhandler_pwrite64(
-        sys: *mut SysCallHandler,
-        args: *const SysCallArgs,
-    ) -> SysCallReturn;
-}
-extern "C" {
-    pub fn syscallhandler_read(sys: *mut SysCallHandler, args: *const SysCallArgs)
-        -> SysCallReturn;
-}
-extern "C" {
-    pub fn syscallhandler_set_tid_address(
-        sys: *mut SysCallHandler,
-        args: *const SysCallArgs,
-    ) -> SysCallReturn;
-}
-extern "C" {
-    pub fn syscallhandler_uname(
-        sys: *mut SysCallHandler,
-        args: *const SysCallArgs,
-    ) -> SysCallReturn;
-}
-extern "C" {
-    pub fn syscallhandler_write(
-        sys: *mut SysCallHandler,
-        args: *const SysCallArgs,
-    ) -> SysCallReturn;
-}
-extern "C" {
     pub fn syscallhandler_accept(
         sys: *mut SysCallHandler,
         args: *const SysCallArgs,
@@ -3539,6 +3487,58 @@ extern "C" {
 }
 extern "C" {
     pub fn syscallhandler_socketpair(
+        sys: *mut SysCallHandler,
+        args: *const SysCallArgs,
+    ) -> SysCallReturn;
+}
+extern "C" {
+    pub fn syscallhandler_exit_group(
+        sys: *mut SysCallHandler,
+        args: *const SysCallArgs,
+    ) -> SysCallReturn;
+}
+extern "C" {
+    pub fn syscallhandler_getpid(
+        sys: *mut SysCallHandler,
+        args: *const SysCallArgs,
+    ) -> SysCallReturn;
+}
+extern "C" {
+    pub fn syscallhandler_getppid(
+        sys: *mut SysCallHandler,
+        args: *const SysCallArgs,
+    ) -> SysCallReturn;
+}
+extern "C" {
+    pub fn syscallhandler_pread64(
+        sys: *mut SysCallHandler,
+        args: *const SysCallArgs,
+    ) -> SysCallReturn;
+}
+extern "C" {
+    pub fn syscallhandler_pwrite64(
+        sys: *mut SysCallHandler,
+        args: *const SysCallArgs,
+    ) -> SysCallReturn;
+}
+extern "C" {
+    pub fn syscallhandler_read(sys: *mut SysCallHandler, args: *const SysCallArgs)
+        -> SysCallReturn;
+}
+extern "C" {
+    pub fn syscallhandler_set_tid_address(
+        sys: *mut SysCallHandler,
+        args: *const SysCallArgs,
+    ) -> SysCallReturn;
+}
+extern "C" {
+    pub fn syscallhandler_uname(
+        sys: *mut SysCallHandler,
+        args: *const SysCallArgs,
+    ) -> SysCallReturn;
+}
+extern "C" {
+    pub fn syscallhandler_write(
         sys: *mut SysCallHandler,
         args: *const SysCallArgs,
     ) -> SysCallReturn;

--- a/src/main/core/controller.rs
+++ b/src/main/core/controller.rs
@@ -92,6 +92,7 @@ impl<'a> Controller<'a> {
                     min_runahead_config,
                 ),
                 bootstrap_end_time,
+                sim_end_time: self.end_time,
             });
 
         let manager_hosts = std::mem::take(&mut sim_config.hosts);

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -132,15 +132,15 @@ static void _scheduler_finishTaskFn(void* voidScheduler) {
     worker_finish(myHosts, scheduler->endTime);
 }
 
-Scheduler* scheduler_new(const ChildPidWatcher* pidWatcher, const ConfigOptions* config,
-                         guint nWorkers, guint schedulerSeed, SimulationTime endTime) {
+Scheduler* scheduler_new(const ConfigOptions* config, guint nWorkers, guint schedulerSeed,
+                         SimulationTime endTime) {
     Scheduler* scheduler = g_new0(Scheduler, 1);
     MAGIC_INIT(scheduler);
 
     /* global lock */
     g_mutex_init(&(scheduler->globalLock));
 
-    scheduler->workerPool = workerpool_new(pidWatcher, config, /*nThreads=*/nWorkers,
+    scheduler->workerPool = workerpool_new(config, /*nThreads=*/nWorkers,
                                            /*nParallel=*/_parallelism);
 
     scheduler->endTime = endTime;

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -132,15 +132,14 @@ static void _scheduler_finishTaskFn(void* voidScheduler) {
     worker_finish(myHosts, scheduler->endTime);
 }
 
-Scheduler* scheduler_new(const ConfigOptions* config, guint nWorkers, guint schedulerSeed,
-                         SimulationTime endTime) {
+Scheduler* scheduler_new(guint nWorkers, guint schedulerSeed, SimulationTime endTime) {
     Scheduler* scheduler = g_new0(Scheduler, 1);
     MAGIC_INIT(scheduler);
 
     /* global lock */
     g_mutex_init(&(scheduler->globalLock));
 
-    scheduler->workerPool = workerpool_new(config, /*nThreads=*/nWorkers,
+    scheduler->workerPool = workerpool_new(/*nThreads=*/nWorkers,
                                            /*nParallel=*/_parallelism);
 
     scheduler->endTime = endTime;

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -46,7 +46,6 @@ struct _Scheduler {
     Random* random;
 
     /* auxiliary information about current running state */
-    gboolean isRunning;
     SimulationTime endTime;
     struct {
         SimulationTime endTime;
@@ -303,18 +302,12 @@ static void _scheduler_assignHosts(Scheduler* scheduler) {
     g_mutex_unlock(&scheduler->globalLock);
 }
 
-gboolean scheduler_isRunning(Scheduler* scheduler) {
-    MAGIC_ASSERT(scheduler);
-    return scheduler->isRunning;
-}
-
 void scheduler_start(Scheduler* scheduler) {
     /* Called by the scheduler thread. */
 
     _scheduler_assignHosts(scheduler);
 
     g_mutex_lock(&scheduler->globalLock);
-    scheduler->isRunning = TRUE;
     g_mutex_unlock(&scheduler->globalLock);
 
     workerpool_startTaskFn(scheduler->workerPool,
@@ -355,7 +348,6 @@ void scheduler_finish(Scheduler* scheduler) {
 
     /* make sure when the workers wake up they know we are done */
     g_mutex_lock(&scheduler->globalLock);
-    scheduler->isRunning = FALSE;
     g_mutex_unlock(&scheduler->globalLock);
 
     workerpool_startTaskFn(scheduler->workerPool, _scheduler_finishTaskFn, scheduler);

--- a/src/main/core/scheduler/scheduler.c
+++ b/src/main/core/scheduler/scheduler.c
@@ -140,7 +140,7 @@ Scheduler* scheduler_new(const ChildPidWatcher* pidWatcher, const ConfigOptions*
     /* global lock */
     g_mutex_init(&(scheduler->globalLock));
 
-    scheduler->workerPool = workerpool_new(pidWatcher, scheduler, config, /*nThreads=*/nWorkers,
+    scheduler->workerPool = workerpool_new(pidWatcher, config, /*nThreads=*/nWorkers,
                                            /*nParallel=*/_parallelism);
 
     scheduler->endTime = endTime;

--- a/src/main/core/scheduler/scheduler.h
+++ b/src/main/core/scheduler/scheduler.h
@@ -33,7 +33,6 @@ Event* scheduler_pop(Scheduler*);
 EmulatedTime scheduler_nextHostEventTime(Scheduler*, Host* host);
 
 int scheduler_addHost(Scheduler*, Host*);
-const ThreadSafeEventQueue* scheduler_getEventQueue(Scheduler* scheduler, HostId host);
 gboolean scheduler_isRunning(Scheduler* scheduler);
 
 #endif /* SHD_SCHEDULER_H_ */

--- a/src/main/core/scheduler/scheduler.h
+++ b/src/main/core/scheduler/scheduler.h
@@ -15,8 +15,8 @@ typedef struct _Scheduler Scheduler;
 #include "main/core/support/definitions.h"
 #include "main/host/host.h"
 
-Scheduler* scheduler_new(const ChildPidWatcher* pidWatcher, const ConfigOptions* config,
-                         guint nWorkers, guint schedulerSeed, SimulationTime endTime);
+Scheduler* scheduler_new(const ConfigOptions* config, guint nWorkers, guint schedulerSeed,
+                         SimulationTime endTime);
 void scheduler_free(Scheduler*);
 void scheduler_shutdown(Scheduler* scheduler);
 

--- a/src/main/core/scheduler/scheduler.h
+++ b/src/main/core/scheduler/scheduler.h
@@ -15,8 +15,7 @@ typedef struct _Scheduler Scheduler;
 #include "main/core/support/definitions.h"
 #include "main/host/host.h"
 
-Scheduler* scheduler_new(const ConfigOptions* config, guint nWorkers, guint schedulerSeed,
-                         SimulationTime endTime);
+Scheduler* scheduler_new(guint nWorkers, guint schedulerSeed, SimulationTime endTime);
 void scheduler_free(Scheduler*);
 void scheduler_shutdown(Scheduler* scheduler);
 

--- a/src/main/core/work/event_queue.rs
+++ b/src/main/core/work/event_queue.rs
@@ -93,40 +93,21 @@ impl<T: PartialOrd + Eq> std::ops::DerefMut for PanickingOrd<T> {
     }
 }
 
+/// A wrapper for [`EventQueue`] that uses interior mutability to make the ffi simpler.
+#[derive(Debug)]
+pub struct ThreadSafeEventQueue(pub Mutex<EventQueue>);
+
 mod export {
     use super::*;
     use crate::cshadow as c;
 
     use std::sync::Arc;
 
-    /// A wrapper for [`EventQueue`] that uses interior mutability to make the ffi simpler.
-    pub struct ThreadSafeEventQueue {
-        event_queue: Mutex<EventQueue>,
-    }
-
-    impl ThreadSafeEventQueue {
-        pub fn new() -> Self {
-            Self {
-                event_queue: Mutex::new(EventQueue::new()),
-            }
-        }
-
-        pub fn push(&self, event: Event) {
-            self.event_queue.lock().unwrap().push(event);
-        }
-
-        pub fn pop(&self) -> Option<Event> {
-            self.event_queue.lock().unwrap().pop()
-        }
-
-        pub fn next_event_time(&self) -> Option<EmulatedTime> {
-            self.event_queue.lock().unwrap().next_event_time()
-        }
-    }
-
     #[no_mangle]
     pub unsafe extern "C" fn eventqueue_new() -> *const ThreadSafeEventQueue {
-        Arc::into_raw(Arc::new(ThreadSafeEventQueue::new()))
+        Arc::into_raw(Arc::new(ThreadSafeEventQueue(
+            Mutex::new(EventQueue::new()),
+        )))
     }
 
     #[no_mangle]
@@ -157,13 +138,16 @@ mod export {
         assert!(!event.is_null());
         let queue = unsafe { queue.as_ref() }.unwrap();
         let event = unsafe { Box::from_raw(event) };
-        queue.push(*event);
+        queue.0.lock().unwrap().push(*event);
     }
 
     #[no_mangle]
     pub unsafe extern "C" fn eventqueue_pop(queue: *const ThreadSafeEventQueue) -> *mut Event {
         let queue = unsafe { queue.as_ref() }.unwrap();
         queue
+            .0
+            .lock()
+            .unwrap()
             .pop()
             .map(Box::new)
             .map(Box::into_raw)
@@ -175,6 +159,6 @@ mod export {
         queue: *const ThreadSafeEventQueue,
     ) -> c::EmulatedTime {
         let queue = unsafe { queue.as_ref() }.unwrap();
-        EmulatedTime::to_c_emutime(queue.next_event_time())
+        EmulatedTime::to_c_emutime(queue.0.lock().unwrap().next_event_time())
     }
 }

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -492,7 +492,7 @@ static void _worker_runDeliverPacketTask(Host* host, gpointer voidPacket, gpoint
 void worker_sendPacket(Host* srcHost, Packet* packet) {
     utility_debugAssert(packet != NULL);
 
-    if (!scheduler_isRunning(_worker_pool()->scheduler)) {
+    if (worker_isSimCompleted()) {
         /* the simulation is over, don't bother */
         return;
     }

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -39,9 +39,6 @@ static void _worker_shutdownHost(Host* host, void* _unused);
 static void _workerpool_setLogicalProcessorIdx(WorkerPool* workerpool, int workerID, int cpuId);
 
 struct _WorkerPool {
-    /* Unowned pointer to the PID watcher for managed processes */
-    const ChildPidWatcher* pidWatcher;
-
     /* Unowned pointer to the configuration options */
     const ConfigOptions* config;
 
@@ -118,8 +115,7 @@ struct WorkerConstructorParams {
     int threadID;
 };
 
-WorkerPool* workerpool_new(const ChildPidWatcher* pidWatcher, const ConfigOptions* config,
-                           int nWorkers, int nParallel) {
+WorkerPool* workerpool_new(const ConfigOptions* config, int nWorkers, int nParallel) {
     // Should have been ensured earlier by `config_getParallelism`.
     utility_debugAssert(nParallel >= 1);
     utility_debugAssert(nWorkers >= 1);
@@ -129,7 +125,6 @@ WorkerPool* workerpool_new(const ChildPidWatcher* pidWatcher, const ConfigOption
 
     WorkerPool* pool = g_new(WorkerPool, 1);
     *pool = (WorkerPool){
-        .pidWatcher = pidWatcher,
         .config = config,
         .nWorkers = nWorkers,
         .finishLatch = countdownlatch_new(nWorkers),
@@ -365,8 +360,6 @@ Address* worker_resolveNameToAddress(const gchar* name) {
     DNS* dns = worker_getDNS();
     return dns_resolveNameToAddress(dns, name);
 }
-
-const ChildPidWatcher* worker_getChildPidWatcher() { return _worker_pool()->pidWatcher; }
 
 const ConfigOptions* worker_getConfig() { return _worker_pool()->config; }
 

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -528,7 +528,6 @@ void worker_sendPacket(Host* srcHost, Packet* packet) {
         /* TODO this should change for sending to remote manager (on a different machine)
          * this is the only place where tasks are sent between separate hosts */
 
-        Scheduler* scheduler = _worker_pool()->scheduler;
         GQuark dstHostID = (GQuark)address_getID(dstAddress);
 
         packet_addDeliveryStatus(packet, PDS_INET_SENT);
@@ -558,8 +557,7 @@ void worker_sendPacket(Host* srcHost, Packet* packet) {
         // round and calculated its min event time, so we put this in our min event time instead
         worker_setMinEventTimeNextRound(event_getTime(packetEvent));
 
-        const ThreadSafeEventQueue* eventQueue = scheduler_getEventQueue(scheduler, dstHostID);
-        eventqueue_push(eventQueue, packetEvent);
+        worker_pushToHost(dstHostID, packetEvent);
     } else {
         packet_addDeliveryStatus(packet, PDS_INET_DROPPED);
     }

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -20,7 +20,6 @@
 #include "lib/logger/log_level.h"
 #include "lib/logger/logger.h"
 #include "main/bindings/c/bindings.h"
-#include "main/core/scheduler/scheduler.h"
 #include "main/core/support/config_handlers.h"
 #include "main/core/support/definitions.h"
 #include "main/host/affinity.h"
@@ -45,10 +44,6 @@ struct _WorkerPool {
 
     /* Unowned pointer to the configuration options */
     const ConfigOptions* config;
-
-    /* Unowned pointer to the per-manager parallel scheduler object that feeds
-     * events to all workers */
-    Scheduler* scheduler;
 
     /* Number of Worker threads */
     int nWorkers;
@@ -123,8 +118,8 @@ struct WorkerConstructorParams {
     int threadID;
 };
 
-WorkerPool* workerpool_new(const ChildPidWatcher* pidWatcher, Scheduler* scheduler,
-                           const ConfigOptions* config, int nWorkers, int nParallel) {
+WorkerPool* workerpool_new(const ChildPidWatcher* pidWatcher, const ConfigOptions* config,
+                           int nWorkers, int nParallel) {
     // Should have been ensured earlier by `config_getParallelism`.
     utility_debugAssert(nParallel >= 1);
     utility_debugAssert(nWorkers >= 1);
@@ -136,7 +131,6 @@ WorkerPool* workerpool_new(const ChildPidWatcher* pidWatcher, Scheduler* schedul
     *pool = (WorkerPool){
         .pidWatcher = pidWatcher,
         .config = config,
-        .scheduler = scheduler,
         .nWorkers = nWorkers,
         .finishLatch = countdownlatch_new(nWorkers),
         .joined = FALSE,

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -441,8 +441,6 @@ void worker_finish(GQueue* hosts, SimulationTime time) {
 
     worker_clearCurrentTime();
 
-    WorkerPool* pool = _worker_pool();
-
     /* send object counts to global counters */
     worker_addToGlobalAllocCounters(_worker_objectAllocCounter(), _worker_objectDeallocCounter());
 

--- a/src/main/core/worker.c
+++ b/src/main/core/worker.c
@@ -39,9 +39,6 @@ static void _worker_shutdownHost(Host* host, void* _unused);
 static void _workerpool_setLogicalProcessorIdx(WorkerPool* workerpool, int workerID, int cpuId);
 
 struct _WorkerPool {
-    /* Unowned pointer to the configuration options */
-    const ConfigOptions* config;
-
     /* Number of Worker threads */
     int nWorkers;
 
@@ -115,7 +112,7 @@ struct WorkerConstructorParams {
     int threadID;
 };
 
-WorkerPool* workerpool_new(const ConfigOptions* config, int nWorkers, int nParallel) {
+WorkerPool* workerpool_new(int nWorkers, int nParallel) {
     // Should have been ensured earlier by `config_getParallelism`.
     utility_debugAssert(nParallel >= 1);
     utility_debugAssert(nWorkers >= 1);
@@ -125,7 +122,6 @@ WorkerPool* workerpool_new(const ConfigOptions* config, int nWorkers, int nParal
 
     WorkerPool* pool = g_new(WorkerPool, 1);
     *pool = (WorkerPool){
-        .config = config,
         .nWorkers = nWorkers,
         .finishLatch = countdownlatch_new(nWorkers),
         .joined = FALSE,
@@ -360,8 +356,6 @@ Address* worker_resolveNameToAddress(const gchar* name) {
     DNS* dns = worker_getDNS();
     return dns_resolveNameToAddress(dns, name);
 }
-
-const ConfigOptions* worker_getConfig() { return _worker_pool()->config; }
 
 /* this is the entry point for worker threads when running in parallel mode,
  * and otherwise is the main event loop when running in serial mode */

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -33,7 +33,7 @@ void worker_finish(GQueue* hosts, SimulationTime time);
 
 // Create a workerpool with `nThreads` threads, allowing up to `nConcurrent` to
 // run at a time.
-WorkerPool* workerpool_new(const ConfigOptions* config, int nWorkers, int nParallel);
+WorkerPool* workerpool_new(int nWorkers, int nParallel);
 
 // Begin executing taskFn(data) on each worker thread in the pool.
 void workerpool_startTaskFn(WorkerPool* pool, WorkerPoolTaskFn taskFn,
@@ -64,7 +64,6 @@ void worker_setMinEventTimeNextRound(SimulationTime simtime);
 void worker_setRoundEndTime(SimulationTime newRoundEndTime);
 
 int worker_getAffinity();
-const ConfigOptions* worker_getConfig();
 gboolean worker_scheduleTaskWithDelay(TaskRef* task, Host* host, SimulationTime nanoDelay);
 gboolean worker_scheduleTaskAtEmulatedTime(TaskRef* task, Host* host, EmulatedTime t);
 void worker_sendPacket(Host* src, Packet* packet);

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -33,8 +33,7 @@ void worker_finish(GQueue* hosts, SimulationTime time);
 
 // Create a workerpool with `nThreads` threads, allowing up to `nConcurrent` to
 // run at a time.
-WorkerPool* workerpool_new(const ChildPidWatcher* pidWatcher, const ConfigOptions* config,
-                           int nWorkers, int nParallel);
+WorkerPool* workerpool_new(const ConfigOptions* config, int nWorkers, int nParallel);
 
 // Begin executing taskFn(data) on each worker thread in the pool.
 void workerpool_startTaskFn(WorkerPool* pool, WorkerPoolTaskFn taskFn,
@@ -65,7 +64,6 @@ void worker_setMinEventTimeNextRound(SimulationTime simtime);
 void worker_setRoundEndTime(SimulationTime newRoundEndTime);
 
 int worker_getAffinity();
-const ChildPidWatcher* worker_getChildPidWatcher();
 const ConfigOptions* worker_getConfig();
 gboolean worker_scheduleTaskWithDelay(TaskRef* task, Host* host, SimulationTime nanoDelay);
 gboolean worker_scheduleTaskAtEmulatedTime(TaskRef* task, Host* host, EmulatedTime t);

--- a/src/main/core/worker.h
+++ b/src/main/core/worker.h
@@ -17,7 +17,6 @@ typedef struct _WorkerPool WorkerPool;
 typedef void (*WorkerPoolTaskFn)(void*);
 
 #include "lib/logger/log_level.h"
-#include "main/core/scheduler/scheduler.h"
 #include "main/core/support/definitions.h"
 #include "main/host/host.h"
 #include "main/host/syscall_types.h"
@@ -34,8 +33,8 @@ void worker_finish(GQueue* hosts, SimulationTime time);
 
 // Create a workerpool with `nThreads` threads, allowing up to `nConcurrent` to
 // run at a time.
-WorkerPool* workerpool_new(const ChildPidWatcher* pidWatcher, Scheduler* scheduler,
-                           const ConfigOptions* config, int nWorkers, int nParallel);
+WorkerPool* workerpool_new(const ChildPidWatcher* pidWatcher, const ConfigOptions* config,
+                           int nWorkers, int nParallel);
 
 // Begin executing taskFn(data) on each worker thread in the pool.
 void workerpool_startTaskFn(WorkerPool* pool, WorkerPoolTaskFn taskFn,

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -326,6 +326,7 @@ pub struct WorkerShared {
     // calculates the runahead for the next simulation round
     pub runahead: Runahead,
     pub bootstrap_end_time: EmulatedTime,
+    pub sim_end_time: EmulatedTime,
 }
 
 impl WorkerShared {
@@ -635,6 +636,11 @@ mod export {
     #[no_mangle]
     pub extern "C" fn worker_isBootstrapActive() -> bool {
         Worker::with(|w| w.clock.now.unwrap() < w.shared.bootstrap_end_time).unwrap()
+    }
+
+    #[no_mangle]
+    pub extern "C" fn worker_isSimCompleted() -> bool {
+        Worker::with(|w| w.clock.now.unwrap() >= w.shared.sim_end_time).unwrap()
     }
 
     #[no_mangle]

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -2690,7 +2690,6 @@ TCP* tcp_new(Host* host, guint receiveBufferSize, guint sendBufferSize) {
     legacysocket_init(
         &(tcp->super), host, &tcp_functions, DT_TCPSOCKET, receiveBufferSize, sendBufferSize);
 
-    const ConfigOptions* config = worker_getConfig();
     guint32 initial_window = 10;
     gint tcpSSThresh = 0;
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use crate::core::support::emulated_time::EmulatedTime;
 use crate::core::support::simulation_time::SimulationTime;
+use crate::core::work::event_queue::ThreadSafeEventQueue;
 use crate::core::work::task::TaskRef;
 use crate::cshadow;
 use crate::host::descriptor::socket::abstract_unix_ns::AbstractUnixNamespace;
@@ -158,6 +159,11 @@ impl Host {
         };
         // Intentionally drop `task`. An eventual event_new clones.
         res != 0
+    }
+
+    pub fn event_queue(&self) -> Arc<ThreadSafeEventQueue> {
+        let new_arc = unsafe { cshadow::host_getOwnedEventQueue(self.chost()) };
+        unsafe { Arc::from_raw(new_arc) }
     }
 
     pub fn chost(&self) -> *mut cshadow::Host {

--- a/src/main/utility/childpid_watcher.rs
+++ b/src/main/utility/childpid_watcher.rs
@@ -15,6 +15,7 @@ use std::thread;
 /// Utility for monitoring a set of child pid's, calling registered callbacks
 /// when one exits or is killed. Starts a background thread, which is shut down
 /// when the object is dropped.
+#[derive(Debug)]
 pub struct ChildPidWatcher {
     inner: Arc<Mutex<Inner>>,
     epoll: std::os::unix::io::RawFd,
@@ -22,6 +23,7 @@ pub struct ChildPidWatcher {
 
 pub type WatchHandle = u64;
 
+#[derive(Debug)]
 enum Command {
     RunCallbacks(Pid),
     Finish,
@@ -37,6 +39,7 @@ struct PidData {
     unregistered: bool,
 }
 
+#[derive(Debug)]
 struct Inner {
     // Next unique handle ID.
     next_handle: WatchHandle,
@@ -330,6 +333,15 @@ impl Drop for ChildPidWatcher {
         };
         handle.join().unwrap();
         nix::unistd::close(self.epoll).unwrap();
+    }
+}
+
+impl std::fmt::Debug for PidData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PidData")
+            .field("fd", &self.fd)
+            .field("unregistered", &self.unregistered)
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
These changes allow us to remove the `WorkerPool`s pointers to the `Scheduler` and the `ConfigOptions`, which brings us a step closer to being able to write the scheduler and work pool in rust. The manager is becoming a bit overloaded with stuff, but it'll be easier to reorganize things later once it's all in rust.