### PR TITLE
Improve design of rust global shared state

### DIFF
--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -243,7 +243,8 @@ impl<'a> Manager<'a> {
                 // update the status logger
                 let display_time = std::cmp::min(window_start, window_end);
                 worker::WORKER_SHARED
-                    .get()
+                    .borrow()
+                    .as_ref()
                     .unwrap()
                     .update_status_logger(|state| {
                         state.current = display_time;
@@ -286,7 +287,8 @@ impl<'a> Manager<'a> {
 
         // simulation is finished, so update the status logger
         worker::WORKER_SHARED
-            .get()
+            .borrow()
+            .as_ref()
             .unwrap()
             .update_status_logger(|state| {
                 state.current = self.end_time;
@@ -387,7 +389,7 @@ impl<'a> Manager<'a> {
             unsafe {
                 c::host_setup(
                     c_host,
-                    worker::WORKER_SHARED.get().unwrap().dns(),
+                    worker::WORKER_SHARED.borrow().as_ref().unwrap().dns(),
                     self.raw_frequency_khz,
                     hosts_path.as_ptr(),
                 )


### PR DESCRIPTION
- wraps the global shared state (`WORKER_SHARED`) in an `AtomicRefCell` so that we can drop the state when the simulation ends
- adds a borrowed reference to the shared global state to the thread-local global state (`WORKER`) to reverse any performance impact caused by the `AtomicRefCell`