### PR TITLE
Updates the forked-from commit for bytes from 1.1.0 to 1.2.1

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -93,8 +93,8 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
-source = "git+https://github.com/shadow/bytes?rev=cc32de596039e0b1d5c2e349e9ab17e6a98a5074#cc32de596039e0b1d5c2e349e9ab17e6a98a5074"
+version = "1.2.1"
+source = "git+https://github.com/shadow/bytes?rev=c48bd4439e7e043300521925524ecdcce7ff6bcc#c48bd4439e7e043300521925524ecdcce7ff6bcc"
 
 [[package]]
 name = "cc"

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -16,7 +16,7 @@ bitflags = "1.3"
 # custom version of the bytes crate required to make the 'try_unsplit' method public
 # issue: https://github.com/tokio-rs/bytes/issues/287
 # pr: https://github.com/tokio-rs/bytes/pull/513
-bytes = { git = "https://github.com/shadow/bytes", rev = "cc32de596039e0b1d5c2e349e9ab17e6a98a5074" }
+bytes = { git = "https://github.com/shadow/bytes", rev = "c48bd4439e7e043300521925524ecdcce7ff6bcc" }
 clap = { version = "3.2.16", features = ["derive", "wrap_help"] }
 crossbeam = "0.8.2"
 gml-parser = { path = "../lib/gml-parser" }


### PR DESCRIPTION
The [shadow/bytes](https://github.com/shadow/bytes) repository has been updated, and this points shadow to the new commit.