### PR TITLE
Make shadow installation directory relocatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,10 @@ endforeach(library)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 ## use the installed shim path only when shadow is installed
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+##
+## We use "$ORIGIN" here to make the shadow installation directory relocatable.
+## See also "Rpath token expansion" in ls.do(8).
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
 
 ## get general includes
 include(CheckIncludeFile)

--- a/ci/container_scripts/build_and_install.sh
+++ b/ci/container_scripts/build_and_install.sh
@@ -34,5 +34,6 @@ case "$BUILDTYPE" in
         ;;
 esac
 
-./setup build -j4 --test --extra --werror $OPTIONS
+./setup build -j4 --test --extra --werror --prefix=/opt/shadow $OPTIONS
 ./setup install
+stow -d /opt -t /usr shadow

--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -15,6 +15,7 @@ APT_PACKAGES="
   pkg-config
   python3
   python3-pip
+  stow
   xz-utils
   util-linux
   "
@@ -35,6 +36,7 @@ RPM_PACKAGES="
   pkg-config
   python3
   python3-pip
+  stow
   xz
   xz-devel
   yum-utils


### PR DESCRIPTION
We probably especially want this if we decide to release pre-built binaries ourselves (#2389), but even if we don't, it gives users some additional flexibility.