### PR TITLE
Make shadow installation directory relocatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,10 @@ endforeach(library)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 ## use the installed shim path only when shadow is installed
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+##
+## We use "$ORIGIN" here to make the shadow installation directory relocatable.
+## See also "Rpath token expansion" in ls.do(8).
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
 
 ## get general includes
 include(CheckIncludeFile)


### PR DESCRIPTION
We probably especially want this if we decide to release pre-built binaries ourselves (#2389), but even if we don't, it gives users some additional flexibility.

Make shadow installation directory relocatable