### PR TITLE
shadow-shim-helper-rs: omit C APIs in rust library

### DIFF
--- a/src/lib/shadow-shim-helper-rs/CMakeLists.txt
+++ b/src/lib/shadow-shim-helper-rs/CMakeLists.txt
@@ -1,4 +1,4 @@
-rust_static_lib(shadow-shim-helper-rs)
+rust_static_lib(shadow-shim-helper-rs FEATURES c_apis)
 
 # Generate bindings.h in the source tree.
 add_custom_command(OUTPUT shim_helper.h

--- a/src/lib/shadow-shim-helper-rs/Cargo.toml
+++ b/src/lib/shadow-shim-helper-rs/Cargo.toml
@@ -14,3 +14,8 @@ nix = "0.25.0"
 # don't log debug or trace levels in release mode
 log = { version = "0.4", features = ["release_max_level_debug"] }
 rkyv = "0.7.39"
+
+[features]
+# Whether to generate C APIs. Generally this should only be enabled
+# when compiling as a staticlib, to prevent duplicate symbols.
+c_apis = []

--- a/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
@@ -135,6 +135,7 @@ impl std::ops::Sub<EmulatedTime> for EmulatedTime {
     }
 }
 
+#[cfg(feature = "c_apis")]
 pub mod export {
     use super::*;
 

--- a/src/lib/shadow-shim-helper-rs/src/signals.rs
+++ b/src/lib/shadow-shim-helper-rs/src/signals.rs
@@ -237,6 +237,7 @@ pub fn defaultaction(sig: Signal) -> ShdKernelDefaultAction {
     }
 }
 
+#[cfg(feature = "c_apis")]
 mod export {
     use super::*;
 


### PR DESCRIPTION
We build this library both as a system static library, which can be
linked from C, and as a Rust static library, which can be linked from
Rust. We end up pulling in both in the final linking of Shadow.

For the non-#[no_mangle] (C) api's, I think Rust knows how to sort this
out.

For the #[no_mangle] api's, though, the linker can end up with multiple
versions of the same symbol and fail. For some reason this currently
only happens in the coverage build.

We can omit the #[no_mangle] APIs when compiling the Rust version of the
library, since Rust code shouldn't call those APIs anyway.