### PR TITLE
Add rust synchronization primitives needed for the scheduler

### DIFF
--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -19,6 +19,7 @@ pub mod random;
 pub mod shm_cleanup;
 pub mod status_bar;
 pub mod stream_len;
+pub mod synchronization;
 pub mod syscall;
 pub mod time;
 

--- a/src/main/utility/synchronization/count_down_latch.rs
+++ b/src/main/utility/synchronization/count_down_latch.rs
@@ -1,0 +1,379 @@
+use std::sync::{Arc, Condvar, Mutex};
+
+/// A latch counter.
+///
+/// If a counter is cloned, it will inherit the counter's state for the current generation. For
+/// example if a counter is cloned after it has already counted down, then the new counter will also
+/// be treated as if it had already counted down in the current generation. If a counter is cloned
+/// before it has counted down, then the new counter will also need to count down in the current
+/// generation.
+#[derive(Debug)]
+pub struct LatchCounter {
+    inner: Arc<LatchInner>,
+    /// An ID for this counter's count-down round.
+    generation: usize,
+}
+
+/// A latch waiter.
+///
+/// If a waiter is cloned, it will inherit the waiter's state for the current generation. For
+/// example if a waiter is cloned after it has already waited, then the new waiter will also be
+/// treated as if it had already waited in the current generation. If a waiter is cloned before it
+/// has waited, then the new waiter will also need to wait in the current generation.
+#[derive(Debug)]
+pub struct LatchWaiter {
+    inner: Arc<LatchInner>,
+    /// An ID for this waiter's count-down round.
+    generation: usize,
+}
+
+#[derive(Debug)]
+struct LatchInner {
+    lock: Mutex<LatchState>,
+    cond: Condvar,
+}
+
+#[derive(Debug)]
+struct LatchState {
+    /// The current latch "round".
+    generation: usize,
+    /// Number of counters remaining.
+    counters: usize,
+    /// Number of waiters remaining.
+    waiters: usize,
+    /// Total number of counters.
+    total_counters: usize,
+    /// Total number of waiters.
+    total_waiters: usize,
+}
+
+/// Build a latch counter and waiter. The counter and waiter can be cloned to create new counters
+/// and waiters.
+pub fn build_count_down_latch() -> (LatchCounter, LatchWaiter) {
+    let inner = Arc::new(LatchInner {
+        lock: Mutex::new(LatchState {
+            generation: 0,
+            counters: 1,
+            waiters: 1,
+            total_counters: 1,
+            total_waiters: 1,
+        }),
+        cond: Condvar::new(),
+    });
+
+    let counter = LatchCounter {
+        inner: Arc::clone(&inner),
+        generation: 0,
+    };
+
+    let waiter = LatchWaiter {
+        inner,
+        generation: 0,
+    };
+
+    (counter, waiter)
+}
+
+impl LatchState {
+    pub fn advance_generation(&mut self) {
+        debug_assert_eq!(self.counters, 0);
+        debug_assert_eq!(self.waiters, 0);
+        self.counters = self.total_counters;
+        self.waiters = self.total_waiters;
+        self.generation = self.generation.wrapping_add(1);
+    }
+}
+
+impl LatchCounter {
+    /// Decrement the latch count and wake the waiters if the count reaches 0. This must not be
+    /// called more than once per generation (must not be called again until all of the waiters have
+    /// returned from their [`wait`] calls), otherwise it will panic.
+    pub fn count_down(&mut self) {
+        let counters;
+        {
+            let mut lock = self.inner.lock.lock().unwrap();
+
+            if self.generation != lock.generation {
+                let latch_gen = lock.generation;
+                std::mem::drop(lock);
+                panic!(
+                    "Counter generation does not match latch generation ({} != {})",
+                    self.generation, latch_gen
+                );
+            }
+
+            lock.counters = lock.counters.checked_sub(1).unwrap();
+            counters = lock.counters;
+        }
+
+        // if this is the last counter, notify the waiters
+        if counters == 0 {
+            self.inner.cond.notify_all();
+        }
+
+        self.generation = self.generation.wrapping_add(1);
+    }
+}
+
+impl LatchWaiter {
+    /// Wait for the latch count to reach 0. If the latch count has already reached 0 for the
+    /// current genration, this will return immediately.
+    pub fn wait(&mut self) {
+        {
+            let lock = self.inner.lock.lock().unwrap();
+
+            let mut lock = self
+                .inner
+                .cond
+                // wait until we're in the active generation and all counters have counted down
+                .wait_while(lock, |x| self.generation != x.generation || x.counters > 0)
+                .unwrap();
+
+            lock.waiters = lock.waiters.checked_sub(1).unwrap();
+
+            // if this is the last waiter (and we already know that there are no more counters), start
+            // the next generation
+            if lock.waiters == 0 {
+                lock.advance_generation();
+            }
+        }
+
+        self.generation = self.generation.wrapping_add(1);
+    }
+}
+
+impl Clone for LatchCounter {
+    fn clone(&self) -> Self {
+        let mut lock = self.inner.lock.lock().unwrap();
+        lock.total_counters = lock.total_counters.checked_add(1).unwrap();
+
+        // if we haven't already counted down during the current generation
+        if self.generation == lock.generation {
+            lock.counters = lock.counters.checked_add(1).unwrap();
+        }
+
+        LatchCounter {
+            inner: Arc::clone(&self.inner),
+            generation: self.generation,
+        }
+    }
+}
+
+impl Clone for LatchWaiter {
+    fn clone(&self) -> Self {
+        let mut lock = self.inner.lock.lock().unwrap();
+        lock.total_waiters = lock.total_waiters.checked_add(1).unwrap();
+
+        // if we haven't already waited during the current generation
+        if self.generation == lock.generation {
+            lock.waiters = lock.waiters.checked_add(1).unwrap();
+        }
+
+        LatchWaiter {
+            inner: Arc::clone(&self.inner),
+            generation: self.generation,
+        }
+    }
+}
+
+impl std::ops::Drop for LatchCounter {
+    fn drop(&mut self) {
+        let mut lock = self.inner.lock.lock().unwrap();
+        lock.total_counters = lock.total_counters.checked_sub(1).unwrap();
+
+        // if we haven't already counted down during the current generation
+        if self.generation == lock.generation {
+            lock.counters = lock.counters.checked_sub(1).unwrap();
+        }
+
+        // if this is the last counter, notify the waiters
+        if lock.counters == 0 {
+            self.inner.cond.notify_all();
+        }
+    }
+}
+
+impl std::ops::Drop for LatchWaiter {
+    fn drop(&mut self) {
+        let mut lock = self.inner.lock.lock().unwrap();
+        lock.total_waiters = lock.total_waiters.checked_sub(1).unwrap();
+
+        // if we haven't already waited during the current generation
+        if self.generation == lock.generation {
+            lock.waiters = lock.waiters.checked_sub(1).unwrap();
+        }
+
+        // if this is the last waiter and there are no more counters, start the next generation
+        if lock.waiters == 0 && lock.counters == 0 {
+            lock.advance_generation();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::time::Duration;
+
+    use atomic_refcell::AtomicRefCell;
+    use rand::{Rng, SeedableRng};
+
+    #[test]
+    fn test_clone() {
+        let (mut counter, mut waiter) = build_count_down_latch();
+        let (mut counter_clone, mut waiter_clone) = (counter.clone(), waiter.clone());
+
+        counter.count_down();
+        counter_clone.count_down();
+        waiter.wait();
+        waiter_clone.wait();
+    }
+
+    #[test]
+    fn test_clone_before_countdown() {
+        let (mut counter, mut waiter) = build_count_down_latch();
+
+        // the cloned counter will also need to count down for the current generation
+        let mut counter_clone = counter.clone();
+        counter.count_down();
+        counter_clone.count_down();
+        waiter.wait();
+
+        counter.count_down();
+        counter_clone.count_down();
+        waiter.wait();
+
+        let (mut counter, mut waiter) = build_count_down_latch();
+
+        // the cloned waiter will also need to wait for the current generation
+        let mut waiter_clone = waiter.clone();
+        counter.count_down();
+        waiter.wait();
+        waiter_clone.wait();
+
+        counter.count_down();
+        waiter.wait();
+        waiter_clone.wait();
+    }
+
+    #[test]
+    fn test_clone_after_countdown() {
+        let (mut counter, mut waiter) = build_count_down_latch();
+
+        counter.count_down();
+        // the cloned counter will also be considered "counted down" for the current generation
+        let mut counter_clone = counter.clone();
+        // if the cloned counter did count down here, it would panic
+        waiter.wait();
+
+        counter.count_down();
+        counter_clone.count_down();
+        waiter.wait();
+
+        let (mut counter, mut waiter) = build_count_down_latch();
+        let mut waiter_clone = waiter.clone();
+
+        counter.count_down();
+        waiter.wait();
+        // the cloned waiter will also be considered "waited" for the current generation
+        let mut waiter_clone_2 = waiter.clone();
+        // if the cloned waiter did wait here, it would be waiting for the next generation
+        waiter_clone.wait();
+
+        counter.count_down();
+        waiter.wait();
+        waiter_clone.wait();
+        waiter_clone_2.wait();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_double_count() {
+        let (mut counter, mut _waiter) = build_count_down_latch();
+        counter.count_down();
+        counter.count_down();
+    }
+
+    #[test]
+    fn test_single_thread() {
+        let (mut counter, mut waiter) = build_count_down_latch();
+
+        counter.count_down();
+        waiter.wait();
+        counter.count_down();
+        waiter.wait();
+        counter.count_down();
+        waiter.wait();
+
+        let mut waiter_clone = waiter.clone();
+
+        counter.count_down();
+        waiter.wait();
+        waiter_clone.wait();
+
+        counter.count_down();
+        waiter.wait();
+        waiter_clone.wait();
+    }
+
+    #[test]
+    fn test_multi_thread() {
+        let (mut exclusive_counter, mut exclusive_waiter) = build_count_down_latch();
+        let (mut shared_counter, mut shared_waiter) = build_count_down_latch();
+        let repeat = 30;
+
+        let lock = Arc::new(AtomicRefCell::new(()));
+        let lock_clone = Arc::clone(&lock);
+
+        // The goal of this test is to make sure that the new threads alternate with the main thread
+        // to access the atomic refcell. The new threads each hold on to a shared borrow of the
+        // atomic refcell for ~5 ms, then the main thread gets an exclusive borrow for ~5 ms,
+        // repeating. If these time slices ever overlap, then either a shared or exclusive borrow
+        // will cause a panic and the test will fail. Randomness is added to the sleeps to vary the
+        // order in which threads wait and count down, to try to cover more edge cases.
+
+        let thread_fn = move |seed| {
+            let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+            for _ in 0..repeat {
+                // wait for the main thread to be done with its exclusive borrow
+                std::thread::sleep(Duration::from_millis(5));
+                exclusive_waiter.wait();
+                {
+                    // a shared borrow for a duration in the range of 0-10 ms
+                    let _x = lock_clone.borrow();
+                    std::thread::sleep(Duration::from_millis(rng.gen_range(0..10)));
+                }
+                shared_counter.count_down();
+            }
+        };
+
+        // start 5 threads
+        let handles: Vec<_> = (0..5)
+            .map(|seed| {
+                let mut f = thread_fn.clone();
+                std::thread::spawn(move || f(seed))
+            })
+            .collect();
+        std::mem::drop(thread_fn);
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(100);
+
+        for _ in 0..repeat {
+            {
+                // an exclusive borrow for a duration in the range of 0-10 ms
+                let _x = lock.borrow_mut();
+                std::thread::sleep(Duration::from_millis(rng.gen_range(0..10)));
+            }
+            exclusive_counter.count_down();
+            // wait for the other threads to be done with their shared borrow
+            std::thread::sleep(Duration::from_millis(5));
+            shared_waiter.wait();
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+}

--- a/src/main/utility/synchronization/mod.rs
+++ b/src/main/utility/synchronization/mod.rs
@@ -1,0 +1,1 @@
+pub mod semaphore;

--- a/src/main/utility/synchronization/mod.rs
+++ b/src/main/utility/synchronization/mod.rs
@@ -1,1 +1,2 @@
+pub mod count_down_latch;
 pub mod semaphore;

--- a/src/main/utility/synchronization/semaphore.rs
+++ b/src/main/utility/synchronization/semaphore.rs
@@ -1,0 +1,211 @@
+use std::cell::UnsafeCell;
+use std::sync::Arc;
+
+/// A libc semaphore that provides synchronization between threads. Any memory barrier/ordering
+/// properties are the same as provided by [`libc::sem_post`] and [`libc::sem_wait`].
+///
+/// We could use a third-party semaphore library, but most seem to not have the semantics we need (a
+/// simple signaling mechanism with the ability to block). Other libraries are either meant for an
+/// async context, don't have the ability to block/wait, or are intended to protect some resource
+/// like a lock. We also are already familiar with the performance charactersitics of the libc
+/// semaphore.
+#[derive(Clone)]
+pub struct LibcSemaphore {
+    // SAFETY: the `LibcSemWrapper` must not be moved
+    inner: Arc<LibcSemWrapper>,
+}
+
+impl LibcSemaphore {
+    /// Create a new semaphore. See `sem_init(3)` for details.
+    pub fn new(val: libc::c_uint) -> Self {
+        let rv = Self {
+            // this will move the LibcSemWrapper into the Arc, but that's fine since we haven't
+            // initialized it yet
+            inner: Arc::new(LibcSemWrapper::new()),
+        };
+
+        // SAFETY: do not wait, post, get, format/print, etc here before it's initialized
+
+        // the LibcSemWrapper is in the Arc and we will never move it again
+        unsafe { rv.inner.init(val) };
+
+        rv
+    }
+
+    /// Lock the semaphore. See `sem_wait(3)` for details.
+    pub fn wait(&self) {
+        unsafe { self.inner.wait() }
+    }
+
+    /// Unlock the semaphore. See `sem_post(3)` for details.
+    pub fn post(&self) {
+        unsafe { self.inner.post() }
+    }
+
+    /// Get the semaphore value. See `sem_getvalue(3)` for details.
+    pub fn get(&self) -> libc::c_int {
+        unsafe { self.inner.get() }
+    }
+}
+
+impl std::fmt::Debug for LibcSemaphore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LibcSemaphore")
+            // it should have been initialized by this point
+            .field("value", unsafe { &self.inner.get() })
+            .finish()
+    }
+}
+
+/// A wrapper for a [`libc::sem_t`].
+struct LibcSemWrapper {
+    // SAFETY: the `sem_t` must not be moved
+    inner: UnsafeCell<libc::sem_t>,
+}
+
+unsafe impl Send for LibcSemWrapper {}
+unsafe impl Sync for LibcSemWrapper {}
+
+impl LibcSemWrapper {
+    /// Create a new libc semaphore. After this semaphore object is moved to its final memory
+    /// location, it must be initialized using [`init`].
+    pub fn new() -> Self {
+        Self {
+            inner: UnsafeCell::new(unsafe { std::mem::zeroed() }),
+        }
+        // we cannot call sem_init() here since we will be copying/moving Self (and the sem_t) out
+        // of this function
+    }
+
+    /// Initialize the semaphore. See `sem_init(3)` for details.
+    ///
+    /// SAFETY:
+    ///   - this must not be called more than once
+    pub unsafe fn init(&self, val: libc::c_uint) {
+        unsafe { libc::sem_init(self.inner.get(), 0, val) };
+    }
+
+    /// Lock the semaphore. See `sem_wait(3)` for details.
+    ///
+    /// SAFETY:
+    ///   - the `LibcSemWrapper` must have been initialized using [`init`]
+    ///   - the `LibcSemWrapper` must not have been moved between the call to [`init`] and here
+    pub unsafe fn wait(&self) {
+        loop {
+            if unsafe { libc::sem_wait(self.inner.get()) } == 0 {
+                break;
+            }
+
+            match std::io::Error::last_os_error().kind() {
+                std::io::ErrorKind::Interrupted => {}
+                e => panic!("Unexpected semaphore wait error: {e}"),
+            }
+        }
+    }
+
+    /// Unlock the semaphore. See `sem_post(3)` for details.
+    ///
+    /// SAFETY:
+    ///   - the `LibcSemWrapper` must have been initialized using [`init`]
+    ///   - the `LibcSemWrapper` must not have been moved between the call to [`init`] and here
+    pub unsafe fn post(&self) {
+        if unsafe { libc::sem_post(self.inner.get()) } == 0 {
+            return;
+        }
+
+        panic!(
+            "Unexpected semaphore post error: {}",
+            std::io::Error::last_os_error().kind()
+        );
+    }
+
+    /// Get the semaphore value. See `sem_getvalue(3)` for details.
+    ///
+    /// SAFETY:
+    ///   - the `LibcSemWrapper` must have been initialized using [`init`]
+    ///   - the `LibcSemWrapper` must not have been moved between the call to [`init`] and here
+    pub unsafe fn get(&self) -> libc::c_int {
+        let mut val = 0;
+        if unsafe { libc::sem_getvalue(self.inner.get(), &mut val) } == 0 {
+            return val;
+        }
+
+        panic!(
+            "Unexpected semaphore post error: {}",
+            std::io::Error::last_os_error().kind()
+        );
+    }
+}
+
+impl std::ops::Drop for LibcSemWrapper {
+    fn drop(&mut self) {
+        unsafe { libc::sem_destroy(self.inner.get()) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clone() {
+        let sem = LibcSemaphore::new(0);
+        let sem_clone = sem.clone();
+
+        assert_eq!(sem.get(), 0);
+        sem.post();
+        assert_eq!(sem.get(), 1);
+        sem_clone.wait();
+        assert_eq!(sem.get(), 0);
+    }
+
+    #[test]
+    fn test_single_thread() {
+        let sem = LibcSemaphore::new(0);
+        sem.post();
+        sem.wait();
+
+        let sem = LibcSemaphore::new(0);
+        sem.post();
+        sem.post();
+        sem.post();
+        sem.wait();
+        sem.wait();
+        sem.wait();
+
+        let sem = LibcSemaphore::new(3);
+        sem.wait();
+        sem.wait();
+        sem.wait();
+
+        let sem = LibcSemaphore::new(0);
+        sem.post();
+        sem.wait();
+        sem.post();
+        sem.wait();
+        sem.post();
+        sem.wait();
+    }
+
+    #[test]
+    fn test_multi_thread() {
+        let sem = LibcSemaphore::new(0);
+        let sem_clone = sem.clone();
+
+        let t0 = std::time::Instant::now();
+
+        let handle = std::thread::spawn(move || {
+            sem_clone.post();
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            sem_clone.post();
+        });
+
+        sem.wait();
+        assert!((0..10).contains(&t0.elapsed().as_millis()));
+
+        sem.wait();
+        assert!((50..60).contains(&t0.elapsed().as_millis()));
+
+        handle.join().unwrap();
+    }
+}


### PR DESCRIPTION
Adds the synchronization primitives (semaphore and count down latch) needed for the rust scheduler.

This count down latch is a little more complex than the C version since it supports multiple waiters. The main difficulties of using multiple waiters in the C version are:
1. There isn't a nice way to synchronize which waiting thread will reset the latch, since it must always be the last waiting thread that resets the latch.
2. If the waiters are modified so that the waiting thread that last takes the lock is the one to reset the latch, it leads to a new issue where the waiting threads could be notified, and one thread resumes and loops all the way back to the wait again before the other threads have a chance to resume.