### PR TITLE
Exclude semaphore tests from miri

### DIFF
--- a/src/main/utility/synchronization/semaphore.rs
+++ b/src/main/utility/synchronization/semaphore.rs
@@ -148,6 +148,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_clone() {
         let sem = LibcSemaphore::new(0);
         let sem_clone = sem.clone();
@@ -160,6 +161,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_single_thread() {
         let sem = LibcSemaphore::new(0);
         sem.post();
@@ -188,6 +190,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_multi_thread() {
         let sem = LibcSemaphore::new(0);
         let sem_clone = sem.clone();


### PR DESCRIPTION
```
error: unsupported operation: can't call foreign function: sem_init
   --> main/utility/synchronization/semaphore.rs:85:18
    |
85  |         unsafe { libc::sem_init(self.inner.get(), 0, val) };
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function: sem_init
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
    = note: BACKTRACE:
    = note: inside `utility::synchronization::semaphore::LibcSemWrapper::init` at main/utility/synchronization/semaphore.rs:85:18
note: inside `utility::synchronization::semaphore::LibcSemaphore::new` at main/utility/synchronization/semaphore.rs:30:18
```