### PR TITLE
Fix Box::from_raw `unused_must_use` warning in rust 1.64

### DIFF
--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -118,9 +118,7 @@ mod export {
         if handler_ptr.is_null() {
             return;
         }
-        unsafe {
-            Box::from_raw(handler_ptr);
-        }
+        unsafe { Box::from_raw(handler_ptr) };
     }
 
     #[no_mangle]

--- a/src/main/network/router/token_bucket.rs
+++ b/src/main/network/router/token_bucket.rs
@@ -102,9 +102,7 @@ mod export {
         if tokenbucket_ptr.is_null() {
             return;
         }
-        unsafe {
-            Box::from_raw(tokenbucket_ptr);
-        }
+        unsafe { Box::from_raw(tokenbucket_ptr) };
     }
 
     #[no_mangle]

--- a/src/main/utility/byte_queue.rs
+++ b/src/main/utility/byte_queue.rs
@@ -407,9 +407,7 @@ mod export {
         if bq_ptr.is_null() {
             return;
         }
-        unsafe {
-            Box::from_raw(bq_ptr);
-        }
+        unsafe { Box::from_raw(bq_ptr) };
     }
 
     #[no_mangle]

--- a/src/main/utility/counter.rs
+++ b/src/main/utility/counter.rs
@@ -182,9 +182,7 @@ mod export {
         if counter_ptr.is_null() {
             return;
         }
-        unsafe {
-            Box::from_raw(counter_ptr);
-        }
+        unsafe { Box::from_raw(counter_ptr) };
     }
 
     #[no_mangle]


### PR DESCRIPTION
I guess moving the value from inside to outside of the unsafe block counts as "using" the value, so the warning goes away.