### PR TITLE
Run rust unit tests (including doc tests)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,11 @@ foreach(DEFINITION IN LISTS COMPILE_DEFINITIONS)
   set(RUST_CXXFLAGS "${RUST_CXXFLAGS} -D${DEFINITION}")
 endforeach()
 
+set(RUST_TARGETS "--lib")
+if(SHADOW_TEST STREQUAL ON)
+  set(RUST_TARGETS "${RUST_TARGETS} --tests")
+endif()
+
 ## build the rust library
 set(CARGO_ENV_VARS "${CARGO_ENV_VARS} RUSTFLAGS=\"${RUSTFLAGS}\"")
 set(CARGO_ENV_VARS "${CARGO_ENV_VARS} CFLAGS=\"${RUST_CFLAGS}\"")
@@ -35,7 +40,7 @@ ExternalProject_Add(
     BUILD_ALWAYS 1
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND bash -c "${CARGO_ENV_VARS} cargo build ${RUST_BUILD_FLAG} --target-dir \"${TARGETDIR}\" --features \"${RUST_FEATURES}\""
+    BUILD_COMMAND bash -c "${CARGO_ENV_VARS} cargo build ${RUST_BUILD_FLAG} ${RUST_TARGETS} --target-dir \"${TARGETDIR}\" --features \"${RUST_FEATURES}\""
     BUILD_BYPRODUCTS
       ${TARGETDIR}/debug/libshadow_shim_helper_rs.a ${TARGETDIR}/release/libshadow_shim_helper_rs.a
     INSTALL_COMMAND ""
@@ -48,6 +53,23 @@ foreach(LIBRARY shadow-shim-helper-rs logger shadow-shmem shadow-tsc shadow-rs)
   set_target_properties(${LIBRARY} PROPERTIES IMPORTED_LOCATION_DEBUG ${TARGETDIR}/debug/${LIBRARY_FILE})
   set_target_properties(${LIBRARY} PROPERTIES IMPORTED_LOCATION_RELEASE ${TARGETDIR}/release/${LIBRARY_FILE})
 endforeach()
+
+# Unit test executables don't have predictable names: https://github.com/rust-lang/cargo/issues/1924
+#
+# We previously looked for executables with names matching '${UNDERBARRED_CRATENAME}*' in
+# `${TARGETDIR}/${RUST_BUILD_TYPE}/deps/`, but this would require us to enumerate all the crates
+# with unit tests, which would be particularly error prone now that we're not individually building
+# the crates from cmake. (This is a larger set than the library-list above, which are only
+# the crates that we need to link from C code)
+#
+# Just using `cargo test` for now. It potentially (re)builds code, but seems
+# better than trying to fight the "rust way" here. It also includes doc tests,
+# which normally don't have persistent executables at all.
+add_test(NAME rust-unit-tests
+         COMMAND bash -c "${CARGO_ENV_VARS} cargo test ${RUST_BUILD_FLAG} --manifest-path \"${CMAKE_CURRENT_SOURCE_DIR}\"/Cargo.toml --target-dir \"${TARGETDIR}\" --features \"${RUST_FEATURES}\"")
+# Longer timeout here and run serially, since it's running a whole test suite,
+# and may end up rebuilding code if anything has changed.
+set_tests_properties(rust-unit-tests PROPERTIES TIMEOUT 120 RUN_SERIAL TRUE)
 
 # Outside of external, inclusion of headers within the project should be
 # relative to this directory.

--- a/src/main/lib.rs
+++ b/src/main/lib.rs
@@ -16,3 +16,9 @@ pub mod utility;
 pub mod core;
 pub mod host;
 pub mod network;
+
+// cargo spuriously drops the dependency on this crate if we don't reference it
+// from our Rust code (it's otherwise currently only referenced from our C
+// code).
+#[allow(unused)]
+use shadow_shmem;


### PR DESCRIPTION
Accidentally dropped running any rust unit tests in https://github.com/shadow/shadow/pull/2404

We were also previously not running doc tests, and I think not running tests for any crates for which we don't build a `staticlib` for C code to link to. (I'm not sure whether there were any such tests before, but there increasingly will be)

For simplicity and maintainability I just invoke `cargo test` now, instead of trying to directly run the test executables. While the cargo behavior of always rebuilding (if needed) may be slightly surprising, this approach should be more robust and maintainable.