### PR TITLE
Use "extern crate" to force linking otherwise-unused crates

### DIFF
--- a/src/lib/shadow-shim-helper-rs/src/lib.rs
+++ b/src/lib/shadow-shim-helper-rs/src/lib.rs
@@ -6,9 +6,8 @@ pub mod scmutex;
 pub mod signals;
 pub mod simulation_time;
 
-// Force cargo to link against crates that aren't (yet) referenced from Rust code (but are referenced
-// from this crate's C code).
-#[allow(unused)]
-use logger;
-#[allow(unused)]
-use shadow_shmem;
+// Force cargo to link against crates that aren't (yet) referenced from Rust
+// code (but are referenced from this crate's C code).
+// https://github.com/rust-lang/cargo/issues/9391
+extern crate logger;
+extern crate shadow_shmem;

--- a/src/lib/shmem/src/lib.rs
+++ b/src/lib/shmem/src/lib.rs
@@ -1,7 +1,4 @@
-#[allow(unused)]
-mod bindings;
-
-// Force cargo to link against crates that aren't (yet) referenced from Rust code (but are referenced
-// from this crate's C code).
-#[allow(unused)]
-use logger;
+// Force cargo to link against crates that aren't (yet) referenced from Rust
+// code (but are referenced from this crate's C code).
+// https://github.com/rust-lang/cargo/issues/9391
+extern crate logger;

--- a/src/lib/tsc/src/lib.rs
+++ b/src/lib/tsc/src/lib.rs
@@ -1,4 +1,4 @@
 // Force cargo to link against crates that aren't (yet) referenced from Rust
 // code (but are referenced from this crate's C code).
-#[allow(unused)]
-use logger;
+// https://github.com/rust-lang/cargo/issues/9391
+extern crate logger;

--- a/src/main/lib.rs
+++ b/src/main/lib.rs
@@ -17,9 +17,8 @@ pub mod core;
 pub mod host;
 pub mod network;
 
-// Force cargo to link against crates that aren't (yet) referenced from Rust code (but are referenced
-// from this crate's C code).
-#[allow(unused)]
-use shadow_shmem;
-#[allow(unused)]
-use shadow_tsc;
+// Force cargo to link against crates that aren't (yet) referenced from Rust
+// code (but are referenced from this crate's C code).
+// https://github.com/rust-lang/cargo/issues/9391
+extern crate shadow_shmem;
+extern crate shadow_tsc;


### PR DESCRIPTION
This is a more idiomatic solution for ensuring crates only referenced via C code are actually linked, as per
https://github.com/rust-lang/cargo/issues/9391