### PR TITLE
Lint rust documentation in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,21 @@ jobs:
           # if the Shadow version is bumped without using Cargo to update the lock file.
           (cd src && cargo update --locked --workspace)
 
+  lint-cargo-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Run on PR head instead of merge result. Running on the merge
+          # result can give confusing results, and we require PR to be up to
+          # date with target branch before merging, anyway.
+          # See https://github.com/shadow/shadow/issues/2166
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Cargo doc check
+        run: |
+          cmake -S . -B build
+          (cd src && RUSTDOCFLAGS='-D warnings' cargo doc)
+
   lint-bindings:
     runs-on: ubuntu-latest
     container:

--- a/src/lib/shadow-shim-helper-rs/shim_helper.h
+++ b/src/lib/shadow-shim-helper-rs/shim_helper.h
@@ -53,6 +53,7 @@ typedef struct SimulationTime SimulationTime;
 // distinguish each type of time in the code.
 typedef uint64_t CEmulatedTime;
 
+// The same as the type alias in the 'main/cshadow.rs' bindings.
 typedef uint64_t CSimulationTime;
 
 // Compatible with the Linux kernel's definition of sigset_t on x86_64.
@@ -65,7 +66,7 @@ typedef struct shd_kernel_sigset_t {
 #define shd_kernel_sigset_t_FULL (shd_kernel_sigset_t){ .val = ~0 }
 
 // In C this is conventioanlly an anonymous union, but those aren't supported
-// in Rust. https://github.com/rust-lang/rust/issues/49804
+// in Rust. <https://github.com/rust-lang/rust/issues/49804>
 typedef union ShdKernelSigactionUnion {
   void (*ksa_handler)(int32_t);
   void (*ksa_sigaction)(int32_t, siginfo_t*, void*);

--- a/src/lib/shadow-shim-helper-rs/src/signals.rs
+++ b/src/lib/shadow-shim-helper-rs/src/signals.rs
@@ -158,7 +158,7 @@ fn test_not() {
 }
 
 /// In C this is conventioanlly an anonymous union, but those aren't supported
-/// in Rust. https://github.com/rust-lang/rust/issues/49804
+/// in Rust. <https://github.com/rust-lang/rust/issues/49804>
 #[repr(C)]
 pub union ShdKernelSigactionUnion {
     ksa_handler: fn(i32),

--- a/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
@@ -3,7 +3,7 @@ Values for working with a simulated duration. Use `EmulatedTime` to represent an
 
 In Rust, use `EmulatedTime` to represent an instant in time, or
 `SimulationTime` to represent a time interval. `SimulationTime` is meant to
-replace [`c::SimulationTime`] from the C APIs.
+replace [`SimulationTime`] from the C APIs.
 
 This module contains some identically-named constants defined as C macros in
 `main/core/support/definitions.h`.
@@ -15,6 +15,7 @@ use std::time::Duration;
 #[derive(Copy, Clone, Eq, PartialEq, Debug, PartialOrd, Ord)]
 pub struct SimulationTime(CSimulationTime);
 
+/// The same as the type alias in the 'main/cshadow.rs' bindings.
 pub type CSimulationTime = u64;
 
 impl SimulationTime {

--- a/src/main/utility/synchronization/count_down_latch.rs
+++ b/src/main/utility/synchronization/count_down_latch.rs
@@ -87,7 +87,7 @@ impl LatchState {
 impl LatchCounter {
     /// Decrement the latch count and wake the waiters if the count reaches 0. This must not be
     /// called more than once per generation (must not be called again until all of the waiters have
-    /// returned from their [`wait`] calls), otherwise it will panic.
+    /// returned from their [`LatchWaiter::wait()`] calls), otherwise it will panic.
     pub fn count_down(&mut self) {
         let counters;
         {


### PR DESCRIPTION
Linting the code documentation might be a little over-the-top, but I don't think it will be that bad and it makes sure that our documentation links are correct.