### PR TITLE
Remove host lock

### DIFF
--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -322,13 +322,13 @@ impl<'a> Manager<'a> {
                 s.run_with_hosts(move |_, hosts| {
                     while let Some(host) = hosts.next() {
                         worker::Worker::set_current_time(EmulatedTime::SIMULATION_START);
-                        unsafe { host.lock() };
+                        unsafe { host.lock_shmem() };
                         worker::Worker::set_active_host(host);
 
                         host.boot();
 
                         worker::Worker::clear_active_host();
-                        unsafe { host.unlock() };
+                        unsafe { host.unlock_shmem() };
                         worker::Worker::clear_current_time();
                     }
                 });
@@ -383,14 +383,14 @@ impl<'a> Manager<'a> {
 
                             // get the next host for this thread from the scheduler
                             while let Some(host) = hosts.next() {
-                                unsafe { host.lock() };
+                                unsafe { host.lock_shmem() };
                                 worker::Worker::set_active_host(host);
 
                                 host.execute(window_end);
                                 let host_next_event_time = host.next_event_time();
 
                                 worker::Worker::clear_active_host();
-                                unsafe { host.unlock() };
+                                unsafe { host.unlock_shmem() };
 
                                 *next_event_time = [*next_event_time, host_next_event_time]
                                     .into_iter()

--- a/src/main/cshadow.rs
+++ b/src/main/cshadow.rs
@@ -2817,12 +2817,6 @@ extern "C" {
     pub fn host_getOwnedEventQueue(host: *mut Host) -> *const ThreadSafeEventQueue;
 }
 extern "C" {
-    pub fn host_lock(host: *mut Host);
-}
-extern "C" {
-    pub fn host_unlock(host: *mut Host);
-}
-extern "C" {
     pub fn host_continueExecutionTimer(host: *mut Host);
 }
 extern "C" {

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -46,10 +46,6 @@
 #include "main/utility/utility.h"
 
 struct _Host {
-    /* general node lock. nothing that belongs to the node should be touched
-     * unless holding this lock. everything following this falls under the lock. */
-    GMutex lock;
-
     HostParameters params;
 
     /* for event scheduling */
@@ -138,9 +134,6 @@ Host* host_new(const HostParameters* params) {
     utility_debugAssert(params->hostname);
     host->params.hostname = g_strdup(params->hostname);
     if(params->pcapDir) host->params.pcapDir = g_strdup(params->pcapDir);
-
-    /* thread-level event communication with other nodes */
-    g_mutex_init(&(host->lock));
 
     host->eventQueue = eventqueue_new();
 
@@ -321,8 +314,6 @@ void host_shutdown(Host* host) {
 
     if(host->params.pcapDir) g_free((gchar*)host->params.pcapDir);
 
-    g_mutex_clear(&(host->lock));
-
     if(host->dataDirPath) {
         g_free(host->dataDirPath);
     }
@@ -356,16 +347,6 @@ void host_unref(Host* host) {
     if(host->referenceCount == 0) {
         _host_free(host);
     }
-}
-
-void host_lock(Host* host) {
-    MAGIC_ASSERT(host);
-    g_mutex_lock(&(host->lock));
-}
-
-void host_unlock(Host* host) {
-    MAGIC_ASSERT(host);
-    g_mutex_unlock(&(host->lock));
 }
 
 /* resumes the execution timer for this host */

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -44,9 +44,6 @@ void host_execute(Host* host, CEmulatedTime until);
 CEmulatedTime host_nextEventTime(Host* host);
 const ThreadSafeEventQueue* host_getOwnedEventQueue(Host* host);
 
-void host_lock(Host* host);
-void host_unlock(Host* host);
-
 void host_continueExecutionTimer(Host* host);
 void host_stopExecutionTimer(Host* host);
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -187,14 +187,12 @@ impl Host {
         EmulatedTime::from_c_emutime(unsafe { cshadow::host_nextEventTime(self.chost()) })
     }
 
-    pub unsafe fn lock(&mut self) {
-        unsafe { cshadow::host_lock(self.chost()) };
+    pub unsafe fn lock_shmem(&mut self) {
         unsafe { cshadow::host_lockShimShmemLock(self.chost()) };
     }
 
-    pub unsafe fn unlock(&mut self) {
+    pub unsafe fn unlock_shmem(&mut self) {
         unsafe { cshadow::host_unlockShimShmemLock(self.chost()) };
-        unsafe { cshadow::host_unlock(self.chost()) };
     }
 
     pub fn chost(&self) -> *mut cshadow::Host {


### PR DESCRIPTION
Now that the hosts are managed in rust code, this lock isn't needed.