### PR TITLE
Upgrade from clap 3 to 4

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
+ "clap 3.2.20",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -157,7 +157,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
 dependencies = [
- "clap",
+ "clap 3.2.20",
  "heck",
  "indexmap",
  "log",
@@ -222,21 +222,34 @@ checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
- "once_cell",
  "strsim",
  "termcolor",
- "terminal_size",
  "textwrap",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "3.2.18"
+name = "clap"
+version = "4.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "5840cd9093aabeabf7fd932754c435b7674520fc3ddc935c397837050f0f1e4b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92289ffc6fb4a85d85c246ddb874c05a87a2e540fb6ad52f7ca07c8c1e1840b1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -250,6 +263,15 @@ name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -358,6 +380,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +542,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "log"
@@ -698,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -879,6 +934,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.35.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,7 +1066,7 @@ dependencies = [
  "bytes",
  "cbindgen",
  "cc",
- "clap",
+ "clap 4.0.8",
  "crossbeam",
  "gml-parser",
  "libc",
@@ -1169,12 +1238,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
 dependencies = [
- "libc",
- "winapi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1182,9 +1251,6 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-dependencies = [
- "terminal_size",
-]
 
 [[package]]
 name = "toml"
@@ -1275,3 +1341,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = "1.3"
 # issue: https://github.com/tokio-rs/bytes/issues/287
 # pr: https://github.com/tokio-rs/bytes/pull/513
 bytes = { git = "https://github.com/shadow/bytes", rev = "c48bd4439e7e043300521925524ecdcce7ff6bcc" }
-clap = { version = "3.2.20", features = ["derive", "wrap_help"] }
+clap = { version = "4.0.8", features = ["derive", "wrap_help"] }
 crossbeam = "0.8.2"
 gml-parser = { path = "../lib/gml-parser" }
 libc = "0.2"

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -4,7 +4,6 @@ use std::num::NonZeroU32;
 use std::os::unix::ffi::OsStrExt;
 use std::str::FromStr;
 
-use clap::ArgEnum;
 use clap::Parser;
 use merge::Merge;
 use once_cell::sync::Lazy;
@@ -33,9 +32,10 @@ const END_HELP_TEXT: &str = "\
 #[derive(Debug, Clone, Parser)]
 #[clap(name = "Shadow", about = START_HELP_TEXT, after_help = END_HELP_TEXT)]
 #[clap(version = std::option_env!("SHADOW_VERSION").unwrap_or(std::env!("CARGO_PKG_VERSION")))]
+#[clap(next_display_order = None)]
 pub struct CliOptions {
     /// Path to the Shadow configuration file. Use '-' to read from stdin
-    #[clap(required_unless_present_any(&["show-build-info", "shm-cleanup"]))]
+    #[clap(required_unless_present_any(&["show_build_info", "shm_cleanup"]))]
     pub config: Option<String>,
 
     /// Pause to allow gdb to attach
@@ -43,7 +43,7 @@ pub struct CliOptions {
     pub gdb: bool,
 
     /// Pause after starting any processes on the comma-delimited list of hostnames
-    #[clap(parse(try_from_str = parse_set_str))]
+    #[clap(value_parser = parse_set_str)]
     #[clap(long, value_name = "hostnames")]
     pub debug_hosts: Option<HashSet<String>>,
 
@@ -140,7 +140,8 @@ static GENERAL_HELP: Lazy<std::collections::HashMap<String, String>> =
 // these must all be Option types since they aren't required by the CLI, even if they're
 // required in the configuration file
 #[derive(Debug, Clone, Parser, Serialize, Deserialize, Merge, JsonSchema)]
-#[clap(next_help_heading = "GENERAL (Override configuration file options)")]
+#[clap(next_help_heading = "General (Override configuration file options)")]
+#[clap(next_display_order = None)]
 #[serde(deny_unknown_fields)]
 pub struct GeneralOptions {
     /// The simulated time at which simulated processes are sent a SIGKILL signal
@@ -225,7 +226,8 @@ static NETWORK_HELP: Lazy<std::collections::HashMap<String, String>> =
 // these must all be Option types since they aren't required by the CLI, even if they're
 // required in the configuration file
 #[derive(Debug, Clone, Parser, Serialize, Deserialize, Merge, JsonSchema)]
-#[clap(next_help_heading = "NETWORK (Override network options)")]
+#[clap(next_help_heading = "Network (Override network options)")]
+#[clap(next_display_order = None)]
 #[serde(deny_unknown_fields)]
 pub struct NetworkOptions {
     /// The network topology graph
@@ -255,8 +257,9 @@ static EXP_HELP: Lazy<std::collections::HashMap<String, String>> =
 
 #[derive(Debug, Clone, Parser, Serialize, Deserialize, Merge, JsonSchema)]
 #[clap(
-    next_help_heading = "EXPERIMENTAL (Unstable and may change or be removed at any time, regardless of Shadow version)"
+    next_help_heading = "Experimental (Unstable and may change or be removed at any time, regardless of Shadow version)"
 )]
+#[clap(next_display_order = None)]
 #[serde(default, deny_unknown_fields)]
 pub struct ExperimentalOptions {
     /// Use the SCHED_FIFO scheduler. Requires CAP_SYS_NICE. See sched(7), capabilities(7)
@@ -390,7 +393,7 @@ pub struct ExperimentalOptions {
 
     /// List of information to show in the host's heartbeat message
     #[clap(hide_short_help = true)]
-    #[clap(parse(try_from_str = parse_set_log_info_flags))]
+    #[clap(value_parser = parse_set_log_info_flags)]
     #[clap(long, value_name = "options")]
     #[clap(help = EXP_HELP.get("host_heartbeat_log_info").unwrap().as_str())]
     pub host_heartbeat_log_info: Option<HashSet<LogInfoFlag>>,
@@ -506,7 +509,8 @@ static HOST_HELP: Lazy<std::collections::HashMap<String, String>> =
     Lazy::new(|| generate_help_strs(schema_for!(HostDefaultOptions)));
 
 #[derive(Debug, Clone, Parser, Serialize, Deserialize, Merge, JsonSchema)]
-#[clap(next_help_heading = "HOST DEFAULTS (Default options for hosts)")]
+#[clap(next_help_heading = "Host Defaults (Default options for hosts)")]
+#[clap(next_display_order = None)]
 #[serde(default, deny_unknown_fields)]
 pub struct HostDefaultOptions {
     /// Log level at which to print node messages
@@ -670,7 +674,7 @@ fn default_data_directory() -> Option<String> {
     Some("shadow.data".into())
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, ArgEnum, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum LogInfoFlag {
     Node,
@@ -716,7 +720,7 @@ fn parse_set_str(s: &str) -> Result<HashSet<String>, <String as FromStr>::Err> {
     parse_set(s)
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, ArgEnum, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 #[repr(C)]
 pub enum QDiscMode {


### PR DESCRIPTION
Some of the changes seem to have been reverted between the v4 rc and this current v4.0.8, so less changes were required than I was expecting.

Unfortunately this adds a bunch of windows dependencies to the lock file, but not much we can do about that.

Short help output changes (whitespace ignored):

```diff
diff --git a/help-clap-3 b/help-clap-4
index 9548607..fcbb67b 100644
--- a/help-clap-3
+++ b/help-clap-4
@@ -1,69 +1,60 @@
-Shadow v2.2.0-322-gf49f6e02-dirty 2022-10-03--11:07:21
 Run real applications over simulated networks.

 For documentation, visit https://shadow.github.io/docs/guide

-USAGE:
-    shadow [OPTIONS] [CONFIG]
+Usage: shadow [OPTIONS] [CONFIG]

-ARGS:
-    <CONFIG>    Path to the Shadow configuration file. Use '-' to read from stdin
+Arguments:
+  [CONFIG]  Path to the Shadow configuration file. Use '-' to read from stdin

-OPTIONS:
-        --debug-hosts <hostnames>    Pause after starting any processes on the comma-delimited list
-                                     of hostnames
+Options:
+      --debug-hosts <hostnames>  Pause after starting any processes on the comma-delimited list of
+                                 hostnames
   -g, --gdb                      Pause to allow gdb to attach
-    -h, --help                       Print help information
+  -h, --help                     Print help information (use `--help` for more detail)
       --shm-cleanup              Exit after running shared memory cleanup routine
       --show-build-info          Exit after printing build information
       --show-config              Exit after printing the final configuration
   -V, --version                  Print version information

-GENERAL (Override configuration file options):
+General (Override configuration file options):
       --bootstrap-end-time <seconds>
-            The simulated time that ends Shadow's high network bandwidth/reliability bootstrap
-            period [default: "0 sec"]
-
+          The simulated time that ends Shadow's high network bandwidth/reliability bootstrap period
+          [default: "0 sec"]
   -d, --data-directory <path>
           Path to store simulation output [default: "shadow.data"]
-
   -e, --template-directory <path>
           Path to recursively copy during startup and use as the data-directory [default: null]
-
       --heartbeat-interval <seconds>
           Interval at which to print heartbeat messages [default: "1 sec"]
-
   -l, --log-level <level>
           Log level of output written on stdout. If Shadow was built in release mode, then log
           messages at level 'trace' will always be dropped [default: "info"]
-
       --model-unblocked-syscall-latency <bool>
           Model syscalls and VDSO functions that don't block as having some latency. This should
           have minimal effect on typical simulations, but can be helpful for programs with "busy
-            loops" that otherwise deadlock under Shadow. [default: false]
-
+          loops" that otherwise deadlock under Shadow. [default: false] [possible values: true,
+          false]
   -p, --parallelism <cores>
           How many parallel threads to use to run the simulation. Optimal performance is usually
           obtained with `nproc`, or sometimes `nproc`/2 with hyperthreading. [default: 1]
-
       --progress <bool>
-            Show the simulation progress on stderr [default: false]
-
+          Show the simulation progress on stderr [default: false] [possible values: true, false]
       --seed <N>
           Initialize randomness using seed N [default: 1]
-
       --stop-time <seconds>
           The simulated time at which simulated processes are sent a SIGKILL signal

-NETWORK (Override network options):
+Network (Override network options):
       --use-shortest-path <bool>  When routing packets, follow the shortest path rather than
-                                      following a direct edge between nodes. If false, the network
-                                      graph is required to be complete. [default: true]
+                                  following a direct edge between nodes. If false, the network graph
+                                  is required to be complete. [default: true] [possible values:
+                                  true, false]

-HOST DEFAULTS (Default options for hosts):
+Host Defaults (Default options for hosts):
       --host-log-level <level>     Log level at which to print node messages [default: null]
-        --pcap-capture-size <bytes>    How much data to capture per packet (header and payload) if
-                                       pcap logging is enabled [default: "65535 B"]
+      --pcap-capture-size <bytes>  How much data to capture per packet (header and payload) if pcap
+                                   logging is enabled [default: "65535 B"]
       --pcap-directory <path>      Where to save the pcap files (relative to the host directory)
                                    [default: null]

```

Long help output changes (whitespace ignored):

```diff
diff --git a/help-clap-3 b/help-clap-4
index ec252f9..559dd2b 100644
--- a/help-clap-3
+++ b/help-clap-4
@@ -1,16 +1,14 @@
-Shadow v2.2.0-322-gf49f6e02-dirty 2022-10-03--11:07:21
 Run real applications over simulated networks.

 For documentation, visit https://shadow.github.io/docs/guide

-USAGE:
-    shadow [OPTIONS] [CONFIG]
+Usage: shadow [OPTIONS] [CONFIG]

-ARGS:
-    <CONFIG>
+Arguments:
+  [CONFIG]
           Path to the Shadow configuration file. Use '-' to read from stdin

-OPTIONS:
+Options:
       --debug-hosts <hostnames>
           Pause after starting any processes on the comma-delimited list of hostnames

@@ -18,7 +16,7 @@ OPTIONS:
           Pause to allow gdb to attach

   -h, --help
-            Print help information
+          Print help information (use `-h` for a summary)

       --shm-cleanup
           Exit after running shared memory cleanup routine
@@ -32,10 +30,10 @@ OPTIONS:
   -V, --version
           Print version information

-GENERAL (Override configuration file options):
+General (Override configuration file options):
       --bootstrap-end-time <seconds>
-            The simulated time that ends Shadow's high network bandwidth/reliability bootstrap
-            period [default: "0 sec"]
+          The simulated time that ends Shadow's high network bandwidth/reliability bootstrap period
+          [default: "0 sec"]

   -d, --data-directory <path>
           Path to store simulation output [default: "shadow.data"]
@@ -55,6 +53,8 @@ GENERAL (Override configuration file options):
           have minimal effect on typical simulations, but can be helpful for programs with "busy
           loops" that otherwise deadlock under Shadow. [default: false]

+          [possible values: true, false]
+
   -p, --parallelism <cores>
           How many parallel threads to use to run the simulation. Optimal performance is usually
           obtained with `nproc`, or sometimes `nproc`/2 with hyperthreading. [default: 1]
@@ -62,18 +62,22 @@ GENERAL (Override configuration file options):
       --progress <bool>
           Show the simulation progress on stderr [default: false]

+          [possible values: true, false]
+
       --seed <N>
           Initialize randomness using seed N [default: 1]

       --stop-time <seconds>
           The simulated time at which simulated processes are sent a SIGKILL signal

-NETWORK (Override network options):
+Network (Override network options):
       --use-shortest-path <bool>
-            When routing packets, follow the shortest path rather than following a direct edge
-            between nodes. If false, the network graph is required to be complete. [default: true]
+          When routing packets, follow the shortest path rather than following a direct edge between
+          nodes. If false, the network graph is required to be complete. [default: true]
+
+          [possible values: true, false]

-HOST DEFAULTS (Default options for hosts):
+Host Defaults (Default options for hosts):
       --host-log-level <level>
           Log level at which to print node messages [default: null]

@@ -84,7 +88,7 @@ HOST DEFAULTS (Default options for hosts):
       --pcap-directory <path>
           Where to save the pcap files (relative to the host directory) [default: null]

-EXPERIMENTAL (Unstable and may change or be removed at any time, regardless of Shadow version):
+Experimental (Unstable and may change or be removed at any time, regardless of Shadow version):
       --host-heartbeat-interval <seconds>
           Amount of time between heartbeat messages for this host [default: null]

@@ -95,8 +99,7 @@ EXPERIMENTAL (Unstable and may change or be removed at any time, regardless of S
           Log level at which to print host statistics [default: "info"]

       --interface-buffer <bytes>
-            Size of the interface receive buffer that accepts incoming packets [default: "1024000
-            B"]
+          Size of the interface receive buffer that accepts incoming packets [default: "1024000 B"]

       --interface-qdisc <mode>
           The queueing discipline to use at the network interface [default: "fifo"]
@@ -122,12 +125,16 @@ EXPERIMENTAL (Unstable and may change or be removed at any time, regardless of S
       --socket-recv-autotune <bool>
           Enable receive window autotuning [default: true]

+          [possible values: true, false]
+
       --socket-recv-buffer <bytes>
           Initial size of the socket's receive buffer [default: "174760 B"]

       --socket-send-autotune <bool>
           Enable send window autotuning [default: true]

+          [possible values: true, false]
+
       --socket-send-buffer <bytes>
           Initial size of the socket's send buffer [default: "131072 B"]

@@ -146,52 +153,77 @@ EXPERIMENTAL (Unstable and may change or be removed at any time, regardless of S
           Pin each thread and any processes it executes to the same logical CPU Core to improve
           cache affinity [default: true]

+          [possible values: true, false]
+
       --use-dynamic-runahead <bool>
           Update the minimum runahead dynamically throughout the simulation. [default: false]

+          [possible values: true, false]
+
       --use-explicit-block-message <bool>
-            Send message to plugin telling it to stop spinning when a syscall blocks [default:
-            false]
+          Send message to plugin telling it to stop spinning when a syscall blocks [default: false]
+
+          [possible values: true, false]

       --use-extended-yaml <bool>
-            Enable extended YAML conventions (merge keys and extension fields). Can only be enabled
-            on the command line (enabling in the configuration file is a no-op). [default: false]
+          Enable extended YAML conventions (merge keys and extension fields). Can only be enabled on
+          the command line (enabling in the configuration file is a no-op). [default: false]
+
+          [possible values: true, false]

       --use-legacy-working-dir <bool>
           Don't adjust the working directories of the plugins [default: false]

+          [possible values: true, false]
+
       --use-memory-manager <bool>
           Use the MemoryManager. It can be useful to disable for debugging, but will hurt
           performance in most cases [default: true]

+          [possible values: true, false]
+
       --use-object-counters <bool>
           Count object allocations and deallocations. If disabled, we will not be able to detect
           object memory leaks [default: true]

+          [possible values: true, false]
+
       --use-preload-libc <bool>
           Preload our libc library for all managed processes for fast syscall interposition when
           possible. [default: true]

+          [possible values: true, false]
+
       --use-preload-openssl-crypto <bool>
           Preload our OpenSSL crypto library for all managed processes to skip some crypto
           operations (may speed up simulation if your CPU lacks AES-NI support, but can cause bugs
           so do not use unless you know what you're doing). [default: false]

+          [possible values: true, false]
+
       --use-preload-openssl-rng <bool>
           Preload our OpenSSL RNG library for all managed processes to mitigate non-deterministic
           use of OpenSSL. [default: true]

+          [possible values: true, false]
+
       --use-sched-fifo <bool>
           Use the SCHED_FIFO scheduler. Requires CAP_SYS_NICE. See sched(7), capabilities(7)
           [default: false]

+          [possible values: true, false]
+
       --use-shim-syscall-handler <bool>
           Use shim-side syscall handler to force hot-path syscalls to be handled via an
           inter-process syscall with Shadow [default: true]

+          [possible values: true, false]
+
       --use-syscall-counters <bool>
           Count the number of occurrences for individual syscalls [default: true]

+          [possible values: true, false]
+
 If units are not specified, all values are assumed to be given in their base unit (seconds, bytes,
 bits, etc). Units can optionally be specified (for example: '1024 B', '1024 bytes', '1 KiB', '1
 kibibyte', etc) and are case-sensitive.

```