### PR TITLE
Use formatted help output

### DIFF
--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -32,11 +32,14 @@ pub fn run_shadow<'a>(args: Vec<&'a OsStr>) -> anyhow::Result<()> {
     let options = match CliOptions::try_parse_from(args.clone()) {
         Ok(x) => x,
         Err(e) => {
+            // will print to either stdout or stderr with formatting
+            e.print().unwrap();
             if e.use_stderr() {
-                eprint!("{}", e);
+                // the `clap::Error` represents an error (ex: invalid flag)
                 std::process::exit(1);
             } else {
-                print!("{}", e);
+                // the `clap::Error` represents a non-error, but we'll want to exit anyways (ex:
+                // '--help')
                 std::process::exit(0);
             }
         }


### PR DESCRIPTION
This uses coloring and underlining in clap's help output (including help error messages).

Example:

![1664825117_grim](https://user-images.githubusercontent.com/3708797/193661589-2addc52a-e7c6-4acf-bfb1-9a385fb7b4d5.png)