### PR TITLE
Allow for sourcing executables from $PATH

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,4 +11,8 @@ A list of user-facing changes since the latest Shadow release.
   to search for pkg-config files, C headers, and libraries. It obsoletes the options `--library` and `--include`.
 * Fixed a bug causing `mmap` to fail when called on a file descriptor that was
 opened with `O_NOFOLLOW`. https://github.com/shadow/shadow/pull/2353
+* Bare executable names are now resolved by searching shadow's `PATH`. Previously these were
+interpreted as relative to the current directory. For backwards compatibility, Shadow will currently
+prefer a binary in that location if one is found but log a warning. Such cases should be disambiguated
+by using an absolute path or prefixing with `./`.
 * (add entry here)

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -720,6 +720,13 @@ Type: String
 If the path begins with `~/`, it will be considered relative to the current
 user's home directory.
 
+Bare file basenames like `sleep` will be located using Shadow's `PATH`
+environment variable (e.g. to `/usr/bin/sleep`). For backwards compatibility, if
+that path is also found relative to shadow's working directory, *that* binary
+will be used instead. This behavior is expected to be dropped in *the next major
+Shadow release; users should disambiguate by prefixing with `./` or using an
+absolute path as appropriate.
+
 #### `hosts.<hostname>.processes[*].quantity`
 
 Default: 1  

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1094,6 +1094,7 @@ dependencies = [
  "system-deps",
  "tempfile",
  "vsprintf",
+ "which",
 ]
 
 [[package]]

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -51,6 +51,7 @@ tempfile = "3.3"
 # `c_variadic` is stabilized, or if we decide to enable it anyway.
 # https://github.com/rust-lang/rust/issues/44930
 vsprintf = { git = "https://github.com/shadow/vsprintf", rev = "fa9a307e3043a972501b3157323ed8a9973ad45a" }
+which = "4.3.0"
 
 [features]
 perf_timers = []

--- a/src/main/core/sim_config.rs
+++ b/src/main/core/sim_config.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Context;
+use log::warn;
 use rand::{Rng, SeedableRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
 
@@ -342,38 +343,56 @@ fn build_process(proc: &ProcessOptions) -> anyhow::Result<Vec<ProcessInfo>> {
             .with_context(|| format!("Failed to parse arguments: {x}"))?,
     };
 
-    let proc_path = proc.path.to_str().unwrap();
+    let expanded_path = tilde_expansion(proc.path.to_str().unwrap());
 
-    // Check if the path has no '/' where it is likely to be a executable that should be sourced from $PATH
-    // TODO: In next breaking release, if likely_not_path is true, source from $PATH by default and remove deprecation warning below. Also make sure to fix all the broken tests that will result.
-    let likely_not_path = proc_path.chars().find(|c|*c == '/').is_none();
-    
-    let expanded_path = tilde_expansion(proc_path);
+    // We currently use `which::which`, which searches the `PATH` similarly to a
+    // shell.
+    let new_canonical_path: Result<PathBuf, anyhow::Error> = which::which(&expanded_path)
+        .map_err(anyhow::Error::from)
+        // `which` returns an absolute path, but it may still contain
+        // symbolic links, .., etc.
+        .and_then(|p| p.canonicalize().map_err(anyhow::Error::from));
+    // We previously used only `std::fs::canonicalize`, which doesn't search
+    // `PATH`, and *does* search the current directory.
+    let legacy_canonical_path: Result<PathBuf, anyhow::Error> = expanded_path
+        .canonicalize()
+        .map_err(|e| anyhow::Error::from(e));
 
-    let plugin = match expanded_path
-        .canonicalize().with_context(|| format!("Failed to canonicalize plugin path '{}'", expanded_path.display())) {
-        Ok(plugin) => { // Warn that relative path "thing" should be changed to "./thing" 
-            if likely_not_path { log::warn!("The relative path \"{0}\" will be deprecated in favor of \"./{0}\"", proc_path) }
-            plugin
-        }
-        Err(_) if likely_not_path => {
-            let plugin = which::which(proc_path).with_context(|| format!("Failed to resolve \"{proc_path}\" from $PATH"))?;
-            log::info!("Resolved process path \"{proc_path}\" to \"{}\"", plugin.display());
-            plugin
-        }
-        Err(err) => Err(err)?,
+    let canonical_path = if new_canonical_path.is_ok()
+        && legacy_canonical_path.is_ok()
+        && *new_canonical_path.as_ref().unwrap() != *legacy_canonical_path.as_ref().unwrap()
+    {
+        warn!("Ambiguous path: {:?} resolves to either {:?} or {:?}. Using {:?} for backards compatibility, but a future version of shadow will not implicitly search the current working directory. Consider making absolute or prefixing with './'",
+            expanded_path,
+            legacy_canonical_path.as_ref().unwrap(),
+            new_canonical_path.as_ref().unwrap(),
+            legacy_canonical_path.as_ref().unwrap());
+        legacy_canonical_path.as_ref().unwrap()
+    } else if let Ok(p) = new_canonical_path.as_ref() {
+        p
+    } else if let Ok(p) = legacy_canonical_path.as_ref() {
+        warn!("Expanded path {:?} only via legacy fallback search, which implicitly searched current working dir. Consider prefixing with './'", proc.path.to_str().unwrap());
+        p
+    } else {
+        return Err(new_canonical_path
+            .with_context(|| format!("Failed to resolve plugin path '{:?}'", expanded_path))
+            .unwrap_err());
     };
 
-    // verify that the path is a file and is executable
-    verify_plugin_path(&plugin)
-        .with_context(|| format!("Failed to verify plugin path '{}'", plugin.display()))?;
+    verify_plugin_path(&canonical_path)
+        .with_context(|| format!("Failed to verify plugin path '{:?}'", canonical_path))?;
+    log::info!(
+        "Resolved binary path {:?} to {:?}",
+        proc.path,
+        canonical_path
+    );
 
     // set argv[0] as the user-provided expanded string, not the canonicalized version
     args.insert(0, expanded_path.into());
 
     Ok(vec![
         ProcessInfo {
-            plugin: plugin,
+            plugin: canonical_path.clone(),
             start_time,
             stop_time,
             args: args,

--- a/src/test/compressed-graph/compressed-graph.yaml
+++ b/src/test/compressed-graph/compressed-graph.yaml
@@ -10,5 +10,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: /bin/true
+    - path: "true"
       start_time: 1

--- a/src/test/regression/sigkill_self.yaml
+++ b/src/test/regression/sigkill_self.yaml
@@ -8,6 +8,6 @@ hosts:
   host:
     network_node_id: 0
     processes:
-    - path: /bin/kill
+    - path: "kill"
       args: -KILL 1000
       start_time: 1s

--- a/src/test/regression/small_stop_time.yaml
+++ b/src/test/regression/small_stop_time.yaml
@@ -11,12 +11,12 @@ hosts:
   b:
     network_node_id: 0
     processes:
-    - path: /bin/sleep
+    - path: "sleep"
       args: "30"
       start_time: 10s
   a:
     network_node_id: 0
     processes:
-    - path: /bin/sleep
+    - path: "sleep"
       args: "30"
       start_time: 20s

--- a/src/test/tor/minimal/CMakeLists.txt
+++ b/src/test/tor/minimal/CMakeLists.txt
@@ -5,8 +5,8 @@ add_custom_target(tor-minimal-shadow-conf ALL
                     ${CMAKE_CURRENT_BINARY_DIR}/conf
                   # older tor versions don't support the AuthDirTestReachability torrc option,
                   # so comment out those lines if not supported
-                  COMMAND /bin/bash -c
-                    "(~/.local/bin/tor --list-torrc-options | grep -q 'AuthDirTestReachability') \
+                  COMMAND bash -c
+                    "(tor --list-torrc-options | grep -q 'AuthDirTestReachability') \
                     || find ${CMAKE_CURRENT_BINARY_DIR}/conf -type f -print0 \
                       | xargs -0 sed -i '/AuthDirTestReachability/s/^/#/g'"
                   VERBATIM)


### PR DESCRIPTION
This is a pretty large PR (with some possibly controversial changes) so just tell me what I should remove / change / split up to get this merged.

This PR does the following:
Reimplements `tilde_expansion` as `resolve_path`. It now takes a `&Path`, returns an `anyhow::Result<PathBuf>`, and looks in `$PATH` if input is a standalone string (e.g. `true` will now resolve to `/bin/true`)
Various edits to fix yaml files with absolute paths or relative paths that conflicted with the $PATH lookup.
