### PR TITLE
Disable 'test_shortest_path' test under miri

### DIFF
--- a/src/main/network/network_graph.rs
+++ b/src/main/network/network_graph.rs
@@ -550,7 +550,9 @@ mod tests {
         }
     }
 
+    // disabled under miri due to https://github.com/rayon-rs/rayon/issues/952
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_shortest_path() {
         for directed in &[true, false] {
             let graph = format!(


### PR DESCRIPTION
This test failed in the CI again, even with the rust version pinned (#2427). This seems to be caused by https://github.com/rayon-rs/rayon/issues/952.

```
Error: Undefined Behavior: deallocating while item [SharedReadOnly for <5756175>] is protected by call 1624160
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.3/src/registry.rs:479:9
    |
479 |         })
    |         ^ deallocating while item [SharedReadOnly for <5756175>] is protected by call 1624160
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
    = note: BACKTRACE:
    = note: inside closure at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-core-1.9.3/src/registry.rs:479:9
    = note: inside `std::thread::LocalKey::<rayon_core::latch::LockLatch>::try_with::<[closure@rayon_core::registry::Registry::in_worker_cold<[closure@rayon::join_context<[closure@rayon::iter::plumbing::bridge_producer_consumer::helper<rayon::slice::IterProducer<petgraph::prelude::NodeIndex>, rayon::iter::flat_map::FlatMapConsumer<rayon::iter::extend::ListVecConsumer, [closure@main/network/network_graph.rs:192:23: 192:28]>>::{closure#0}], [closure@rayon::iter::plumbing::bridge_producer_consumer::helper<rayon::slice::IterProducer<petgraph::prelude::NodeIndex>, rayon::iter::flat_map::FlatMapConsumer<rayon::iter::extend::ListVecConsumer, [closure@main/network/network_graph.rs:192:23: 192:28]>>::{closure#1}], std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>, std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>>::{closure#0}], (std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>, std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>)>::{closure#0}], (std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>, std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>)>` at /home/runner/.rustup/toolchains/nightly-2022-09-24-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:445:16
    = note: inside `std::thread::LocalKey::<rayon_core::latch::LockLatch>::with::<[closure@rayon_core::registry::Registry::in_worker_cold<[closure@rayon::join_context<[closure@rayon::iter::plumbing::bridge_producer_consumer::helper<rayon::slice::IterProducer<petgraph::prelude::NodeIndex>, rayon::iter::flat_map::FlatMapConsumer<rayon::iter::extend::ListVecConsumer, [closure@main/network/network_graph.rs:192:23: 192:28]>>::{closure#0}], [closure@rayon::iter::plumbing::bridge_producer_consumer::helper<rayon::slice::IterProducer<petgraph::prelude::NodeIndex>, rayon::iter::flat_map::FlatMapConsumer<rayon::iter::extend::ListVecConsumer, [closure@main/network/network_graph.rs:192:23: 192:28]>>::{closure#1}], std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>, std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>>::{closure#0}], (std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>, std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>)>::{closure#0}], (std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>, std::collections::LinkedList<std::vec::Vec<((petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties)>>)>` at /home/runner/.rustup/toolchains/nightly-2022-09-24-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:421:9

[...]

    = note: inside `<rayon::iter::FlatMap<rayon::slice::Iter<petgraph::prelude::NodeIndex>, [closure@main/network/network_graph.rs:192:23: 192:28]> as rayon::iter::ParallelIterator>::collect::<std::collections::HashMap<(petgraph::prelude::NodeIndex, petgraph::prelude::NodeIndex), network::network_graph::PathProperties>>` at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.5.3/src/iter/mod.rs:2046:9
note: inside `network::network_graph::NetworkGraph::compute_shortest_paths` at main/network/network_graph.rs:190:58
   --> main/network/network_graph.rs:190:58
    |
190 |           let mut paths: HashMap<(_, _), PathProperties> = nodes
    |  __________________________________________________________^
191 | |             .into_par_iter()
192 | |             .flat_map(|src| {
193 | |                 match &self.graph {
...   |
207 | |             })
208 | |             .collect();
    | |______________________^
note: inside `network::network_graph::tests::test_shortest_path` at main/network/network_graph.rs:611:34
   --> main/network/network_graph.rs:611:34
    |
611 |               let shortest_paths = graph
    |  __________________________________^
612 | |                 .compute_shortest_paths(&[node_0, node_1, node_2])
    | |__________________________________________________________________^
note: inside closure at main/network/network_graph.rs:554:5
   --> main/network/network_graph.rs:554:5
    |
553 |       #[test]
    |       ------- in this procedural macro expansion
554 | /     fn test_shortest_path() {
555 | |         for directed in &[true, false] {
556 | |             let graph = format!(
557 | |                 r#"graph [
...   |
638 | |         }
639 | |     }
    | |_____^
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to previous error
```