### PR TITLE
Return a netmask in `getifaddrs()`

### DIFF
--- a/src/lib/shim/shim_api_ifaddrs.c
+++ b/src/lib/shim/shim_api_ifaddrs.c
@@ -32,6 +32,8 @@ int shim_api_getifaddrs(struct ifaddrs** ifap) {
 
     i->ifa_addr = calloc(1, sizeof(struct sockaddr));
     i->ifa_addr->sa_family = AF_INET;
+    i->ifa_netmask = calloc(1, sizeof(struct sockaddr));
+    i->ifa_netmask->sa_family = AF_INET;
 
     struct in_addr addr_buf;
     if (inet_pton(AF_INET, "127.0.0.1", &addr_buf) != 1) {
@@ -41,6 +43,22 @@ int shim_api_getifaddrs(struct ifaddrs** ifap) {
     }
 
     ((struct sockaddr_in*)i->ifa_addr)->sin_addr = addr_buf;
+
+    if (inet_pton(AF_INET, "255.0.0.0", &addr_buf) != 1) {
+        shim_api_freeifaddrs(i);
+        errno = EADDRNOTAVAIL;
+        return -1;
+    }
+
+    ((struct sockaddr_in*)i->ifa_netmask)->sin_addr = addr_buf;
+
+    /* a /24 netmask */
+    struct in_addr netmask_24;
+    if (inet_pton(AF_INET, "255.255.255.0", &netmask_24) != 1) {
+        shim_api_freeifaddrs(i);
+        errno = EADDRNOTAVAIL;
+        return -1;
+    }
 
     /* get the hostname so we can use it to lookup the default net address */
     char hostname_buf[HOST_NAME_MAX] = {};
@@ -56,6 +74,12 @@ int shim_api_getifaddrs(struct ifaddrs** ifap) {
 
             j->ifa_addr = calloc(1, sizeof(struct sockaddr));
             memcpy(j->ifa_addr, host_ai->ai_addr, (unsigned long)host_ai->ai_addrlen);
+
+            /* assign it a /24 netmask */
+            /* some applications/libraries like libuv assume this will be non-null */
+            j->ifa_netmask = calloc(1, sizeof(struct sockaddr));
+            j->ifa_netmask->sa_family = AF_INET;
+            ((struct sockaddr_in*)j->ifa_netmask)->sin_addr = netmask_24;
 
             i->ifa_next = j;
 
@@ -73,6 +97,9 @@ void shim_api_freeifaddrs(struct ifaddrs* ifa) {
         struct ifaddrs* next = iter->ifa_next;
         if (iter->ifa_addr) {
             free(iter->ifa_addr);
+        }
+        if (iter->ifa_netmask) {
+            free(iter->ifa_netmask);
         }
         if (iter->ifa_name) {
             free(iter->ifa_name);

--- a/src/test/ifaddrs/test_ifaddrs.rs
+++ b/src/test/ifaddrs/test_ifaddrs.rs
@@ -29,11 +29,20 @@ fn main() {
                 continue;
             }
         };
+
+        // if there was an ipv4 address, the netmask should also be an ipv4 address
+        let netmask: nix::sys::socket::SockaddrStorage = ifaddr.netmask.unwrap();
+        let netmask: &nix::sys::socket::SockaddrIn = netmask.as_sockaddr_in().unwrap();
+
         let address_str = address.to_string();
         let ip = address_str.split(":").collect::<Vec<&str>>()[0];
+
+        let netmask = netmask.to_string();
+        let netmask = netmask.split(":").collect::<Vec<&str>>()[0];
+
         println!(
-            "found ifaddr interface {} address {}",
-            ifaddr.interface_name, ip
+            "found ifaddr interface {} address {} netmask {:?}",
+            ifaddr.interface_name, ip, netmask
         );
         ip_vec.push(String::from(ip));
     }


### PR DESCRIPTION
The man page for `getifaddrs()` says this is allowed to be NULL, but some applications/libraries such as libuv assume that this is non-null, so we may as well return something here. It returns a netmask of /8 for localhost and /24 for the public IP.

Fixes the segfault in #2451.