### PR TITLE
Replace shim logger's usage of `gmtime_r()`

### DIFF
--- a/src/lib/shim/shim_logger.c
+++ b/src/lib/shim/shim_logger.c
@@ -22,14 +22,18 @@ typedef struct _ShimLogger {
 } ShimLogger;
 
 static size_t _simulation_nanos_string(char* dst, size_t size) {
-    uint64_t simulation_nanos = shim_sys_get_simtime_nanos();
     const long nanos_per_sec = 1000000000l;
-    time_t seconds = simulation_nanos / nanos_per_sec;
-    uint64_t nanos = simulation_nanos % nanos_per_sec;
-    struct tm tm;
-    gmtime_r(&seconds, &tm);
-    return snprintf(
-        dst, size, "%02d:%02d:%02d.%09" PRIu64, tm.tm_hour, tm.tm_min, tm.tm_sec, nanos);
+
+    uint64_t nanos = shim_sys_get_simtime_nanos();
+    uint32_t seconds = nanos / nanos_per_sec;
+    nanos = nanos % nanos_per_sec;
+    uint32_t mins = seconds / 60;
+    seconds = seconds % 60;
+    uint32_t hours = mins / 60;
+    mins = mins % 60;
+
+    return snprintf(dst, size, "%02" PRIu32 ":%02" PRIu32 ":%02" PRIu32 ".%09" PRIu64, hours, mins,
+                    seconds, nanos);
 }
 
 void shimlogger_log(Logger* base, LogLevel level, const char* fileName, const char* functionName,

--- a/src/lib/shim/shim_sys.c
+++ b/src/lib/shim/shim_sys.c
@@ -12,9 +12,9 @@
 #include <time.h>
 
 #include "lib/logger/logger.h"
+#include "lib/shadow-shim-helper-rs/shim_helper.h"
 #include "lib/shim/shim.h"
 #include "lib/shim/shim_sys.h"
-#include "main/core/support/definitions.h" // for SIMTIME definitions
 #include "main/host/syscall_numbers.h"
 
 static CEmulatedTime _shim_sys_get_time() {

--- a/src/lib/shim/shim_sys.c
+++ b/src/lib/shim/shim_sys.c
@@ -28,7 +28,10 @@ static CEmulatedTime _shim_sys_get_time() {
     return shimshmem_getEmulatedTime(mem);
 }
 
-uint64_t shim_sys_get_simtime_nanos() { return _shim_sys_get_time() / SIMTIME_ONE_NANOSECOND; }
+uint64_t shim_sys_get_simtime_nanos() {
+    return emutime_sub_emutime(_shim_sys_get_time(), EMUTIME_SIMULATION_START) /
+           SIMTIME_ONE_NANOSECOND;
+}
 
 static CSimulationTime _shim_sys_latency_for_syscall(long n) {
     switch (n) {


### PR DESCRIPTION
`gmtime_r` is not async-signal-safe, but we should only call async-signal-safe functions from the shim logger. This seems to fix #2457.

https://stackoverflow.com/a/53156211