### PR TITLE
Use thread park/unpark instead of semaphores in work pools

### DIFF
--- a/src/main/utility/synchronization/mod.rs
+++ b/src/main/utility/synchronization/mod.rs
@@ -1,2 +1,3 @@
 pub mod count_down_latch;
 pub mod semaphore;
+pub mod thread_parking;

--- a/src/main/utility/synchronization/thread_parking.rs
+++ b/src/main/utility/synchronization/thread_parking.rs
@@ -1,10 +1,16 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+#[cfg(debug_assertions)]
+use std::sync::Mutex;
+
 /// Used to unpark a thread, but which hasn't been assigned a specific thread yet.
 #[derive(Debug, Clone)]
 pub struct ThreadUnparkerUnassigned {
     ready_flag: Arc<AtomicBool>,
+    /// The ID of the thread which is allowed to park.
+    #[cfg(debug_assertions)]
+    shared_thread_id: Arc<Mutex<Option<std::thread::ThreadId>>>,
 }
 
 /// Used to unpark a thread.
@@ -12,6 +18,9 @@ pub struct ThreadUnparkerUnassigned {
 pub struct ThreadUnparker {
     thread: std::thread::Thread,
     ready_flag: Arc<AtomicBool>,
+    /// The ID of the thread which is allowed to park.
+    #[cfg(debug_assertions)]
+    shared_thread_id: Arc<Mutex<Option<std::thread::ThreadId>>>,
 }
 
 /// Used to park a thread. The `ThreadParker` is derived from a `ThreadUnparker` or
@@ -21,32 +30,74 @@ pub struct ThreadUnparker {
 #[derive(Debug, Clone)]
 pub struct ThreadParker {
     ready_flag: Arc<AtomicBool>,
+    /// The ID of the thread which is allowed to park.
+    #[cfg(debug_assertions)]
+    shared_thread_id: Arc<Mutex<Option<std::thread::ThreadId>>>,
 }
 
 impl ThreadUnparkerUnassigned {
     pub fn new() -> Self {
         Self {
             ready_flag: Arc::new(AtomicBool::new(false)),
+            // there is no assigned thread yet
+            #[cfg(debug_assertions)]
+            shared_thread_id: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Assign this to a thread that will be unparked.
     #[must_use]
     pub fn assign(self, thread: std::thread::Thread) -> ThreadUnparker {
-        ThreadUnparker::new(self.ready_flag, thread)
+        ThreadUnparker::new(
+            self.ready_flag,
+            thread,
+            #[cfg(debug_assertions)]
+            self.shared_thread_id,
+        )
     }
 
     /// Get a new [`ThreadParker`]. The `ThreadParker` must only be used from the thread which we
     /// will later assign ourselves to using `assign()`. This is useful if you want to pass a
     /// `ThreadParker` to a new thread before you have a handle to that thread.
     pub fn parker(&self) -> ThreadParker {
-        ThreadParker::new(Arc::clone(&self.ready_flag))
+        ThreadParker::new(
+            Arc::clone(&self.ready_flag),
+            #[cfg(debug_assertions)]
+            Arc::clone(&self.shared_thread_id),
+        )
     }
 }
 
 impl ThreadUnparker {
-    fn new(ready_flag: Arc<AtomicBool>, thread: std::thread::Thread) -> Self {
-        Self { ready_flag, thread }
+    fn new(
+        ready_flag: Arc<AtomicBool>,
+        thread: std::thread::Thread,
+        #[cfg(debug_assertions)] shared_thread_id: Arc<Mutex<Option<std::thread::ThreadId>>>,
+    ) -> Self {
+        // set the value of `shared_thread_id`, or if it was already set, verify that it's the
+        // correct value
+        #[cfg(debug_assertions)]
+        {
+            let mut shared_thread_id = shared_thread_id.lock().unwrap();
+
+            // it's valid to park before the unparker has been assigned to a thread
+            // (`shared_thread_id` would be `Some` in this case), so if it was already set we should
+            // check that it is the correct thread
+            let shared_thread_id = shared_thread_id.get_or_insert_with(|| thread.id());
+
+            assert_eq!(
+                *shared_thread_id,
+                thread.id(),
+                "An earlier `ThreadParker::park()` was called from the wrong thread"
+            );
+        }
+
+        Self {
+            ready_flag,
+            thread,
+            #[cfg(debug_assertions)]
+            shared_thread_id,
+        }
     }
 
     /// Unpark the assigned thread.
@@ -62,24 +113,54 @@ impl ThreadUnparker {
 
     /// Get a new [`ThreadParker`] for the assigned thread.
     pub fn parker(&self) -> ThreadParker {
-        ThreadParker::new(Arc::clone(&self.ready_flag))
+        ThreadParker::new(
+            Arc::clone(&self.ready_flag),
+            #[cfg(debug_assertions)]
+            Arc::clone(&self.shared_thread_id),
+        )
     }
 }
 
 impl ThreadParker {
-    fn new(ready_flag: Arc<AtomicBool>) -> Self {
-        Self { ready_flag }
+    fn new(
+        ready_flag: Arc<AtomicBool>,
+        #[cfg(debug_assertions)] shared_thread_id: Arc<Mutex<Option<std::thread::ThreadId>>>,
+    ) -> Self {
+        Self {
+            ready_flag,
+            #[cfg(debug_assertions)]
+            shared_thread_id,
+        }
     }
 
     /// Park the current thread until [`ThreadUnparker::unpark()`] is called. You must only call
     /// `park()` from the thread which the corresponding `ThreadUnparker` is assigned, otherwise a
-    /// deadlock may occur.
+    /// deadlock may occur. In debug builds, this should panic instead of deadlock.
     pub fn park(&self) {
         while self
             .ready_flag
             .compare_exchange(true, false, Ordering::Release, Ordering::Relaxed)
             .is_err()
         {
+            // verify that we're parking from the proper thread (only in debug builds since this is
+            // slow)
+            #[cfg(debug_assertions)]
+            {
+                let mut shared_thread_id = self.shared_thread_id.lock().unwrap();
+
+                // it's valid to park before the unparker has been assigned to a thread
+                // (`shared_thread_id` would be `None` in this case), so we should set the thread ID
+                // here and let the unparker panic instead if this is the wrong thread
+                let shared_thread_id =
+                    shared_thread_id.get_or_insert_with(|| std::thread::current().id());
+
+                assert_eq!(
+                    *shared_thread_id,
+                    std::thread::current().id(),
+                    "`ThreadParker::park()` was called from the wrong thread"
+                );
+            }
+
             // if unpark() was called before this park(), this park() will return immediately
             std::thread::park();
         }

--- a/src/main/utility/synchronization/thread_parking.rs
+++ b/src/main/utility/synchronization/thread_parking.rs
@@ -1,0 +1,110 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Used to unpark a thread, but which hasn't been assigned a specific thread yet.
+#[derive(Debug, Clone)]
+pub struct ThreadUnparkerUnassigned {
+    ready_flag: Arc<AtomicBool>,
+}
+
+/// Used to unpark a thread.
+#[derive(Debug, Clone)]
+pub struct ThreadUnparker {
+    thread: std::thread::Thread,
+    ready_flag: Arc<AtomicBool>,
+}
+
+/// Used to park a thread. The `ThreadParker` is derived from a `ThreadUnparker` or
+/// `ThreadUnparkerUnassigned`, and must only be used on the thread which the unparker was assigned
+/// to. If the `ThreadUnparker` was assigned to thread A, then `ThreadParker::park()` must only be
+/// called from thread A.
+#[derive(Debug, Clone)]
+pub struct ThreadParker {
+    ready_flag: Arc<AtomicBool>,
+}
+
+impl ThreadUnparkerUnassigned {
+    pub fn new() -> Self {
+        Self {
+            ready_flag: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Assign this to a thread that will be unparked.
+    #[must_use]
+    pub fn assign(self, thread: std::thread::Thread) -> ThreadUnparker {
+        ThreadUnparker::new(self.ready_flag, thread)
+    }
+
+    /// Get a new [`ThreadParker`]. The `ThreadParker` must only be used from the thread which we
+    /// will later assign ourselves to using `assign()`. This is useful if you want to pass a
+    /// `ThreadParker` to a new thread before you have a handle to that thread.
+    pub fn parker(&self) -> ThreadParker {
+        ThreadParker::new(Arc::clone(&self.ready_flag))
+    }
+}
+
+impl ThreadUnparker {
+    fn new(ready_flag: Arc<AtomicBool>, thread: std::thread::Thread) -> Self {
+        Self { ready_flag, thread }
+    }
+
+    /// Unpark the assigned thread.
+    pub fn unpark(&self) {
+        // rust guarantees that everything that happens before the `unpark()` is visible on the
+        // other thread after returning from `park()`, so the `ready_flag` should always be visible
+        // as true after the other thread returns from `park()` (the store should not be reordered
+        // after the `unpark()`):
+        // https://github.com/rust-lang/rust/blob/21b246587c2687935bd6004ffa5dcc4f4dd6600d/library/std/src/sys_common/thread_parker/futex.rs#L21-L27
+        self.ready_flag.store(true, Ordering::Release);
+        self.thread.unpark();
+    }
+
+    /// Get a new [`ThreadParker`] for the assigned thread.
+    pub fn parker(&self) -> ThreadParker {
+        ThreadParker::new(Arc::clone(&self.ready_flag))
+    }
+}
+
+impl ThreadParker {
+    fn new(ready_flag: Arc<AtomicBool>) -> Self {
+        Self { ready_flag }
+    }
+
+    /// Park the current thread until [`ThreadUnparker::unpark()`] is called. You must only call
+    /// `park()` from the thread which the corresponding `ThreadUnparker` is assigned, otherwise a
+    /// deadlock may occur.
+    pub fn park(&self) {
+        while self
+            .ready_flag
+            .compare_exchange(true, false, Ordering::Release, Ordering::Relaxed)
+            .is_err()
+        {
+            // if unpark() was called before this park(), this park() will return immediately
+            std::thread::park();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parking() {
+        let unparker = ThreadUnparkerUnassigned::new();
+        let parker = unparker.parker();
+
+        let handle = std::thread::spawn(move || {
+            parker.park();
+        });
+
+        let unparker = unparker.assign(handle.thread().clone());
+
+        // there is no race condition here: if `unpark` happens first, `park` will return
+        // immediately
+        unparker.unpark();
+
+        handle.join().unwrap();
+    }
+}


### PR DESCRIPTION
The interface of this 'thread_parking' module is a little weird, but it was written this way to support both work pools, which take different approaches to how the flag is shared between threads.

There's no noticeable change in performance when switching from semaphores to park/unpark. On Linux, park/unpark is implemented [with a futex](https://twitter.com/m_ou_se/status/1312803599689355266) so this isn't surprising.

Thread-per-host:

![run_time_tph](https://user-images.githubusercontent.com/3708797/196197362-602e69b6-1c8d-48a8-95ff-8e2be09c858a.png)

Thread-per-core:

![run_time_tpc](https://user-images.githubusercontent.com/3708797/196197403-442861b4-b655-413b-aaf2-6e0147b176e5.png)