### PR TITLE
open, openat: use manual wrappers to make mode deterministic

### DIFF
--- a/src/lib/libc_preload/gen_syscall_wrappers_c.py
+++ b/src/lib/libc_preload/gen_syscall_wrappers_c.py
@@ -28,6 +28,11 @@ skip.add('pwritev2')
 # `FILE*` objects, etc.
 skip.add('exit')
 
+# These have an optional `mode` argument, which the wrappers should initialize
+# to 0 when not provided by the caller.
+skip.add('open')
+skip.add('openat')
+
 # syscall wrappers that return errors directly instead of through errno.
 direct_errors = set()
 direct_errors.add('clock_nanosleep')

--- a/src/lib/libc_preload/syscall_wrappers.c
+++ b/src/lib/libc_preload/syscall_wrappers.c
@@ -560,18 +560,14 @@ INTERPOSE(nanosleep);
 #ifdef SYS_newfstatat // kernel entry: num=262 func=sys_newfstatat
 INTERPOSE(newfstatat);
 #endif
-#ifdef SYS_open // kernel entry: num=2 func=sys_open
-INTERPOSE(open);
-#endif
+// Skipping SYS_open
 #ifdef SYS_open_by_handle_at // kernel entry: num=304 func=sys_open_by_handle_at
 INTERPOSE(open_by_handle_at);
 #endif
 #ifdef SYS_open_tree // kernel entry: num=428 func=sys_open_tree
 INTERPOSE(open_tree);
 #endif
-#ifdef SYS_openat // kernel entry: num=257 func=sys_openat
-INTERPOSE(openat);
-#endif
+// Skipping SYS_openat
 #ifdef SYS_openat2 // kernel entry: num=437 func=sys_openat2
 INTERPOSE(openat2);
 #endif


### PR DESCRIPTION
libc uses varargs to make the last option, `mode`, optional. When the caller doesn't explicitly provide a `mode`, we were getting unitialized data from the stack, which was sometimes causing the determinism tests to fail.

Fixes https://github.com/shadow/shadow/issues/2466