### PR TITLE
SelfContainedMutex: avoid wake operations when there are no waiters

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
  "log",
  "logger",
  "nix",
+ "rand",
  "rkyv",
  "shadow-build-common",
  "shadow_shmem",

--- a/src/lib/shadow-shim-helper-rs/Cargo.toml
+++ b/src/lib/shadow-shim-helper-rs/Cargo.toml
@@ -23,6 +23,9 @@ shadow-build-common = { path = "../shadow-build-common" }
 system-deps = "6.0"
 cbindgen = { version = "0.24.3" }
 
+[dev-dependencies]
+rand = "0.8.5"
+
 [package.metadata.system-deps]
 # Keep consistent with the minimum version number in src/CMakeLists.txt
 glib = { name = "glib-2.0", version = "2.32" }

--- a/src/lib/shadow-shim-helper-rs/src/scmutex.rs
+++ b/src/lib/shadow-shim-helper-rs/src/scmutex.rs
@@ -255,6 +255,10 @@ mod tests {
                 let mutex = mutex.clone();
                 std::thread::spawn(move || {
                     let mut guard = mutex.lock();
+                    // Hold the lock for up to 10 ms; checking for races
+                    std::thread::sleep(std::time::Duration::from_nanos(
+                        rand::random::<u64>() % 10_000_000,
+                    ));
                     *guard += 1;
                 })
             })


### PR DESCRIPTION
This addresses a performance regression when using SelfContainedMutex to protect the shim's shared memory.

This adds some atomic operations to track whether anything is sleeping on the mutex, but saves a much more expensive `futex` syscall in the common case of unlocking while there is nothing waiting on it.

I benchmarked this on top of the shim-shared-memory pr in https://github.com/shadow/shadow/pull/2470 to verify the performance gain (well, lack of performance regression from switching from pthread_mutex to SelfContainedMutex)