### PR TITLE
Refactor Rust Thread

### DIFF
--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -10,7 +10,7 @@ use crate::core::work::event_queue::ThreadSafeEventQueue;
 use crate::cshadow;
 use crate::host::host::{Host, HostInfo};
 use crate::host::process::{Process, ProcessId};
-use crate::host::thread::{Thread, ThreadId};
+use crate::host::thread::{ThreadId, ThreadRef};
 use crate::network::network_graph::{IpAssignment, RoutingInfo};
 use crate::utility::childpid_watcher::ChildPidWatcher;
 use crate::utility::counter::Counter;
@@ -165,7 +165,7 @@ impl Worker {
     }
 
     /// Set the currently-active Thread.
-    pub fn set_active_thread(thread: &Thread) {
+    pub fn set_active_thread(thread: &ThreadRef) {
         debug_assert_eq!(
             thread.host_id(),
             Worker::with_active_host_info(|h| h.id).unwrap()
@@ -641,7 +641,7 @@ mod export {
         if thread.is_null() {
             Worker::clear_active_thread();
         } else {
-            let thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
+            let thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             Worker::set_active_thread(&thread);
         }
     }

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -10,7 +10,7 @@ use crate::core::work::event_queue::ThreadSafeEventQueue;
 use crate::cshadow;
 use crate::host::host::{Host, HostInfo};
 use crate::host::process::{Process, ProcessId};
-use crate::host::thread::{CThread, Thread, ThreadId};
+use crate::host::thread::{Thread, ThreadId};
 use crate::network::network_graph::{IpAssignment, RoutingInfo};
 use crate::utility::childpid_watcher::ChildPidWatcher;
 use crate::utility::counter::Counter;
@@ -165,7 +165,7 @@ impl Worker {
     }
 
     /// Set the currently-active Thread.
-    pub fn set_active_thread(thread: &CThread) {
+    pub fn set_active_thread(thread: &Thread) {
         debug_assert_eq!(
             thread.host_id(),
             Worker::with_active_host_info(|h| h.id).unwrap()
@@ -641,7 +641,7 @@ mod export {
         if thread.is_null() {
             Worker::clear_active_thread();
         } else {
-            let thread = unsafe { CThread::new(notnull_mut_debug(thread)) };
+            let thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
             Worker::set_active_thread(&thread);
         }
     }

--- a/src/main/host/context.rs
+++ b/src/main/host/context.rs
@@ -32,7 +32,7 @@
 //! alternatively be implemented by providing methods that borrow some or all of
 //! their internal references simultaneously.
 
-use super::{host::Host, process::Process, thread::Thread};
+use super::{host::Host, process::Process, thread::ThreadRef};
 use crate::cshadow;
 
 /// Represent the "current" Host.
@@ -64,7 +64,7 @@ impl<'a> ProcessContext<'a> {
         Self { host, process }
     }
 
-    pub fn with_thread(&'a mut self, thread: &'a mut Thread) -> ThreadContext<'a> {
+    pub fn with_thread(&'a mut self, thread: &'a mut ThreadRef) -> ThreadContext<'a> {
         ThreadContext::new(self.host, self.process, thread)
     }
 }
@@ -73,11 +73,11 @@ impl<'a> ProcessContext<'a> {
 pub struct ThreadContext<'a> {
     pub host: &'a mut Host,
     pub process: &'a mut Process,
-    pub thread: &'a mut Thread,
+    pub thread: &'a mut ThreadRef,
 }
 
 impl<'a> ThreadContext<'a> {
-    pub fn new(host: &'a mut Host, process: &'a mut Process, thread: &'a mut Thread) -> Self {
+    pub fn new(host: &'a mut Host, process: &'a mut Process, thread: &'a mut ThreadRef) -> Self {
         Self {
             host,
             process,
@@ -91,7 +91,7 @@ impl<'a> ThreadContext<'a> {
 pub struct ThreadContextObjs {
     host: Host,
     process: Process,
-    thread: Thread,
+    thread: ThreadRef,
 }
 
 impl ThreadContextObjs {
@@ -99,7 +99,7 @@ impl ThreadContextObjs {
         let sys = unsafe { sys.as_mut().unwrap() };
         let host = unsafe { Host::borrow_from_c(sys.host) };
         let process = unsafe { Process::borrow_from_c(sys.process) };
-        let thread = unsafe { Thread::new(sys.thread) };
+        let thread = unsafe { ThreadRef::new(sys.thread) };
         Self {
             host,
             process,
@@ -112,7 +112,7 @@ impl ThreadContextObjs {
         let sys = unsafe { sys.as_mut().unwrap() };
         let host = unsafe { Host::borrow_from_c(sys.host) };
         let process = unsafe { Process::borrow_from_c(sys.process) };
-        let thread = unsafe { Thread::new(sys.thread) };
+        let thread = unsafe { ThreadRef::new(sys.thread) };
         Self {
             host,
             process,

--- a/src/main/host/context.rs
+++ b/src/main/host/context.rs
@@ -32,11 +32,7 @@
 //! alternatively be implemented by providing methods that borrow some or all of
 //! their internal references simultaneously.
 
-use super::{
-    host::Host,
-    process::Process,
-    thread::{CThread, Thread},
-};
+use super::{host::Host, process::Process, thread::Thread};
 use crate::cshadow;
 
 /// Represent the "current" Host.
@@ -68,7 +64,7 @@ impl<'a> ProcessContext<'a> {
         Self { host, process }
     }
 
-    pub fn with_thread(&'a mut self, thread: &'a mut dyn Thread) -> ThreadContext<'a> {
+    pub fn with_thread(&'a mut self, thread: &'a mut Thread) -> ThreadContext<'a> {
         ThreadContext::new(self.host, self.process, thread)
     }
 }
@@ -77,11 +73,11 @@ impl<'a> ProcessContext<'a> {
 pub struct ThreadContext<'a> {
     pub host: &'a mut Host,
     pub process: &'a mut Process,
-    pub thread: &'a mut dyn Thread,
+    pub thread: &'a mut Thread,
 }
 
 impl<'a> ThreadContext<'a> {
-    pub fn new(host: &'a mut Host, process: &'a mut Process, thread: &'a mut dyn Thread) -> Self {
+    pub fn new(host: &'a mut Host, process: &'a mut Process, thread: &'a mut Thread) -> Self {
         Self {
             host,
             process,
@@ -95,7 +91,7 @@ impl<'a> ThreadContext<'a> {
 pub struct ThreadContextObjs {
     host: Host,
     process: Process,
-    thread: CThread,
+    thread: Thread,
 }
 
 impl ThreadContextObjs {
@@ -103,7 +99,7 @@ impl ThreadContextObjs {
         let sys = unsafe { sys.as_mut().unwrap() };
         let host = unsafe { Host::borrow_from_c(sys.host) };
         let process = unsafe { Process::borrow_from_c(sys.process) };
-        let thread = unsafe { CThread::new(sys.thread) };
+        let thread = unsafe { Thread::new(sys.thread) };
         Self {
             host,
             process,
@@ -116,7 +112,7 @@ impl ThreadContextObjs {
         let sys = unsafe { sys.as_mut().unwrap() };
         let host = unsafe { Host::borrow_from_c(sys.host) };
         let process = unsafe { Process::borrow_from_c(sys.process) };
-        let thread = unsafe { CThread::new(sys.thread) };
+        let thread = unsafe { Thread::new(sys.thread) };
         Self {
             host,
             process,

--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -157,7 +157,7 @@ impl ShmFile {
     }
 
     /// Map the given range of the file into the plugin's address space.
-    fn mmap_into_plugin(&self, thread: &mut dyn Thread, interval: &Interval, prot: i32) {
+    fn mmap_into_plugin(&self, thread: &mut Thread, interval: &Interval, prot: i32) {
         thread
             .native_mmap(
                 PluginPtr::from(interval.start),
@@ -203,7 +203,7 @@ fn get_regions(pid: Pid) -> IntervalMap<Region> {
 /// Find the heap range, and map it if non-empty.
 fn get_heap(
     shm_file: &mut ShmFile,
-    thread: &mut impl Thread,
+    thread: &mut Thread,
     memory_manager: &MemoryManager,
     regions: &mut IntervalMap<Region>,
 ) -> Interval {
@@ -248,7 +248,7 @@ fn get_heap(
 /// stack size.
 fn map_stack(
     memory_manager: &mut MemoryManager,
-    thread: &mut dyn Thread,
+    thread: &mut Thread,
     shm_file: &mut ShmFile,
     regions: &mut IntervalMap<Region>,
 ) {
@@ -327,7 +327,7 @@ impl Drop for MemoryMapper {
 }
 
 impl MemoryMapper {
-    pub fn new(memory_manager: &mut MemoryManager, thread: &mut impl Thread) -> MemoryMapper {
+    pub fn new(memory_manager: &mut MemoryManager, thread: &mut Thread) -> MemoryMapper {
         let shm_path = format!(
             "/dev/shm/shadow_memory_manager_{}_{:?}_{}",
             process::id(),
@@ -490,7 +490,7 @@ impl MemoryMapper {
     #[allow(clippy::too_many_arguments)]
     pub fn handle_mmap_result(
         &mut self,
-        thread: &mut dyn Thread,
+        thread: &mut Thread,
         ptr: TypedPluginPtr<u8>,
         prot: i32,
         flags: i32,
@@ -578,7 +578,7 @@ impl MemoryMapper {
     /// if applicable.
     pub fn handle_mremap(
         &mut self,
-        thread: &mut impl Thread,
+        thread: &mut Thread,
         old_address: PluginPtr,
         old_size: usize,
         new_size: usize,
@@ -704,7 +704,7 @@ impl MemoryMapper {
     /// Execute the requested `brk` and update our mappings accordingly. May invalidate outstanding
     /// pointers. (Rust won't allow mutable methods such as this one to be called with outstanding
     /// borrowed references).
-    pub fn handle_brk(&mut self, thread: &mut impl Thread, ptr: PluginPtr) -> SyscallResult {
+    pub fn handle_brk(&mut self, thread: &mut Thread, ptr: PluginPtr) -> SyscallResult {
         let requested_brk = usize::from(ptr);
 
         // On error, brk syscall returns current brk (end of heap). The only errors we specifically
@@ -824,7 +824,7 @@ impl MemoryMapper {
     /// memory in a way that the plugin itself can't.
     pub fn handle_mprotect(
         &mut self,
-        thread: &mut impl Thread,
+        thread: &mut Thread,
         addr: PluginPtr,
         size: usize,
         prot: i32,

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -17,7 +17,7 @@
 
 use crate::cshadow as c;
 use crate::host::syscall_types::{PluginPtr, SyscallError, SyscallResult, TypedPluginPtr};
-use crate::host::thread::{CThread, Thread};
+use crate::host::thread::Thread;
 use crate::utility::notnull::*;
 use crate::utility::pod;
 use crate::utility::pod::Pod;
@@ -552,7 +552,7 @@ impl MemoryManager {
 
     /// Initialize the MemoryMapper, allowing for more efficient access. Needs a
     /// running thread.
-    pub fn init_mapper(&mut self, thread: &mut impl Thread) {
+    pub fn init_mapper(&mut self, thread: &mut Thread) {
         assert!(self.memory_mapper.is_none());
         self.memory_mapper = Some(MemoryMapper::new(self, thread));
     }
@@ -571,7 +571,7 @@ impl MemoryManager {
         }
     }
 
-    fn handle_brk(&mut self, thread: &mut impl Thread, ptr: PluginPtr) -> SyscallResult {
+    fn handle_brk(&mut self, thread: &mut Thread, ptr: PluginPtr) -> SyscallResult {
         match &mut self.memory_mapper {
             Some(mm) => mm.handle_brk(thread, ptr),
             None => Err(SyscallError::Native),
@@ -581,7 +581,7 @@ impl MemoryManager {
     #[allow(clippy::too_many_arguments)]
     fn do_mmap(
         &mut self,
-        thread: &mut dyn Thread,
+        thread: &mut Thread,
         addr: PluginPtr,
         length: usize,
         prot: i32,
@@ -604,7 +604,7 @@ impl MemoryManager {
 
     fn handle_munmap(
         &mut self,
-        thread: &mut impl Thread,
+        thread: &mut Thread,
         addr: PluginPtr,
         length: usize,
     ) -> SyscallResult {
@@ -622,7 +622,7 @@ impl MemoryManager {
 
     fn do_munmap(
         &mut self,
-        thread: &mut dyn Thread,
+        thread: &mut Thread,
         addr: PluginPtr,
         length: usize,
     ) -> nix::Result<()> {
@@ -635,7 +635,7 @@ impl MemoryManager {
 
     fn handle_mremap(
         &mut self,
-        thread: &mut impl Thread,
+        thread: &mut Thread,
         old_address: PluginPtr,
         old_size: usize,
         new_size: usize,
@@ -652,7 +652,7 @@ impl MemoryManager {
 
     fn handle_mprotect(
         &mut self,
-        thread: &mut impl Thread,
+        thread: &mut Thread,
         addr: PluginPtr,
         size: usize,
         prot: i32,
@@ -787,7 +787,7 @@ mod export {
     ) {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
         if !memory_manager.has_mapper() {
-            let mut thread = unsafe { CThread::new(notnull_mut_debug(thread)) };
+            let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
             memory_manager.init_mapper(&mut thread)
         }
     }
@@ -994,7 +994,7 @@ mod export {
         plugin_src: c::PluginPtr,
     ) -> c::SysCallReturn {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let mut thread = unsafe { CThread::new(notnull_mut_debug(thread)) };
+        let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
         memory_manager
             .handle_brk(&mut thread, PluginPtr::from(plugin_src))
             .into()
@@ -1013,7 +1013,7 @@ mod export {
         offset: i64,
     ) -> c::SysCallReturn {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let mut thread = unsafe { CThread::new(notnull_mut_debug(thread)) };
+        let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
         memory_manager
             .do_mmap(
                 &mut thread,
@@ -1036,7 +1036,7 @@ mod export {
         len: usize,
     ) -> c::SysCallReturn {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let mut thread = unsafe { CThread::new(notnull_mut_debug(thread)) };
+        let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
         memory_manager
             .handle_munmap(&mut thread, PluginPtr::from(addr), len)
             .into()
@@ -1053,7 +1053,7 @@ mod export {
         new_addr: c::PluginPtr,
     ) -> c::SysCallReturn {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let mut thread = unsafe { CThread::new(notnull_mut_debug(thread)) };
+        let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
         memory_manager
             .handle_mremap(
                 &mut thread,
@@ -1075,7 +1075,7 @@ mod export {
         prot: i32,
     ) -> c::SysCallReturn {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let mut thread = unsafe { CThread::new(notnull_mut_debug(thread)) };
+        let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
         memory_manager
             .handle_mprotect(&mut thread, PluginPtr::from(addr), size, prot)
             .into()

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -17,7 +17,7 @@
 
 use crate::cshadow as c;
 use crate::host::syscall_types::{PluginPtr, SyscallError, SyscallResult, TypedPluginPtr};
-use crate::host::thread::Thread;
+use crate::host::thread::ThreadRef;
 use crate::utility::notnull::*;
 use crate::utility::pod;
 use crate::utility::pod::Pod;
@@ -552,7 +552,7 @@ impl MemoryManager {
 
     /// Initialize the MemoryMapper, allowing for more efficient access. Needs a
     /// running thread.
-    pub fn init_mapper(&mut self, thread: &mut Thread) {
+    pub fn init_mapper(&mut self, thread: &mut ThreadRef) {
         assert!(self.memory_mapper.is_none());
         self.memory_mapper = Some(MemoryMapper::new(self, thread));
     }
@@ -571,7 +571,7 @@ impl MemoryManager {
         }
     }
 
-    fn handle_brk(&mut self, thread: &mut Thread, ptr: PluginPtr) -> SyscallResult {
+    fn handle_brk(&mut self, thread: &mut ThreadRef, ptr: PluginPtr) -> SyscallResult {
         match &mut self.memory_mapper {
             Some(mm) => mm.handle_brk(thread, ptr),
             None => Err(SyscallError::Native),
@@ -581,7 +581,7 @@ impl MemoryManager {
     #[allow(clippy::too_many_arguments)]
     fn do_mmap(
         &mut self,
-        thread: &mut Thread,
+        thread: &mut ThreadRef,
         addr: PluginPtr,
         length: usize,
         prot: i32,
@@ -604,7 +604,7 @@ impl MemoryManager {
 
     fn handle_munmap(
         &mut self,
-        thread: &mut Thread,
+        thread: &mut ThreadRef,
         addr: PluginPtr,
         length: usize,
     ) -> SyscallResult {
@@ -622,7 +622,7 @@ impl MemoryManager {
 
     fn do_munmap(
         &mut self,
-        thread: &mut Thread,
+        thread: &mut ThreadRef,
         addr: PluginPtr,
         length: usize,
     ) -> nix::Result<()> {
@@ -635,7 +635,7 @@ impl MemoryManager {
 
     fn handle_mremap(
         &mut self,
-        thread: &mut Thread,
+        thread: &mut ThreadRef,
         old_address: PluginPtr,
         old_size: usize,
         new_size: usize,
@@ -652,7 +652,7 @@ impl MemoryManager {
 
     fn handle_mprotect(
         &mut self,
-        thread: &mut Thread,
+        thread: &mut ThreadRef,
         addr: PluginPtr,
         size: usize,
         prot: i32,
@@ -787,7 +787,7 @@ mod export {
     ) {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
         if !memory_manager.has_mapper() {
-            let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
+            let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             memory_manager.init_mapper(&mut thread)
         }
     }
@@ -994,7 +994,7 @@ mod export {
         plugin_src: c::PluginPtr,
     ) -> c::SysCallReturn {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
+        let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
         memory_manager
             .handle_brk(&mut thread, PluginPtr::from(plugin_src))
             .into()
@@ -1013,7 +1013,7 @@ mod export {
         offset: i64,
     ) -> c::SysCallReturn {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
+        let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
         memory_manager
             .do_mmap(
                 &mut thread,
@@ -1036,7 +1036,7 @@ mod export {
         len: usize,
     ) -> c::SysCallReturn {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
+        let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
         memory_manager
             .handle_munmap(&mut thread, PluginPtr::from(addr), len)
             .into()
@@ -1053,7 +1053,7 @@ mod export {
         new_addr: c::PluginPtr,
     ) -> c::SysCallReturn {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
+        let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
         memory_manager
             .handle_mremap(
                 &mut thread,
@@ -1075,7 +1075,7 @@ mod export {
         prot: i32,
     ) -> c::SysCallReturn {
         let memory_manager = unsafe { memory_manager.as_mut().unwrap() };
-        let mut thread = unsafe { Thread::new(notnull_mut_debug(thread)) };
+        let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
         memory_manager
             .handle_mprotect(&mut thread, PluginPtr::from(addr), size, prot)
             .into()

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -6,153 +6,14 @@ use crate::utility::syscall;
 use nix::unistd::Pid;
 use shadow_shim_helper_rs::HostId;
 
-pub trait Thread {
-    /// Have the plugin thread natively execute the given syscall.
-    fn native_syscall(&mut self, n: i64, args: &[SysCallReg]) -> nix::Result<SysCallReg>;
-
-    fn process_id(&self) -> ProcessId;
-    fn host_id(&self) -> HostId;
-    fn system_pid(&self) -> Pid;
-    fn system_tid(&self) -> Pid;
-    fn csyscallhandler(&mut self) -> *mut c::SysCallHandler;
-    fn id(&self) -> ThreadId;
-    fn syscall_condition(&self) -> Option<SysCallConditionRef>;
-    fn syscall_condition_mut(&mut self) -> Option<SysCallConditionRefMut>;
-
-    /// Natively execute munmap(2) on the given thread.
-    fn native_munmap(&mut self, ptr: PluginPtr, size: usize) -> nix::Result<()> {
-        self.native_syscall(libc::SYS_munmap, &[ptr.into(), size.into()])?;
-        Ok(())
-    }
-
-    /// Natively execute mmap(2) on the given thread.
-    fn native_mmap(
-        &mut self,
-        addr: PluginPtr,
-        len: usize,
-        prot: i32,
-        flags: i32,
-        fd: i32,
-        offset: i64,
-    ) -> nix::Result<PluginPtr> {
-        Ok(self
-            .native_syscall(
-                libc::SYS_mmap,
-                &[
-                    SysCallReg::from(addr),
-                    SysCallReg::from(len),
-                    SysCallReg::from(prot),
-                    SysCallReg::from(flags),
-                    SysCallReg::from(fd),
-                    SysCallReg::from(offset),
-                ],
-            )?
-            .into())
-    }
-
-    /// Natively execute mremap(2) on the given thread.
-    fn native_mremap(
-        &mut self,
-        old_addr: PluginPtr,
-        old_len: usize,
-        new_len: usize,
-        flags: i32,
-        new_addr: PluginPtr,
-    ) -> nix::Result<PluginPtr> {
-        Ok(self
-            .native_syscall(
-                libc::SYS_mremap,
-                &[
-                    SysCallReg::from(old_addr),
-                    SysCallReg::from(old_len),
-                    SysCallReg::from(new_len),
-                    SysCallReg::from(flags),
-                    SysCallReg::from(new_addr),
-                ],
-            )?
-            .into())
-    }
-
-    /// Natively execute mmap(2) on the given thread.
-    fn native_mprotect(&mut self, addr: PluginPtr, len: usize, prot: i32) -> nix::Result<()> {
-        self.native_syscall(
-            libc::SYS_mprotect,
-            &[
-                SysCallReg::from(addr),
-                SysCallReg::from(len),
-                SysCallReg::from(prot),
-            ],
-        )?;
-        Ok(())
-    }
-
-    /// Natively execute open(2) on the given thread.
-    fn native_open(&mut self, pathname: PluginPtr, flags: i32, mode: i32) -> nix::Result<i32> {
-        let res = self.native_syscall(
-            libc::SYS_open,
-            &[
-                SysCallReg::from(pathname),
-                SysCallReg::from(flags),
-                SysCallReg::from(mode),
-            ],
-        );
-        Ok(i32::from(res?))
-    }
-
-    /// Natively execute close(2) on the given thread.
-    fn native_close(&mut self, fd: i32) -> nix::Result<()> {
-        self.native_syscall(libc::SYS_close, &[SysCallReg::from(fd)])?;
-        Ok(())
-    }
-
-    /// Natively execute brk(2) on the given thread.
-    fn native_brk(&mut self, addr: PluginPtr) -> nix::Result<PluginPtr> {
-        let res = self.native_syscall(libc::SYS_brk, &[SysCallReg::from(addr)])?;
-        Ok(PluginPtr::from(res))
-    }
-
-    /// Allocates some space in the plugin's memory. Use `get_writeable_ptr` to write to it, and
-    /// `flush` to ensure that the write is flushed to the plugin's memory.
-    fn malloc_plugin_ptr(&mut self, size: usize) -> nix::Result<PluginPtr> {
-        // SAFETY: No pointer specified; can't pass a bad one.
-        self.native_mmap(
-            PluginPtr::from(0usize),
-            size,
-            libc::PROT_READ | libc::PROT_WRITE,
-            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
-            -1,
-            0,
-        )
-    }
-
-    /// Frees a pointer previously returned by `malloc_plugin_ptr`
-    fn free_plugin_ptr(&mut self, ptr: PluginPtr, size: usize) -> nix::Result<()> {
-        self.native_munmap(ptr, size)?;
-        Ok(())
-    }
-}
-
 /// Wraps the C Thread struct.
-pub struct CThread {
+pub struct Thread {
     cthread: *mut c::Thread,
 }
 
-impl CThread {
-    /// # Safety
-    /// * `cthread` must point to a valid Thread struct.
-    pub unsafe fn new(cthread: *mut c::Thread) -> CThread {
-        assert!(!cthread.is_null());
-        unsafe { c::thread_ref(cthread) };
-        CThread { cthread }
-    }
-
-    pub fn cthread(&self) -> *mut c::Thread {
-        self.cthread
-    }
-}
-
-impl Thread for CThread {
-    fn native_syscall(&mut self, n: i64, args: &[SysCallReg]) -> nix::Result<SysCallReg> {
+impl Thread {
+    /// Have the plugin thread natively execute the given syscall.
+    pub fn native_syscall(&mut self, n: i64, args: &[SysCallReg]) -> nix::Result<SysCallReg> {
         // We considered using an iterator here rather than having to pass an index everywhere
         // below; we avoided it because argument evaluation order is currently a bit of a murky
         // issue, even though it'll *probably* always be left-to-right.
@@ -186,11 +47,35 @@ impl Thread for CThread {
         syscall::raw_return_value_to_result(raw_res)
     }
 
-    fn id(&self) -> ThreadId {
+    pub fn process_id(&self) -> ProcessId {
+        // Safety: self.cthread initialized in CThread::new.
+        ProcessId::from(unsafe { c::thread_getProcessId(self.cthread) })
+    }
+
+    pub fn host_id(&self) -> HostId {
+        // Safety: self.cthread initialized in CThread::new.
+        unsafe { c::thread_getHostId(self.cthread) }
+    }
+
+    pub fn system_pid(&self) -> Pid {
+        // Safety: self.cthread initialized in CThread::new.
+        Pid::from_raw(unsafe { c::thread_getNativePid(self.cthread) })
+    }
+
+    pub fn system_tid(&self) -> Pid {
+        // Safety: self.cthread initialized in CThread::new.
+        Pid::from_raw(unsafe { c::thread_getNativeTid(self.cthread) })
+    }
+
+    pub fn csyscallhandler(&mut self) -> *mut c::SysCallHandler {
+        unsafe { c::thread_getSysCallHandler(self.cthread) }
+    }
+
+    pub fn id(&self) -> ThreadId {
         ThreadId(unsafe { c::thread_getID(self.cthread).try_into().unwrap() })
     }
 
-    fn syscall_condition(&self) -> Option<SysCallConditionRef> {
+    pub fn syscall_condition(&self) -> Option<SysCallConditionRef> {
         let syscall_condition_ptr = unsafe { c::thread_getSysCallCondition(self.cthread) };
         if syscall_condition_ptr.is_null() {
             return None;
@@ -199,7 +84,7 @@ impl Thread for CThread {
         Some(unsafe { SysCallConditionRef::borrow_from_c(syscall_condition_ptr) })
     }
 
-    fn syscall_condition_mut(&mut self) -> Option<SysCallConditionRefMut> {
+    pub fn syscall_condition_mut(&mut self) -> Option<SysCallConditionRefMut> {
         let syscall_condition_ptr = unsafe { c::thread_getSysCallCondition(self.cthread) };
         if syscall_condition_ptr.is_null() {
             return None;
@@ -208,32 +93,132 @@ impl Thread for CThread {
         Some(unsafe { SysCallConditionRefMut::borrow_from_c(syscall_condition_ptr) })
     }
 
-    fn process_id(&self) -> ProcessId {
-        // Safety: self.cthread initialized in CThread::new.
-        ProcessId::from(unsafe { c::thread_getProcessId(self.cthread) })
+    /// Natively execute munmap(2) on the given thread.
+    pub fn native_munmap(&mut self, ptr: PluginPtr, size: usize) -> nix::Result<()> {
+        self.native_syscall(libc::SYS_munmap, &[ptr.into(), size.into()])?;
+        Ok(())
     }
 
-    fn host_id(&self) -> HostId {
-        // Safety: self.cthread initialized in CThread::new.
-        unsafe { c::thread_getHostId(self.cthread) }
+    /// Natively execute mmap(2) on the given thread.
+    pub fn native_mmap(
+        &mut self,
+        addr: PluginPtr,
+        len: usize,
+        prot: i32,
+        flags: i32,
+        fd: i32,
+        offset: i64,
+    ) -> nix::Result<PluginPtr> {
+        Ok(self
+            .native_syscall(
+                libc::SYS_mmap,
+                &[
+                    SysCallReg::from(addr),
+                    SysCallReg::from(len),
+                    SysCallReg::from(prot),
+                    SysCallReg::from(flags),
+                    SysCallReg::from(fd),
+                    SysCallReg::from(offset),
+                ],
+            )?
+            .into())
     }
 
-    fn system_pid(&self) -> Pid {
-        // Safety: self.cthread initialized in CThread::new.
-        Pid::from_raw(unsafe { c::thread_getNativePid(self.cthread) })
+    /// Natively execute mremap(2) on the given thread.
+    pub fn native_mremap(
+        &mut self,
+        old_addr: PluginPtr,
+        old_len: usize,
+        new_len: usize,
+        flags: i32,
+        new_addr: PluginPtr,
+    ) -> nix::Result<PluginPtr> {
+        Ok(self
+            .native_syscall(
+                libc::SYS_mremap,
+                &[
+                    SysCallReg::from(old_addr),
+                    SysCallReg::from(old_len),
+                    SysCallReg::from(new_len),
+                    SysCallReg::from(flags),
+                    SysCallReg::from(new_addr),
+                ],
+            )?
+            .into())
     }
 
-    fn system_tid(&self) -> Pid {
-        // Safety: self.cthread initialized in CThread::new.
-        Pid::from_raw(unsafe { c::thread_getNativeTid(self.cthread) })
+    /// Natively execute mmap(2) on the given thread.
+    pub fn native_mprotect(&mut self, addr: PluginPtr, len: usize, prot: i32) -> nix::Result<()> {
+        self.native_syscall(
+            libc::SYS_mprotect,
+            &[
+                SysCallReg::from(addr),
+                SysCallReg::from(len),
+                SysCallReg::from(prot),
+            ],
+        )?;
+        Ok(())
     }
 
-    fn csyscallhandler(&mut self) -> *mut c::SysCallHandler {
-        unsafe { c::thread_getSysCallHandler(self.cthread) }
+    /// Natively execute open(2) on the given thread.
+    pub fn native_open(&mut self, pathname: PluginPtr, flags: i32, mode: i32) -> nix::Result<i32> {
+        let res = self.native_syscall(
+            libc::SYS_open,
+            &[
+                SysCallReg::from(pathname),
+                SysCallReg::from(flags),
+                SysCallReg::from(mode),
+            ],
+        );
+        Ok(i32::from(res?))
+    }
+
+    /// Natively execute close(2) on the given thread.
+    pub fn native_close(&mut self, fd: i32) -> nix::Result<()> {
+        self.native_syscall(libc::SYS_close, &[SysCallReg::from(fd)])?;
+        Ok(())
+    }
+
+    /// Natively execute brk(2) on the given thread.
+    pub fn native_brk(&mut self, addr: PluginPtr) -> nix::Result<PluginPtr> {
+        let res = self.native_syscall(libc::SYS_brk, &[SysCallReg::from(addr)])?;
+        Ok(PluginPtr::from(res))
+    }
+
+    /// Allocates some space in the plugin's memory. Use `get_writeable_ptr` to write to it, and
+    /// `flush` to ensure that the write is flushed to the plugin's memory.
+    pub fn malloc_plugin_ptr(&mut self, size: usize) -> nix::Result<PluginPtr> {
+        // SAFETY: No pointer specified; can't pass a bad one.
+        self.native_mmap(
+            PluginPtr::from(0usize),
+            size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            0,
+        )
+    }
+
+    /// Frees a pointer previously returned by `malloc_plugin_ptr`
+    pub fn free_plugin_ptr(&mut self, ptr: PluginPtr, size: usize) -> nix::Result<()> {
+        self.native_munmap(ptr, size)?;
+        Ok(())
+    }
+
+    /// # Safety
+    /// * `cthread` must point to a valid Thread struct.
+    pub unsafe fn new(cthread: *mut c::Thread) -> Self {
+        assert!(!cthread.is_null());
+        unsafe { c::thread_ref(cthread) };
+        Self { cthread }
+    }
+
+    pub fn cthread(&self) -> *mut c::Thread {
+        self.cthread
     }
 }
 
-impl Drop for CThread {
+impl Drop for Thread {
     fn drop(&mut self) {
         // Safety: self.cthread initialized in CThread::new.
         unsafe {

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -7,11 +7,11 @@ use nix::unistd::Pid;
 use shadow_shim_helper_rs::HostId;
 
 /// Wraps the C Thread struct.
-pub struct Thread {
+pub struct ThreadRef {
     cthread: *mut c::Thread,
 }
 
-impl Thread {
+impl ThreadRef {
     /// Have the plugin thread natively execute the given syscall.
     pub fn native_syscall(&mut self, n: i64, args: &[SysCallReg]) -> nix::Result<SysCallReg> {
         // We considered using an iterator here rather than having to pass an index everywhere
@@ -218,7 +218,7 @@ impl Thread {
     }
 }
 
-impl Drop for Thread {
+impl Drop for ThreadRef {
     fn drop(&mut self) {
         // Safety: self.cthread initialized in CThread::new.
         unsafe {


### PR DESCRIPTION
* Get rid of the Thread trait, since we don't anticipate needing it anymore.
* Rename to ThreadRef