### PR TITLE
Add NGINX example/test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,7 @@ endif()
 
 ## recurse our project tree
 add_subdirectory(${CMAKE_SOURCE_DIR}/src/)
+add_subdirectory(${CMAKE_SOURCE_DIR}/examples/)
 
 ## Add more build info that will appear in 'shadow -v' and in the log file
 ## This should come after the project tree recursion so we can pick up the

--- a/ci/container_scripts/test.sh
+++ b/ci/container_scripts/test.sh
@@ -31,7 +31,8 @@ FLAGS+=("--")
 FLAGS+=("--exclude-regex" "$EXCLUDE")
 
 # Exclude tor tests as we test them in a different workflow
-FLAGS+=("--label-exclude" "tor")
+# Exclude examples as we don't have all the required dependencies
+FLAGS+=("--label-exclude" "tor|example")
 
 FLAGS+=("--output-on-failure")
 

--- a/docs/compatibility_notes.md
+++ b/docs/compatibility_notes.md
@@ -92,72 +92,17 @@ version provided in Ubuntu 20.04, don't have this issue. See issue
 #### `shadow.yaml`
 
 ```yaml
-general:
-  stop_time: 10s
-
-network:
-  graph:
-    type: 1_gbit_switch
-
-hosts:
-  server:
-    network_node_id: 0
-    processes:
-    - path: /usr/sbin/nginx
-      args: -c ../../../nginx.conf -p .
-      start_time: 0s
-  client:
-    network_node_id: 0
-    quantity: 3
-    processes:
-    - path: /usr/bin/curl
-      args: -s server
-      start_time: 2s
+{{#include ../examples/nginx/shadow.yaml}}
 ```
 
 #### `nginx.conf`
 
 ```
-error_log stderr;
-
-# shadow wants to run nginx in the foreground
-daemon off;
-
-# shadow doesn't support fork()
-master_process off;
-worker_processes 0;
-
-# don't use the system pid file
-pid nginx.pid;
-
-events {
-  # we're not using any workers, so this is the maximum number
-  # of simultaneous connections we can support
-  worker_connections 1024;
-}
-
-http {
-  include             /etc/nginx/mime.types;
-  default_type        application/octet-stream;
-
-  # shadow does not support sendfile()
-  sendfile off;
-
-  access_log off;
-
-  server {
-    listen 80;
-
-    location / {
-      root /var/www/html;
-      index index.nginx-debian.html;
-    }
-  }
-}
+{{#include ../examples/nginx/nginx.conf}}
 ```
 
 ```bash
-rm -rf shadow.data; shadow shadow.yaml > shadow.log
+{{#include ../examples/nginx/run.sh:body}}
 ```
 
 ### Notes

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(nginx)

--- a/examples/nginx/CMakeLists.txt
+++ b/examples/nginx/CMakeLists.txt
@@ -1,0 +1,14 @@
+file(COPY
+       ${CMAKE_CURRENT_SOURCE_DIR}/run.sh
+       ${CMAKE_CURRENT_SOURCE_DIR}/shadow.yaml
+       ${CMAKE_CURRENT_SOURCE_DIR}/nginx.conf
+     DESTINATION
+       ${CMAKE_CURRENT_BINARY_DIR})
+
+add_test(
+  NAME nginx-example
+  COMMAND bash run.sh ${CMAKE_BINARY_DIR}/src/main
+  CONFIGURATIONS extra
+)
+
+set_property(TEST nginx-example PROPERTY LABELS shadow example)

--- a/examples/nginx/nginx.conf
+++ b/examples/nginx/nginx.conf
@@ -1,0 +1,36 @@
+error_log stderr;
+
+# shadow wants to run nginx in the foreground
+daemon off;
+
+# shadow doesn't support fork()
+master_process off;
+worker_processes 0;
+
+# don't use the system pid file
+pid nginx.pid;
+
+events {
+  # we're not using any workers, so this is the maximum number
+  # of simultaneous connections we can support
+  worker_connections 1024;
+}
+
+http {
+  include             /etc/nginx/mime.types;
+  default_type        application/octet-stream;
+
+  # shadow does not support sendfile()
+  sendfile off;
+
+  access_log off;
+
+  server {
+    listen 80;
+
+    location / {
+      root /var/www/html;
+      index index.nginx-debian.html;
+    }
+  }
+}

--- a/examples/nginx/run.sh
+++ b/examples/nginx/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# first argument is the path to shadow
+if [ "$#" -ge 1 ]; then
+    echo "Prepending $1 to PATH"
+    export PATH="$1:${PATH}"
+fi
+
+# ANCHOR: body
+rm -rf shadow.data; shadow shadow.yaml > shadow.log
+cat shadow.data/hosts/client1/client1.curl.1000.stdout
+# ANCHOR_END: body

--- a/examples/nginx/shadow.yaml
+++ b/examples/nginx/shadow.yaml
@@ -1,0 +1,21 @@
+general:
+  stop_time: 10s
+
+network:
+  graph:
+    type: 1_gbit_switch
+
+hosts:
+  server:
+    network_node_id: 0
+    processes:
+    - path: /usr/sbin/nginx
+      args: -c ../../../nginx.conf -p .
+      start_time: 0s
+  client:
+    network_node_id: 0
+    quantity: 3
+    processes:
+    - path: /usr/bin/curl
+      args: -s server
+      start_time: 2s


### PR DESCRIPTION
This PR makes an "examples" subdirectory where we can add examples, and can run these examples in ctest. The configuration code is also used in the documentation so that we can make sure our documentation is up to date.

I think it's better to have a dedicated "examples" directory rather than putting these in "src/test/" so that we can keep them self-contained, and so that they're easier to find.

In the future it would be nice to also run a CI workflow to test the examples, and to move the remaining examples from the "compatibility notes" documentation here.