### PR TITLE
Change default scheduler to 'thread-per-core'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,4 +22,6 @@ by using an absolute path or prefixing with `./`.
   network simulations, the bug didn't appear to affect Tor network performance
   enough to lead us to believe that previous Tor simulations are invalid.
   https://github.com/shadow/shadow/pull/2479
+* Changed the default scheduler from `thread-per-host` to `thread-per-core`, which has better
+  performance on most machines.
 * (add entry here)

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -371,8 +371,8 @@ ahead when sending events between virtual hosts.
 
 #### `experimental.scheduler`
 
-Default: "thread-per-host"  
-Type: "thread-per-host" OR "thread-per-core"
+Default: "thread-per-core"  
+Type: "thread-per-core" OR "thread-per-host"
 
 The host scheduler implementation, which decides how to assign hosts to threads
 and threads to CPU cores.

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -498,7 +498,7 @@ impl Default for ExperimentalOptions {
             host_heartbeat_interval: None,
             strace_logging_mode: Some(StraceLoggingMode::Off),
             use_extended_yaml: Some(false),
-            scheduler: Some(Scheduler::ThreadPerHost),
+            scheduler: Some(Scheduler::ThreadPerCore),
         }
     }
 }


### PR DESCRIPTION
After more benchmarking, it seems that the thread-per-core scheduler is faster than the thread-per-host scheduler in most cases. We ran micro-benchmarks on 7 machines and 20% Tor benchmarks on 2 machines, which show the thread-per-core scheduler performing significantly better in all cases. The only regression is on a 5% Tor benchmark on our benchmark runner, where the thread-per-core performance is slightly worse (and we don't know why).

The following two graphs show the performance difference with a 20% Tor network on two different machines.

![1666816018_grim](https://user-images.githubusercontent.com/3708797/198130328-ed09710f-646b-4d4c-a767-8560c8922a31.png)

![1666815977_grim](https://user-images.githubusercontent.com/3708797/198130349-27450745-707e-4eb6-a979-bffd1c8cf4a3.png)

On the benchmark runner, it's expected that the thread-per-core scheduler will run slightly slower than the thread-per-host scheduler. Compare the blue "PR #2467 - tcp" line and the green "nightly benchmark" line in an older benchmark:

![run_time](https://user-images.githubusercontent.com/3708797/198129583-a15a2568-ef74-46fa-80f2-a8fc82d184d6.png)