### PR TITLE
Build shadow-tests in the same target directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(DEFINITION IN LISTS COMPILE_DEFINITIONS)
   set(RUST_CXXFLAGS "${RUST_CXXFLAGS} -D${DEFINITION}")
 endforeach()
 
-set(RUST_TARGETS "--lib")
+set(RUST_TARGETS "--lib --bins")
 if(SHADOW_TEST STREQUAL ON)
   set(RUST_TARGETS "${RUST_TARGETS} --tests")
 endif()
@@ -61,7 +61,24 @@ ExternalProject_Add(
     BUILD_ALWAYS 1
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND bash -c "${CARGO_ENV_VARS} cargo build ${RUST_TARGET_FLAG} ${RUST_BUILD_FLAG} ${RUST_TARGETS} --target-dir \"${TARGETDIR}\" --features \"${RUST_FEATURES}\""
+    BUILD_COMMAND bash -c " \
+        ${CARGO_ENV_VARS} \
+        cargo build \
+        --workspace --exclude shadow-tests \
+        ${RUST_TARGET_FLAG} \
+        ${RUST_BUILD_FLAG} \
+        ${RUST_TARGETS} \
+        --target-dir \"${TARGETDIR}\" \
+        --features \"${RUST_FEATURES}\" \
+        "
+    # always build shadow-tests with the debug profile, even when shadow is built in release mode
+    COMMAND bash -c " \
+        ${CARGO_ENV_VARS} \
+        cargo build \
+        --package shadow-tests \
+        --target-dir \"${TARGETDIR}\" \
+        --features \"${RUST_FEATURES}\" \
+        "
     BUILD_BYPRODUCTS
       ${TARGETDIR}/debug/${RUST_TARGET}/libshadow_shim_helper_rs.a ${TARGETDIR}/release/${RUST_TARGET}/libshadow_shim_helper_rs.a
     INSTALL_COMMAND ""
@@ -87,7 +104,16 @@ endforeach()
 # better than trying to fight the "rust way" here. It also includes doc tests,
 # which normally don't have persistent executables at all.
 add_test(NAME rust-unit-tests
-         COMMAND bash -c "${CARGO_ENV_VARS} cargo test ${RUST_TARGET_FLAG} ${RUST_BUILD_FLAG} --manifest-path \"${CMAKE_CURRENT_SOURCE_DIR}\"/Cargo.toml --target-dir \"${TARGETDIR}\" --features \"${RUST_FEATURES}\"")
+         COMMAND bash -c " \
+            ${CARGO_ENV_VARS} \
+            cargo test \
+            ${RUST_TARGET_FLAG} \
+            ${RUST_BUILD_FLAG} \
+            --manifest-path \"${CMAKE_CURRENT_SOURCE_DIR}\"/Cargo.toml \
+            --target-dir \"${TARGETDIR}\" \
+            --features \"${RUST_FEATURES}\" \
+            "
+         )
 # Longer timeout here and run serially, since it's running a whole test suite,
 # and may end up rebuilding code if anything has changed.
 set_tests_properties(rust-unit-tests PROPERTIES TIMEOUT 240 RUN_SERIAL TRUE)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -20,27 +20,6 @@ add_definitions(-fPIC -g3 -DDEBUG -D_GNU_SOURCE)
 ## ensure that the Host LLVM plugin is built first
 #get_property(LLVMHoistGlobalsPATH TARGET LLVMHoistGlobals PROPERTY LOCATION)
 
-if(SHADOW_COVERAGE STREQUAL ON)
-    # https://github.com/shadow/shadow/issues/1236
-    set(RUSTFLAGS "${RUSTFLAGS} --remap-path-prefix \"=${CMAKE_CURRENT_SOURCE_DIR}/\"")
-endif()
-
-include(ExternalProject)
-
-## always build tests with the debug profile, even when shadow is built in release mode
-set(CARGO_ENV_VARS "${CARGO_ENV_VARS} RUSTFLAGS=\"${RUSTFLAGS}\"")
-ExternalProject_Add(
-   shadow-tests
-   PREFIX ${CMAKE_CURRENT_BINARY_DIR}
-   BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-   BUILD_ALWAYS 1
-   DOWNLOAD_COMMAND ""
-   CONFIGURE_COMMAND ""
-   BUILD_COMMAND bash -c "${CARGO_ENV_VARS} cargo build --target-dir \"${CMAKE_CURRENT_BINARY_DIR}/target\""
-   INSTALL_COMMAND ""
-   LOG_BUILD OFF
-)
-
 ## a helper program for tests needing multiple processes
 add_executable(shadow-test-launcher test_launcher.c test_launcher_common.c)
 add_executable(shadow-test-launcher-fail test_launcher_fail.c test_launcher_common.c)

--- a/src/test/dup/CMakeLists.txt
+++ b/src/test/dup/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME dup COMMAND sh -c "../target/debug/test_dup --libc-passing")
+add_linux_tests(BASENAME dup COMMAND sh -c "../../target/debug/test_dup --libc-passing")
 add_shadow_tests(BASENAME dup)

--- a/src/test/dup/dup.yaml
+++ b/src/test/dup/dup.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_dup
+    - path: ../../target/debug/test_dup
       args: --shadow-passing
       start_time: 1

--- a/src/test/environment/environment.yaml
+++ b/src/test/environment/environment.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_env
+    - path: ../../target/debug/test_env
       environment: "TESTING_ENV_VAR_1=HELLO WORLD;LD_PRELOAD=/my/custom/ld/preload/path.so;TESTING_ENV_VAR_2=SOMETHING"
       start_time: 1

--- a/src/test/epoll/CMakeLists.txt
+++ b/src/test/epoll/CMakeLists.txt
@@ -8,5 +8,5 @@ add_shadow_tests(BASENAME epoll)
 add_executable(test-epoll-writeable test_epoll_writeable.c)
 add_shadow_tests(BASENAME epoll-writeable LOGLEVEL debug)
 
-add_linux_tests(BASENAME epoll-rs COMMAND "../target/debug/test_epoll")
+add_linux_tests(BASENAME epoll-rs COMMAND "../../target/debug/test_epoll")
 add_shadow_tests(BASENAME epoll-rs)

--- a/src/test/epoll/epoll-rs.yaml
+++ b/src/test/epoll/epoll-rs.yaml
@@ -7,4 +7,4 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_epoll
+    - path: ../../target/debug/test_epoll

--- a/src/test/eventfd/CMakeLists.txt
+++ b/src/test/eventfd/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME eventfd COMMAND sh -c "../target/debug/test_eventfd --libc-passing")
+add_linux_tests(BASENAME eventfd COMMAND sh -c "../../target/debug/test_eventfd --libc-passing")
 add_shadow_tests(BASENAME eventfd)

--- a/src/test/eventfd/eventfd.yaml
+++ b/src/test/eventfd/eventfd.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_eventfd
+    - path: ../../target/debug/test_eventfd
       args: --shadow-passing
       start_time: 1

--- a/src/test/exit/CMakeLists.txt
+++ b/src/test/exit/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_linux_tests(BASENAME exit COMMAND sh -c "../target/debug/test_exit")
+add_linux_tests(BASENAME exit COMMAND sh -c "../../target/debug/test_exit")
 add_shadow_tests(BASENAME exit)
 
 add_executable(test_exit_sigsegv test_exit_sigsegv.c)

--- a/src/test/exit/exit.yaml
+++ b/src/test/exit/exit.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_exit
+    - path: ../../target/debug/test_exit
       start_time: 1

--- a/src/test/ifaddrs/CMakeLists.txt
+++ b/src/test/ifaddrs/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME ifaddrs COMMAND sh -c "../target/debug/test_ifaddrs 127.0.0.1")
+add_linux_tests(BASENAME ifaddrs COMMAND sh -c "../../target/debug/test_ifaddrs 127.0.0.1")
 add_shadow_tests(BASENAME ifaddrs)

--- a/src/test/ifaddrs/ifaddrs.yaml
+++ b/src/test/ifaddrs/ifaddrs.yaml
@@ -8,6 +8,6 @@ hosts:
     network_node_id: 0
     ip_addr: 128.1.2.3
     processes:
-    - path: ../target/debug/test_ifaddrs
+    - path: ../../target/debug/test_ifaddrs
       args: 127.0.0.1 128.1.2.3
       start_time: 1

--- a/src/test/itimer/CMakeLists.txt
+++ b/src/test/itimer/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME itimer COMMAND sh -c "../target/debug/test_itimer")
+add_linux_tests(BASENAME itimer COMMAND sh -c "../../target/debug/test_itimer")
 add_shadow_tests(BASENAME itimer)

--- a/src/test/itimer/itimer.yaml
+++ b/src/test/itimer/itimer.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_itimer
+    - path: ../../target/debug/test_itimer
       start_time: 1

--- a/src/test/memory/CMakeLists.txt
+++ b/src/test/memory/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_linux_tests(BASENAME mmap COMMAND sh -c "../target/debug/test_mmap --libc-passing")
+add_linux_tests(BASENAME mmap COMMAND sh -c "../../target/debug/test_mmap --libc-passing")
 add_shadow_tests(BASENAME mmap)
 
-add_linux_tests(BASENAME unaligned COMMAND sh -c "../target/debug/test_unaligned --libc-passing")
+add_linux_tests(BASENAME unaligned COMMAND sh -c "../../target/debug/test_unaligned --libc-passing")
 add_shadow_tests(BASENAME unaligned)

--- a/src/test/memory/mmap.yaml
+++ b/src/test/memory/mmap.yaml
@@ -7,6 +7,6 @@ hosts:
   mytesthost:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_mmap
+    - path: ../../target/debug/test_mmap
       args: --shadow-passing
       start_time: 1

--- a/src/test/memory/unaligned.yaml
+++ b/src/test/memory/unaligned.yaml
@@ -7,6 +7,6 @@ hosts:
   mytesthost:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_unaligned
+    - path: ../../target/debug/test_unaligned
       args: --shadow-passing
       start_time: 1

--- a/src/test/pipe/CMakeLists.txt
+++ b/src/test/pipe/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME pipe COMMAND sh -c "../target/debug/test_pipe --libc-passing")
+add_linux_tests(BASENAME pipe COMMAND sh -c "../../target/debug/test_pipe --libc-passing")
 add_shadow_tests(BASENAME pipe)

--- a/src/test/pipe/pipe.yaml
+++ b/src/test/pipe/pipe.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_pipe
+    - path: ../../target/debug/test_pipe
       args: --shadow-passing
       start_time: 1

--- a/src/test/poll/CMakeLists.txt
+++ b/src/test/poll/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME poll COMMAND sh -c "../target/debug/test_poll --libc-passing")
+add_linux_tests(BASENAME poll COMMAND sh -c "../../target/debug/test_poll --libc-passing")
 add_shadow_tests(BASENAME poll)

--- a/src/test/poll/poll.yaml
+++ b/src/test/poll/poll.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_poll
+    - path: ../../target/debug/test_poll
       args: --shadow-passing
       start_time: 1

--- a/src/test/random/CMakeLists.txt
+++ b/src/test/random/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME random COMMAND sh -c "../target/debug/test_random --libc-passing")
+add_linux_tests(BASENAME random COMMAND sh -c "../../target/debug/test_random --libc-passing")
 add_shadow_tests(BASENAME random)

--- a/src/test/random/random.yaml
+++ b/src/test/random/random.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_random
+    - path: ../../target/debug/test_random
       args: --shadow-passing
       start_time: 1

--- a/src/test/regression/CMakeLists.txt
+++ b/src/test/regression/CMakeLists.txt
@@ -24,7 +24,7 @@ add_shadow_tests(
 add_executable(test_flush_after_exit test_flush_after_exit.c)
 add_linux_tests(BASENAME flush_after_exit COMMAND bash -c "test `./test_flush_after_exit` == 'Hello'")
 add_shadow_tests(BASENAME flush_after_exit POST_CMD "test `cat hosts/*/*.stdout` = 'Hello'")
-add_linux_tests(BASENAME busy_wait COMMAND ../target/debug/test_busy_wait)
+add_linux_tests(BASENAME busy_wait COMMAND ../../target/debug/test_busy_wait)
 add_shadow_tests(
     BASENAME busy_wait
     # Avoid expensive trace-level logging in busy loop.

--- a/src/test/regression/busy_wait.yaml
+++ b/src/test/regression/busy_wait.yaml
@@ -12,5 +12,5 @@ hosts:
   host:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_busy_wait
+    - path: ../../target/debug/test_busy_wait
       start_time: 1s

--- a/src/test/regression/exit_after_signal_sched.yaml
+++ b/src/test/regression/exit_after_signal_sched.yaml
@@ -10,6 +10,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_exit_after_signal_sched
+    - path: ../../target/debug/test_exit_after_signal_sched
       args: --shadow-passing
       start_time: 1

--- a/src/test/regression/signal_resched.yaml
+++ b/src/test/regression/signal_resched.yaml
@@ -10,6 +10,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_signal_resched
+    - path: ../../target/debug/test_signal_resched
       args: --shadow-passing
       start_time: 1

--- a/src/test/select/CMakeLists.txt
+++ b/src/test/select/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME select COMMAND sh -c "../target/debug/test_select --libc-passing")
+add_linux_tests(BASENAME select COMMAND sh -c "../../target/debug/test_select --libc-passing")
 add_shadow_tests(BASENAME select)

--- a/src/test/select/select.yaml
+++ b/src/test/select/select.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_select
+    - path: ../../target/debug/test_select
       args: --shadow-passing
       start_time: 1

--- a/src/test/signal/CMakeLists.txt
+++ b/src/test/signal/CMakeLists.txt
@@ -7,5 +7,5 @@ add_linux_tests(BASENAME signal COMMAND shadow-test-launcher test-signal : test-
 add_shadow_tests(BASENAME signal)
 
 ## More complete signal functionality.
-add_linux_tests(BASENAME signals-extra COMMAND sh -c "../target/debug/test_signals --libc-passing")
+add_linux_tests(BASENAME signals-extra COMMAND sh -c "../../target/debug/test_signals --libc-passing")
 add_shadow_tests(BASENAME signals-extra)

--- a/src/test/signal/signals-extra.yaml
+++ b/src/test/signal/signals-extra.yaml
@@ -7,6 +7,6 @@ hosts:
   mytesthost:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_signals
+    - path: ../../target/debug/test_signals
       args: --shadow-passing
       start_time: 1

--- a/src/test/sleep/CMakeLists.txt
+++ b/src/test/sleep/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME sleep COMMAND sh -c "../target/debug/test_sleep")
+add_linux_tests(BASENAME sleep COMMAND sh -c "../../target/debug/test_sleep")
 add_shadow_tests(BASENAME sleep)

--- a/src/test/sleep/sleep.yaml
+++ b/src/test/sleep/sleep.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_sleep
+    - path: ../../target/debug/test_sleep
       start_time: 1

--- a/src/test/socket/accept/CMakeLists.txt
+++ b/src/test/socket/accept/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME accept COMMAND sh -c "../../target/debug/test_accept --libc-passing")
+add_linux_tests(BASENAME accept COMMAND sh -c "../../../target/debug/test_accept --libc-passing")
 add_shadow_tests(BASENAME accept LOGLEVEL debug)

--- a/src/test/socket/accept/accept.yaml
+++ b/src/test/socket/accept/accept.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_accept
+    - path: ../../../target/debug/test_accept
       args: --shadow-passing
       start_time: 1

--- a/src/test/socket/bind/CMakeLists.txt
+++ b/src/test/socket/bind/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_linux_tests(BASENAME bind COMMAND sh -c "../../target/debug/test_bind --libc-passing")
+add_linux_tests(BASENAME bind COMMAND sh -c "../../../target/debug/test_bind --libc-passing")
 add_shadow_tests(BASENAME bind LOGLEVEL debug ARGS --strace-logging-mode off)
 
 add_shadow_tests(BASENAME bind_in_new_process CHECK_RETVAL false)

--- a/src/test/socket/bind/bind.yaml
+++ b/src/test/socket/bind/bind.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_bind
+    - path: ../../../target/debug/test_bind
       args: --shadow-passing
       start_time: 1

--- a/src/test/socket/bind/bind_in_new_process.yaml
+++ b/src/test/socket/bind/bind_in_new_process.yaml
@@ -8,22 +8,22 @@ hosts:
   test-shadow-stop:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_bind_in_new_process
+    - path: ../../../target/debug/test_bind_in_new_process
       args: '10000000'
       start_time: 1
       stop_time: 2
     # start the process a second time, which tries to bind to the same port
-    - path: ../../target/debug/test_bind_in_new_process
+    - path: ../../../target/debug/test_bind_in_new_process
       args: '10000000'
       start_time: 3
   # test when the process stops by itself (before it reaches its stop_time)
   test-self-stop:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_bind_in_new_process
+    - path: ../../../target/debug/test_bind_in_new_process
       args: '0'
       start_time: 1
     # start the process a second time, which tries to bind to the same port
-    - path: ../../target/debug/test_bind_in_new_process
+    - path: ../../../target/debug/test_bind_in_new_process
       args: '0'
       start_time: 3

--- a/src/test/socket/connect/CMakeLists.txt
+++ b/src/test/socket/connect/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME connect COMMAND sh -c "../../target/debug/test_connect --libc-passing")
+add_linux_tests(BASENAME connect COMMAND sh -c "../../../target/debug/test_connect --libc-passing")
 add_shadow_tests(BASENAME connect)

--- a/src/test/socket/connect/connect.yaml
+++ b/src/test/socket/connect/connect.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_connect
+    - path: ../../../target/debug/test_connect
       args: --shadow-passing
       start_time: 1

--- a/src/test/socket/getpeername/CMakeLists.txt
+++ b/src/test/socket/getpeername/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME getpeername COMMAND sh -c "../../target/debug/test_getpeername --libc-passing")
+add_linux_tests(BASENAME getpeername COMMAND sh -c "../../../target/debug/test_getpeername --libc-passing")
 add_shadow_tests(BASENAME getpeername)

--- a/src/test/socket/getpeername/getpeername.yaml
+++ b/src/test/socket/getpeername/getpeername.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_getpeername
+    - path: ../../../target/debug/test_getpeername
       args: --shadow-passing
       start_time: 1

--- a/src/test/socket/getsockname/CMakeLists.txt
+++ b/src/test/socket/getsockname/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME getsockname COMMAND sh -c "../../target/debug/test_getsockname --libc-passing")
+add_linux_tests(BASENAME getsockname COMMAND sh -c "../../../target/debug/test_getsockname --libc-passing")
 add_shadow_tests(BASENAME getsockname)

--- a/src/test/socket/getsockname/getsockname.yaml
+++ b/src/test/socket/getsockname/getsockname.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_getsockname
+    - path: ../../../target/debug/test_getsockname
       args: --shadow-passing
       start_time: 1

--- a/src/test/socket/ioctl/CMakeLists.txt
+++ b/src/test/socket/ioctl/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME ioctl COMMAND sh -c "../../target/debug/test_ioctl --libc-passing")
+add_linux_tests(BASENAME ioctl COMMAND sh -c "../../../target/debug/test_ioctl --libc-passing")
 add_shadow_tests(BASENAME ioctl)

--- a/src/test/socket/ioctl/ioctl.yaml
+++ b/src/test/socket/ioctl/ioctl.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_ioctl
+    - path: ../../../target/debug/test_ioctl
       args: --shadow-passing
       start_time: 1

--- a/src/test/socket/listen/CMakeLists.txt
+++ b/src/test/socket/listen/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME listen COMMAND sh -c "../../target/debug/test_listen --libc-passing")
+add_linux_tests(BASENAME listen COMMAND sh -c "../../../target/debug/test_listen --libc-passing")
 add_shadow_tests(BASENAME listen)

--- a/src/test/socket/listen/listen.yaml
+++ b/src/test/socket/listen/listen.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_listen
+    - path: ../../../target/debug/test_listen
       args: --shadow-passing
       start_time: 1

--- a/src/test/socket/sendto_recvfrom/CMakeLists.txt
+++ b/src/test/socket/sendto_recvfrom/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME sendto-recvfrom COMMAND sh -c "../../target/debug/test_sendto_recvfrom --libc-passing")
+add_linux_tests(BASENAME sendto-recvfrom COMMAND sh -c "../../../target/debug/test_sendto_recvfrom --libc-passing")
 add_shadow_tests(BASENAME sendto-recvfrom LOGLEVEL debug)

--- a/src/test/socket/sendto_recvfrom/sendto-recvfrom.yaml
+++ b/src/test/socket/sendto_recvfrom/sendto-recvfrom.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_sendto_recvfrom
+    - path: ../../../target/debug/test_sendto_recvfrom
       args: --shadow-passing
       start_time: 1

--- a/src/test/socket/shutdown/CMakeLists.txt
+++ b/src/test/socket/shutdown/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME shutdown COMMAND sh -c "../../target/debug/test_shutdown --libc-passing")
+add_linux_tests(BASENAME shutdown COMMAND sh -c "../../../target/debug/test_shutdown --libc-passing")
 add_shadow_tests(BASENAME shutdown LOGLEVEL debug)

--- a/src/test/socket/shutdown/shutdown.yaml
+++ b/src/test/socket/shutdown/shutdown.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_shutdown
+    - path: ../../../target/debug/test_shutdown
       args: --shadow-passing
       start_time: 1

--- a/src/test/socket/socket/CMakeLists.txt
+++ b/src/test/socket/socket/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME socket COMMAND sh -c "../../target/debug/test_socket --libc-passing")
+add_linux_tests(BASENAME socket COMMAND sh -c "../../../target/debug/test_socket --libc-passing")
 add_shadow_tests(BASENAME socket)

--- a/src/test/socket/socket/socket.yaml
+++ b/src/test/socket/socket/socket.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_socket
+    - path: ../../../target/debug/test_socket
       args: --shadow-passing
       start_time: 1

--- a/src/test/socket/socketpair/CMakeLists.txt
+++ b/src/test/socket/socketpair/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME socketpair COMMAND sh -c "../../target/debug/test_socketpair --libc-passing")
+add_linux_tests(BASENAME socketpair COMMAND sh -c "../../../target/debug/test_socketpair --libc-passing")
 add_shadow_tests(BASENAME socketpair)

--- a/src/test/socket/socketpair/socketpair.yaml
+++ b/src/test/socket/socketpair/socketpair.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_socketpair
+    - path: ../../../target/debug/test_socketpair
       args: --shadow-passing
       start_time: 1

--- a/src/test/socket/sockopt/CMakeLists.txt
+++ b/src/test/socket/sockopt/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME sockopt COMMAND sh -c "../../target/debug/test_sockopt --libc-passing")
+add_linux_tests(BASENAME sockopt COMMAND sh -c "../../../target/debug/test_sockopt --libc-passing")
 add_shadow_tests(BASENAME sockopt)

--- a/src/test/socket/sockopt/sockopt.yaml
+++ b/src/test/socket/sockopt/sockopt.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_sockopt
+    - path: ../../../target/debug/test_sockopt
       args: --shadow-passing
       start_time: 1

--- a/src/test/stdio/stdio.yaml
+++ b/src/test/stdio/stdio.yaml
@@ -7,4 +7,4 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_stdio
+    - path: ../../target/debug/test_stdio

--- a/src/test/sysinfo/CMakeLists.txt
+++ b/src/test/sysinfo/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_linux_tests(BASENAME sysinfo COMMAND sh -c "../target/debug/test_sysinfo")
+add_linux_tests(BASENAME sysinfo COMMAND sh -c "../../target/debug/test_sysinfo")
 add_shadow_tests(BASENAME sysinfo)

--- a/src/test/sysinfo/sysinfo.yaml
+++ b/src/test/sysinfo/sysinfo.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_sysinfo
+    - path: ../../target/debug/test_sysinfo
       start_time: 1

--- a/src/test/threads/CMakeLists.txt
+++ b/src/test/threads/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_linux_tests(BASENAME pthreads COMMAND sh -c "../target/debug/test_pthreads --libc-passing")
+add_linux_tests(BASENAME pthreads COMMAND sh -c "../../target/debug/test_pthreads --libc-passing")
 add_shadow_tests(BASENAME pthreads)
 
-add_linux_tests(BASENAME threads-noexit COMMAND sh -c "../target/debug/test_threads_noexit")
+add_linux_tests(BASENAME threads-noexit COMMAND sh -c "../../target/debug/test_threads_noexit")
 add_shadow_tests(BASENAME threads-noexit CHECK_RETVAL FALSE)
 
-add_linux_tests(BASENAME threads-group-leader-exits COMMAND sh -c "../target/debug/test_threads_group_leader_exits")
+add_linux_tests(BASENAME threads-group-leader-exits COMMAND sh -c "../../target/debug/test_threads_group_leader_exits")
 add_shadow_tests(BASENAME threads-group-leader-exits)

--- a/src/test/threads/pthreads.yaml
+++ b/src/test/threads/pthreads.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_pthreads
+    - path: ../../target/debug/test_pthreads
       args: --shadow-passing
       start_time: 1

--- a/src/test/threads/threads-group-leader-exits.yaml
+++ b/src/test/threads/threads-group-leader-exits.yaml
@@ -8,5 +8,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_threads_group_leader_exits
+    - path: ../../target/debug/test_threads_group_leader_exits
       start_time: 1

--- a/src/test/threads/threads-noexit.yaml
+++ b/src/test/threads/threads-noexit.yaml
@@ -8,5 +8,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_threads_noexit
+    - path: ../../target/debug/test_threads_noexit
       start_time: 1

--- a/src/test/unistd/CMakeLists.txt
+++ b/src/test/unistd/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_linux_tests(BASENAME unistd COMMAND sh -c "\
-../target/debug/test_unistd \"$(uname -s)\" \"$(uname -n)\" \"$(uname -r)\" \"$(uname -v)\" \"$(uname -m)\" \
+../../target/debug/test_unistd \"$(uname -s)\" \"$(uname -n)\" \"$(uname -r)\" \"$(uname -v)\" \"$(uname -m)\" \
 ")
 add_shadow_tests(BASENAME unistd)
 

--- a/src/test/unistd/pid_assignment.yaml
+++ b/src/test/unistd/pid_assignment.yaml
@@ -9,10 +9,10 @@ hosts:
   host1:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_pid_assignment
+    - path: ../../target/debug/test_pid_assignment
       args: "1000"
       start_time: 2
-    - path: ../target/debug/test_pid_assignment
+    - path: ../../target/debug/test_pid_assignment
       args: "1001"
       # Start *before* the other process. PID should still be
       # assigned by order of this list.
@@ -21,5 +21,5 @@ hosts:
   host2:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_pid_assignment
+    - path: ../../target/debug/test_pid_assignment
       args: "1000"

--- a/src/test/unistd/unistd.yaml
+++ b/src/test/unistd/unistd.yaml
@@ -7,6 +7,6 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../target/debug/test_unistd
+    - path: ../../target/debug/test_unistd
       args: shadowsys testnode shadowrelease shadowversion shadowmachine
       start_time: 1


### PR DESCRIPTION
In Shadow we run `cargo build` twice, once on the workspace (in `src/`) and once on the "shadow-tests" package (in `src/test/`). Each cargo invocation is given a different target directory. This means that we end up building "shadow-tests" twice, once in each target directory. This hasn't really been an issue for us yet since for the workspace build we only build `--lib --tests` and not `--bins`, so none of the binary crates from "shadow-tests" were being built in the workspace build.

We need the two cargo builds since "shadow-tests" should always be built with the dev profile, and cargo [doesn't yet](https://doc.rust-lang.org/cargo/reference/unstable.html#per-package-target) let you build a workspace using different profiles.

I think it's better to build both "shadow-tests" and the remainder of the workspace into the same target directory, and include only "shadow-tests" when building "shadow-tests", and excluding only "shadow-tests" when building the workspace. This also allows us to create binary crates in shadow, which previously wouldn't have been built since we used to only specify `--lib --tests`.

This PR also makes it so that both `cargo build`s don't run at the same time anymore, and they are run in sequence instead.