### PR TITLE
Add new token bucket unit tests

### DIFF
--- a/src/main/network/mod.rs
+++ b/src/main/network/mod.rs
@@ -2,3 +2,13 @@ pub mod graph;
 mod packet;
 mod relay;
 pub mod router;
+
+#[cfg(test)]
+mod tests {
+    use shadow_shim_helper_rs::{emulated_time::EmulatedTime, simulation_time::SimulationTime};
+
+    pub fn mock_time_millis(millis_since_sim_start: u64) -> EmulatedTime {
+        let simtime = SimulationTime::from_millis(millis_since_sim_start);
+        EmulatedTime::from_abs_simtime(simtime)
+    }
+}

--- a/src/main/network/router/codel_queue.rs
+++ b/src/main/network/router/codel_queue.rs
@@ -325,7 +325,7 @@ impl CoDelQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::network::router::tests::mock_time_millis;
+    use crate::network::tests::mock_time_millis;
 
     // Some of the tests here don't run in miri because they cause c::packet*
     // functions to be called during the test.

--- a/src/main/network/router/mod.rs
+++ b/src/main/network/router/mod.rs
@@ -119,14 +119,8 @@ mod export {
 
 #[cfg(test)]
 mod tests {
-    use shadow_shim_helper_rs::{emulated_time::EmulatedTime, simulation_time::SimulationTime};
-
     use super::*;
-
-    pub fn mock_time_millis(millis_since_sim_start: u64) -> EmulatedTime {
-        let simtime = SimulationTime::from_millis(millis_since_sim_start);
-        EmulatedTime::from_abs_simtime(simtime)
-    }
+    use crate::network::tests::mock_time_millis;
 
     #[test]
     fn empty() {


### PR DESCRIPTION
This PR refactors the token bucket a bit so that we can write unit tests without calling into the worker module, and then adds several unit tests.