### PR TITLE
Set dependabot to ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
   - package-ecosystem: 'cargo'
     directory: '/src'
     schedule:
-      interval: 'monthly'
-    # use a high limit since dependabot only checks monthly
+      interval: 'daily'
+    # a high limit is useful when dependabot only checks monthly
     open-pull-requests-limit: 30
+    # ignore non-security patch updates on all deps
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
     target-branch: 'main'
     # don't auto-rebase, otherwise dependabot will rebase several PRs at once
     # and create many hours of unnecessary workflow runs


### PR DESCRIPTION
Run daily, but ignore non-security patch updates. We hope this still keeps the number of new dependabot PRs low.