### PR TITLE
Move host handling of network interfaces to rust

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -68,7 +68,6 @@ hosts:
 - [`experimental.host_heartbeat_interval`](#experimentalhost_heartbeat_interval)
 - [`experimental.host_heartbeat_log_info`](#experimentalhost_heartbeat_log_info)
 - [`experimental.host_heartbeat_log_level`](#experimentalhost_heartbeat_log_level)
-- [`experimental.interface_buffer`](#experimentalinterface_buffer)
 - [`experimental.interface_qdisc`](#experimentalinterface_qdisc)
 - [`experimental.max_unapplied_cpu_latency`](#experimentalmax_unapplied_cpu_latency)
 - [`experimental.preload_spin_max`](#experimentalpreload_spin_max)
@@ -323,13 +322,6 @@ Default: "info"
 Type: "error" OR "warning" OR "info" OR "debug" OR "trace"
 
 Log level at which to print host statistics.
-
-#### `experimental.interface_buffer`
-
-Default: "1024000 B"  
-Type: String OR Integer
-
-Size of the interface receive buffer that accepts incoming packets.
 
 #### `experimental.interface_qdisc`
 

--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -18,6 +18,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
             "Thread".into(),
             "EmulatedTime".into(),
             "SimulationTime".into(),
+            "NetworkInterface".into(),
         ]);
         c
     };
@@ -151,6 +152,8 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .allowlist_function("rustlogger_new")
         .allowlist_function("dns_.*")
         .allowlist_function("address_getID")
+        .allowlist_function("address_unref")
+        .allowlist_function("compatsocket_getSocketName")
 
         .allowlist_function("workerpool_updateMinHostRunahead")
 

--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -138,7 +138,7 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .allowlist_function("legacyfile_getHandle")
         .allowlist_function("legacyfile_setHandle")
         .allowlist_function("legacyfile_shutdownHelper")
-        .allowlist_function("networkinterface_receivePackets")
+        .allowlist_function("networkinterface_.*")
         .allowlist_function("hostc_.*")
 
         // used by shadow's main function

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -577,7 +577,6 @@ impl<'a> Manager<'a> {
                 autotuneRecvBuf: if host_info.autotune_recv_buf { 1 } else { 0 },
                 sendBufSize: host_info.send_buf_size,
                 autotuneSendBuf: if host_info.autotune_send_buf { 1 } else { 0 },
-                interfaceBufSize: host_info.interface_buf_size,
             };
 
             let host = Box::new(Host::new(params));

--- a/src/main/core/sim_config.rs
+++ b/src/main/core/sim_config.rs
@@ -181,7 +181,6 @@ pub struct HostInfo {
     pub recv_buf_size: u64,
     pub autotune_send_buf: bool,
     pub autotune_recv_buf: bool,
-    pub interface_buf_size: u64,
     pub qdisc: QDiscMode,
 }
 
@@ -305,13 +304,6 @@ fn build_host(
                 .value(),
             autotune_send_buf: config.experimental.socket_send_autotune.unwrap(),
             autotune_recv_buf: config.experimental.socket_recv_autotune.unwrap(),
-            interface_buf_size: config
-                .experimental
-                .interface_buffer
-                .unwrap()
-                .convert(units::SiPrefixUpper::Base)
-                .unwrap()
-                .value(),
             qdisc: config.experimental.interface_qdisc.unwrap(),
         });
     }

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -367,12 +367,6 @@ pub struct ExperimentalOptions {
     #[clap(help = EXP_HELP.get("socket_recv_autotune").unwrap().as_str())]
     pub socket_recv_autotune: Option<bool>,
 
-    /// Size of the interface receive buffer that accepts incoming packets
-    #[clap(hide_short_help = true)]
-    #[clap(long, value_name = "bytes")]
-    #[clap(help = EXP_HELP.get("interface_buffer").unwrap().as_str())]
-    pub interface_buffer: Option<units::Bytes<units::SiPrefixUpper>>,
-
     /// The queueing discipline to use at the network interface
     #[clap(hide_short_help = true)]
     #[clap(long, value_name = "mode")]
@@ -490,7 +484,6 @@ impl Default for ExperimentalOptions {
             socket_send_autotune: Some(true),
             socket_recv_buffer: Some(units::Bytes::new(174_760, units::SiPrefixUpper::Base)),
             socket_recv_autotune: Some(true),
-            interface_buffer: Some(units::Bytes::new(1_024_000, units::SiPrefixUpper::Base)),
             interface_qdisc: Some(QDiscMode::Fifo),
             use_legacy_working_dir: Some(false),
             host_heartbeat_log_level: Some(LogLevel::Info),

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -356,9 +356,7 @@ impl Worker {
                 unsafe { crate::network::router::router_enqueue(router, packet.into_inner()) };
 
             if became_nonempty {
-                let default_ip = host.default_ip();
-                let interface = host.interface(default_ip);
-                unsafe { cshadow::networkinterface_receivePackets(interface, host) };
+                host.packets_are_available_to_receive();
             }
         });
 

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -141,6 +141,16 @@ impl Worker {
         .flatten()
     }
 
+    /// Run `f` with a reference to the global DNS.
+    ///
+    /// Panics if the Worker or its DNS hasn't yet been initialized.
+    pub fn with_dns<F, R>(f: F) -> R
+    where
+        F: FnOnce(&mut cshadow::DNS) -> R,
+    {
+        Worker::with(|w| f(unsafe { w.shared.dns().as_mut().unwrap() })).unwrap()
+    }
+
     /// Set the currently-active Host.
     pub fn set_active_host(host: Box<Host>) {
         let old = Worker::with(|w| w.active_host.borrow_mut().replace(host)).unwrap();
@@ -592,7 +602,7 @@ mod export {
 
     #[no_mangle]
     pub extern "C" fn worker_getDNS() -> *mut cshadow::DNS {
-        Worker::with(|w| w.shared.dns()).unwrap()
+        Worker::with_dns(|dns| dns as *mut cshadow::DNS)
     }
 
     /// Addresses must be provided in network byte order.

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -16,7 +16,6 @@
 #include "main/host/descriptor/tcp.h"
 #include "main/host/descriptor/transport.h"
 #include "main/host/host.h"
-#include "main/host/network_interface.h"
 #include "main/host/protocol.h"
 #include "main/host/tracker.h"
 #include "main/routing/address.h"
@@ -453,9 +452,8 @@ gboolean legacysocket_addToOutputBuffer(LegacySocket* socket, const Host* host, 
 
     /* tell the interface to include us when sending out to the network */
     in_addr_t ip = packet_getSourceIP(packet);
-    NetworkInterface* interface = host_lookupInterface(host, ip);
     CompatSocket compat_socket = compatsocket_fromLegacySocket(socket);
-    networkinterface_wantsSend(interface, host, &compat_socket);
+    host_socketWantsToSend(host, &compat_socket, ip);
 
     return TRUE;
 }

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -30,7 +30,6 @@
 #include "main/host/descriptor/tcp_retransmit_tally.h"
 #include "main/host/descriptor/transport.h"
 #include "main/host/host.h"
-#include "main/host/network_interface.h"
 #include "main/host/protocol.h"
 #include "main/host/tracker.h"
 #include "main/routing/address.h"

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -192,10 +192,10 @@ void hostc_setup(const Host* rhost, DNS* dns, gulong rawCPUFreq) {
     }
 
     /* virtual addresses and interfaces for managing network I/O */
-    host->loopback = networkinterface_new(loopbackAddress, pcapDir, host->params.pcapCaptureSize,
-                                          host->params.qdisc, host->params.interfaceBufSize, false);
-    host->internet = networkinterface_new(ethernetAddress, pcapDir, host->params.pcapCaptureSize,
-                                          host->params.qdisc, host->params.interfaceBufSize, true);
+    host->loopback = networkinterface_new(
+        loopbackAddress, pcapDir, host->params.pcapCaptureSize, host->params.qdisc, false);
+    host->internet = networkinterface_new(
+        ethernetAddress, pcapDir, host->params.pcapCaptureSize, host->params.qdisc, true);
 
     g_free(pcapDir);
 

--- a/src/main/host/host.c
+++ b/src/main/host/host.c
@@ -326,8 +326,8 @@ void hostc_boot(const Host* rhost) {
     guint64 bwDownKiBps = hostc_get_bw_down_kiBps(host);
     guint64 bwUpKiBps = hostc_get_bw_up_kiBps(host);
 
-    networkinterface_startRefillingTokenBuckets(host->loopback, rhost, bwDownKiBps, bwUpKiBps);
-    networkinterface_startRefillingTokenBuckets(host->internet, rhost, bwDownKiBps, bwUpKiBps);
+    networkinterface_startRefillingTokenBuckets(host->loopback, bwDownKiBps, bwUpKiBps);
+    networkinterface_startRefillingTokenBuckets(host->internet, bwDownKiBps, bwUpKiBps);
 }
 
 void hostc_addApplication(const Host* rhost, CSimulationTime startTime, CSimulationTime stopTime,

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -61,7 +61,8 @@ gboolean hostc_autotuneSendBuffer(HostCInternal* host);
 guint64 hostc_getConfiguredRecvBufSize(HostCInternal* host);
 guint64 hostc_getConfiguredSendBufSize(HostCInternal* host);
 
-NetworkInterface* hostc_lookupInterface(HostCInternal* host, in_addr_t handle);
+void hostc_packetsAreAvailableToReceive(const Host* rhost);
+void hostc_socketWantsToSend(const Host* rhost, const CompatSocket* socket, in_addr_t interfaceIP);
 Router* hostc_getUpstreamRouter(HostCInternal* host);
 
 uint64_t hostc_get_bw_down_kiBps(HostCInternal* host);

--- a/src/main/host/host.h
+++ b/src/main/host/host.h
@@ -26,7 +26,6 @@ typedef struct _HostCInternal HostCInternal;
 #include "main/host/descriptor/descriptor.h"
 #include "main/host/futex_table.h"
 #include "main/host/host_parameters.h"
-#include "main/host/network_interface.h"
 #include "main/host/protocol.h"
 #include "main/host/thread.h"
 #include "main/host/tracker_types.h"
@@ -39,7 +38,7 @@ void hostc_unref(HostCInternal* host);
 void hostc_continueExecutionTimer(HostCInternal* host);
 void hostc_stopExecutionTimer(HostCInternal* host);
 
-void hostc_setup(const Host* host, DNS* dns, gulong rawCPUFreq);
+void hostc_setup(const Host* host, Address* ethernetAddress, gulong rawCPUFreq);
 void hostc_boot(const Host* rhost);
 void hostc_shutdown(HostCInternal* host);
 
@@ -61,8 +60,6 @@ gboolean hostc_autotuneSendBuffer(HostCInternal* host);
 guint64 hostc_getConfiguredRecvBufSize(HostCInternal* host);
 guint64 hostc_getConfiguredSendBufSize(HostCInternal* host);
 
-void hostc_packetsAreAvailableToReceive(const Host* rhost);
-void hostc_socketWantsToSend(const Host* rhost, const CompatSocket* socket, in_addr_t interfaceIP);
 Router* hostc_getUpstreamRouter(HostCInternal* host);
 
 uint64_t hostc_get_bw_down_kiBps(HostCInternal* host);
@@ -71,12 +68,6 @@ uint64_t hostc_get_bw_up_kiBps(HostCInternal* host);
 Tracker* hostc_getTracker(HostCInternal* host);
 LogLevel hostc_getLogLevel(HostCInternal* host);
 
-gboolean hostc_doesInterfaceExist(HostCInternal* host, in_addr_t interfaceIP);
-gboolean hostc_isInterfaceAvailable(HostCInternal* host, ProtocolType type, in_addr_t interfaceIP,
-                                    in_port_t port, in_addr_t peerIP, in_port_t peerPort);
-void hostc_associateInterface(HostCInternal* host, const CompatSocket* socket,
-                              in_addr_t bindAddress);
-void hostc_disassociateInterface(HostCInternal* host, const CompatSocket* socket);
 in_port_t hostc_getRandomFreePort(const Host* host, ProtocolType type, in_addr_t interfaceIP,
                                   in_addr_t peerIP, in_port_t peerPort);
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -4,11 +4,11 @@ use rand::SeedableRng;
 use rand_xoshiro::Xoshiro256PlusPlus;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::rootedcell::Root;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::ffi::{CStr, CString, OsString};
 use std::net::Ipv4Addr;
 use std::os::raw::c_char;
-use std::os::unix::prelude::{OsStrExt, OsStringExt};
+use std::os::unix::prelude::OsStringExt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -18,8 +18,9 @@ use crate::core::work::task::TaskRef;
 use crate::core::worker::Worker;
 use crate::cshadow;
 use crate::host::descriptor::socket::abstract_unix_ns::AbstractUnixNamespace;
+use crate::host::network_interface::NetworkInterface;
 use crate::network::router::Router;
-use crate::utility::SyncSendPointer;
+use crate::utility::{self, SyncSendPointer};
 use shadow_shim_helper_rs::emulated_time::EmulatedTime;
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
 use shadow_shim_helper_rs::HostId;
@@ -62,6 +63,10 @@ pub struct Host {
 
     random: RootedRefCell<Xoshiro256PlusPlus>,
 
+    // TODO: rearrange our setup process so we don't need Option types here.
+    localhost: RefCell<Option<NetworkInterface>>,
+    internet: RefCell<Option<NetworkInterface>>,
+
     // Store as a CString so that we can return a borrowed pointer to C code
     // instead of having to allocate a new string.
     //
@@ -100,13 +105,6 @@ impl std::fmt::Debug for Host {
     }
 }
 
-/// Helper for converting a PathBuf to a CString
-fn pathbuf_to_nul_term_cstring(buf: PathBuf) -> CString {
-    let mut bytes = buf.as_os_str().to_os_string().as_bytes().to_vec();
-    bytes.push(0);
-    CString::from_vec_with_nul(bytes).unwrap()
-}
-
 impl Host {
     pub fn new(params: cshadow::HostParameters) -> Self {
         // Ok because hostc_new copies params rather than saving this pointer.
@@ -133,6 +131,8 @@ impl Host {
             event_queue: Arc::new(Mutex::new(EventQueue::new())),
             params,
             random,
+            localhost: RefCell::new(None),
+            internet: RefCell::new(None),
             data_dir_path,
             process_id_counter,
             event_id_counter,
@@ -147,13 +147,59 @@ impl Host {
             let data_dir_path = self.data_dir_path(host_root_path);
             std::fs::create_dir_all(&data_dir_path).unwrap();
 
-            let data_dir_path = pathbuf_to_nul_term_cstring(data_dir_path);
+            let data_dir_path = utility::pathbuf_to_nul_term_cstring(data_dir_path);
             self.data_dir_path
                 .borrow_mut(&self.root)
                 .replace(data_dir_path);
         }
 
-        unsafe { cshadow::hostc_setup(self, dns, raw_cpu_freq) }
+        // Register using the param hints.
+        // We already checked that the addresses are available, so fail if they are not.
+        let local_ipv4 = u32::from(Ipv4Addr::LOCALHOST).to_be();
+        let local_addr =
+            unsafe { cshadow::dns_register(dns, self.params.id, self.params.hostname, local_ipv4) };
+        assert!(!local_addr.is_null());
+
+        let inet_addr = unsafe {
+            cshadow::dns_register(
+                dns,
+                self.params.id,
+                self.params.hostname,
+                self.params.ipAddr,
+            )
+        };
+        assert!(!inet_addr.is_null());
+
+        unsafe { cshadow::hostc_setup(self, inet_addr, raw_cpu_freq) }
+
+        // Virtual addresses and interfaces for managing network I/O
+        let localhost = unsafe {
+            NetworkInterface::new(
+                self.id(),
+                local_addr,
+                self.pcap_dir_path(host_root_path),
+                self.params.pcapCaptureSize,
+                self.params.qdisc,
+                false,
+            )
+        };
+        self.localhost.borrow_mut().replace(localhost);
+
+        let internet = unsafe {
+            NetworkInterface::new(
+                self.id(),
+                inet_addr,
+                self.pcap_dir_path(host_root_path),
+                self.params.pcapCaptureSize,
+                self.params.qdisc,
+                true,
+            )
+        };
+        self.internet.borrow_mut().replace(internet);
+
+        // Cleanup
+        unsafe { cshadow::address_unref(local_addr) };
+        unsafe { cshadow::address_unref(inet_addr) };
     }
 
     fn data_dir_path(&self, host_root_path: &Path) -> PathBuf {
@@ -166,6 +212,22 @@ impl Host {
         data_dir_path.push(host_root_path);
         data_dir_path.push(&hostname);
         data_dir_path
+    }
+
+    fn pcap_dir_path(&self, host_root_path: &Path) -> Option<PathBuf> {
+        if self.params.pcapDir.is_null() {
+            None
+        } else {
+            let path_string: OsString = {
+                let path_str = unsafe { CStr::from_ptr(self.params.pcapDir) };
+                OsString::from_vec(path_str.to_bytes().to_vec())
+            };
+
+            let mut path = self.data_dir_path(host_root_path);
+            // If relative it will append, if absolute it will replace.
+            path.push(PathBuf::from(path_string));
+            path.canonicalize().ok()
+        }
     }
 
     pub unsafe fn add_application(
@@ -236,6 +298,34 @@ impl Host {
         unsafe { cshadow::hostc_getUpstreamRouter(self.chost()) }
     }
 
+    fn interface(&self, addr: Ipv4Addr) -> Option<&RefCell<Option<NetworkInterface>>> {
+        if addr.is_loopback() {
+            Some(&self.localhost)
+        } else if addr == self.info().default_ip {
+            Some(&self.internet)
+        } else {
+            None
+        }
+    }
+
+    /// Run `f` with a reference to the network interface associated with
+    /// `addr`, or returns `None` if there is no such interface.
+    ///
+    /// Panics if we have not yet initialized our network interfaces yet.
+    #[must_use]
+    fn with_interface_mut<Func, Res>(&self, addr: Ipv4Addr, f: Func) -> Option<Res>
+    where
+        Func: FnOnce(&mut NetworkInterface) -> Res,
+    {
+        match self.interface(addr) {
+            Some(rc) => {
+                let mut iface = rc.borrow_mut();
+                Some(f(iface.as_mut().unwrap()))
+            }
+            None => None,
+        }
+    }
+
     pub fn with_random_mut<Res>(&self, f: impl FnOnce(&mut Xoshiro256PlusPlus) -> Res) -> Res {
         let mut rng = self.random.borrow_mut(&self.root);
         f(&mut *rng)
@@ -302,10 +392,38 @@ impl Host {
 
     pub fn boot(&self) {
         unsafe { cshadow::hostc_boot(self) };
+
+        // Start refilling the token buckets for all interfaces.
+        let bw_down = unsafe { cshadow::hostc_get_bw_down_kiBps(self.chost()) };
+        let bw_up = unsafe { cshadow::hostc_get_bw_up_kiBps(self.chost()) };
+        self.localhost
+            .borrow()
+            .as_ref()
+            .unwrap()
+            .start_refilling_token_buckets(bw_down, bw_up);
+        self.internet
+            .borrow()
+            .as_ref()
+            .unwrap()
+            .start_refilling_token_buckets(bw_down, bw_up);
     }
 
     pub fn shutdown(&self) {
+        // Need to drop the interfaces early because they trigger worker accesses
+        // that will not be valid at the normal drop time. The interfaces will
+        // become None after this and should not be unwrapped anymore.
+        // TODO: clean this up when removing the interface's C internals.
+        {
+            self.localhost.replace(None);
+            self.internet.replace(None);
+        }
+
         unsafe { cshadow::hostc_shutdown(self.chost()) };
+
+        // Deregistering localhost is a no-op, so we skip it.
+        let _ = Worker::with_dns(|dns| unsafe {
+            cshadow::dns_deregister(dns, cshadow::hostc_getDefaultAddress(self.chost()))
+        });
     }
 
     pub fn free_all_applications(&self) {
@@ -370,7 +488,13 @@ impl Host {
     }
 
     pub fn packets_are_available_to_receive(&self) {
-        unsafe { cshadow::hostc_packetsAreAvailableToReceive(self) };
+        // TODO: ideally we call
+        //   `self.internet.borrow().as_ref().unwrap().receive_packets(self);`
+        // but that causes a double-borrow loop. See `host_socketWantsToSend()`.
+        unsafe {
+            let netif_ptr = self.internet.borrow().as_ref().unwrap().borrow_inner();
+            cshadow::networkinterface_receivePackets(netif_ptr, self)
+        };
     }
 
     pub unsafe fn lock_shmem(&self) {
@@ -552,28 +676,43 @@ mod export {
         interface_ip: in_addr_t,
     ) -> bool {
         let hostrc = unsafe { hostrc.as_ref().unwrap() };
-        unsafe { cshadow::hostc_doesInterfaceExist(hostrc.chost(), interface_ip) != 0 }
+        let ipv4 = Ipv4Addr::from(u32::from_be(interface_ip));
+        ipv4.is_unspecified() || hostrc.interface(ipv4).is_some()
     }
 
     #[no_mangle]
     pub unsafe extern "C" fn host_isInterfaceAvailable(
         hostrc: *const Host,
         protocol_type: cshadow::ProtocolType,
-        interface_ip: in_addr_t,
+        interface_addr: in_addr_t,
         port: in_port_t,
-        peer_ip: in_addr_t,
+        peer_addr: in_addr_t,
         peer_port: in_port_t,
     ) -> bool {
         let hostrc = unsafe { hostrc.as_ref().unwrap() };
-        unsafe {
-            cshadow::hostc_isInterfaceAvailable(
-                hostrc.chost(),
+        let ipv4 = Ipv4Addr::from(u32::from_be(interface_addr));
+
+        if ipv4.is_unspecified() {
+            // Check that all interfaces are available.
+            !hostrc.localhost.borrow().as_ref().unwrap().is_associated(
                 protocol_type,
-                interface_ip,
                 port,
-                peer_ip,
+                peer_addr,
                 peer_port,
-            ) != 0
+            ) && !hostrc.internet.borrow().as_ref().unwrap().is_associated(
+                protocol_type,
+                port,
+                peer_addr,
+                peer_port,
+            )
+        } else {
+            // The interface is not available if it does not exist.
+            match hostrc.with_interface_mut(ipv4, |iface| {
+                iface.is_associated(protocol_type, port, peer_addr, peer_port)
+            }) {
+                Some(is_associated) => !is_associated,
+                None => false,
+            }
         }
     }
 
@@ -581,10 +720,25 @@ mod export {
     pub unsafe extern "C" fn host_associateInterface(
         hostrc: *const Host,
         socket: *const cshadow::CompatSocket,
-        bind_address: in_addr_t,
+        bind_addr: in_addr_t,
     ) {
         let hostrc = unsafe { hostrc.as_ref().unwrap() };
-        unsafe { cshadow::hostc_associateInterface(hostrc.chost(), socket, bind_address) }
+        let ipv4 = Ipv4Addr::from(u32::from_be(bind_addr));
+
+        // Associate the interfaces corresponding to bind_addr with socket
+        if ipv4.is_unspecified() {
+            // Need to associate all interfaces.
+            hostrc
+                .localhost
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .associate(socket);
+            hostrc.internet.borrow().as_ref().unwrap().associate(socket);
+        } else {
+            // TODO: return error if interface does not exist.
+            let _ = hostrc.with_interface_mut(ipv4, |iface| iface.associate(socket));
+        }
     }
 
     #[no_mangle]
@@ -593,7 +747,34 @@ mod export {
         socket: *const cshadow::CompatSocket,
     ) {
         let hostrc = unsafe { hostrc.as_ref().unwrap() };
-        unsafe { cshadow::hostc_disassociateInterface(hostrc.chost(), socket) }
+
+        let mut bind_addr = 0;
+        let found = unsafe {
+            cshadow::compatsocket_getSocketName(socket, &mut bind_addr, std::ptr::null_mut())
+        };
+        if found {
+            let ipv4 = Ipv4Addr::from(u32::from_be(bind_addr));
+
+            // Associate the interfaces corresponding to bind_addr with socket
+            if ipv4.is_unspecified() {
+                // Need to disassociate all interfaces.
+                hostrc
+                    .localhost
+                    .borrow()
+                    .as_ref()
+                    .unwrap()
+                    .disassociate(socket);
+                hostrc
+                    .internet
+                    .borrow()
+                    .as_ref()
+                    .unwrap()
+                    .disassociate(socket);
+            } else {
+                // TODO: return error if interface does not exist.
+                let _ = hostrc.with_interface_mut(ipv4, |iface| iface.disassociate(socket));
+            }
+        }
     }
 
     #[no_mangle]
@@ -766,8 +947,19 @@ mod export {
     pub unsafe extern "C" fn host_socketWantsToSend(
         hostrc: *const Host,
         socket: *const cshadow::CompatSocket,
-        handle: in_addr_t,
+        addr: in_addr_t,
     ) {
-        unsafe { cshadow::hostc_socketWantsToSend(hostrc, socket, handle) };
+        let host = unsafe { hostrc.as_ref().unwrap() };
+        let ipv4 = u32::from_be(addr).into();
+
+        // TODO: ideally we call `iface.wants_send(socket, hostrc)` in the closure,
+        // but that causes a double borrow loop. This will be fixed in Rob's next
+        // PR, but will cause us to process packets slightly differently than we do now.
+        // For now, we mimic the call flow of the old C code.
+        unsafe {
+            if let Some(netif_ptr) = host.with_interface_mut(ipv4, |iface| iface.borrow_inner()) {
+                cshadow::networkinterface_wantsSend(netif_ptr, host, socket);
+            }
+        };
     }
 }

--- a/src/main/host/host_parameters.h
+++ b/src/main/host/host_parameters.h
@@ -39,7 +39,6 @@ struct _HostParameters {
     gboolean autotuneRecvBuf;
     guint64 sendBufSize;
     gboolean autotuneSendBuf;
-    guint64 interfaceBufSize;
 };
 
 #endif

--- a/src/main/host/mod.rs
+++ b/src/main/host/mod.rs
@@ -2,6 +2,7 @@ pub mod context;
 pub mod descriptor;
 pub mod host;
 pub mod memory_manager;
+pub mod network_interface;
 pub mod process;
 pub mod syscall;
 pub mod syscall_condition;

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -625,8 +625,7 @@ void networkinterface_wantsSend(NetworkInterface* interface, const Host* host,
 }
 
 NetworkInterface* networkinterface_new(Address* address, const gchar* pcapDir,
-                                       guint32 pcapCaptureSize, QDiscMode qdisc,
-                                       guint64 interfaceReceiveLength, bool uses_router) {
+                                       guint32 pcapCaptureSize, QDiscMode qdisc, bool uses_router) {
     NetworkInterface* interface = g_new0(NetworkInterface, 1);
     MAGIC_INIT(interface);
 

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -22,7 +22,6 @@
 #include "main/host/protocol.h"
 #include "main/host/tracker.h"
 #include "main/routing/address.h"
-#include "main/routing/dns.h"
 #include "main/routing/packet.h"
 #include "main/utility/priority_queue.h"
 #include "main/utility/tagged_ptr.h"
@@ -678,7 +677,6 @@ void networkinterface_free(NetworkInterface* interface) {
 
     g_hash_table_destroy(interface->boundSockets);
 
-    dns_deregister(worker_getDNS(), interface->address);
     address_unref(interface->address);
 
     if(interface->pcap) {

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -123,8 +123,8 @@ static TokenBucket* _networkinterface_create_tb(uint64_t bwKiBps) {
     return tokenbucket_new(capacity, refill_size, refill_interval_nanos);
 }
 
-void networkinterface_startRefillingTokenBuckets(NetworkInterface* interface, const Host* host,
-                                                 uint64_t bwDownKiBps, uint64_t bwUpKiBps) {
+void networkinterface_startRefillingTokenBuckets(NetworkInterface* interface, uint64_t bwDownKiBps,
+                                                 uint64_t bwUpKiBps) {
     MAGIC_ASSERT(interface);
     // Set size and refill rates for token buckets.
     // This needs to be called when host is booting, i.e. when the worker exists.

--- a/src/main/host/network_interface.h
+++ b/src/main/host/network_interface.h
@@ -32,8 +32,8 @@ void networkinterface_disassociate(NetworkInterface* interface, const CompatSock
 void networkinterface_wantsSend(NetworkInterface* interface, const Host* host,
                                 const CompatSocket* socket);
 
-void networkinterface_startRefillingTokenBuckets(NetworkInterface* interface, const Host* host,
-                                                 uint64_t bwDownKiBps, uint64_t bwUpKiBps);
+void networkinterface_startRefillingTokenBuckets(NetworkInterface* interface, uint64_t bwDownKiBps,
+                                                 uint64_t bwUpKiBps);
 
 void networkinterface_receivePackets(NetworkInterface* interface, const Host* host);
 

--- a/src/main/host/network_interface.h
+++ b/src/main/host/network_interface.h
@@ -19,8 +19,7 @@ typedef struct _NetworkInterface NetworkInterface;
 #include "main/routing/address.h"
 
 NetworkInterface* networkinterface_new(Address* address, const gchar* pcapDir,
-                                       guint32 pcapCaptureSize, QDiscMode qdisc,
-                                       guint64 interfaceReceiveLength, bool uses_router);
+                                       guint32 pcapCaptureSize, QDiscMode qdisc, bool uses_router);
 void networkinterface_free(NetworkInterface* interface);
 
 /* The address and ports must be in network byte order. */

--- a/src/main/host/network_interface.rs
+++ b/src/main/host/network_interface.rs
@@ -1,0 +1,106 @@
+use std::path::PathBuf;
+
+use libc::{in_addr_t, in_port_t};
+
+use crate::core::support::configuration::QDiscMode;
+use crate::cshadow as c;
+use crate::host::host::Host;
+use crate::utility::{self, HostTreePointer};
+use shadow_shim_helper_rs::HostId;
+
+/// Represents a network device that can send and receive packets. All accesses
+/// to the internal C implementation should be done through this module.
+pub struct NetworkInterface {
+    c_ptr: HostTreePointer<c::NetworkInterface>,
+}
+
+impl NetworkInterface {
+    /// Create a new network interface for `host_id` with the assigned `addr`.
+    ///
+    /// SAFETY: This function will trigger undefined behavior if `addr` is
+    /// invalid. The reference count of `addr` will be increased by one using
+    /// `address_ref()`, so the caller should call `address_unref()` on it to
+    /// drop their reference when they no longer need it.
+    pub unsafe fn new(
+        host_id: HostId,
+        addr: *mut c::Address,
+        maybe_pcap_dir: Option<PathBuf>,
+        pcap_capture_size: u32,
+        qdisc: QDiscMode,
+        uses_router: bool,
+    ) -> NetworkInterface {
+        let maybe_pcap_dir = maybe_pcap_dir.map(|p| utility::pathbuf_to_nul_term_cstring(p));
+        let pcap_dir_cptr = maybe_pcap_dir
+            .as_ref()
+            .map_or(std::ptr::null(), |p| p.as_ptr());
+
+        let c_ptr = unsafe {
+            c::networkinterface_new(addr, pcap_dir_cptr, pcap_capture_size, qdisc, uses_router)
+        };
+
+        NetworkInterface {
+            c_ptr: HostTreePointer::new_for_host(host_id, c_ptr),
+        }
+    }
+
+    pub fn associate(&self, socket_ptr: *const c::CompatSocket) {
+        unsafe { c::networkinterface_associate(self.c_ptr.ptr(), socket_ptr) };
+    }
+
+    pub fn disassociate(&self, socket_ptr: *const c::CompatSocket) {
+        unsafe { c::networkinterface_disassociate(self.c_ptr.ptr(), socket_ptr) };
+    }
+
+    pub fn is_associated(
+        &self,
+        protocol: c::ProtocolType,
+        port: in_port_t,
+        peer_addr: in_addr_t,
+        peer_port: in_port_t,
+    ) -> bool {
+        unsafe {
+            c::networkinterface_isAssociated(self.c_ptr.ptr(), protocol, port, peer_addr, peer_port)
+                != 0
+        }
+    }
+
+    pub fn start_refilling_token_buckets(&self, bw_down_kibps: u64, bw_up_kibps: u64) {
+        unsafe {
+            c::networkinterface_startRefillingTokenBuckets(
+                self.c_ptr.ptr(),
+                bw_down_kibps,
+                bw_up_kibps,
+            )
+        };
+    }
+
+    pub fn wants_send(&self, socket_ptr: &c::CompatSocket, host: &Host) {
+        unsafe {
+            c::networkinterface_wantsSend(
+                self.c_ptr.ptr(),
+                host as *const Host,
+                socket_ptr as *const c::CompatSocket,
+            )
+        };
+    }
+
+    pub fn receive_packets(&self, host: &Host) {
+        unsafe { c::networkinterface_receivePackets(self.c_ptr.ptr(), host as *const Host) };
+    }
+
+    /// Returns a pointer to our internal C network interface object so that
+    /// network interface functions can be called outside of the rust API.
+    ///
+    /// SAFETY: The returned pointer is only valid until the reference to this
+    /// `NetworkInterface` object is dropped.
+    // TODO: Remove this function to remove unsafe access to internals.
+    pub unsafe fn borrow_inner(&self) -> *mut c::NetworkInterface {
+        unsafe { self.c_ptr.ptr() }
+    }
+}
+
+impl Drop for NetworkInterface {
+    fn drop(&mut self) {
+        unsafe { c::networkinterface_free(self.c_ptr.ptr()) };
+    }
+}

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -22,8 +22,10 @@ pub mod synchronization;
 pub mod syscall;
 pub mod time;
 
+use std::ffi::CString;
 use std::marker::PhantomData;
 use std::os::unix::fs::{DirBuilderExt, MetadataExt};
+use std::os::unix::prelude::OsStrExt;
 use std::path::{Path, PathBuf};
 
 use crate::core::worker::Worker;
@@ -264,6 +266,13 @@ fn create_dir_with_mode(path: impl AsRef<Path>, mode: u32) -> std::io::Result<()
     let mut dir_builder = std::fs::DirBuilder::new();
     dir_builder.mode(mode);
     dir_builder.create(&path)
+}
+
+/// Helper for converting a PathBuf to a CString
+pub fn pathbuf_to_nul_term_cstring(buf: PathBuf) -> CString {
+    let mut bytes = buf.as_os_str().to_os_string().as_bytes().to_vec();
+    bytes.push(0);
+    CString::from_vec_with_nul(bytes).unwrap()
 }
 
 #[cfg(test)]

--- a/src/test/config/convert/shadow.original.xml
+++ b/src/test/config/convert/shadow.original.xml
@@ -22,7 +22,7 @@
 </graphml>]]></topology>
   <plugin id="testconfig" path="test-config-convert"/>
   <plugin id="shimpath" path="/tor/shim/path.so"/>
-  <node id="testclient" quantity="1" bandwidthdown="1000">
+  <node id="testclient" quantity="1" bandwidthdown="1000" interfacebuffer="10000" >
     <application plugin="testconfig" starttime="1" arguments="client 5678" preload="shimpath"/>
   </node>
   <node id="testserver" quantity="1">

--- a/src/tools/convert_legacy_config.py
+++ b/src/tools/convert_legacy_config.py
@@ -266,6 +266,14 @@ def shadow_dict_post_processing(shadow: Dict):
                 if 'socket_recv_buffer' in host['options']:
                     host['options']['socket_recv_autotune'] = False
 
+                if 'interface_buffer' in host['options']:
+                    # we no longer use this attribute
+                    removed = host['options'].pop('interface_buffer')
+                    print_deprecation_msg('interface_buffer', removed)
+
+                if len(host['options']) == 0:
+                    del host['options']
+
             for process in host['processes']:
                 # replace the plugin name with its path
                 plugin = process.pop('plugin')


### PR DESCRIPTION
This PR includes:
- isolating use of network interfaces to the host module
- creating a new network interface rust module (still using the C netif code internally for the time being, to change in future PR)
- moving the interactions with the netif module from `host.c` to `host.rs`

NOTE: There are two places in `host.rs` where we do a potentially unsafe borrow of the internal netif C pointer: the places where we need to trigger the netif to send or receive more packets. I'm merging the current version for two reasons:
  1. It keeps the control flow of receives and sends the same as it was before this PR (we cannot keep the same control flow with safe rust because of a double borrow problem)
  2. I have another in-progress PR to make the flow safe, but it uses tasks to unwind the stack (to avoid double borrows) and will therefore change the receive/send processing flow relative to the current implementation.