### PR TITLE
Set executable /dev/shm in all workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
       # https://docs.docker.com/engine/security/seccomp/
       #
       # by default /dev/shm doesn't support executable mappings.
-      options: '--shm-size="1g" --security-opt seccomp=unconfined --tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g'
+      options: '--tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt seccomp=unconfined'
     env:
       CC: 'clang-12'
       CONTAINER: 'ubuntu:22.04'

--- a/.github/workflows/run_examples.yml
+++ b/.github/workflows/run_examples.yml
@@ -30,7 +30,7 @@ jobs:
       # 65536k. github's default docker seccomp policy seems to disallow
       # process_vm_readv and process_vm_writev; disable it altogether. See
       # https://docs.docker.com/engine/security/seccomp/
-      options: '--shm-size="1g" --security-opt seccomp=unconfined'
+      options: '--tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt seccomp=unconfined'
 
     env:
       CC: 'clang'

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -76,7 +76,7 @@ jobs:
       # 65536k. github's default docker seccomp policy seems to disallow
       # process_vm_readv and process_vm_writev; disable it altogether. See
       # https://docs.docker.com/engine/security/seccomp/
-      options: '--shm-size="1g" --security-opt seccomp=unconfined'
+      options: '--tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt seccomp=unconfined'
     env:
       CC: ${{ matrix.cc }}
       CONTAINER: ${{ matrix.container }}

--- a/.github/workflows/run_tor.yml
+++ b/.github/workflows/run_tor.yml
@@ -30,7 +30,7 @@ jobs:
       # 65536k. github's default docker seccomp policy seems to disallow
       # process_vm_readv and process_vm_writev; disable it altogether. See
       # https://docs.docker.com/engine/security/seccomp/
-      options: '--shm-size="1g" --security-opt seccomp=unconfined'
+      options: '--tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt seccomp=unconfined'
 
     strategy:
       matrix:


### PR DESCRIPTION
I think it hasn't been an issue so far since we don't run the regular shadow tests in these workflows, and the mmap test would have failed if we did.