### PR TITLE
Save counters to `sim-stats.json` file

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1063,6 +1063,7 @@ dependencies = [
  "regex",
  "schemars",
  "serde",
+ "serde_json",
  "serde_yaml",
  "shadow-build-common",
  "shadow-shim-helper-rs",

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -39,6 +39,7 @@ rayon = "1.5.3"
 regex = "1"
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.87"
 serde_yaml = "0.9"
 shadow_shmem = { path = "../lib/shmem" }
 shadow_tsc = { path = "../lib/tsc" }

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -955,37 +955,3 @@ where
 
     duplicates
 }
-
-mod export {
-    use std::ffi::CStr;
-
-    use crate::core::support::configuration::ConfigOptions;
-
-    #[no_mangle]
-    pub extern "C" fn manager_saveProcessedConfigYaml(
-        config: *const ConfigOptions,
-        filename: *const libc::c_char,
-    ) -> libc::c_int {
-        let config = unsafe { config.as_ref() }.unwrap();
-        let filename = unsafe { CStr::from_ptr(filename) }.to_str().unwrap();
-
-        let file = match std::fs::File::create(&filename) {
-            Ok(f) => f,
-            Err(e) => {
-                log::warn!("Could not create file {:?}: {}", filename, e);
-                return 1;
-            }
-        };
-
-        if let Err(e) = serde_yaml::to_writer(file, &config) {
-            log::warn!(
-                "Could not write processed config yaml to file {:?}: {}",
-                filename,
-                e
-            );
-            return 1;
-        }
-
-        return 0;
-    }
-}

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -512,8 +512,8 @@ impl<'a> Manager<'a> {
             worker::with_global_object_counters(|alloc_counter, dealloc_counter| {
                 log::info!("Global allocated object counts: {}", alloc_counter);
                 log::info!("Global deallocated object counts: {}", dealloc_counter);
-                stats.objects.alloc_counts = alloc_counter.clone();
-                stats.objects.dealloc_counts = dealloc_counter.clone();
+                stats.alloc_counts = alloc_counter.clone();
+                stats.dealloc_counts = dealloc_counter.clone();
 
                 if alloc_counter == dealloc_counter {
                     log::info!("We allocated and deallocated the same number of objects :)");

--- a/src/main/core/mod.rs
+++ b/src/main/core/mod.rs
@@ -4,6 +4,7 @@ pub mod main;
 pub mod manager;
 pub mod scheduler;
 pub mod sim_config;
+pub mod sim_stats;
 pub mod support;
 pub mod work;
 pub mod worker;

--- a/src/main/core/sim_stats.rs
+++ b/src/main/core/sim_stats.rs
@@ -1,5 +1,6 @@
 use crate::utility::counter::Counter;
 
+use anyhow::Context;
 use serde::Serialize;
 
 #[derive(Serialize, Clone, Debug)]
@@ -24,4 +25,18 @@ impl SimStats {
             syscalls: Counter::new(),
         }
     }
+}
+
+pub fn write_stats_to_file(filename: &std::path::Path, stats: SimStats) -> anyhow::Result<()> {
+    let file = std::fs::File::create(&filename)
+        .with_context(|| format!("Failed to create file '{}'", filename.display()))?;
+
+    serde_json::to_writer_pretty(file, &stats).with_context(|| {
+        format!(
+            "Failed to write stats json to file '{}'",
+            filename.display()
+        )
+    })?;
+
+    Ok(())
 }

--- a/src/main/core/sim_stats.rs
+++ b/src/main/core/sim_stats.rs
@@ -3,31 +3,52 @@ use crate::utility::counter::Counter;
 use anyhow::Context;
 use serde::Serialize;
 
-#[derive(Serialize, Clone, Debug)]
-pub struct ObjectStats {
+/// Simulation statistics.
+#[derive(Clone, Debug)]
+pub struct SimStats {
     pub alloc_counts: Counter,
     pub dealloc_counts: Counter,
-}
-
-#[derive(Serialize, Clone, Debug)]
-pub struct SimStats {
-    pub objects: ObjectStats,
     pub syscalls: Counter,
 }
 
 impl SimStats {
     pub fn new() -> Self {
         Self {
-            objects: ObjectStats {
-                alloc_counts: Counter::new(),
-                dealloc_counts: Counter::new(),
-            },
+            alloc_counts: Counter::new(),
+            dealloc_counts: Counter::new(),
             syscalls: Counter::new(),
         }
     }
 }
 
+/// Simulation statistics in the format to be output.
+#[derive(Serialize, Clone, Debug)]
+struct SimStatsForOutput {
+    pub objects: ObjectStatsForOutput,
+    pub syscalls: Counter,
+}
+
+#[derive(Serialize, Clone, Debug)]
+struct ObjectStatsForOutput {
+    pub alloc_counts: Counter,
+    pub dealloc_counts: Counter,
+}
+
+impl SimStatsForOutput {
+    pub fn new(stats: SimStats) -> Self {
+        Self {
+            objects: ObjectStatsForOutput {
+                alloc_counts: stats.alloc_counts,
+                dealloc_counts: stats.dealloc_counts,
+            },
+            syscalls: stats.syscalls,
+        }
+    }
+}
+
 pub fn write_stats_to_file(filename: &std::path::Path, stats: SimStats) -> anyhow::Result<()> {
+    let stats = SimStatsForOutput::new(stats);
+
     let file = std::fs::File::create(&filename)
         .with_context(|| format!("Failed to create file '{}'", filename.display()))?;
 

--- a/src/main/core/sim_stats.rs
+++ b/src/main/core/sim_stats.rs
@@ -1,0 +1,27 @@
+use crate::utility::counter::Counter;
+
+use serde::Serialize;
+
+#[derive(Serialize, Clone, Debug)]
+pub struct ObjectStats {
+    pub alloc_counts: Counter,
+    pub dealloc_counts: Counter,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct SimStats {
+    pub objects: ObjectStats,
+    pub syscalls: Counter,
+}
+
+impl SimStats {
+    pub fn new() -> Self {
+        Self {
+            objects: ObjectStats {
+                alloc_counts: Counter::new(),
+                dealloc_counts: Counter::new(),
+            },
+            syscalls: Counter::new(),
+        }
+    }
+}

--- a/src/main/core/sim_stats.rs
+++ b/src/main/core/sim_stats.rs
@@ -1,23 +1,63 @@
+use std::cell::RefCell;
+use std::sync::Mutex;
+
 use crate::utility::counter::Counter;
 
 use anyhow::Context;
 use serde::Serialize;
 
-/// Simulation statistics.
-#[derive(Clone, Debug)]
-pub struct SimStats {
-    pub alloc_counts: Counter,
-    pub dealloc_counts: Counter,
-    pub syscalls: Counter,
+/// Simulation statistics to be accessed by a single thread.
+#[derive(Debug)]
+pub struct LocalSimStats {
+    pub alloc_counts: RefCell<Counter>,
+    pub dealloc_counts: RefCell<Counter>,
+    pub syscall_counts: RefCell<Counter>,
 }
 
-impl SimStats {
+impl LocalSimStats {
     pub fn new() -> Self {
         Self {
-            alloc_counts: Counter::new(),
-            dealloc_counts: Counter::new(),
-            syscalls: Counter::new(),
+            alloc_counts: RefCell::new(Counter::new()),
+            dealloc_counts: RefCell::new(Counter::new()),
+            syscall_counts: RefCell::new(Counter::new()),
         }
+    }
+}
+
+/// Simulation statistics to be accessed by multiple threads.
+#[derive(Debug)]
+pub struct SharedSimStats {
+    pub alloc_counts: Mutex<Counter>,
+    pub dealloc_counts: Mutex<Counter>,
+    pub syscall_counts: Mutex<Counter>,
+}
+
+impl SharedSimStats {
+    pub fn new() -> Self {
+        Self {
+            alloc_counts: Mutex::new(Counter::new()),
+            dealloc_counts: Mutex::new(Counter::new()),
+            syscall_counts: Mutex::new(Counter::new()),
+        }
+    }
+
+    /// Add stats from a local object to a shared object. May reset fields of `local`.
+    pub fn add_from_local_stats(&self, local: &LocalSimStats) {
+        let mut shared_alloc_counts = self.alloc_counts.lock().unwrap();
+        let mut shared_dealloc_counts = self.dealloc_counts.lock().unwrap();
+        let mut shared_syscall_counts = self.syscall_counts.lock().unwrap();
+
+        let mut local_alloc_counts = local.alloc_counts.borrow_mut();
+        let mut local_dealloc_counts = local.dealloc_counts.borrow_mut();
+        let mut local_syscall_counts = local.syscall_counts.borrow_mut();
+
+        shared_alloc_counts.add_counter(&local_alloc_counts);
+        shared_dealloc_counts.add_counter(&local_dealloc_counts);
+        shared_syscall_counts.add_counter(&local_syscall_counts);
+
+        *local_alloc_counts = Counter::new();
+        *local_dealloc_counts = Counter::new();
+        *local_syscall_counts = Counter::new();
     }
 }
 
@@ -35,18 +75,30 @@ struct ObjectStatsForOutput {
 }
 
 impl SimStatsForOutput {
-    pub fn new(stats: SimStats) -> Self {
+    /// Takes data from `stats` and puts it into a structure designed for output. May reset fields
+    /// of `stats`.
+    pub fn new(stats: &SharedSimStats) -> Self {
         Self {
             objects: ObjectStatsForOutput {
-                alloc_counts: stats.alloc_counts,
-                dealloc_counts: stats.dealloc_counts,
+                alloc_counts: std::mem::replace(
+                    &mut stats.alloc_counts.lock().unwrap(),
+                    Counter::new(),
+                ),
+                dealloc_counts: std::mem::replace(
+                    &mut stats.dealloc_counts.lock().unwrap(),
+                    Counter::new(),
+                ),
             },
-            syscalls: stats.syscalls,
+            syscalls: std::mem::replace(&mut stats.syscall_counts.lock().unwrap(), Counter::new()),
         }
     }
 }
 
-pub fn write_stats_to_file(filename: &std::path::Path, stats: SimStats) -> anyhow::Result<()> {
+/// May reset fields of `stats`.
+pub fn write_stats_to_file(
+    filename: &std::path::Path,
+    stats: &SharedSimStats,
+) -> anyhow::Result<()> {
     let stats = SimStatsForOutput::new(stats);
 
     let file = std::fs::File::create(&filename)

--- a/src/main/utility/counter.rs
+++ b/src/main/utility/counter.rs
@@ -17,6 +17,8 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::ops::{Add, Sub};
 
+use serde::ser::SerializeMap;
+
 /// The main counter object that maps individual keys to count values.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Counter {
@@ -156,6 +158,20 @@ impl Display for Counter {
             }
         }
         write!(f, "}}")
+    }
+}
+
+impl serde::Serialize for Counter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let items = self.sorted_for_display().into_iter();
+        let mut map = serializer.serialize_map(Some(items.len()))?;
+        for (k, v) in items {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
     }
 }
 

--- a/src/main/utility/counter.rs
+++ b/src/main/utility/counter.rs
@@ -14,7 +14,7 @@ generic types.
 */
 
 use std::collections::HashMap;
-use std::fmt::{Display, Formatter, Result};
+use std::fmt::{Display, Formatter};
 use std::ops::{Add, Sub};
 
 /// The main counter object that maps individual keys to count values.
@@ -119,14 +119,13 @@ impl Counter {
             }
         }
     }
-}
 
-impl Display for Counter {
-    /// Returns a string representation of the counter in the form
-    ///   `{key1:value1, key2:value2, ..., keyN:valueN}`
-    /// for known keys and values, where the list is sorted by value with the
-    /// largest value first.
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    /// Get an iterator that returns elements in the order best suited for human-readable output
+    /// (currently sorted by value with the largest value first).
+    fn sorted_for_display<'a>(
+        &'a self,
+    ) -> impl IntoIterator<IntoIter = impl Iterator<Item = (&'a String, &'a i64)> + ExactSizeIterator + 'a>
+    {
         // Get the items in a vector so we can sort them.
         let mut item_vec = Vec::from_iter(&self.items);
 
@@ -136,11 +135,23 @@ impl Display for Counter {
             val_a.cmp(val_b).reverse().then(key_a.cmp(key_b))
         });
 
+        item_vec
+    }
+}
+
+impl Display for Counter {
+    /// Returns a string representation of the counter in the form
+    ///   `{key1:value1, key2:value2, ..., keyN:valueN}`
+    /// for known keys and values.
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let items = self.sorted_for_display().into_iter();
+        let items_len = items.len();
+
         // Create a string representation of the counts by iterating over the items.
         write!(f, "{{")?;
-        for i in 0..item_vec.len() {
-            write!(f, "{}:{}", item_vec[i].0, item_vec[i].1)?;
-            if i < (item_vec.len() - 1) {
+        for (i, item) in items.enumerate() {
+            write!(f, "{}:{}", item.0, item.1)?;
+            if i < items_len - 1 {
                 write!(f, ", ")?;
             }
         }


### PR DESCRIPTION
Saves the total syscall counters and alloc/dealloc counters to a json file.

Example:

```json
{
  "objects": {
    "alloc_counts": {
      "TaskRef": 18349,
      "Event": 8928,
      "Packet": 7616,
      "Payload": 7316,
      "SysCallCondition": 517,
      "Timer": 492,
      "LegacyDescriptor": 161,
      "TCP": 82,
      "UDP": 74,
      "StatusListener": 26,
      "RegularFile": 4,
      "NetworkInterface": 2,
      "Epoll": 1,
      "FutexTable": 1,
      "HostCInternal": 1,
      "ManagedThread": 1,
      "Process": 1,
      "Router": 1,
      "SysCallHandler": 1
    },
    "dealloc_counts": {
      "TaskRef": 18349,
      "Event": 8928,
      "Packet": 7616,
      "Payload": 7316,
      "SysCallCondition": 517,
      "Timer": 492,
      "LegacyDescriptor": 161,
      "TCP": 82,
      "UDP": 74,
      "StatusListener": 26,
      "RegularFile": 4,
      "NetworkInterface": 2,
      "Epoll": 1,
      "FutexTable": 1,
      "HostCInternal": 1,
      "ManagedThread": 1,
      "Process": 1,
      "Router": 1,
      "SysCallHandler": 1
    }
  },
  "syscalls": {
    "poll": 14466,
    "sendto": 12649,
    "write": 2658,
    "read": 2133,
    "close": 615,
    "nanosleep": 491,
    "recvfrom": 353,
    "socket": 348,
    "getsockname": 229,
    "bind": 183,
    "connect": 160,
    "socketpair": 91,
    "accept4": 84,
    "listen": 84,
    "brk": 8,
    "rt_sigaction": 5,
    "mmap": 3,
    "munmap": 3,
    "sigaltstack": 3,
    "exit_group": 1,
    "fstat": 1,
    "getrandom": 1,
    "mprotect": 1,
    "openat": 1,
    "shadow_init_memory_manager": 1
  }
}
```