### PR TITLE
Enable host heartbeat messages by default

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -143,7 +143,7 @@ Path to store simulation output.
 Default: "1 sec"  
 Type: String OR Integer OR null
 
-Interval at which to print heartbeat messages.
+Interval at which to print simulation heartbeat messages.
 
 #### `general.log_level`
 
@@ -304,10 +304,10 @@ time, regardless of Shadow version.
 
 #### `experimental.host_heartbeat_interval`
 
-Default: null  
+Default: "1 sec"  
 Type: String OR Integer OR null
 
-Amount of time between heartbeat messages for this host.
+Amount of time between host heartbeat messages.
 
 #### `experimental.host_heartbeat_log_info`
 
@@ -321,7 +321,7 @@ List of information to show in the host's heartbeat message.
 Default: "info"  
 Type: "error" OR "warning" OR "info" OR "debug" OR "trace"
 
-Log level at which to print host statistics.
+Log level at which to print host heartbeat messages.
 
 #### `experimental.interface_qdisc`
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -488,7 +488,10 @@ impl Default for ExperimentalOptions {
             use_legacy_working_dir: Some(false),
             host_heartbeat_log_level: Some(LogLevel::Info),
             host_heartbeat_log_info: Some(IntoIterator::into_iter([LogInfoFlag::Node]).collect()),
-            host_heartbeat_interval: None,
+            host_heartbeat_interval: Some(NullableOption::Value(units::Time::new(
+                1,
+                units::TimePrefixUpper::Sec,
+            ))),
             strace_logging_mode: Some(StraceLoggingMode::Off),
             use_extended_yaml: Some(false),
             scheduler: Some(Scheduler::ThreadPerCore),


### PR DESCRIPTION
Enables host heartbeat messages. Each host will log its own header, and one line per simulated second.