### PR TITLE
Host::get_random_free_port: avoid linear-time iterator operations

### DIFF
--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -652,9 +652,20 @@ impl Host {
         // now if we tried too many times and still don't have a port, fall back
         // to a linear search to make sure we get a free port if we have one.
         // but start from a random port instead of the min.
-        let ports = MIN_RANDOM_PORT..=u16::MAX;
-        let start_offset = self.random.borrow_mut(&self.root).gen_range(0..ports.len());
-        for port in ports.clone().cycle().skip(start_offset).take(ports.len()) {
+        let start = self
+            .random
+            .borrow_mut(&self.root)
+            .gen_range(MIN_RANDOM_PORT..=u16::MAX);
+        let mut port = start;
+        loop {
+            port = if port == u16::MAX {
+                MIN_RANDOM_PORT
+            } else {
+                port + 1
+            };
+            if port == start {
+                break;
+            }
             if self.is_interface_available(
                 protocol_type,
                 SocketAddrV4::new(interface_ip, port),


### PR DESCRIPTION
We thought the chained iterator adapters here would end up being constant time, but it looks like they interfere with eachother s.t. they're not. e.g. a contrived bigger version of this hangs, even in release builds:

```
use std::convert::TryInto;

pub fn main() -> std::process::ExitCode {
    let ports = 0..=u64::MAX;
    let random_offset = u64::MAX/2;
    let start_offset = unsafe { std::ptr::read_volatile(&random_offset) };

    let result = ports.clone().cycle().skip(start_offset.try_into().unwrap()).take(u64::MAX.try_into().unwrap()).next().unwrap();

    (result as u8).into()
}
```