### PR TITLE
SelfContainedMutex: Strengthen compiler fence

### DIFF
--- a/src/lib/shadow-shim-helper-rs/src/scmutex.rs
+++ b/src/lib/shadow-shim-helper-rs/src/scmutex.rs
@@ -117,9 +117,11 @@ impl<T> SelfContainedMutex<T> {
     fn unlock(&self) {
         self.futex.store(UNLOCKED, Ordering::Release);
 
-        // Ensure that the `futex.store` above can't be moved after the
-        // `sleepers.load` below.
-        std::sync::atomic::compiler_fence(Ordering::Acquire);
+        // Acquire: Ensure that the `sleepers.load` below can't be moved to before
+        // this fence (and therefore before the `futex.store` above)
+        // Release: Ensure that the `futex.store` above can't be moved to after
+        // this fence (and therefore not after the `sleepers.load`)
+        std::sync::atomic::compiler_fence(Ordering::AcqRel);
 
         // Only perform a FUTEX_WAKE operation if other threads are actually
         // sleeping on the lock.


### PR DESCRIPTION
Using just `Acquire` here still lets the compiler move writes before the fence to after the fence. We need both `Acquire` and `Release` semantics.

Pointed out here:
https://masto.ai/@rfc1149/109359308547583544

And handy visual aid here:
https://masto.ai/@rfc1149/109359347916681723