### PR TITLE
Fix unsound methods in Pod and cleanup MemoryManager

### DIFF
--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -501,6 +501,13 @@ impl MemoryManager {
     /// WARNING: If the reference is flushed without initializing its contents,
     /// the unspecified contents will be written back into process memory.
     /// This can be avoided by calling `noflush` on the reference.
+    //
+    // In some cases we initialize data to avoid actually returning
+    // uninitialized memory.  We use inline(always) so that the compiler can
+    // hopefully optimize away this initialization, in cases where the caller
+    // overwrites the data.
+    // TODO: return ProcessMemoryRefMut<MaybeUninit<T>> instead.
+    #[inline(always)]
     pub fn memory_ref_mut_uninit<'a, T: Pod + Debug>(
         &'a mut self,
         ptr: TypedPluginPtr<T>,
@@ -511,10 +518,14 @@ impl MemoryManager {
         let pid = self.pid;
 
         let mut mref = if let Some(mref) = self.mapped_mut(ptr) {
+            // Even if we haven't initialized the data from this process, the
+            // data is initialized from the Rust compiler's perspective; it has
+            // *some* set contents via mmap, even if the other process hasn't
+            // initialized it either.
             ProcessMemoryRefMut::new_mapped(mref)
         } else {
             let mut v = Vec::with_capacity(ptr.len());
-            unsafe { v.set_len(v.capacity()) };
+            v.resize(ptr.len(), pod::zeroed());
             ProcessMemoryRefMut::new_copied(MemoryCopier::new(pid), ptr, v)
         };
 
@@ -522,7 +533,11 @@ impl MemoryManager {
         // caller treats as initd; e.g. by reading the data or flushing it
         // back to the process without initializing it.
         if cfg!(debug_assertions) {
-            pod::to_u8_slice_mut(&mut mref[..]).fill(0x42);
+            // SAFETY: We do not write uninitialized data into `bytes`.
+            let bytes = unsafe { pod::to_u8_slice_mut(&mut mref[..]) };
+            for byte in bytes {
+                unsafe { byte.as_mut_ptr().write(0x42) }
+            }
         }
 
         Ok(mref)

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -497,10 +497,6 @@ impl MemoryManager {
     /// mapped into Shadow, just returns a buffer with unspecified contents,
     /// which will be written back into the process if and when the reference
     /// is flushed.
-    ///
-    /// WARNING: If the reference is flushed without initializing its contents,
-    /// the unspecified contents will be written back into process memory.
-    /// This can be avoided by calling `noflush` on the reference.
     //
     // In some cases we initialize data to avoid actually returning
     // uninitialized memory.  We use inline(always) so that the compiler can

--- a/src/main/utility/pod.rs
+++ b/src/main/utility/pod.rs
@@ -1,3 +1,5 @@
+use std::mem::MaybeUninit;
+
 /// Marker trait that the given type is Plain Old Data; i.e. that it is safe to
 /// interpret any pattern of bits as a value of this type.
 ///
@@ -10,29 +12,36 @@
 pub unsafe trait Pod: Copy + 'static {}
 
 /// Convert to a slice of raw bytes.
-pub fn to_u8_slice<T>(slice: &[T]) -> &[u8]
+///
+/// Some bytes may be uninialized if T has padding.
+pub fn to_u8_slice<T>(slice: &[T]) -> &[MaybeUninit<u8>]
 where
     T: Pod,
 {
     // SAFETY: Any value and alignment is safe for u8.
     unsafe {
         std::slice::from_raw_parts(
-            slice.as_ptr() as *const u8,
-            slice.len() * std::mem::size_of::<T>(),
+            slice.as_ptr() as *const MaybeUninit<u8>,
+            slice.len() * std::mem::size_of::<MaybeUninit<T>>(),
         )
     }
 }
 
 /// Convert to a mut slice of raw bytes.
-pub fn to_u8_slice_mut<T>(slice: &mut [T]) -> &mut [u8]
+///
+/// Some bytes may be uninialized if T has padding.
+///
+/// SAFETY: Uninitialized bytes ([`MaybeUninit::uninit`] must not be written
+/// into the returned slice, which would invalidate the source `slice`.
+pub unsafe fn to_u8_slice_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<u8>]
 where
     T: Pod,
 {
     // SAFETY: Any value and alignment is safe for u8.
     unsafe {
         std::slice::from_raw_parts_mut(
-            slice.as_mut_ptr() as *mut u8,
-            slice.len() * std::mem::size_of::<T>(),
+            slice.as_mut_ptr() as *mut MaybeUninit<u8>,
+            slice.len() * std::mem::size_of::<MaybeUninit<T>>(),
         )
     }
 }

--- a/src/main/utility/pod.rs
+++ b/src/main/utility/pod.rs
@@ -43,7 +43,7 @@ where
     T: Pod,
 {
     // SAFETY: Any value is legal for Pod.
-    unsafe { std::mem::MaybeUninit::<T>::zeroed().assume_init() }
+    unsafe { std::mem::zeroed() }
 }
 
 // Integer primitives

--- a/src/main/utility/pod.rs
+++ b/src/main/utility/pod.rs
@@ -64,6 +64,8 @@ unsafe impl Pod for usize {}
 // No! `char` must be a valid unicode value.
 // impl !Pod for char {}
 
+unsafe impl<T> Pod for std::mem::MaybeUninit<T> where T: Pod {}
+
 // libc types
 unsafe impl Pod for libc::Dl_info {}
 unsafe impl Pod for libc::Elf32_Chdr {}


### PR DESCRIPTION
Progress on https://github.com/shadow/shadow/issues/2555, though maybe we should keep it open until we can fix the unsafe transformations from `&[MaybeUninit<u8>]` to `&[u8]`, which are currently needed to work with nix's wrappers around `process_vm_readv` and `process_vm_writev`.