### PR TITLE
Host accessors: use impl trait instead of taking closures

### DIFF
--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -354,9 +354,10 @@ impl Worker {
         let packet_task = TaskRef::new(move |host| {
             let packet = packet.take().expect("Packet task ran twice");
 
-            let became_nonempty = host.with_upstream_router_mut(|router| unsafe {
-                crate::network::router::router_enqueue(router, packet.into_inner())
-            });
+            let became_nonempty = {
+                let mut router = host.upstream_router_mut();
+                unsafe { crate::network::router::router_enqueue(&mut *router, packet.into_inner()) }
+            };
 
             if became_nonempty {
                 host.packets_are_available_to_receive();

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -316,7 +316,7 @@ impl Worker {
             .unwrap()
             .try_into()
             .unwrap();
-        let chance: f64 = src_host.with_random_mut(|r| r.gen());
+        let chance: f64 = src_host.random_mut().gen();
 
         // don't drop control packets with length 0, otherwise congestion control has problems
         // responding to packet loss

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -443,9 +443,9 @@ impl Host {
         crate::core::logger::log_wrapper::c_to_rust_log_level(level).map(|l| l.to_level_filter())
     }
 
-    pub fn with_upstream_router_mut<Res>(&self, f: impl FnOnce(&mut Router) -> Res) -> Res {
-        let mut router = self.router.borrow_mut();
-        f(router.deref_mut())
+    #[track_caller]
+    pub fn upstream_router_mut(&self) -> impl Deref<Target = Router> + DerefMut + '_ {
+        self.router.borrow_mut()
     }
 
     /// Calls `f` with the Host's tracker, if it has one.
@@ -981,7 +981,7 @@ mod export {
     #[no_mangle]
     pub unsafe extern "C" fn host_getUpstreamRouter(hostrc: *const Host) -> *mut Router {
         let hostrc = unsafe { hostrc.as_ref().unwrap() };
-        hostrc.with_upstream_router_mut(|r| r as *mut _)
+        &mut *hostrc.upstream_router_mut()
     }
 
     #[no_mangle]

--- a/src/main/host/syscall/handler/random.rs
+++ b/src/main/host/syscall/handler/random.rs
@@ -31,7 +31,8 @@ impl SyscallHandler {
         };
 
         // Get random bytes using host rng to maintain determinism.
-        ctx.host.with_random_mut(|rng| rng.fill_bytes(&mut mem_ref));
+        let mut rng = ctx.host.random_mut();
+        rng.fill_bytes(&mut mem_ref);
 
         // We must flush the memory reference to write it back.
         match mem_ref.flush() {

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -125,8 +125,8 @@ impl SyscallHandler {
 
         debug!("Attempting to bind fd {} to {:?}", fd, addr);
 
-        ctx.host
-            .with_random_mut(|rng| Socket::bind(socket, addr.as_ref(), rng))
+        let mut rng = ctx.host.random_mut();
+        Socket::bind(socket, addr.as_ref(), &mut *rng)
     }
 
     #[log_syscall(/* rv */ libc::ssize_t, /* sockfd */ libc::c_int, /* buf */ *const libc::c_char,


### PR DESCRIPTION
I got this idea from what look like a style guide for `std` development, but now can't find it again :/

Anyway, the idea is to use [impl Trait](https://doc.rust-lang.org/stable/rust-by-example/trait/impl_trait.html) to return borrowed objects, while still isolating the caller from most of the implementation details about how they're stored.

The previous approach of `with_*` hides the implementation details, but forces callers to write a closure, which is sometimes inconvenient or messy.

Using impl Trait involves a little more boilerplate in the accessors, particularly when we want to provide both const and mut options, but not as much as e.g. wrapping references to the cells themselves in newtypes.

This approach also still lets us use `Ref::map` and `RefMut::map` to transform the internals of the borrowed object (e.g. dereference pointers, unwrap options, etc), which we wouldn't be able to easily do by exposing a reference to the cell itself.