### PR TITLE
Custom socket address types to replace deprecated nix `SockAddr`

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.6.5",
  "scopeguard",
 ]
 
@@ -606,6 +606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "merge"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,7 +661,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
  "pin-utils",
 ]
 
@@ -1128,6 +1137,7 @@ dependencies = [
  "log",
  "logger",
  "lzma-rs",
+ "memoffset 0.7.1",
  "merge",
  "nix",
  "once_cell",
@@ -1147,6 +1157,7 @@ dependencies = [
  "shadow_shmem",
  "shadow_tsc",
  "signal-hook",
+ "static_assertions",
  "syscall-logger",
  "system-deps",
  "tempfile",

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -27,6 +27,7 @@ log = { version = "0.4", features = ["release_max_level_debug"] }
 logger = { path = "../lib/logger" }
 shadow-shim-helper-rs = { path = "../lib/shadow-shim-helper-rs" }
 lzma-rs = "0.2"
+memoffset = "0.7.1"
 merge = "0.1"
 nix = "0.25.0"
 once_cell = "1.16"
@@ -44,6 +45,7 @@ serde_yaml = "0.9"
 shadow_shmem = { path = "../lib/shmem" }
 shadow_tsc = { path = "../lib/tsc" }
 signal-hook = "0.3.14"
+static_assertions = "1.1.0"
 syscall-logger = { path = "../lib/syscall-logger" }
 tempfile = "3.3"
 # TODO: switch to upstream crate if/when they merge and release

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -118,17 +118,13 @@ impl SocketRef<'_> {
 impl SocketRef<'_> {
     pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
-            Self::Unix(socket) => socket
-                .getpeername()
-                .map(|x| x.map(|y| SockaddrStorage::from_unix(&y.as_ref()))),
+            Self::Unix(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
         }
     }
 
     pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
-            Self::Unix(socket) => socket
-                .getsockname()
-                .map(|x| x.map(|y| SockaddrStorage::from_unix(&y.as_ref()))),
+            Self::Unix(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
         }
     }
 
@@ -188,17 +184,13 @@ impl SocketRefMut<'_> {
 impl SocketRefMut<'_> {
     pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
-            Self::Unix(socket) => socket
-                .getpeername()
-                .map(|x| x.map(|y| SockaddrStorage::from_unix(&y.as_ref()))),
+            Self::Unix(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
         }
     }
 
     pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
-            Self::Unix(socket) => socket
-                .getsockname()
-                .map(|x| x.map(|y| SockaddrStorage::from_unix(&y.as_ref()))),
+            Self::Unix(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
         }
     }
 

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -9,7 +9,7 @@ use crate::host::descriptor::shared_buf::{
     BufferHandle, BufferState, ReaderHandle, SharedBuf, WriterHandle,
 };
 use crate::host::descriptor::socket::abstract_unix_ns::AbstractUnixNamespace;
-use crate::host::descriptor::socket::{empty_sockaddr, Socket};
+use crate::host::descriptor::socket::Socket;
 use crate::host::descriptor::{
     File, FileMode, FileState, FileStatus, StateEventSource, StateListenerFilter, SyscallResult,
 };
@@ -18,6 +18,7 @@ use crate::host::syscall::Trigger;
 use crate::host::syscall_condition::SysCallCondition;
 use crate::host::syscall_types::{Blocked, PluginPtr, SysCallReg, SyscallError};
 use crate::utility::callback_queue::{CallbackQueue, Handle};
+use crate::utility::sockaddr::{SockaddrStorage, SockaddrUnix};
 use crate::utility::stream_len::StreamLen;
 use crate::utility::HostTreePointer;
 
@@ -90,21 +91,21 @@ impl UnixSocket {
         self.common.has_open_file = val;
     }
 
-    pub fn getsockname(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    pub fn getsockname(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         // return the bound address if set, otherwise return an empty unix sockaddr
         Ok(Some(
             self.protocol_state
                 .bound_address()?
-                .unwrap_or_else(|| empty_unix_sockaddr()),
+                .unwrap_or_else(|| SockaddrUnix::new_unnamed()),
         ))
     }
 
-    pub fn getpeername(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    pub fn getpeername(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         // return the peer address if set, otherwise return an empty unix sockaddr
         Ok(Some(
             self.protocol_state
                 .peer_address()?
-                .unwrap_or_else(|| empty_unix_sockaddr()),
+                .unwrap_or_else(|| SockaddrUnix::new_unnamed()),
         ))
     }
 
@@ -130,11 +131,9 @@ impl UnixSocket {
             .refresh_file_state(&mut self.common, cb_queue)
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     pub fn bind(
         socket: &Arc<AtomicRefCell<Self>>,
-        addr: Option<&nix::sys::socket::SockAddr>,
+        addr: Option<&SockaddrStorage>,
         rng: impl rand::Rng,
     ) -> SyscallResult {
         let socket_ref = &mut *socket.borrow_mut();
@@ -173,12 +172,10 @@ impl UnixSocket {
         panic!("Called UnixSocket::write() on a unix socket");
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     pub fn sendto<R>(
         &mut self,
         bytes: R,
-        addr: Option<nix::sys::socket::SockAddr>,
+        addr: Option<SockaddrStorage>,
         cb_queue: &mut CallbackQueue,
     ) -> SyscallResult
     where
@@ -188,13 +185,11 @@ impl UnixSocket {
             .sendto(&mut self.common, bytes, addr, cb_queue)
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     pub fn recvfrom<W>(
         &mut self,
         bytes: W,
         cb_queue: &mut CallbackQueue,
-    ) -> Result<(SysCallReg, Option<nix::sys::socket::SockAddr>), SyscallError>
+    ) -> Result<(SysCallReg, Option<SockaddrStorage>), SyscallError>
     where
         W: std::io::Write + std::io::Seek,
     {
@@ -221,11 +216,9 @@ impl UnixSocket {
             .listen(&mut self.common, backlog, cb_queue)
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     pub fn connect(
         socket: &Arc<AtomicRefCell<Self>>,
-        addr: &nix::sys::socket::SockAddr,
+        addr: &SockaddrStorage,
         cb_queue: &mut CallbackQueue,
     ) -> Result<(), SyscallError> {
         let socket_ref = &mut *socket.borrow_mut();
@@ -304,16 +297,16 @@ impl UnixSocket {
 }
 
 struct ConnOrientedInitial {
-    bound_addr: Option<nix::sys::socket::UnixAddr>,
+    bound_addr: Option<SockaddrUnix<libc::sockaddr_un>>,
 }
 struct ConnOrientedListening {
-    bound_addr: nix::sys::socket::UnixAddr,
+    bound_addr: SockaddrUnix<libc::sockaddr_un>,
     queue: VecDeque<Arc<AtomicRefCell<UnixSocket>>>,
     queue_limit: u32,
 }
 struct ConnOrientedConnected {
-    bound_addr: Option<nix::sys::socket::UnixAddr>,
-    peer_addr: Option<nix::sys::socket::UnixAddr>,
+    bound_addr: Option<SockaddrUnix<libc::sockaddr_un>>,
+    peer_addr: Option<SockaddrUnix<libc::sockaddr_un>>,
     peer: Arc<AtomicRefCell<UnixSocket>>,
     reader_handle: ReaderHandle,
     writer_handle: WriterHandle,
@@ -325,8 +318,8 @@ struct ConnOrientedClosed {}
 
 struct ConnLessInitial {
     this_socket: Weak<AtomicRefCell<UnixSocket>>,
-    bound_addr: Option<nix::sys::socket::UnixAddr>,
-    peer_addr: Option<nix::sys::socket::UnixAddr>,
+    bound_addr: Option<SockaddrUnix<libc::sockaddr_un>>,
+    peer_addr: Option<SockaddrUnix<libc::sockaddr_un>>,
     peer: Option<Arc<AtomicRefCell<UnixSocket>>>,
     recv_data: LinkedList<ByteData>,
     reader_handle: ReaderHandle,
@@ -420,7 +413,7 @@ impl ProtocolState {
         }
     }
 
-    fn peer_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn peer_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         match self {
             Self::ConnOrientedInitial(x) => x.as_ref().unwrap().peer_address(),
             Self::ConnOrientedListening(x) => x.as_ref().unwrap().peer_address(),
@@ -431,7 +424,7 @@ impl ProtocolState {
         }
     }
 
-    fn bound_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn bound_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         match self {
             Self::ConnOrientedInitial(x) => x.as_ref().unwrap().bound_address(),
             Self::ConnOrientedListening(x) => x.as_ref().unwrap().bound_address(),
@@ -477,13 +470,11 @@ impl ProtocolState {
         rv
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn bind(
         &mut self,
         common: &mut UnixSocketCommon,
         socket: &Arc<AtomicRefCell<UnixSocket>>,
-        addr: Option<&nix::sys::socket::SockAddr>,
+        addr: Option<&SockaddrStorage>,
         rng: impl rand::Rng,
     ) -> SyscallResult {
         match self {
@@ -496,13 +487,11 @@ impl ProtocolState {
         }
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn sendto<R>(
         &mut self,
         common: &mut UnixSocketCommon,
         bytes: R,
-        addr: Option<nix::sys::socket::SockAddr>,
+        addr: Option<SockaddrStorage>,
         cb_queue: &mut CallbackQueue,
     ) -> SyscallResult
     where
@@ -526,14 +515,12 @@ impl ProtocolState {
         }
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn recvfrom<W>(
         &mut self,
         common: &mut UnixSocketCommon,
         bytes: W,
         cb_queue: &mut CallbackQueue,
-    ) -> Result<(SysCallReg, Option<nix::sys::socket::SockAddr>), SyscallError>
+    ) -> Result<(SysCallReg, Option<SockaddrStorage>), SyscallError>
     where
         W: std::io::Write + std::io::Seek,
     {
@@ -633,13 +620,11 @@ impl ProtocolState {
         rv
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn connect(
         &mut self,
         common: &mut UnixSocketCommon,
         socket: &Arc<AtomicRefCell<UnixSocket>>,
-        addr: &nix::sys::socket::SockAddr,
+        addr: &SockaddrStorage,
         cb_queue: &mut CallbackQueue,
     ) -> Result<(), SyscallError> {
         let (new_state, rv) = match self {
@@ -720,7 +705,7 @@ impl ProtocolState {
     fn queue_incoming_conn(
         &mut self,
         common: &mut UnixSocketCommon,
-        from_address: Option<nix::sys::socket::UnixAddr>,
+        from_address: Option<SockaddrUnix<libc::sockaddr_un>>,
         peer: &Arc<AtomicRefCell<UnixSocket>>,
         child_send_buffer: &Arc<AtomicRefCell<SharedBuf>>,
         cb_queue: &mut CallbackQueue,
@@ -779,8 +764,8 @@ trait Protocol
 where
     Self: Sized + Into<ProtocolState>,
 {
-    fn peer_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError>;
-    fn bound_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError>;
+    fn peer_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError>;
+    fn bound_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError>;
     fn refresh_file_state(&self, common: &mut UnixSocketCommon, cb_queue: &mut CallbackQueue);
 
     fn close(
@@ -792,26 +777,22 @@ where
         (self.into(), Err(Errno::EOPNOTSUPP.into()))
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn bind(
         &mut self,
         _common: &mut UnixSocketCommon,
         _socket: &Arc<AtomicRefCell<UnixSocket>>,
-        _addr: Option<&nix::sys::socket::SockAddr>,
+        _addr: Option<&SockaddrStorage>,
         _rng: impl rand::Rng,
     ) -> SyscallResult {
         log::warn!("bind() while in state {}", std::any::type_name::<Self>());
         Err(Errno::EOPNOTSUPP.into())
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn sendto<R>(
         &mut self,
         _common: &mut UnixSocketCommon,
         _bytes: R,
-        _addr: Option<nix::sys::socket::SockAddr>,
+        _addr: Option<SockaddrStorage>,
         _cb_queue: &mut CallbackQueue,
     ) -> SyscallResult
     where
@@ -821,14 +802,12 @@ where
         Err(Errno::EOPNOTSUPP.into())
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn recvfrom<W>(
         &mut self,
         _common: &mut UnixSocketCommon,
         _bytes: W,
         _cb_queue: &mut CallbackQueue,
-    ) -> Result<(SysCallReg, Option<nix::sys::socket::SockAddr>), SyscallError>
+    ) -> Result<(SysCallReg, Option<SockaddrStorage>), SyscallError>
     where
         W: std::io::Write + std::io::Seek,
     {
@@ -872,13 +851,11 @@ where
         (self.into(), Err(Errno::EOPNOTSUPP.into()))
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn connect(
         self,
         _common: &mut UnixSocketCommon,
         _socket: &Arc<AtomicRefCell<UnixSocket>>,
-        _addr: &nix::sys::socket::SockAddr,
+        _addr: &SockaddrStorage,
         _cb_queue: &mut CallbackQueue,
     ) -> (ProtocolState, Result<(), SyscallError>) {
         log::warn!("connect() while in state {}", std::any::type_name::<Self>());
@@ -911,7 +888,7 @@ where
     fn queue_incoming_conn(
         &mut self,
         _common: &mut UnixSocketCommon,
-        _from_address: Option<nix::sys::socket::UnixAddr>,
+        _from_address: Option<SockaddrUnix<libc::sockaddr_un>>,
         _peer: &Arc<AtomicRefCell<UnixSocket>>,
         _child_send_buffer: &Arc<AtomicRefCell<SharedBuf>>,
         _cb_queue: &mut CallbackQueue,
@@ -925,11 +902,11 @@ where
 }
 
 impl Protocol for ConnOrientedInitial {
-    fn peer_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn peer_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         Err(Errno::ENOTCONN.into())
     }
 
-    fn bound_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn bound_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         Ok(self.bound_addr)
     }
 
@@ -951,13 +928,11 @@ impl Protocol for ConnOrientedInitial {
         (new_state.into(), common.close(cb_queue))
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn bind(
         &mut self,
         common: &mut UnixSocketCommon,
         socket: &Arc<AtomicRefCell<UnixSocket>>,
-        addr: Option<&nix::sys::socket::SockAddr>,
+        addr: Option<&SockaddrStorage>,
         rng: impl rand::Rng,
     ) -> SyscallResult {
         // if already bound
@@ -969,13 +944,11 @@ impl Protocol for ConnOrientedInitial {
         Ok(0.into())
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn sendto<R>(
         &mut self,
         common: &mut UnixSocketCommon,
         _bytes: R,
-        addr: Option<nix::sys::socket::SockAddr>,
+        addr: Option<SockaddrStorage>,
         _cb_queue: &mut CallbackQueue,
     ) -> SyscallResult
     where
@@ -992,14 +965,12 @@ impl Protocol for ConnOrientedInitial {
         }
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn recvfrom<W>(
         &mut self,
         common: &mut UnixSocketCommon,
         _bytes: W,
         _cb_queue: &mut CallbackQueue,
-    ) -> Result<(SysCallReg, Option<nix::sys::socket::SockAddr>), SyscallError>
+    ) -> Result<(SysCallReg, Option<SockaddrStorage>), SyscallError>
     where
         W: std::io::Write + std::io::Seek,
     {
@@ -1047,22 +1018,23 @@ impl Protocol for ConnOrientedInitial {
         (new_state.into(), Ok(()))
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn connect(
         self,
         common: &mut UnixSocketCommon,
         socket: &Arc<AtomicRefCell<UnixSocket>>,
-        addr: &nix::sys::socket::SockAddr,
+        addr: &SockaddrStorage,
         cb_queue: &mut CallbackQueue,
     ) -> (ProtocolState, Result<(), SyscallError>) {
-        let addr = match addr {
-            nix::sys::socket::SockAddr::Unix(x) => x,
-            _ => return (self.into(), Err(Errno::EINVAL.into())),
+        let Some(addr) = addr.as_unix() else {
+            return (self.into(), Err(Errno::EINVAL.into()));
         };
 
         // look up the server socket
-        let server = match lookup_address(&common.namespace.borrow(), common.socket_type, addr) {
+        let server = match lookup_address(
+            &common.namespace.borrow(),
+            common.socket_type,
+            &addr.as_ref(),
+        ) {
             Ok(x) => x,
             Err(e) => return (self.into(), Err(e.into())),
         };
@@ -1134,7 +1106,7 @@ impl Protocol for ConnOrientedInitial {
 
         let new_state = ConnOrientedConnected {
             bound_addr: self.bound_addr,
-            peer_addr: Some(addr.clone()),
+            peer_addr: Some(addr.into_owned()),
             peer: Arc::clone(peer),
             reader_handle,
             writer_handle,
@@ -1216,11 +1188,11 @@ impl Protocol for ConnOrientedInitial {
 }
 
 impl Protocol for ConnOrientedListening {
-    fn peer_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn peer_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         Err(Errno::ENOTCONN.into())
     }
 
-    fn bound_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn bound_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         Ok(Some(self.bound_addr))
     }
 
@@ -1291,7 +1263,7 @@ impl Protocol for ConnOrientedListening {
     fn queue_incoming_conn(
         &mut self,
         common: &mut UnixSocketCommon,
-        from_address: Option<nix::sys::socket::UnixAddr>,
+        from_address: Option<SockaddrUnix<libc::sockaddr_un>>,
         peer: &Arc<AtomicRefCell<UnixSocket>>,
         child_send_buffer: &Arc<AtomicRefCell<SharedBuf>>,
         cb_queue: &mut CallbackQueue,
@@ -1372,15 +1344,11 @@ impl Protocol for ConnOrientedListening {
 }
 
 impl Protocol for ConnOrientedConnected {
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
-    fn peer_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn peer_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         Ok(self.peer_addr)
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
-    fn bound_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn bound_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         Ok(self.bound_addr)
     }
 
@@ -1428,13 +1396,11 @@ impl Protocol for ConnOrientedConnected {
         (new_state.into(), common.close(cb_queue))
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn sendto<R>(
         &mut self,
         common: &mut UnixSocketCommon,
         bytes: R,
-        addr: Option<nix::sys::socket::SockAddr>,
+        addr: Option<SockaddrStorage>,
         cb_queue: &mut CallbackQueue,
     ) -> SyscallResult
     where
@@ -1448,14 +1414,12 @@ impl Protocol for ConnOrientedConnected {
         Ok(rv.into())
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn recvfrom<W>(
         &mut self,
         common: &mut UnixSocketCommon,
         bytes: W,
         cb_queue: &mut CallbackQueue,
-    ) -> Result<(SysCallReg, Option<nix::sys::socket::SockAddr>), SyscallError>
+    ) -> Result<(SysCallReg, Option<SockaddrStorage>), SyscallError>
     where
         W: std::io::Write + std::io::Seek,
     {
@@ -1475,7 +1439,8 @@ impl Protocol for ConnOrientedConnected {
 
         Ok((
             num_copied.into(),
-            self.peer_addr.map(nix::sys::socket::SockAddr::Unix),
+            self.peer_addr
+                .map(|x| SockaddrStorage::from_unix(&x.as_ref())),
         ))
     }
 
@@ -1510,15 +1475,11 @@ impl Protocol for ConnOrientedConnected {
 }
 
 impl Protocol for ConnOrientedClosed {
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
-    fn peer_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn peer_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         Err(Errno::ENOTCONN.into())
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
-    fn bound_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn bound_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         Err(Errno::EBADFD.into())
     }
 
@@ -1550,18 +1511,14 @@ impl Protocol for ConnOrientedClosed {
 }
 
 impl Protocol for ConnLessInitial {
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
-    fn peer_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn peer_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         match self.peer {
             Some(_) => Ok(self.peer_addr),
             None => Err(Errno::ENOTCONN.into()),
         }
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
-    fn bound_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn bound_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         Ok(self.bound_addr)
     }
 
@@ -1604,13 +1561,11 @@ impl Protocol for ConnLessInitial {
         (new_state.into(), common.close(cb_queue))
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn bind(
         &mut self,
         common: &mut UnixSocketCommon,
         socket: &Arc<AtomicRefCell<UnixSocket>>,
-        addr: Option<&nix::sys::socket::SockAddr>,
+        addr: Option<&SockaddrStorage>,
         rng: impl rand::Rng,
     ) -> SyscallResult {
         // if already bound
@@ -1622,13 +1577,11 @@ impl Protocol for ConnLessInitial {
         Ok(0.into())
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn sendto<R>(
         &mut self,
         common: &mut UnixSocketCommon,
         bytes: R,
-        addr: Option<nix::sys::socket::SockAddr>,
+        addr: Option<SockaddrStorage>,
         cb_queue: &mut CallbackQueue,
     ) -> SyscallResult
     where
@@ -1658,14 +1611,12 @@ impl Protocol for ConnLessInitial {
         Ok(rv.into())
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn recvfrom<W>(
         &mut self,
         common: &mut UnixSocketCommon,
         bytes: W,
         cb_queue: &mut CallbackQueue,
-    ) -> Result<(SysCallReg, Option<nix::sys::socket::SockAddr>), SyscallError>
+    ) -> Result<(SysCallReg, Option<SockaddrStorage>), SyscallError>
     where
         W: std::io::Write + std::io::Seek,
     {
@@ -1687,7 +1638,9 @@ impl Protocol for ConnLessInitial {
 
         Ok((
             num_copied.into(),
-            byte_data.from_addr.map(nix::sys::socket::SockAddr::Unix),
+            byte_data
+                .from_addr
+                .map(|x| SockaddrStorage::from_unix(&x.as_ref())),
         ))
     }
 
@@ -1711,29 +1664,26 @@ impl Protocol for ConnLessInitial {
         common.ioctl(request, arg_ptr, memory_manager)
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     fn connect(
         self,
         common: &mut UnixSocketCommon,
         _socket: &Arc<AtomicRefCell<UnixSocket>>,
-        addr: &nix::sys::socket::SockAddr,
+        addr: &SockaddrStorage,
         cb_queue: &mut CallbackQueue,
     ) -> (ProtocolState, Result<(), SyscallError>) {
         // TODO: support AF_UNSPEC to disassociate
-        let addr = match addr {
-            nix::sys::socket::SockAddr::Unix(x) => x,
-            _ => return (self.into(), Err(Errno::EINVAL.into())),
+        let Some(addr) = addr.as_unix() else {
+            return (self.into(), Err(Errno::EINVAL.into()));
         };
 
         // find the socket bound at the address
-        let peer = match lookup_address(&common.namespace.borrow(), common.socket_type, addr) {
+        let peer = match lookup_address(&common.namespace.borrow(), common.socket_type, &addr) {
             Ok(x) => x,
             Err(e) => return (self.into(), Err(e.into())),
         };
 
         let new_state = Self {
-            peer_addr: Some(addr.clone()),
+            peer_addr: Some(addr.into_owned()),
             peer: Some(peer),
             ..self
         };
@@ -1767,15 +1717,11 @@ impl Protocol for ConnLessInitial {
 }
 
 impl Protocol for ConnLessClosed {
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
-    fn peer_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn peer_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         Ok(None)
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
-    fn bound_address(&self) -> Result<Option<nix::sys::socket::UnixAddr>, SyscallError> {
+    fn bound_address(&self) -> Result<Option<SockaddrUnix<libc::sockaddr_un>>, SyscallError> {
         Ok(None)
     }
 
@@ -1842,24 +1788,19 @@ impl UnixSocketCommon {
         Ok(())
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     pub fn bind(
         &mut self,
         socket: &Arc<AtomicRefCell<UnixSocket>>,
-        addr: Option<&nix::sys::socket::SockAddr>,
+        addr: Option<&SockaddrStorage>,
         rng: impl rand::Rng,
-    ) -> Result<nix::sys::socket::UnixAddr, SyscallError> {
+    ) -> Result<SockaddrUnix<libc::sockaddr_un>, SyscallError> {
         // get the unix address
-        let addr = match addr {
-            Some(nix::sys::socket::SockAddr::Unix(x)) => x,
-            _ => {
-                log::warn!(
-                    "Attempted to bind unix socket to non-unix address {:?}",
-                    addr
-                );
-                return Err(Errno::EINVAL.into());
-            }
+        let Some(addr) = addr.map(|x| x.as_unix()).flatten() else {
+            log::warn!(
+                "Attempted to bind unix socket to non-unix address {:?}",
+                addr
+            );
+            return Err(Errno::EINVAL.into());
         };
 
         // bind the socket
@@ -1873,11 +1814,11 @@ impl UnixSocketCommon {
                 socket,
                 &mut self.event_source,
             ) {
-                Ok(()) => *addr,
+                Ok(()) => addr.into_owned(),
                 // address is in use
                 Err(_) => return Err(Errno::EADDRINUSE.into()),
             }
-        } else if addr.path_len() == 0 {
+        } else if addr.is_unnamed() {
             // if given an "unnamed" address
             let namespace = Arc::clone(&self.namespace);
             match AbstractUnixNamespace::autobind(
@@ -1887,7 +1828,7 @@ impl UnixSocketCommon {
                 &mut self.event_source,
                 rng,
             ) {
-                Ok(ref name) => nix::sys::socket::UnixAddr::new_abstract(name).unwrap(),
+                Ok(ref name) => SockaddrUnix::new_abstract(name).unwrap(),
                 Err(_) => return Err(Errno::EADDRINUSE.into()),
             }
         } else {
@@ -1898,17 +1839,14 @@ impl UnixSocketCommon {
         Ok(bound_addr)
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     pub fn resolve_destination(
         &self,
         peer: Option<&Arc<AtomicRefCell<UnixSocket>>>,
-        addr: Option<nix::sys::socket::SockAddr>,
+        addr: Option<SockaddrStorage>,
     ) -> Result<Arc<AtomicRefCell<UnixSocket>>, SyscallError> {
         let addr = match addr {
-            Some(nix::sys::socket::SockAddr::Unix(x)) => Some(x),
+            Some(ref addr) => Some(addr.as_unix().ok_or(Errno::EINVAL)?),
             None => None,
-            _ => return Err(Errno::EINVAL.into()),
         };
 
         // returns either the send buffer, or None if we should look up the send buffer from the
@@ -1948,8 +1886,6 @@ impl UnixSocketCommon {
         return Ok(peer);
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     pub fn sendto<R>(
         &mut self,
         mut bytes: R,
@@ -2024,8 +1960,6 @@ impl UnixSocketCommon {
         Ok(num_copied)
     }
 
-    // https://github.com/shadow/shadow/issues/2093
-    #[allow(deprecated)]
     pub fn recvfrom<W>(
         &mut self,
         mut bytes: W,
@@ -2091,7 +2025,7 @@ impl UnixSocketCommon {
 fn lookup_address(
     namespace: &AbstractUnixNamespace,
     socket_type: UnixSocketType,
-    addr: &nix::sys::socket::UnixAddr,
+    addr: &SockaddrUnix<&libc::sockaddr_un>,
 ) -> Result<Arc<AtomicRefCell<UnixSocket>>, nix::errno::Errno> {
     // if an abstract address
     if let Some(name) = addr.as_abstract() {
@@ -2116,15 +2050,6 @@ fn backlog_to_queue_size(backlog: i32) -> u32 {
     // linux uses a limit of one greater than the provided backlog (ex: a backlog value of 0 allows
     // for one incoming connection at a time)
     queue_limit.saturating_add(1)
-}
-
-fn empty_unix_sockaddr() -> nix::sys::socket::UnixAddr {
-    match empty_sockaddr(nix::sys::socket::AddressFamily::Unix) {
-        // https://github.com/shadow/shadow/issues/2093
-        #[allow(deprecated)]
-        nix::sys::socket::SockAddr::Unix(x) => x,
-        x => panic!("Unexpected socket address type: {:?}", x),
-    }
 }
 
 // WARNING: don't add new enum variants without updating 'AbstractUnixNamespace::new()'
@@ -2170,6 +2095,6 @@ enum IncomingConnError {
 
 struct ByteData {
     from_socket: Arc<AtomicRefCell<UnixSocket>>,
-    from_addr: Option<nix::sys::socket::UnixAddr>,
+    from_addr: Option<SockaddrUnix<libc::sockaddr_un>>,
     num_bytes: u64,
 }

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -1437,11 +1437,7 @@ impl Protocol for ConnOrientedConnected {
 
         self.refresh_file_state(common, cb_queue);
 
-        Ok((
-            num_copied.into(),
-            self.peer_addr
-                .map(|x| SockaddrStorage::from_unix(&x.as_ref())),
-        ))
+        Ok((num_copied.into(), self.peer_addr.map(|x| x.into())))
     }
 
     fn inform_bytes_read(
@@ -1636,12 +1632,7 @@ impl Protocol for ConnLessInitial {
 
         self.refresh_file_state(common, cb_queue);
 
-        Ok((
-            num_copied.into(),
-            byte_data
-                .from_addr
-                .map(|x| SockaddrStorage::from_unix(&x.as_ref())),
-        ))
+        Ok((num_copied.into(), byte_data.from_addr.map(|x| x.into())))
     }
 
     fn inform_bytes_read(

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -16,6 +16,7 @@ pub mod perf_timer;
 pub mod pod;
 pub mod proc_maps;
 pub mod shm_cleanup;
+pub mod sockaddr;
 pub mod status_bar;
 pub mod stream_len;
 pub mod synchronization;

--- a/src/main/utility/sockaddr.rs
+++ b/src/main/utility/sockaddr.rs
@@ -179,6 +179,27 @@ impl std::fmt::Debug for SockaddrStorage {
     }
 }
 
+impl<T> From<SockaddrUnix<T>> for SockaddrStorage
+where
+    T: Borrow<libc::sockaddr_un>,
+{
+    fn from(addr: SockaddrUnix<T>) -> Self {
+        SockaddrStorage::from_unix(&addr.as_ref())
+    }
+}
+
+impl From<nix::sys::socket::SockaddrIn> for SockaddrStorage {
+    fn from(addr: nix::sys::socket::SockaddrIn) -> Self {
+        SockaddrStorage::from_inet(&addr)
+    }
+}
+
+impl From<nix::sys::socket::SockaddrIn6> for SockaddrStorage {
+    fn from(addr: nix::sys::socket::SockaddrIn6) -> Self {
+        SockaddrStorage::from_inet6(&addr)
+    }
+}
+
 /// A Unix socket address. Typically will be used as an owned address
 /// `SockaddrUnix<libc::sockaddr_un>` or a borrowed address `SockaddrUnix<&libc::sockaddr_un>`, and
 /// you can convert between them using methods such as [`as_ref`](Self::as_ref) or

--- a/src/main/utility/sockaddr.rs
+++ b/src/main/utility/sockaddr.rs
@@ -1,0 +1,671 @@
+use std::borrow::Borrow;
+use std::borrow::BorrowMut;
+use std::ffi::CStr;
+use std::mem::MaybeUninit;
+
+use nix::sys::socket::AddressFamily;
+use nix::sys::socket::SockaddrLike;
+use static_assertions::{assert_eq_align, assert_eq_size};
+
+/// A container for any type of socket address.
+#[derive(Clone, Copy)]
+pub struct SockaddrStorage {
+    addr: Addr,
+    len: libc::socklen_t,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+union Addr {
+    slice: [MaybeUninit<u8>; std::mem::size_of::<libc::sockaddr_storage>()],
+    storage: libc::sockaddr_storage,
+    inet: libc::sockaddr_in,
+    inet6: libc::sockaddr_in6,
+    unix: libc::sockaddr_un,
+}
+
+// verify there are no larger fields larger than `libc::sockaddr_storage`
+assert_eq_size!(libc::sockaddr_storage, Addr);
+
+// NOTE: If any mutable methods are added to `SockaddrStorage` in the future, they should make sure
+// that the address family cannot be changed. Otherwise a `SockaddrStorage` containing for example a
+// `sockaddr_in` could be reinterpreted as another type such as `sockaddr_un`, the `sockaddr_in` may
+// have uninitialized padding bytes in the location of a field of `sockaddr_un`, and a read of this
+// field of `sockaddr_un` would then cause UB.
+
+impl SockaddrStorage {
+    /// SAFETY:
+    /// - The address must be fully initialized, including padding fields (for example
+    ///   `sockaddr_in.sin_zero`), up until `len` bytes.
+    /// - Padding bytes do not need to be initialized.
+    /// - The address does not need to be aligned.
+    /// - If `len` is large enough for the address to hold the family field, the family must
+    ///   correctly represent the address type. For example if `addr` points to a `sockaddr_in`,
+    ///   then `addr.sin_family` must be `AF_INET`.
+    pub unsafe fn from_ptr(
+        addr: *const MaybeUninit<u8>,
+        len: libc::socklen_t,
+    ) -> Option<SockaddrStorage> {
+        if addr.is_null() {
+            return None;
+        }
+
+        const STORAGE_LEN: usize = std::mem::size_of::<libc::sockaddr_storage>();
+
+        if (len as usize) > STORAGE_LEN {
+            return None;
+        }
+
+        // 'new_addr' starts will all bytes initialized
+        let mut new_addr = [MaybeUninit::new(0u8); STORAGE_LEN];
+
+        // after the copy, 'new_addr' may have uninitialized bytes if `addr` had padding bytes
+        unsafe { std::ptr::copy_nonoverlapping(addr, new_addr.as_mut_ptr(), len as usize) };
+
+        Some(SockaddrStorage {
+            addr: Addr { slice: new_addr },
+            len,
+        })
+    }
+
+    /// SAFETY: See [`Self::from_ptr`].
+    pub unsafe fn from_bytes(address: &[MaybeUninit<u8>]) -> Option<Self> {
+        unsafe { Self::from_ptr(address.as_ptr(), address.len().try_into().ok()?) }
+    }
+
+    /// Get the socket protocol family. Will return `None` if the socket address length is too
+    /// short, or if the family value does not correspond to a valid/known family.
+    pub fn family(&self) -> Option<AddressFamily> {
+        if (self.len as usize) < memoffset::span_of!(libc::sockaddr_storage, ss_family).end {
+            return None;
+        }
+
+        // SAFETY: we don't know what bytes of the address have initialized/uninitialized memory,
+        // but we should be guarenteed the the `ss_family` field is initialized for any socket type.
+        let family = unsafe { self.addr.storage }.ss_family;
+        AddressFamily::from_i32(family.into())
+    }
+
+    /// If the socket address represents a valid ipv4 socket address (correct family and length),
+    /// returns the ipv4 socket address.
+    pub fn as_inet(&self) -> Option<&nix::sys::socket::SockaddrIn> {
+        if (self.len as usize) < std::mem::size_of::<libc::sockaddr_in>() {
+            return None;
+        }
+        if self.family() != Some(AddressFamily::Inet) {
+            return None;
+        }
+
+        // SAFETY: Assume that `nix::sys::socket::SockaddrIn` is a transparent wrapper around a
+        // `libc::sockaddr_in`. Verify (as best we can) that this is true.
+        assert_eq_size!(libc::sockaddr_in, nix::sys::socket::SockaddrIn);
+        assert_eq_align!(libc::sockaddr_in, nix::sys::socket::SockaddrIn);
+
+        Some(unsafe { &*(&self.addr.inet as *const _ as *const nix::sys::socket::SockaddrIn) })
+    }
+
+    /// Get a new `SockaddrStorage` with a copy of the ipv4 socket address.
+    pub fn from_inet(addr: &nix::sys::socket::SockaddrIn) -> Self {
+        // SAFETY: Assume that `nix::sys::socket::SockaddrIn` is a transparent wrapper around a
+        // `libc::sockaddr_in`. Verify (as best we can) that this is true.
+        assert_eq_size!(libc::sockaddr_in, nix::sys::socket::SockaddrIn);
+        assert_eq_align!(libc::sockaddr_in, nix::sys::socket::SockaddrIn);
+
+        unsafe { Self::from_ptr(addr.as_ptr() as *const MaybeUninit<u8>, addr.len()) }.unwrap()
+    }
+
+    /// If the socket address represents a valid ipv6 socket address (correct family and length),
+    /// returns the ipv6 socket address.
+    pub fn as_inet6(&self) -> Option<&nix::sys::socket::SockaddrIn6> {
+        if (self.len as usize) < std::mem::size_of::<libc::sockaddr_in6>() {
+            return None;
+        }
+        if self.family() != Some(AddressFamily::Inet6) {
+            return None;
+        }
+
+        // SAFETY: Assume that `nix::sys::socket::SockaddrIn6` is a transparent wrapper around a
+        // `libc::sockaddr_in6`. Verify (as best we can) that this is true.
+        assert_eq_size!(libc::sockaddr_in6, nix::sys::socket::SockaddrIn6);
+        assert_eq_align!(libc::sockaddr_in6, nix::sys::socket::SockaddrIn6);
+
+        Some(unsafe { &*(&self.addr.inet6 as *const _ as *const nix::sys::socket::SockaddrIn6) })
+    }
+
+    /// Get a new `SockaddrStorage` with a copy of the ipv6 socket address.
+    pub fn from_inet6(addr: &nix::sys::socket::SockaddrIn6) -> Self {
+        // SAFETY: Assume that `nix::sys::socket::SockaddrIn6` is a transparent wrapper around a
+        // `libc::sockaddr_in6`. Verify (as best we can) that this is true.
+        assert_eq_size!(libc::sockaddr_in6, nix::sys::socket::SockaddrIn6);
+        assert_eq_align!(libc::sockaddr_in6, nix::sys::socket::SockaddrIn6);
+
+        unsafe { Self::from_ptr(addr.as_ptr() as *const MaybeUninit<u8>, addr.len()) }.unwrap()
+    }
+
+    /// If the socket address represents a valid unix socket address (correct family and length),
+    /// returns the unix socket address.
+    pub fn as_unix(&self) -> Option<SockaddrUnix<&libc::sockaddr_un>> {
+        if self.family() != Some(AddressFamily::Unix) {
+            return None;
+        }
+
+        SockaddrUnix::new(unsafe { &self.addr.unix }, self.len)
+    }
+
+    /// Get a new `SockaddrStorage` with a copy of the unix socket address.
+    pub fn from_unix(addr: &SockaddrUnix<&libc::sockaddr_un>) -> Self {
+        let (ptr, len) = addr.as_ptr();
+
+        unsafe { Self::from_ptr(ptr as *const MaybeUninit<u8>, len) }.unwrap()
+    }
+
+    /// A pointer to the socket address. Some bytes may be uninitialized.
+    pub fn as_ptr(&self) -> (*const MaybeUninit<u8>, libc::socklen_t) {
+        (unsafe { &self.addr.slice }.as_ptr(), self.len)
+    }
+
+    /// The socket address as a slice of bytes. Some bytes may be uninitialized.
+    pub fn as_slice(&self) -> &[MaybeUninit<u8>] {
+        unsafe { &self.addr.slice[..(self.len as usize)] }
+    }
+}
+
+impl std::fmt::Debug for SockaddrStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SockaddrStorage")
+            .field("family", &self.family())
+            .field("len", &self.len)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A Unix socket address. Typically will be used as an owned address
+/// `SockaddrUnix<libc::sockaddr_un>` or a borrowed address `SockaddrUnix<&libc::sockaddr_un>`, and
+/// you can convert between them using methods such as [`as_ref`](Self::as_ref) or
+/// [`into_owned`](Self::into_owned).
+#[derive(Clone, Copy)]
+pub struct SockaddrUnix<T>
+where
+    T: Borrow<libc::sockaddr_un>,
+{
+    addr: T,
+    len: libc::socklen_t,
+}
+
+impl<T> SockaddrUnix<T>
+where
+    T: Borrow<libc::sockaddr_un>,
+{
+    /// Get a new `SockaddrUnix` for a `libc::sockaddr_un`. The `libc::sockaddr_un` must be
+    /// properly initialized. Will return `None` if the length is too short, too long, or if
+    /// `sun_family` is not `AF_UNIX`.
+    pub fn new(addr: T, len: libc::socklen_t) -> Option<Self> {
+        if (len as usize) < memoffset::span_of!(libc::sockaddr_un, sun_family).end {
+            return None;
+        }
+
+        if (len as usize) > std::mem::size_of::<libc::sockaddr_un>() {
+            return None;
+        }
+
+        if addr.borrow().sun_family as i32 != libc::AF_UNIX {
+            return None;
+        }
+
+        Some(Self { addr, len })
+    }
+
+    /// If the socket address represents a pathname address, returns the C string representing the
+    /// filesystem path.
+    pub fn as_path(&self) -> Option<&CStr> {
+        let path = self.sun_path()?;
+
+        // if the address length is too short, or it's an abstract named address
+        if path.is_empty() || path[0] == 0 {
+            return None;
+        }
+
+        // For pathname socket addresses, the path is a C-style nul-terminated string which may be
+        // shorter than the address length (`self.len`). Bytes after the nul are ignored.
+        let first_nul = path.iter().position(|&x| x == 0)?;
+
+        return Some(CStr::from_bytes_with_nul(&path[..(first_nul + 1)]).unwrap());
+    }
+
+    /// If the socket address represents an abstract address, returns the bytes representing the
+    /// name of the abstract socket address. These bytes do not include the nul byte at
+    /// `sun_path[0]`.
+    pub fn as_abstract(&self) -> Option<&[u8]> {
+        let name = self.sun_path()?;
+
+        if name.is_empty() {
+            return None;
+        }
+
+        // the first byte of `sun_path` is always 0 for abstract named socket addresses
+        if name[0] != 0 {
+            return None;
+        }
+
+        return Some(&name[1..]);
+    }
+
+    /// Is the unix socket address unnamed? On Linux, unnamed unix sockets are unnamed if their
+    /// length is `size_of::<libc::sa_family_t>()`.
+    pub fn is_unnamed(&self) -> bool {
+        (self.len as usize) == memoffset::span_of!(libc::sockaddr_un, sun_family).end
+    }
+
+    /// Returns a slice with the valid bytes of `sun_path`, or `None` if the address length is too
+    /// short.
+    fn sun_path(&self) -> Option<&[u8]> {
+        let path_offset = memoffset::offset_of!(libc::sockaddr_un, sun_path);
+        let path_len = (self.len as usize).checked_sub(path_offset)?;
+
+        Some(i8_to_u8_slice(&self.addr.borrow().sun_path[..path_len]))
+    }
+
+    /// Get an owned unix socket address.
+    pub fn into_owned(self) -> SockaddrUnix<libc::sockaddr_un> {
+        SockaddrUnix {
+            addr: *self.addr.borrow(),
+            len: self.len,
+        }
+    }
+
+    /// Get a borrowed unix socket address.
+    pub fn as_ref(&self) -> SockaddrUnix<&libc::sockaddr_un> {
+        SockaddrUnix {
+            addr: self.addr.borrow(),
+            len: self.len,
+        }
+    }
+
+    /// Get a pointer to the unix socket address. All fields of the `libc::sockaddr_un` will be
+    /// properly initialized.
+    pub fn as_ptr(&self) -> (*const libc::sockaddr_un, libc::socklen_t) {
+        (self.addr.borrow(), self.len)
+    }
+}
+
+impl<T> SockaddrUnix<T>
+where
+    T: BorrowMut<libc::sockaddr_un>,
+{
+    /// Get a mutably borrowed unix socket address.
+    pub fn as_mut(&mut self) -> SockaddrUnix<&mut libc::sockaddr_un> {
+        SockaddrUnix {
+            addr: self.addr.borrow_mut(),
+            len: self.len,
+        }
+    }
+}
+
+impl SockaddrUnix<libc::sockaddr_un> {
+    /// Get a new `SockaddrUnix` with the given path. Will return `None` if the path is empty or is
+    /// too large.
+    pub fn new_path(path: &CStr) -> Option<Self> {
+        let path = path.to_bytes();
+
+        // this should be guaranteed by the CStr
+        debug_assert!(!path.contains(&0));
+
+        if path.is_empty() {
+            // you cannot have a pathname unix socket address with no path
+            return None;
+        }
+
+        let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+
+        if path.len() >= std::mem::size_of_val(&addr.sun_path) {
+            // pathname unix sockets should be nul terminated, but there's no room for the nul
+            return None;
+        }
+
+        // there will be a terminating nul byte since the address was zeroed, and the path will
+        // never fill all of `sun_path`
+        addr.sun_family = libc::AF_UNIX as u16;
+        addr.sun_path[..path.len()].copy_from_slice(u8_to_i8_slice(path));
+
+        let len = memoffset::offset_of!(libc::sockaddr_un, sun_path) + path.len() + 1;
+        let len = len as libc::socklen_t;
+
+        Some(Self { addr, len })
+    }
+
+    /// Get a new `SockaddrUnix` with the given abstract address name. The name does not include the
+    /// required nul byte at `sun_path[0]`. Will return `None` if the name is too large.
+    pub fn new_abstract(name: &[u8]) -> Option<Self> {
+        let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+
+        if name.len() + 1 > std::mem::size_of_val(&addr.sun_path) {
+            return None;
+        }
+
+        addr.sun_family = libc::AF_UNIX as u16;
+        addr.sun_path[1..][..name.len()].copy_from_slice(u8_to_i8_slice(name));
+
+        let len = memoffset::offset_of!(libc::sockaddr_un, sun_path) + 1 + name.len();
+        let len = len as libc::socklen_t;
+
+        Some(Self { addr, len })
+    }
+
+    /// Get a new unnamed unix socket address.
+    pub fn new_unnamed() -> SockaddrUnix<libc::sockaddr_un> {
+        let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+        addr.sun_family = libc::AF_UNIX as u16;
+
+        let len = memoffset::span_of!(libc::sockaddr_un, sun_family).end;
+        assert_eq!(len, 2);
+        let len = len as libc::socklen_t;
+
+        Self { addr, len }
+    }
+}
+
+impl<T> std::fmt::Debug for SockaddrUnix<T>
+where
+    T: Borrow<libc::sockaddr_un>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SockaddrUnix")
+            .field("sun_family", &self.addr.borrow().sun_family)
+            .field("sun_path", &self.sun_path())
+            .finish()
+    }
+}
+
+impl<T> PartialEq for SockaddrUnix<T>
+where
+    T: Borrow<libc::sockaddr_un>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        // if this assertion fails, something is very wrong
+        assert_eq!(
+            self.addr.borrow().sun_family,
+            other.addr.borrow().sun_family,
+        );
+        self.len == other.len && self.sun_path() == other.sun_path()
+    }
+}
+
+impl<T> Eq for SockaddrUnix<T> where T: Borrow<libc::sockaddr_un> {}
+
+/// Convert a `&[u8]` to `&[i8]`.
+fn u8_to_i8_slice(s: &[u8]) -> &[i8] {
+    unsafe { std::slice::from_raw_parts(s.as_ptr() as *const i8, s.len()) }
+}
+
+/// Convert a `&[i8]` to `&[u8]`.
+fn i8_to_u8_slice(s: &[i8]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(s.as_ptr() as *const u8, s.len()) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Convert from a `sockaddr_in` to a `SockaddrStorage`.
+    #[test]
+    fn storage_from_inet_ptr() {
+        let mut addr: libc::sockaddr_in = unsafe { std::mem::zeroed() };
+        addr.sin_family = libc::AF_INET as u16;
+        addr.sin_port = 9000u16.to_be();
+        addr.sin_addr = libc::in_addr {
+            s_addr: libc::INADDR_LOOPBACK.to_be(),
+        };
+
+        let ptr = &addr as *const _ as *const MaybeUninit<u8>;
+        let len = std::mem::size_of_val(&addr).try_into().unwrap();
+
+        let addr = unsafe { SockaddrStorage::from_ptr(ptr, len) }.unwrap();
+
+        assert_eq!(addr.family(), Some(AddressFamily::Inet));
+        assert!(addr.as_inet().is_some());
+        assert!(addr.as_inet6().is_none());
+        assert!(addr.as_unix().is_none());
+    }
+
+    /// Convert from a `sockaddr_un` to a `SockaddrStorage`.
+    #[test]
+    fn storage_from_unix_ptr() {
+        // a valid unix pathname sockaddr with a path of length 3
+        let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+        addr.sun_family = libc::AF_UNIX as u16;
+        addr.sun_path = [1; 108];
+        addr.sun_path[..4].copy_from_slice(&[1, 2, 3, 0]);
+
+        let ptr = &addr as *const _ as *const MaybeUninit<u8>;
+        let len = std::mem::size_of_val(&addr).try_into().unwrap();
+
+        let addr = unsafe { SockaddrStorage::from_ptr(ptr, len) }.unwrap();
+
+        assert_eq!(addr.family(), Some(AddressFamily::Unix));
+        assert!(addr.as_unix().is_some());
+        assert!(addr.as_inet().is_none());
+        assert!(addr.as_inet6().is_none());
+    }
+
+    /// Convert from a `sockaddr_in` to a `SockaddrStorage` to a `SockaddrIn`.
+    #[test]
+    fn inet_addr_from_libc() {
+        let mut addr_in: libc::sockaddr_in = unsafe { std::mem::zeroed() };
+        addr_in.sin_family = libc::AF_INET as u16;
+        addr_in.sin_port = 9000u16.to_be();
+        addr_in.sin_addr = libc::in_addr {
+            s_addr: libc::INADDR_LOOPBACK.to_be(),
+        };
+
+        let ptr = &addr_in as *const _ as *const MaybeUninit<u8>;
+        let len = std::mem::size_of_val(&addr_in).try_into().unwrap();
+
+        let addr = unsafe { SockaddrStorage::from_ptr(ptr, len) }.unwrap();
+        let addr = addr.as_inet().unwrap();
+
+        assert_eq!(addr.port(), u16::from_be(addr_in.sin_port));
+        assert_eq!(addr.ip(), u32::from_be(addr_in.sin_addr.s_addr));
+    }
+
+    /// Convert from a `SockaddrIn` to a `SockaddrStorage` to a `sockaddr_in`.
+    #[test]
+    fn inet_addr_to_libc() {
+        let addr_original = nix::sys::socket::SockaddrIn::new(127, 0, 0, 1, 9000);
+        let addr = SockaddrStorage::from_inet(&addr_original);
+
+        let (ptr, len) = addr.as_ptr();
+        let ptr = ptr as *const libc::sockaddr_in;
+        assert_eq!(len as usize, std::mem::size_of::<libc::sockaddr_in>());
+
+        let addr = unsafe { ptr.as_ref() }.unwrap();
+
+        assert_eq!(addr.sin_family, libc::AF_INET as u16);
+        assert_eq!(u16::from_be(addr.sin_port), addr_original.port());
+        assert_eq!(u32::from_be(addr.sin_addr.s_addr), addr_original.ip());
+    }
+
+    /// Convert from a pathname `sockaddr_un` to a `SockaddrStorage` to a `SockaddrUnix`.
+    #[test]
+    fn unix_addr_from_libc_to_path() {
+        let pathname = [1, 2, 3, 0];
+        let pathname_cstr = CStr::from_bytes_with_nul(i8_to_u8_slice(&pathname)).unwrap();
+
+        // a valid unix pathname sockaddr with a path of length 3
+        let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+        addr.sun_family = libc::AF_UNIX as u16;
+        addr.sun_path = [1; 108];
+        addr.sun_path[..pathname.len()].copy_from_slice(&pathname);
+
+        let ptr = &addr as *const _ as *const MaybeUninit<u8>;
+        let len_useful_info = memoffset::offset_of!(libc::sockaddr_un, sun_path) + pathname.len();
+        let len_useful_info = len_useful_info.try_into().unwrap();
+        let len_struct = std::mem::size_of_val(&addr).try_into().unwrap();
+
+        let addr = unsafe { SockaddrStorage::from_ptr(ptr, len_useful_info) }.unwrap();
+
+        assert!(addr.as_inet().is_none());
+        assert!(addr.as_inet6().is_none());
+
+        let addr = addr.as_unix().unwrap();
+
+        assert!(addr.as_abstract().is_none());
+        assert!(!addr.is_unnamed());
+
+        assert_eq!(addr.as_path().unwrap(), pathname_cstr);
+
+        let addr = unsafe { SockaddrStorage::from_ptr(ptr, len_struct) }.unwrap();
+
+        assert!(addr.as_inet().is_none());
+        assert!(addr.as_inet6().is_none());
+
+        let addr = addr.as_unix().unwrap();
+
+        assert!(addr.as_abstract().is_none());
+        assert!(!addr.is_unnamed());
+
+        assert_eq!(addr.as_path().unwrap(), pathname_cstr);
+    }
+
+    /// Convert from a pathname `SockaddrUnix` to a `SockaddrStorage` to a `sockaddr_un`.
+    #[test]
+    fn unix_addr_from_path_to_libc() {
+        let pathname = [1, 2, 3, 0];
+        let pathname_cstr = CStr::from_bytes_with_nul(i8_to_u8_slice(&pathname)).unwrap();
+
+        let addr = SockaddrUnix::new_path(pathname_cstr).unwrap();
+        let addr = SockaddrStorage::from_unix(&addr.as_ref());
+
+        let (ptr, len) = addr.as_ptr();
+        let ptr = ptr as *const libc::sockaddr_un;
+        assert_eq!(len as usize, 2 + pathname.len());
+
+        let addr = unsafe { ptr.as_ref() }.unwrap();
+        let path_len = len as usize - memoffset::offset_of!(libc::sockaddr_un, sun_path);
+
+        assert_eq!(addr.sun_family, libc::AF_UNIX as u16);
+        assert_eq!(addr.sun_path[..path_len], pathname);
+    }
+
+    /// Convert from a abstract-named `sockaddr_un` to a `SockaddrStorage` to a `SockaddrUnix`.
+    #[test]
+    fn unix_addr_from_libc_to_abstract() {
+        let name = [1, 2, 3, 0, 5, 6];
+
+        // a valid unix abstract sockaddr
+        let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+        addr.sun_family = libc::AF_UNIX as u16;
+        addr.sun_path = [1; 108];
+        addr.sun_path[0] = 0;
+        addr.sun_path[1..][..name.len()].copy_from_slice(u8_to_i8_slice(&name));
+
+        let ptr = &addr as *const _ as *const MaybeUninit<u8>;
+
+        // the correct sockaddr length for this abstract unix socket address
+        let len_real = memoffset::offset_of!(libc::sockaddr_un, sun_path) + 1 + name.len();
+        let len_real = len_real.try_into().unwrap();
+
+        // an incorrect sockaddr length (will result in the wrong abstract address name)
+        let len_struct = std::mem::size_of_val(&addr).try_into().unwrap();
+
+        let addr = unsafe { SockaddrStorage::from_ptr(ptr, len_real) }.unwrap();
+
+        assert!(addr.as_inet().is_none());
+        assert!(addr.as_inet6().is_none());
+
+        let addr = addr.as_unix().unwrap();
+
+        assert!(addr.as_path().is_none());
+        assert!(!addr.is_unnamed());
+
+        assert_eq!(addr.as_abstract().unwrap(), &name);
+
+        let addr = unsafe { SockaddrStorage::from_ptr(ptr, len_struct) }.unwrap();
+
+        assert!(addr.as_inet().is_none());
+        assert!(addr.as_inet6().is_none());
+
+        let addr = addr.as_unix().unwrap();
+
+        assert!(addr.as_path().is_none());
+        assert!(!addr.is_unnamed());
+
+        assert_eq!(addr.as_abstract().unwrap().len(), 107);
+    }
+
+    /// Convert from an abstract-named `SockaddrUnix` to a `SockaddrStorage` to a `sockaddr_un`.
+    #[test]
+    fn unix_addr_from_abstract_to_libc() {
+        let name = [1, 2, 3, 0, 5, 6];
+
+        let addr = SockaddrUnix::new_abstract(&name).unwrap();
+        let addr = SockaddrStorage::from_unix(&addr.as_ref());
+
+        let (ptr, len) = addr.as_ptr();
+        let ptr = ptr as *const libc::sockaddr_un;
+        assert_eq!(len as usize, 2 + 1 + name.len());
+
+        let addr = unsafe { ptr.as_ref() }.unwrap();
+        let path_len = len as usize - memoffset::offset_of!(libc::sockaddr_un, sun_path);
+
+        assert_eq!(addr.sun_family, libc::AF_UNIX as u16);
+        assert_eq!(addr.sun_path[0], 0);
+        assert_eq!(&addr.sun_path[1..path_len], u8_to_i8_slice(&name));
+    }
+
+    /// Convert from an unnamed `sockaddr_un` to a `SockaddrStorage` to a `SockaddrUnix`.
+    #[test]
+    fn unix_addr_from_libc_to_unnamed() {
+        // a valid unix abstract sockaddr
+        let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+        addr.sun_family = libc::AF_UNIX as u16;
+        addr.sun_path = [1; 108];
+
+        let ptr = &addr as *const _ as *const MaybeUninit<u8>;
+
+        // the correct sockaddr length for this unnamed unix socket address
+        let len_real = memoffset::offset_of!(libc::sockaddr_un, sun_path);
+        let len_real = len_real.try_into().unwrap();
+
+        // an incorrect sockaddr length (will result in the wrong address)
+        let len_struct = std::mem::size_of_val(&addr).try_into().unwrap();
+
+        let addr = unsafe { SockaddrStorage::from_ptr(ptr, len_real) }.unwrap();
+
+        assert!(addr.as_inet().is_none());
+        assert!(addr.as_inet6().is_none());
+
+        let addr = addr.as_unix().unwrap();
+
+        assert!(addr.is_unnamed());
+        assert!(addr.as_path().is_none());
+        assert!(addr.as_abstract().is_none());
+
+        let addr = unsafe { SockaddrStorage::from_ptr(ptr, len_struct) }.unwrap();
+
+        assert!(addr.as_inet().is_none());
+        assert!(addr.as_inet6().is_none());
+
+        let addr = addr.as_unix().unwrap();
+
+        // the sun_path value isn't a valid pathname or abstract address, and it's not unnamed
+        // because of the length (len_struct > 2)
+        assert!(!addr.is_unnamed());
+        assert!(addr.as_abstract().is_none());
+        assert!(addr.as_path().is_none());
+    }
+
+    /// Convert from an unnamed `SockaddrUnix` to a `SockaddrStorage` to a `sockaddr_un`.
+    #[test]
+    fn unix_addr_from_unnamed_to_libc() {
+        let addr = SockaddrUnix::new_unnamed();
+        let addr = SockaddrStorage::from_unix(&addr.as_ref());
+
+        let (ptr, len) = addr.as_ptr();
+        let ptr = ptr as *const libc::sockaddr_un;
+        assert_eq!(len, 2);
+
+        let addr = unsafe { ptr.as_ref() }.unwrap();
+
+        assert_eq!(addr.sun_family, libc::AF_UNIX as u16);
+    }
+}


### PR DESCRIPTION
This contains custom `SockaddrStorage` and `SockaddrUnix` types to replace the deprecated nix `SockAddr` types. The nix library does have its own [`SockaddrStorage`](https://docs.rs/nix/latest/nix/sys/socket/union.SockaddrStorage.html) type, and our `SockaddrStorage` is heavily influenced by it, but the nix `SockaddrStorage` and `UnixAddr` types have some issues and limitations which prevent us from using them in Shadow. There has been some progress on improving these (mainly unix socket address support on Linux), but for now it's probably best to use our own types that we can customize however we want, and re-evaluate nix again in the future. Rather than implementing our own types for inet/inet6 addresses, we just use nix's [`SockaddrIn`](https://docs.rs/nix/latest/nix/sys/socket/struct.SockaddrIn.html) and [`SockaddrIn6`](https://docs.rs/nix/latest/nix/sys/socket/struct.SockaddrIn6.html) types, which are implemented as transparent wrappers around `libc::sockaddr_in` and `libc::sockaddr_in6`.

Closes: #2093