### PR TITLE
Fix `Counter::sorted_for_display` warning on nightly

### DIFF
--- a/src/main/utility/counter.rs
+++ b/src/main/utility/counter.rs
@@ -126,8 +126,10 @@ impl Counter {
     /// (currently sorted by value with the largest value first).
     fn sorted_for_display<'a>(
         &'a self,
-    ) -> impl IntoIterator<IntoIter = impl Iterator<Item = (&'a String, &'a i64)> + ExactSizeIterator + 'a>
-    {
+    ) -> impl IntoIterator<
+        IntoIter = impl Iterator<Item = (&'a String, &'a i64)> + ExactSizeIterator + 'a,
+        Item = (&'a String, &'a i64),
+    > {
         // Get the items in a vector so we can sort them.
         let mut item_vec = Vec::from_iter(&self.items);
 


### PR DESCRIPTION
Apparently inferred bounds like this are frowned upon.