### PR TITLE
Remove "Tor Tests" ci badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # The Shadow Simulator
 
-[![Shadow Tests](https://github.com/shadow/shadow/actions/workflows/run_tests.yml/badge.svg?branch=main&event=push)](https://github.com/shadow/shadow/actions/workflows/run_tests.yml?query=branch:main+event:push)
-[![Tor Tests](https://github.com/shadow/shadow/actions/workflows/run_tor.yml/badge.svg?branch=main&event=push)](https://github.com/shadow/shadow/actions/workflows/run_tor.yml?query=branch:main+event:push)
+[![Shadow Tests](https://github.com/shadow/shadow/actions/workflows/run_tests_incremental.yml/badge.svg?branch=main&event=push)](https://github.com/shadow/shadow/actions/workflows/run_tests_incremental.yml?query=branch:main+event:push)
 
 ## Quickstart
 


### PR DESCRIPTION
We don't have a "Tor Tests" workflow anymore. We could add one for "Extra Tests", but I think it's better just to remove it. Also fixed the "Shadow Tests" badge.