### PR TITLE
Fix epoll memory leak

### DIFF
--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -943,6 +943,15 @@ mod export {
         unsafe { Box::from_raw(file as *mut File) };
     }
 
+    /// Increment the ref count of the `File` object. The returned pointer will not be the same as
+    /// the given pointer (they are distinct references), and they both must be dropped with
+    /// `file_drop` separately later.
+    #[no_mangle]
+    pub extern "C" fn file_cloneRef(file: *const File) -> *const File {
+        let file = unsafe { file.as_ref() }.unwrap();
+        Box::into_raw(Box::new(file.clone()))
+    }
+
     /// Get the state of the `File` object.
     #[no_mangle]
     pub extern "C" fn file_getStatus(file: *const File) -> c::Status {


### PR DESCRIPTION
This would only leak rust file objects, so probably wouldn't have affected many applications. It would leak memory each time `epoll_ctl` was called with a fd pointing to a rust file object (except in the case of `EPOLL_CTL_ADD`).