### PR TITLE
Make clippy happy

### DIFF
--- a/src/lib/gml-parser/src/parser.rs
+++ b/src/lib/gml-parser/src/parser.rs
@@ -38,7 +38,7 @@ fn take_verify<'a, E: GmlParseError<'a>>(
     count: u32,
     cond: impl Fn(char) -> bool,
 ) -> impl Fn(&'a str) -> IResult<&'a str, &'a str, E> {
-    move |i| verify(take(count), |s: &str| s.chars().all(|c| cond(c)))(i)
+    move |i| verify(take(count), |s: &str| s.chars().all(&cond))(i)
 }
 
 /// Parse a GML key.
@@ -277,7 +277,7 @@ fn result_str_to_nom<'a, T, E: GmlParseError<'a>>(
     result: Result<T, &'a str>,
     error_kind: ErrorKind,
 ) -> Result<T, nom::Err<E>> {
-    Ok(result.map_err(|e| nom::Err::Failure(E::from_external_error(input, error_kind, e)))?)
+    result.map_err(|e| nom::Err::Failure(E::from_external_error(input, error_kind, e)))
 }
 
 fn partition<I, B, F, const N: usize>(iter: I, f: F) -> [B; N]

--- a/src/lib/logger/build.rs
+++ b/src/lib/logger/build.rs
@@ -21,7 +21,7 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
 }
 
 fn main() {
-    let build_common = ShadowBuildCommon::new(&Path::new("../../.."), None);
+    let build_common = ShadowBuildCommon::new(Path::new("../../.."), None);
 
     run_bindgen(&build_common);
 

--- a/src/lib/shadow-build-common/src/lib.rs
+++ b/src/lib/shadow-build-common/src/lib.rs
@@ -69,7 +69,7 @@ impl ShadowBuildCommon {
             b.includes(deps.all_include_paths());
         }
 
-        if let Some("true") = std::env::var("DEBUG").ok().as_ref().map(|s| s.as_str()) {
+        if let Some("true") = std::env::var("DEBUG").ok().as_deref() {
             b.flag("-DDEBUG")
                 // we only check for unused functions when builing in debug mode since some
                 // functions are only called when logging, which can be #ifdef'd out in

--- a/src/lib/shadow-shim-helper-rs/build.rs
+++ b/src/lib/shadow-shim-helper-rs/build.rs
@@ -35,7 +35,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
     }
 
     cbindgen::Builder::new()
-        .with_crate(crate_dir.clone())
+        .with_crate(crate_dir)
         .with_config(config)
         .generate()
         .expect("Unable to generate bindings")
@@ -44,7 +44,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
 
 fn main() {
     let deps = system_deps::Config::new().probe().unwrap();
-    let build_common = ShadowBuildCommon::new(&Path::new("../../.."), Some(deps));
+    let build_common = ShadowBuildCommon::new(Path::new("../../.."), Some(deps));
 
     run_cbindgen(&build_common);
 

--- a/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
@@ -31,7 +31,6 @@ pub const EMUTIME_MIN: CEmulatedTime = 0u64;
 // cbindgen won't do the constant propagation here. We use the static assertion below
 // to ensure this definition is equal to the intended canonical definition.
 pub const EMUTIME_SIMULATION_START: CEmulatedTime = 946684800u64 * 1_000_000_000u64;
-#[allow(clippy::assertions_on_constants)]
 const _: () =
     assert!(EMUTIME_SIMULATION_START == SIMULATION_START_SEC * simulation_time::SIMTIME_ONE_SECOND);
 

--- a/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
@@ -48,9 +48,7 @@ impl EmulatedTime {
 
     /// Get the instance corresponding to `val` SimulationTime units since the Unix Epoch.
     pub const fn from_c_emutime(val: CEmulatedTime) -> Option<Self> {
-        if val == EMUTIME_INVALID {
-            None
-        } else if val > EMUTIME_MAX {
+        if val == EMUTIME_INVALID || val > EMUTIME_MAX {
             None
         } else {
             Some(Self(val))

--- a/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
@@ -31,6 +31,7 @@ pub const EMUTIME_MIN: CEmulatedTime = 0u64;
 // cbindgen won't do the constant propagation here. We use the static assertion below
 // to ensure this definition is equal to the intended canonical definition.
 pub const EMUTIME_SIMULATION_START: CEmulatedTime = 946684800u64 * 1_000_000_000u64;
+#[allow(clippy::assertions_on_constants)]
 const _: () =
     assert!(EMUTIME_SIMULATION_START == SIMULATION_START_SEC * simulation_time::SIMTIME_ONE_SECOND);
 
@@ -70,7 +71,7 @@ impl EmulatedTime {
 
     /// Convert to the SimulationTime since the simulation began.
     pub fn to_abs_simtime(self) -> SimulationTime {
-        SimulationTime::from(self.duration_since(&Self::SIMULATION_START))
+        self.duration_since(&Self::SIMULATION_START)
     }
 
     /// Returns the duration since `earlier`, or panics if `earlier` is after `self`, or

--- a/src/lib/shadow-shim-helper-rs/src/lib.rs
+++ b/src/lib/shadow-shim-helper-rs/src/lib.rs
@@ -1,5 +1,7 @@
 // https://github.com/rust-lang/rfcs/blob/master/text/2585-unsafe-block-in-unsafe-fn.md
 #![deny(unsafe_op_in_unsafe_fn)]
+// we do some static assersions to make sure C bindings are okay.
+#![allow(clippy::assertions_on_constants)]
 
 use vasi::VirtualAddressSpaceIndependent;
 

--- a/src/lib/shadow-shim-helper-rs/src/lib.rs
+++ b/src/lib/shadow-shim-helper-rs/src/lib.rs
@@ -1,6 +1,6 @@
 // https://github.com/rust-lang/rfcs/blob/master/text/2585-unsafe-block-in-unsafe-fn.md
 #![deny(unsafe_op_in_unsafe_fn)]
-// we do some static assersions to make sure C bindings are okay.
+// we do some static assertions to make sure C bindings are okay.
 #![allow(clippy::assertions_on_constants)]
 
 use vasi::VirtualAddressSpaceIndependent;

--- a/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
@@ -373,6 +373,12 @@ impl SiginfoWrapper {
     }
 }
 
+impl Default for SiginfoWrapper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<libc::siginfo_t> for SiginfoWrapper {
     fn from(s: libc::siginfo_t) -> Self {
         Self(s)
@@ -579,7 +585,7 @@ pub mod export {
         let lock = unsafe { lock.as_ref().unwrap() };
         let mut protected = process_mem.protected.borrow_mut(&lock.root);
         let info = unsafe { info.as_ref().unwrap() };
-        protected.set_pending_standard_siginfo(signal_from_i32(sig), &info);
+        protected.set_pending_standard_siginfo(signal_from_i32(sig), info);
     }
 
     #[no_mangle]
@@ -618,7 +624,7 @@ pub mod export {
         lock: *const ShimShmemHostLock,
     ) {
         let lock = unsafe { lock.as_ref().unwrap() };
-        let t = ThreadShmem::new(&lock);
+        let t = ThreadShmem::new(lock);
         assert_shmem_safe!(ThreadShmem, _test_thread_shmem);
         unsafe { thread_mem.write(t) }
     }
@@ -751,7 +757,7 @@ pub mod export {
             } else {
                 let process = unsafe { process.as_ref().unwrap() };
                 let mut process_protected = process.protected.borrow_mut(&lock.root);
-                process_protected.take_pending_unblocked_signal(&*thread_protected)
+                process_protected.take_pending_unblocked_signal(&thread_protected)
             }
         };
 

--- a/src/lib/shadow-shim-helper-rs/src/signals.rs
+++ b/src/lib/shadow-shim-helper-rs/src/signals.rs
@@ -19,7 +19,7 @@ pub const SS_AUTODISARM: i32 = 1 << 31;
 ///
 /// This is analagous to, but typically smaller than, libc's sigset_t.
 #[repr(C)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug, VirtualAddressSpaceIndependent)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, VirtualAddressSpaceIndependent)]
 pub struct shd_kernel_sigset_t {
     val: u64,
 }
@@ -55,12 +55,6 @@ impl shd_kernel_sigset_t {
 
     pub fn add(&mut self, sig: Signal) {
         *self |= shd_kernel_sigset_t::from(sig);
-    }
-}
-
-impl Default for shd_kernel_sigset_t {
-    fn default() -> Self {
-        Self { val: 0 }
     }
 }
 

--- a/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
@@ -321,6 +321,7 @@ pub const SIMTIME_INVALID: CSimulationTime = u64::MAX;
 // cbindgen refuses to do the arithmetic here, so we we pre-compute,
 // and validate in the static assertion below.
 pub const SIMTIME_MAX: CSimulationTime = 17500059273709551614u64;
+#[allow(clippy::assertions_on_constants)]
 const _: () =
     assert!(SIMTIME_MAX == emulated_time::EMUTIME_MAX - emulated_time::EMUTIME_SIMULATION_START);
 

--- a/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
@@ -321,7 +321,6 @@ pub const SIMTIME_INVALID: CSimulationTime = u64::MAX;
 // cbindgen refuses to do the arithmetic here, so we we pre-compute,
 // and validate in the static assertion below.
 pub const SIMTIME_MAX: CSimulationTime = 17500059273709551614u64;
-#[allow(clippy::assertions_on_constants)]
 const _: () =
     assert!(SIMTIME_MAX == emulated_time::EMUTIME_MAX - emulated_time::EMUTIME_SIMULATION_START);
 

--- a/src/lib/shmem/build.rs
+++ b/src/lib/shmem/build.rs
@@ -31,7 +31,7 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
 }
 
 fn main() {
-    let build_common = ShadowBuildCommon::new(&Path::new("../../.."), None);
+    let build_common = ShadowBuildCommon::new(Path::new("../../.."), None);
 
     run_bindgen(&build_common);
 

--- a/src/lib/shmem/src/allocator.rs
+++ b/src/lib/shmem/src/allocator.rs
@@ -202,7 +202,6 @@ impl ShMemBlockSerialized {
 
 impl fmt::Display for ShMemBlockSerialized {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-
         let mut buf = Vec::new();
         buf.resize(Self::SHD_SHMEM_BLOCK_SERIALIZED_MAX_STRLEN, 0i8);
         unsafe { c_bindings::shmemblockserialized_toString(&self.internal, buf.as_mut_ptr()) };
@@ -242,8 +241,7 @@ impl Allocator {
         T: Sync + VirtualAddressSpaceIndependent,
     {
         let nbytes = std::mem::size_of_val(&val);
-        let raw_block =
-            unsafe { c_bindings::shmemallocator_alloc(self.internal, nbytes) };
+        let raw_block = unsafe { c_bindings::shmemallocator_alloc(self.internal, nbytes) };
         assert_eq!(raw_block.nbytes as usize, nbytes);
         assert!(!raw_block.p.is_null());
         assert_eq!(raw_block.p.align_offset(std::mem::align_of::<T>()), 0);

--- a/src/lib/shmem/src/scmutex.rs
+++ b/src/lib/shmem/src/scmutex.rs
@@ -121,6 +121,7 @@ mod sync {
     pub struct MutPtr<T: ?Sized>(*mut T);
     #[cfg(not(loom))]
     impl<T: ?Sized> MutPtr<T> {
+        /// SAFETY: See [`loom::cell::MutPtr::deref`].
         #[allow(clippy::mut_from_ref)]
         pub unsafe fn deref(&self) -> &mut T {
             unsafe { &mut *self.0 }

--- a/src/lib/shmem/src/scmutex.rs
+++ b/src/lib/shmem/src/scmutex.rs
@@ -45,8 +45,7 @@ mod sync {
                 u32::from(val),
                 std::ptr::null() as *const libc::timespec,
                 std::ptr::null_mut() as *mut u32,
-                32, //TODO was 032: is it supposed to be octal? man futex suggest val3 is unused
-                    //for FUTEX_WAIT, so this should probably be set to zero?
+                0u32,
             )
         })
     }
@@ -101,8 +100,7 @@ mod sync {
                 1,
                 std::ptr::null() as *const libc::timespec,
                 std::ptr::null_mut() as *mut u32,
-                32, //TODO was 032: is it supposed to be octal? man futex suggest val3 is unused
-                    //for FUTEX_WAKE, so this should probably be set to zero?
+                0u32,
             )
         })?;
         Ok(())

--- a/src/lib/shmem/src/scmutex.rs
+++ b/src/lib/shmem/src/scmutex.rs
@@ -119,6 +119,7 @@ mod sync {
     pub struct MutPtr<T: ?Sized>(*mut T);
     #[cfg(not(loom))]
     impl<T: ?Sized> MutPtr<T> {
+        #[allow(clippy::mut_from_ref)]
         pub unsafe fn deref(&self) -> &mut T {
             unsafe { &mut *self.0 }
         }

--- a/src/lib/syscall-logger/src/lib.rs
+++ b/src/lib/syscall-logger/src/lib.rs
@@ -43,7 +43,7 @@ use quote::ToTokens;
 /// ```
 #[proc_macro_attribute]
 pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
-    let mut item: syn::Item = syn::parse(input.clone()).unwrap();
+    let mut item: syn::Item = syn::parse(input).unwrap();
     let mut fn_item = match &mut item {
         syn::Item::Fn(fn_item) => fn_item,
         _ => panic!("expected fn"),

--- a/src/lib/tsc/build.rs
+++ b/src/lib/tsc/build.rs
@@ -13,7 +13,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
     };
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     cbindgen::Builder::new()
-        .with_crate(crate_dir.clone())
+        .with_crate(crate_dir)
         .with_config(config)
         .generate()
         .expect("Unable to generate bindings")
@@ -34,7 +34,7 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
 }
 
 fn main() {
-    let build_common = ShadowBuildCommon::new(&Path::new("../../.."), None);
+    let build_common = ShadowBuildCommon::new(Path::new("../../.."), None);
 
     // The C bindings should be generated first since cbindgen doesn't require
     // the Rust code to be valid, whereas bindgen does require the C code to be

--- a/src/lib/tsc/src/lib.rs
+++ b/src/lib/tsc/src/lib.rs
@@ -108,7 +108,7 @@ impl Tsc {
         // dereference `ip.offset(1)`, which would be unsound.
         insn.iter()
             .enumerate()
-            .all(|(offset, byte)| unsafe { *ip.offset(offset as isize) == *byte })
+            .all(|(offset, byte)| unsafe { *ip.add(offset) == *byte })
     }
 
     /// Whether `ip` points to an rdtsc instruction.

--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -74,7 +74,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
         .write_to_file("../../build/src/main/bindings/c/bindings.h");
 
     cbindgen::Builder::new()
-        .with_crate(crate_dir.clone())
+        .with_crate(crate_dir)
         .with_config(cbindgen::Config {
             include_guard: Some("main_opaque_bindings_h".into()),
             no_includes: true,
@@ -83,7 +83,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
                 item_types: vec![cbindgen::ItemType::OpaqueItems, cbindgen::ItemType::Enums],
                 ..base_config.export.clone()
             },
-            ..base_config.clone()
+            ..base_config
         })
         .generate()
         .expect("Unable to generate bindings")
@@ -324,7 +324,7 @@ fn build_shadow_c(build_common: &ShadowBuildCommon) {
 fn main() {
     let deps = system_deps::Config::new().probe().unwrap();
     let build_common =
-        shadow_build_common::ShadowBuildCommon::new(&std::path::Path::new("../.."), Some(deps));
+        shadow_build_common::ShadowBuildCommon::new(std::path::Path::new("../.."), Some(deps));
 
     // The C bindings should be generated first since cbindgen doesn't require
     // the Rust code to be valid, whereas bindgen does require the C code to be

--- a/src/main/core/controller.rs
+++ b/src/main/core/controller.rs
@@ -107,7 +107,7 @@ impl SimController for Controller<'_> {
         let new_end = std::cmp::min(new_end, self.end_time);
 
         let continue_running = new_start < new_end;
-        continue_running.then(|| (new_start, new_end))
+        continue_running.then_some((new_start, new_end))
     }
 }
 
@@ -125,8 +125,8 @@ impl std::fmt::Display for ShadowStatusBarState {
         let sim_end = self.end.duration_since(&EmulatedTime::SIMULATION_START);
         let frac = sim_current.as_millis() as f32 / sim_end.as_millis() as f32;
 
-        let sim_current = TimeParts::from_nanos(sim_current.as_nanos().into());
-        let sim_end = TimeParts::from_nanos(sim_end.as_nanos().into());
+        let sim_current = TimeParts::from_nanos(sim_current.as_nanos());
+        let sim_end = TimeParts::from_nanos(sim_end.as_nanos());
         let realtime = TimeParts::from_nanos(self.start.elapsed().as_nanos());
 
         write!(

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -127,10 +127,11 @@ pub fn run_shadow(build_info: &ShadowBuildInfo, args: Vec<&OsStr>) -> anyhow::Re
     }
 
     // save the platform data required for CPU pinning
-    if shadow_config.experimental.use_cpu_pinning.unwrap()
-        && unsafe { c::affinity_initPlatformInfo() } != 0
-    {
-        return Err(anyhow::anyhow!("Unable to initialize platform info"));
+    if shadow_config.experimental.use_cpu_pinning.unwrap() {
+        #[allow(clippy::collapsible_if)]
+        if unsafe { c::affinity_initPlatformInfo() } != 0 {
+            return Err(anyhow::anyhow!("Unable to initialize platform info"));
+        }
     }
 
     // raise fd soft limit to hard limit

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -127,7 +127,9 @@ pub fn run_shadow(build_info: &ShadowBuildInfo, args: Vec<&OsStr>) -> anyhow::Re
     }
 
     // save the platform data required for CPU pinning
-    if shadow_config.experimental.use_cpu_pinning.unwrap() && unsafe { c::affinity_initPlatformInfo() } != 0 {
+    if shadow_config.experimental.use_cpu_pinning.unwrap()
+        && unsafe { c::affinity_initPlatformInfo() } != 0
+    {
         return Err(anyhow::anyhow!("Unable to initialize platform info"));
     }
 

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -17,12 +17,12 @@ use crate::cshadow as c;
 use crate::utility::shm_cleanup;
 
 /// Main entry point for the simulator.
-pub fn run_shadow<'a>(build_info: &ShadowBuildInfo, args: Vec<&'a OsStr>) -> anyhow::Result<()> {
+pub fn run_shadow(build_info: &ShadowBuildInfo, args: Vec<&OsStr>) -> anyhow::Result<()> {
     if unsafe { c::main_checkGlibVersion() } != 0 {
         return Err(anyhow::anyhow!("Unsupported GLib version"));
     }
 
-    let mut signals_list = Signals::new(&[consts::signal::SIGINT, consts::signal::SIGTERM])?;
+    let mut signals_list = Signals::new([consts::signal::SIGINT, consts::signal::SIGTERM])?;
     thread::spawn(move || {
         for signal in signals_list.forever() {
             log::info!("Received signal {}. Flushing log and exiting", signal);
@@ -127,10 +127,8 @@ pub fn run_shadow<'a>(build_info: &ShadowBuildInfo, args: Vec<&'a OsStr>) -> any
     }
 
     // save the platform data required for CPU pinning
-    if shadow_config.experimental.use_cpu_pinning.unwrap() {
-        if unsafe { c::affinity_initPlatformInfo() } != 0 {
-            return Err(anyhow::anyhow!("Unable to initialize platform info"));
-        }
+    if shadow_config.experimental.use_cpu_pinning.unwrap() && unsafe { c::affinity_initPlatformInfo() } != 0 {
+        return Err(anyhow::anyhow!("Unable to initialize platform info"));
     }
 
     // raise fd soft limit to hard limit
@@ -233,7 +231,7 @@ fn load_config_file(
         }
     }
 
-    Ok(serde_yaml::from_value(config_file).context("Could not parse configuration file")?)
+    serde_yaml::from_value(config_file).context("Could not parse configuration file")
 }
 
 fn pause_for_gdb_attach() -> anyhow::Result<()> {
@@ -279,7 +277,7 @@ fn disable_aslr() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn log_environment<'a>(args: Vec<&'a OsStr>) {
+fn log_environment(args: Vec<&OsStr>) {
     for arg in args {
         log::info!("arg: {}", arg.to_string_lossy());
     }

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -408,7 +408,7 @@ impl<'a> Manager<'a> {
                                 };
                                 *next_event_time = [*next_event_time, host_next_event_time]
                                     .into_iter()
-                                    .flatten()
+                                    .flatten() // filter out None
                                     .reduce(std::cmp::min);
                             });
 
@@ -416,7 +416,7 @@ impl<'a> Manager<'a> {
 
                             *next_event_time = [*next_event_time, packet_next_event_time]
                                 .into_iter()
-                                .flatten()
+                                .flatten() // filter out None
                                 .reduce(std::cmp::min);
                         },
                     );

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -134,8 +134,7 @@ impl<'a> Manager<'a> {
             .template_directory
             .flatten_ref()
             .map(|x| cwd.clone().join(x));
-        let data_path = cwd
-            .join(config.general.data_directory.as_ref().unwrap());
+        let data_path = cwd.join(config.general.data_directory.as_ref().unwrap());
         let hosts_path = data_path.join("hosts");
 
         if let Some(template_path) = template_path {
@@ -701,7 +700,8 @@ impl<'a> Manager<'a> {
 
             // if it's not LD_PRELOAD, insert if there's no existing entry
             if name != "LD_PRELOAD" {
-                env.entry(name.into()).or_insert_with(|| value.map(|x| x.into()));
+                env.entry(name.into())
+                    .or_insert_with(|| value.map(|x| x.into()));
                 continue;
             }
 
@@ -838,9 +838,11 @@ impl<'a> Manager<'a> {
 
         let avl_pages = nix::unistd::sysconf(nix::unistd::SysconfVar::_AVPHYS_PAGES)
             .context("Failed to get the number of available pages of physical memory")?
-            .ok_or_else(|| anyhow::anyhow!(
-                "Failed to get the number of available pages of physical memory (no errno)"
-            ))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Failed to get the number of available pages of physical memory (no errno)"
+                )
+            })?;
 
         let page_size: u64 = page_size.try_into().unwrap();
         let avl_pages: u64 = avl_pages.try_into().unwrap();

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -135,9 +135,8 @@ impl<'a> Manager<'a> {
             .flatten_ref()
             .map(|x| cwd.clone().join(x));
         let data_path = cwd
-            .clone()
             .join(config.general.data_directory.as_ref().unwrap());
-        let hosts_path = data_path.clone().join("hosts");
+        let hosts_path = data_path.join("hosts");
 
         if let Some(template_path) = template_path {
             log::debug!(
@@ -179,7 +178,7 @@ impl<'a> Manager<'a> {
         }
 
         // save the processed config as yaml
-        let config_out_filename = data_path.clone().join("processed-config.yaml");
+        let config_out_filename = data_path.join("processed-config.yaml");
         let config_out_file = std::fs::File::create(&config_out_filename).with_context(|| {
             format!("Failed to create file '{}'", config_out_filename.display())
         })?;
@@ -267,7 +266,7 @@ impl<'a> Manager<'a> {
         // the configuration file's yaml format generally prevents duplicate hostnames, but using
         // the `quantity` field can lead to hosts with the same name
         let duplicate_hostnames = find_duplicates(hosts.iter().map(|x| x.name()));
-        if duplicate_hostnames.len() > 0 {
+        if !duplicate_hostnames.is_empty() {
             return Err(anyhow::anyhow!(
                 "Duplicate hostnames: {:?}",
                 duplicate_hostnames
@@ -307,7 +306,7 @@ impl<'a> Manager<'a> {
                 dns: unsafe { SyncSendPointer::new(dns) },
                 num_plugin_errors: AtomicU32::new(0),
                 // allow the status logger's state to be updated from anywhere
-                status_logger_state: status_logger_state.map(|x| Arc::clone(x)),
+                status_logger_state: status_logger_state.map(Arc::clone),
                 runahead: Runahead::new(
                     self.config.experimental.use_dynamic_runahead.unwrap(),
                     smallest_latency,
@@ -410,7 +409,7 @@ impl<'a> Manager<'a> {
                                 };
                                 *next_event_time = [*next_event_time, host_next_event_time]
                                     .into_iter()
-                                    .filter_map(std::convert::identity)
+                                    .flatten()
                                     .reduce(std::cmp::min);
                             });
 
@@ -418,7 +417,7 @@ impl<'a> Manager<'a> {
 
                             *next_event_time = [*next_event_time, packet_next_event_time]
                                 .into_iter()
-                                .filter_map(std::convert::identity)
+                                .flatten()
                                 .reduce(std::cmp::min);
                         },
                     );
@@ -618,7 +617,7 @@ impl<'a> Manager<'a> {
 
             let shim_log_level = host_info
                 .log_level
-                .unwrap_or(self.config.general.log_level.unwrap());
+                .unwrap_or_else(|| self.config.general.log_level.unwrap());
 
             let envv = self.generate_env_vars(&proc.env, shim_log_level);
             let envv: Vec<CString> = envv
@@ -694,15 +693,15 @@ impl<'a> Manager<'a> {
         }
 
         // scan the other env variables that were given in the shadow config file
-        for entry in user_env.split(";") {
+        for entry in user_env.split(';') {
             let (name, value) = entry
-                .split_once("=")
+                .split_once('=')
                 .map(|(name, value)| (name, Some(value)))
                 .unwrap_or((entry, None));
 
             // if it's not LD_PRELOAD, insert if there's no existing entry
             if name != "LD_PRELOAD" {
-                env.entry(name.into()).or_insert(value.map(|x| x.into()));
+                env.entry(name.into()).or_insert_with(|| value.map(|x| x.into()));
                 continue;
             }
 
@@ -724,7 +723,7 @@ impl<'a> Manager<'a> {
             let mut preload_string = OsString::new();
             for (x, path) in preload.iter().enumerate() {
                 if x > 0 {
-                    preload_string.push(&":");
+                    preload_string.push(":");
                 }
                 preload_string.push(path);
             }
@@ -828,18 +827,18 @@ impl<'a> Manager<'a> {
             nix::sys::resource::getrlimit(nix::sys::resource::Resource::RLIMIT_NOFILE)
                 .context("Failed to get the fd limit")?;
 
-        Ok((fd_count, u64::try_from(soft_limit).unwrap()))
+        Ok((fd_count, soft_limit))
     }
 
     /// Returns the number of bytes remaining.
     fn memory_remaining(&mut self) -> anyhow::Result<u64> {
         let page_size = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
             .context("Failed to get the page size")?
-            .ok_or(anyhow::anyhow!("Failed to get the page size (no errno)"))?;
+            .ok_or_else(|| anyhow::anyhow!("Failed to get the page size (no errno)"))?;
 
         let avl_pages = nix::unistd::sysconf(nix::unistd::SysconfVar::_AVPHYS_PAGES)
             .context("Failed to get the number of available pages of physical memory")?
-            .ok_or(anyhow::anyhow!(
+            .ok_or_else(|| anyhow::anyhow!(
                 "Failed to get the number of available pages of physical memory (no errno)"
             ))?;
 

--- a/src/main/core/scheduler/pools/bounded.rs
+++ b/src/main/core/scheduler/pools/bounded.rs
@@ -344,8 +344,8 @@ fn work_loop(
         fn drop(&mut self) {
             start_next_thread(
                 self.current_processor_idx,
-                &self.shared_state,
-                &self.logical_processors,
+                self.shared_state,
+                self.logical_processors,
             );
         }
     }

--- a/src/main/core/sim_config.rs
+++ b/src/main/core/sim_config.rs
@@ -346,9 +346,8 @@ fn build_process(proc: &ProcessOptions) -> anyhow::Result<Vec<ProcessInfo>> {
         .and_then(|p| p.canonicalize().map_err(anyhow::Error::from));
     // We previously used only `std::fs::canonicalize`, which doesn't search
     // `PATH`, and *does* search the current directory.
-    let legacy_canonical_path: Result<PathBuf, anyhow::Error> = expanded_path
-        .canonicalize()
-        .map_err(anyhow::Error::from);
+    let legacy_canonical_path: Result<PathBuf, anyhow::Error> =
+        expanded_path.canonicalize().map_err(anyhow::Error::from);
 
     let canonical_path = if new_canonical_path.is_ok()
         && legacy_canonical_path.is_ok()

--- a/src/main/core/sim_config.rs
+++ b/src/main/core/sim_config.rs
@@ -348,7 +348,7 @@ fn build_process(proc: &ProcessOptions) -> anyhow::Result<Vec<ProcessInfo>> {
     // `PATH`, and *does* search the current directory.
     let legacy_canonical_path: Result<PathBuf, anyhow::Error> = expanded_path
         .canonicalize()
-        .map_err(|e| anyhow::Error::from(e));
+        .map_err(anyhow::Error::from);
 
     let canonical_path = if new_canonical_path.is_ok()
         && legacy_canonical_path.is_ok()
@@ -371,7 +371,7 @@ fn build_process(proc: &ProcessOptions) -> anyhow::Result<Vec<ProcessInfo>> {
             .unwrap_err());
     };
 
-    verify_plugin_path(&canonical_path)
+    verify_plugin_path(canonical_path)
         .with_context(|| format!("Failed to verify plugin path '{:?}'", canonical_path))?;
     log::info!(
         "Resolved binary path {:?} to {:?}",
@@ -387,7 +387,7 @@ fn build_process(proc: &ProcessOptions) -> anyhow::Result<Vec<ProcessInfo>> {
             plugin: canonical_path.clone(),
             start_time,
             stop_time,
-            args: args,
+            args,
             env: proc.environment.clone(),
         };
         (*proc.quantity).try_into().unwrap()
@@ -396,7 +396,7 @@ fn build_process(proc: &ProcessOptions) -> anyhow::Result<Vec<ProcessInfo>> {
 
 /// Generate an IP assignment map using hosts' configured IP addresses and graph node IDs. For hosts
 /// without IP addresses, they will be assigned an arbitrary IP address.
-fn assign_ips(hosts: &mut Vec<HostInfo>) -> anyhow::Result<IpAssignment<u32>> {
+fn assign_ips(hosts: &mut [HostInfo]) -> anyhow::Result<IpAssignment<u32>> {
     let mut ip_assignment = IpAssignment::new();
 
     // first register hosts that have a specific IP address
@@ -463,7 +463,7 @@ fn generate_routing_info(
 /// Check that the plugin path is valid.
 fn verify_plugin_path(path: impl AsRef<std::path::Path>) -> anyhow::Result<()> {
     let path = path.as_ref();
-    let metadata = std::fs::metadata(&path)?;
+    let metadata = std::fs::metadata(path)?;
 
     if !metadata.is_file() {
         return Err(anyhow::anyhow!("The path is not a file"));

--- a/src/main/core/sim_stats.rs
+++ b/src/main/core/sim_stats.rs
@@ -24,6 +24,12 @@ impl LocalSimStats {
     }
 }
 
+impl Default for LocalSimStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Simulation statistics to be accessed by multiple threads.
 #[derive(Debug)]
 pub struct SharedSimStats {
@@ -58,6 +64,12 @@ impl SharedSimStats {
         *local_alloc_counts = Counter::new();
         *local_dealloc_counts = Counter::new();
         *local_syscall_counts = Counter::new();
+    }
+}
+
+impl Default for SharedSimStats {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -101,7 +113,7 @@ pub fn write_stats_to_file(
 ) -> anyhow::Result<()> {
     let stats = SimStatsForOutput::new(stats);
 
-    let file = std::fs::File::create(&filename)
+    let file = std::fs::File::create(filename)
         .with_context(|| format!("Failed to create file '{}'", filename.display()))?;
 
     serde_json::to_writer_pretty(file, &stats).with_context(|| {

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -992,11 +992,11 @@ pub trait Flatten<T> {
 
 impl<T> Flatten<T> for Option<NullableOption<T>> {
     fn flatten(self) -> Option<T> {
-        self.map(|x| x.to_option()).flatten()
+        self.and_then(|x| x.to_option())
     }
 
     fn flatten_ref(&self) -> Option<&T> {
-        self.as_ref().map(|x| x.as_ref().to_option()).flatten()
+        self.as_ref().and_then(|x| x.as_ref().to_option())
     }
 }
 
@@ -1064,7 +1064,7 @@ fn generate_help_strs(
     let mut defaults = std::collections::HashMap::<String, String>::new();
     for (name, obj) in &schema.schema.object.as_ref().unwrap().properties {
         if let Some(meta) = obj.clone().into_object().metadata {
-            let description = meta.description.or(Some("".to_string())).unwrap();
+            let description = meta.description.unwrap_or_default();
             let space = if !description.is_empty() { " " } else { "" };
             match meta.default {
                 Some(default) => defaults.insert(

--- a/src/main/core/support/units.rs
+++ b/src/main/core/support/units.rs
@@ -48,7 +48,7 @@ pub trait Prefix: Clone + Copy + Default + PartialEq + FromStr + Display + Debug
 }
 
 /// Common SI prefixes (including base-2 prefixes since they're similar).
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SiPrefix {
     Nano,
     Micro,
@@ -138,7 +138,7 @@ impl Prefix for SiPrefix {
 
 /// Common SI prefixes larger than the base unit (including base-2 prefixes
 /// since they're similar).
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SiPrefixUpper {
     Base,
     Kilo,
@@ -214,7 +214,7 @@ impl Prefix for SiPrefixUpper {
 /// Time units, which we pretend are prefixes for implementation simplicity. These
 /// contain both the prefix ("n", "u", "m") and the suffix ("sec", "min", "hr")
 /// and should be used with the [`Time`] unit.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TimePrefix {
     Nano,
     Micro,
@@ -282,7 +282,7 @@ impl Prefix for TimePrefix {
 /// Time units larger than the base unit, which we pretend are prefixes for
 /// implementation simplicity. These really contain the unit suffix ("sec",
 /// "min", "hr") and should be used with the [`Time`] unit.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TimePrefixUpper {
     Sec,
     Min,
@@ -537,7 +537,7 @@ pub trait Unit: Sized {
 
 /// An amount of time. Should only use the time prefix types ([`TimePrefix`] and
 /// [`TimePrefixUpper`]) with this type.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Time<T: Prefix> {
     value: u64,
     prefix: T,
@@ -560,7 +560,7 @@ impl From<Time<TimePrefixUpper>> for std::time::Duration {
 }
 
 /// A number of bytes.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Bytes<T: Prefix> {
     pub value: u64,
     pub prefix: T,
@@ -569,7 +569,7 @@ pub struct Bytes<T: Prefix> {
 unit_impl!(Bytes, u64, ["B", "byte", "bytes"]);
 
 /// A throughput in bits-per-second.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BitsPerSec<T: Prefix> {
     pub value: u64,
     pub prefix: T,

--- a/src/main/core/work/event_queue.rs
+++ b/src/main/core/work/event_queue.rs
@@ -49,6 +49,12 @@ impl EventQueue {
     }
 }
 
+impl Default for EventQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A wrapper type that implements [`Ord`] for types that implement [`PartialOrd`]. If the two
 /// objects cannot be compared (`PartialOrd::partial_cmp` returns `None`), the comparison will
 /// panic.

--- a/src/main/core/work/task.rs
+++ b/src/main/core/work/task.rs
@@ -52,6 +52,7 @@ impl PartialEq for TaskRef {
     fn eq(&self, other: &Self) -> bool {
         self.magic.debug_check();
         other.magic.debug_check();
+        #[allow(clippy::vtable_address_comparisons)]
         Arc::ptr_eq(&self.inner, &other.inner)
     }
 }

--- a/src/main/host/context.rs
+++ b/src/main/host/context.rs
@@ -119,6 +119,6 @@ impl<'a> ThreadContextObjs<'a> {
     }
 
     pub fn borrow(&mut self) -> ThreadContext {
-        ThreadContext::new(&mut self.host, &mut self.process, &mut self.thread)
+        ThreadContext::new(self.host, &mut self.process, &mut self.thread)
     }
 }

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -133,11 +133,17 @@ impl DescriptorTable {
     }
 
     /// Remove and return all descriptors.
-    pub fn remove_all<'a>(&mut self) -> impl Iterator<Item = Descriptor> {
+    pub fn remove_all(&mut self) -> impl Iterator<Item = Descriptor> {
         // reset the descriptor table
         let old_self = std::mem::replace(self, Self::new());
         // return the old descriptors
         old_self.descriptors.into_values()
+    }
+}
+
+impl Default for DescriptorTable {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -657,7 +657,6 @@ impl Descriptor {
         Box::into_raw(descriptor)
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn from_raw(descriptor: *mut Self) -> Option<Box<Self>> {
         if descriptor.is_null() {
             return None;

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -650,6 +650,7 @@ impl Descriptor {
         Box::into_raw(descriptor)
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn from_raw(descriptor: *mut Self) -> Option<Box<Self>> {
         if descriptor.is_null() {
             return None;

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -78,6 +78,7 @@ impl FileMode {
 
     /// Returns a tuple of the `FileMode` and any remaining flags, or an empty `Err` if
     /// the flags aren't valid (for example specifying both `O_RDWR` and `O_WRONLY`).
+    #[allow(clippy::result_unit_err)]
     pub fn from_o_flags(flags: OFlag) -> Result<(Self, OFlag), ()> {
         // apply the access mode mask (the O_PATH flag is not contained within the access
         // mode mask, so we need to add it separately)
@@ -270,6 +271,12 @@ impl StateEventSource {
         cb_queue: &mut CallbackQueue,
     ) {
         self.inner.notify_listeners((state, changed), cb_queue)
+    }
+}
+
+impl Default for StateEventSource {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -505,7 +512,7 @@ impl OpenFile {
     }
 
     pub fn inner_file(&self) -> &File {
-        &self.inner.file.as_ref().unwrap()
+        self.inner.file.as_ref().unwrap()
     }
 
     /// Will close the inner `File` object if this is the last `OpenFile` for that `File`. This

--- a/src/main/host/descriptor/pipe.rs
+++ b/src/main/host/descriptor/pipe.rs
@@ -82,7 +82,7 @@ impl Pipe {
         }
 
         // drop the event listener handle so that we stop receiving new events
-        self.buffer_event_handle.take().map(|h| h.stop_listening());
+        if let Some(h) = self.buffer_event_handle.take() { h.stop_listening() }
 
         // if acting as a writer, inform the buffer that there is one fewer writers
         if let Some(writer_handle) = self.writer_handle.take() {

--- a/src/main/host/descriptor/pipe.rs
+++ b/src/main/host/descriptor/pipe.rs
@@ -82,7 +82,9 @@ impl Pipe {
         }
 
         // drop the event listener handle so that we stop receiving new events
-        if let Some(h) = self.buffer_event_handle.take() { h.stop_listening() }
+        if let Some(h) = self.buffer_event_handle.take() {
+            h.stop_listening()
+        }
 
         // if acting as a writer, inform the buffer that there is one fewer writers
         if let Some(writer_handle) = self.writer_handle.take() {

--- a/src/main/host/descriptor/socket/abstract_unix_ns.rs
+++ b/src/main/host/descriptor/socket/abstract_unix_ns.rs
@@ -86,7 +86,7 @@ impl AbstractUnixNamespace {
 
         // when the socket closes, remove this entry from the namespace
         let handle =
-            Self::on_socket_close(Arc::downgrade(&ns_arc), socket_event_source, move |ns| {
+            Self::on_socket_close(Arc::downgrade(ns_arc), socket_event_source, move |ns| {
                 assert!(ns.unbind(sock_type, &name_copy).is_ok());
             });
 
@@ -149,7 +149,7 @@ impl AbstractUnixNamespace {
 
         // when the socket closes, remove this entry from the namespace
         let handle =
-            Self::on_socket_close(Arc::downgrade(&ns_arc), socket_event_source, move |ns| {
+            Self::on_socket_close(Arc::downgrade(ns_arc), socket_event_source, move |ns| {
                 assert!(ns.unbind(sock_type, &name_copy).is_ok());
             });
 
@@ -203,6 +203,12 @@ impl AbstractUnixNamespace {
     }
 }
 
+impl Default for AbstractUnixNamespace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum BindError {
     /// The name is already in use.
@@ -237,8 +243,8 @@ fn random_name<const L: usize>(mut rng: impl rand::Rng) -> [u8; L] {
     let mut name = [0u8; L];
 
     // set each character of the name
-    for x in 0..L {
-        name[x] = *CHARSET.choose(&mut rng).unwrap();
+    for c in &mut name {
+        *c = *CHARSET.choose(&mut rng).unwrap();
     }
 
     name

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -337,7 +337,6 @@ impl ConnOrientedListening {
 /// The current protocol state of the unix socket. An `Option` is required for each variant so that
 /// the inner state object can be removed, transformed into a new state, and then re-added as a
 /// different variant.
-#[allow(clippy::enum_variant_names)]
 enum ProtocolState {
     ConnOrientedInitial(Option<ConnOrientedInitial>),
     ConnOrientedListening(Option<ConnOrientedListening>),

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -96,7 +96,7 @@ impl UnixSocket {
         Ok(Some(
             self.protocol_state
                 .bound_address()?
-                .unwrap_or_else(|| SockaddrUnix::new_unnamed()),
+                .unwrap_or_else(SockaddrUnix::new_unnamed),
         ))
     }
 
@@ -105,7 +105,7 @@ impl UnixSocket {
         Ok(Some(
             self.protocol_state
                 .peer_address()?
-                .unwrap_or_else(|| SockaddrUnix::new_unnamed()),
+                .unwrap_or_else(SockaddrUnix::new_unnamed),
         ))
     }
 
@@ -337,6 +337,7 @@ impl ConnOrientedListening {
 /// The current protocol state of the unix socket. An `Option` is required for each variant so that
 /// the inner state object can be removed, transformed into a new state, and then re-added as a
 /// different variant.
+#[allow(clippy::enum_variant_names)]
 enum ProtocolState {
     ConnOrientedInitial(Option<ConnOrientedInitial>),
     ConnOrientedListening(Option<ConnOrientedListening>),
@@ -1200,7 +1201,7 @@ impl Protocol for ConnOrientedListening {
         let mut new_state = FileState::ACTIVE;
 
         // socket is readable if the queue is not empty
-        new_state.set(FileState::READABLE, self.queue.len() > 0);
+        new_state.set(FileState::READABLE, !self.queue.is_empty());
 
         // socket allows connections if the queue is not full
         new_state.set(FileState::SOCKET_ALLOWING_CONNECT, !self.queue_is_full());
@@ -1312,7 +1313,7 @@ impl Protocol for ConnOrientedListening {
 
         let new_child_state = ConnOrientedConnected {
             // use the parent's bind address
-            bound_addr: Some(self.bound_addr.clone()),
+            bound_addr: Some(self.bound_addr),
             peer_addr: from_address,
             peer: Arc::clone(peer),
             reader_handle,
@@ -1786,7 +1787,7 @@ impl UnixSocketCommon {
         rng: impl rand::Rng,
     ) -> Result<SockaddrUnix<libc::sockaddr_un>, SyscallError> {
         // get the unix address
-        let Some(addr) = addr.map(|x| x.as_unix()).flatten() else {
+        let Some(addr) = addr.and_then(|x| x.as_unix()) else {
             log::warn!(
                 "Attempted to bind unix socket to non-unix address {:?}",
                 addr
@@ -1864,7 +1865,7 @@ impl UnixSocketCommon {
 
         // either use the existing send buffer, or look up the send buffer from the address
         let peer = match peer {
-            Some(ref x) => Arc::clone(x),
+            Some(x) => Arc::clone(x),
             None => {
                 // look up the socket from the address name
                 let recv_socket =
@@ -1874,7 +1875,7 @@ impl UnixSocketCommon {
             }
         };
 
-        return Ok(peer);
+        Ok(peer)
     }
 
     pub fn sendto<R>(
@@ -1941,7 +1942,7 @@ impl UnixSocketCommon {
             }
             UnixSocketType::Dgram | UnixSocketType::SeqPacket => {
                 send_buffer.write_packet(bytes, len, cb_queue)?;
-                len.try_into().unwrap()
+                len
             }
         };
 
@@ -2036,7 +2037,7 @@ fn backlog_to_queue_size(backlog: i32) -> u32 {
     let backlog = backlog as u32;
 
     // the linux '__sys_listen()' applies the somaxconn max to all protocols, including unix sockets
-    let queue_limit = std::cmp::min(backlog, c::SHADOW_SOMAXCONN.try_into().unwrap());
+    let queue_limit = std::cmp::min(backlog, c::SHADOW_SOMAXCONN);
 
     // linux uses a limit of one greater than the provided backlog (ex: a backlog value of 0 allows
     // for one incoming connection at a time)

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -392,7 +392,7 @@ impl Host {
             // using its metadata to create a serialized pointer to it.
             let block = unsafe { &*self.shim_shmem.get() };
             let mut envvar = String::from("SHADOW_SHM_HOST_BLK=");
-            envvar.push_str(&block.serialize().to_string());
+            envvar.push_str(&block.serialize().encode_to_string());
             envv.push(CString::new(envvar).unwrap());
         }
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -377,6 +377,7 @@ impl Host {
         path.canonicalize().ok()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_application(
         &self,
         start_time: SimulationTime,
@@ -662,7 +663,7 @@ impl Host {
         assert!(self.processes.borrow().is_empty());
 
         // Deregistering localhost is a no-op, so we skip it.
-        let _ = Worker::with_dns(|dns| unsafe {
+        Worker::with_dns(|dns| unsafe {
             let dns = dns as *const cshadow::DNS;
             cshadow::dns_deregister(dns.cast_mut(), self.default_address.borrow().ptr())
         });
@@ -678,7 +679,7 @@ impl Host {
 
     pub fn free_all_applications(&self) {
         trace!("start freeing applications for host '{}'", self.name());
-        let processes = std::mem::replace(&mut *self.processes.borrow_mut(), BTreeMap::new());
+        let processes = std::mem::take(&mut *self.processes.borrow_mut());
         for (_id, process) in processes.into_iter() {
             unsafe { cshadow::process_stop(process.ptr()) };
             unsafe { cshadow::process_unref(process.ptr()) };
@@ -1235,7 +1236,7 @@ mod export {
                 return thread;
             }
         }
-        return std::ptr::null_mut();
+        std::ptr::null_mut()
     }
 
     /// Returns host-specific state that's kept in memory shared with the shim(s).

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -377,7 +377,6 @@ impl Host {
         path.canonicalize().ok()
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn add_application(
         &self,
         start_time: SimulationTime,

--- a/src/main/host/memory_manager/memory_copier.rs
+++ b/src/main/host/memory_manager/memory_copier.rs
@@ -20,6 +20,7 @@ impl MemoryCopier {
 
     /// Copy the region.
     /// SAFETY: A mutable reference to the process memory must not exist.
+    #[allow(clippy::uninit_vec)]
     pub unsafe fn clone_mem<T: Pod + Debug>(
         &self,
         ptr: TypedPluginPtr<T>,
@@ -32,6 +33,7 @@ impl MemoryCopier {
 
     /// Copy the readable prefix of the region.
     /// SAFETY: A mutable reference to the process memory must not exist.
+    #[allow(clippy::uninit_vec)]
     pub unsafe fn clone_mem_prefix<T: Pod + Debug>(
         &self,
         ptr: TypedPluginPtr<T>,

--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -501,7 +501,7 @@ impl MemoryMapper {
             usize::from(ptr.ptr()),
             ptr.len()
         );
-        if ptr.len() == 0 {
+        if ptr.is_empty() {
             return;
         }
         let addr = usize::from(ptr.ptr());
@@ -950,7 +950,7 @@ impl MemoryMapper {
     // Get a raw pointer to the plugin's memory, if it's been remapped into Shadow.
     // Panics if called with zero-length `src`.
     fn get_mapped_ptr<T: Pod + Debug>(&self, src: TypedPluginPtr<T>) -> Option<*mut T> {
-        assert!(src.len() > 0);
+        assert!(!src.is_empty());
 
         if usize::from(src.ptr()) % std::mem::align_of::<T>() != 0 {
             // Creating a reference from an unaligned pointer is undefined
@@ -1002,7 +1002,7 @@ impl MemoryMapper {
     }
 
     pub unsafe fn get_ref<T: Debug + Pod>(&self, src: TypedPluginPtr<T>) -> Option<&[T]> {
-        if src.len() == 0 {
+        if src.is_empty() {
             return Some(&[]);
         }
         let ptr = self.get_mapped_ptr_and_count(src)?;
@@ -1010,7 +1010,7 @@ impl MemoryMapper {
     }
 
     pub unsafe fn get_mut<T: Debug + Pod>(&self, src: TypedPluginPtr<T>) -> Option<&mut [T]> {
-        if src.len() == 0 {
+        if src.is_empty() {
             return Some(&mut []);
         }
         let ptr = self.get_mapped_ptr_and_count(src)?;

--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -487,7 +487,6 @@ impl MemoryMapper {
     /// the plugin's address space, and in some cases remaps the given region into the
     /// MemoryManager's shared memory file for fast access. Currently only private anonymous
     /// mappings are remapped.
-    #[allow(clippy::too_many_arguments)]
     pub fn handle_mmap_result(
         &mut self,
         thread: &mut ThreadRef,

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -415,6 +415,7 @@ impl MemoryManager {
         assert_eq!(ptr.len(), N);
 
         // SAFETY: any values are valid for Pod.
+        // see https://github.com/shadow/shadow/issues/2555
         #[allow(clippy::uninit_assumed_init)]
         let mut res: [T; N] = unsafe { MaybeUninit::uninit().assume_init() };
         self.copy_from_ptr(&mut res, ptr)?;
@@ -590,7 +591,6 @@ impl MemoryManager {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn do_mmap(
         &mut self,
         thread: &mut ThreadRef,

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -415,6 +415,8 @@ impl MemoryManager {
         assert_eq!(ptr.len(), N);
 
         // SAFETY: any values are valid for Pod.
+        // UNSAFETY: this is actually UB: https://rust-lang.github.io/rust-clippy/master/#uninit_assumed_init
+        #[allow(clippy::uninit_assumed_init)]
         let mut res: [T; N] = unsafe { MaybeUninit::uninit().assume_init() };
         self.copy_from_ptr(&mut res, ptr)?;
         Ok(res)

--- a/src/main/host/mod.rs
+++ b/src/main/host/mod.rs
@@ -1,6 +1,7 @@
 pub mod context;
 pub mod cpu;
 pub mod descriptor;
+#[allow(clippy::module_inception)]
 pub mod host;
 pub mod memory_manager;
 pub mod network_interface;

--- a/src/main/host/network_interface.rs
+++ b/src/main/host/network_interface.rs
@@ -43,12 +43,10 @@ impl NetworkInterface {
         }
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn associate(&self, socket_ptr: *const c::CompatSocket) {
         unsafe { c::networkinterface_associate(self.c_ptr.ptr(), socket_ptr) };
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn disassociate(&self, socket_ptr: *const c::CompatSocket) {
         unsafe { c::networkinterface_disassociate(self.c_ptr.ptr(), socket_ptr) };
     }

--- a/src/main/host/network_interface.rs
+++ b/src/main/host/network_interface.rs
@@ -29,7 +29,7 @@ impl NetworkInterface {
         qdisc: QDiscMode,
         uses_router: bool,
     ) -> NetworkInterface {
-        let maybe_pcap_dir = maybe_pcap_dir.map(|p| utility::pathbuf_to_nul_term_cstring(p));
+        let maybe_pcap_dir = maybe_pcap_dir.map(utility::pathbuf_to_nul_term_cstring);
         let pcap_dir_cptr = maybe_pcap_dir
             .as_ref()
             .map_or(std::ptr::null(), |p| p.as_ptr());

--- a/src/main/host/network_interface.rs
+++ b/src/main/host/network_interface.rs
@@ -43,10 +43,12 @@ impl NetworkInterface {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn associate(&self, socket_ptr: *const c::CompatSocket) {
         unsafe { c::networkinterface_associate(self.c_ptr.ptr(), socket_ptr) };
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn disassociate(&self, socket_ptr: *const c::CompatSocket) {
         unsafe { c::networkinterface_disassociate(self.c_ptr.ptr(), socket_ptr) };
     }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -5,7 +5,7 @@ use nix::unistd::Pid;
 
 use crate::cshadow;
 use crate::host::descriptor::{CompatFile, Descriptor};
-use crate::host::syscall::format::{FmtOptions, StraceFmtMode};
+use crate::host::syscall::format::FmtOptions;
 
 use super::memory_manager::MemoryManager;
 use super::timer::Timer;
@@ -118,8 +118,7 @@ impl Process {
     }
 
     pub fn strace_logging_options(&self) -> Option<FmtOptions> {
-        StraceFmtMode::try_from(unsafe { cshadow::process_straceLoggingMode(self.cprocess) })
-            .unwrap()
+        unsafe { cshadow::process_straceLoggingMode(self.cprocess) }
             .into()
     }
 

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -118,8 +118,7 @@ impl Process {
     }
 
     pub fn strace_logging_options(&self) -> Option<FmtOptions> {
-        unsafe { cshadow::process_straceLoggingMode(self.cprocess) }
-            .into()
+        unsafe { cshadow::process_straceLoggingMode(self.cprocess) }.into()
     }
 
     /// If strace logging is disabled, this function will do nothing and return `None`.

--- a/src/main/host/syscall/format.rs
+++ b/src/main/host/syscall/format.rs
@@ -290,6 +290,7 @@ impl SyscallPtrDisplay for SyscallPtr<*const i8> {
         s.truncate(DISPLAY_LEN);
         let s: std::ffi::CString = s.into();
 
+        #[allow(clippy::absurd_extreme_comparisons)]
         if len > DISPLAY_LEN || non_graphic_remaining <= 0 {
             write!(f, "{:?}...", s)
         } else {

--- a/src/main/host/syscall/format.rs
+++ b/src/main/host/syscall/format.rs
@@ -282,7 +282,7 @@ impl SyscallPtrDisplay for SyscallPtr<*const i8> {
                 if !x.get().is_ascii_graphic() {
                     non_graphic_remaining = non_graphic_remaining.saturating_sub(1);
                 }
-                (non_graphic_remaining > 0).then(|| x)
+                (non_graphic_remaining > 0).then_some(x)
             })
             .collect();
 
@@ -569,7 +569,7 @@ pub fn write_syscall(
     rv: impl Display,
 ) -> std::io::Result<()> {
     let sim_time = sim_time.duration_since(&EmulatedTime::SIMULATION_START);
-    let sim_time = TimeParts::from_nanos(sim_time.as_nanos().into());
+    let sim_time = TimeParts::from_nanos(sim_time.as_nanos());
     let sim_time = sim_time.fmt_hr_min_sec_milli();
 
     writeln!(
@@ -605,7 +605,7 @@ mod export {
         let args = unsafe { CStr::from_ptr(args) }.to_str().unwrap();
         let result = SyscallResult::from(result);
 
-        let logging_mode = StraceFmtMode::try_from(logging_mode).unwrap().into();
+        let logging_mode = logging_mode.into();
         let Some(logging_mode) = logging_mode else {
             // logging was disabled
             return result.into()

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -24,6 +24,7 @@ pub struct SyscallHandler {
 }
 
 impl SyscallHandler {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> SyscallHandler {
         SyscallHandler {}
     }
@@ -109,12 +110,6 @@ impl SyscallHandler {
             Some(desc) => Ok(desc),
             None => Err(nix::errno::Errno::EBADF),
         }
-    }
-}
-
-impl Default for SyscallHandler {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -112,6 +112,12 @@ impl SyscallHandler {
     }
 }
 
+impl Default for SyscallHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 mod export {
     use crate::{core::worker::Worker, utility::notnull::notnull_mut_debug};
 

--- a/src/main/host/syscall/handler/random.rs
+++ b/src/main/host/syscall/handler/random.rs
@@ -21,7 +21,7 @@ impl SyscallHandler {
         trace!("Trying to read {} random bytes.", count);
 
         // Get a native-process mem buffer where we can copy the random bytes.
-        let dst_ptr = TypedPluginPtr::new::<u8>(PluginPtr::from(buf_ptr), count);
+        let dst_ptr = TypedPluginPtr::new::<u8>(buf_ptr, count);
         let mut mem_ref = match ctx.process.memory_mut().memory_ref_mut_uninit(dst_ptr) {
             Ok(m) => m,
             Err(e) => {

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -173,7 +173,6 @@ impl SyscallHandler {
         self.sendto_helper(ctx, file, buf_ptr, buf_len, flags, addr_ptr, addr_len)
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn sendto_helper(
         &self,
         ctx: &mut ThreadContext,
@@ -286,7 +285,6 @@ impl SyscallHandler {
         self.recvfrom_helper(ctx, file, buf_ptr, buf_len, flags, addr_ptr, addr_len_ptr)
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn recvfrom_helper(
         &self,
         ctx: &mut ThreadContext,

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -149,8 +149,7 @@ impl SyscallHandler {
             .thread
             .syscall_condition()
             // if this was for a C descriptor, then there won't be an active file object
-            .map(|x| x.active_file().cloned())
-            .flatten();
+            .and_then(|x| x.active_file().cloned());
 
         let file = match file {
             // we were previously blocked, so re-use the file from the previous syscall invocation
@@ -174,6 +173,7 @@ impl SyscallHandler {
         self.sendto_helper(ctx, file, buf_ptr, buf_len, flags, addr_ptr, addr_len)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn sendto_helper(
         &self,
         ctx: &mut ThreadContext,
@@ -262,8 +262,7 @@ impl SyscallHandler {
             .thread
             .syscall_condition()
             // if this was for a C descriptor, then there won't be an active file object
-            .map(|x| x.active_file().cloned())
-            .flatten();
+            .and_then(|x| x.active_file().cloned());
 
         let file = match file {
             // we were previously blocked, so re-use the file from the previous syscall invocation
@@ -287,6 +286,7 @@ impl SyscallHandler {
         self.recvfrom_helper(ctx, file, buf_ptr, buf_len, flags, addr_ptr, addr_len_ptr)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn recvfrom_helper(
         &self,
         ctx: &mut ThreadContext,
@@ -499,8 +499,7 @@ impl SyscallHandler {
             .thread
             .syscall_condition()
             // if this was for a C descriptor, then there won't be an active file object
-            .map(|x| x.active_file().cloned())
-            .flatten();
+            .and_then(|x| x.active_file().cloned());
 
         let file = match file {
             // we were previously blocked, so re-use the file from the previous syscall invocation
@@ -538,8 +537,7 @@ impl SyscallHandler {
             .thread
             .syscall_condition()
             // if this was for a C descriptor, then there won't be an active file object
-            .map(|x| x.active_file().cloned())
-            .flatten();
+            .and_then(|x| x.active_file().cloned());
 
         let file = match file {
             // we were previously blocked, so re-use the file from the previous syscall invocation
@@ -651,8 +649,7 @@ impl SyscallHandler {
             .thread
             .syscall_condition()
             // if this was for a C descriptor, then there won't be an active file object
-            .map(|x| x.active_file().cloned())
-            .flatten();
+            .and_then(|x| x.active_file().cloned());
 
         let file = match file {
             // we were previously blocked, so re-use the file from the previous syscall invocation
@@ -803,7 +800,7 @@ impl SyscallHandler {
         let write_res = ctx
             .process
             .memory_mut()
-            .copy_to_ptr(TypedPluginPtr::new::<libc::c_int>(fd_ptr.into(), 2), &fds);
+            .copy_to_ptr(TypedPluginPtr::new::<libc::c_int>(fd_ptr, 2), &fds);
 
         // clean up in case of error
         match write_res {
@@ -975,7 +972,7 @@ fn read_sockaddr(
         TypedPluginPtr::new::<MaybeUninit<u8>>(addr_ptr, addr_len_usize),
     )?;
 
-    let addr = unsafe { SockaddrStorage::from_bytes(&addr_buf).ok_or(Errno::EINVAL)? };
+    let addr = unsafe { SockaddrStorage::from_bytes(addr_buf).ok_or(Errno::EINVAL)? };
 
     Ok(Some(addr))
 }

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -143,8 +143,7 @@ impl SyscallHandler {
             .thread
             .syscall_condition()
             // if this was for a C descriptor, then there won't be an active file object
-            .map(|x| x.active_file().cloned())
-            .flatten();
+            .and_then(|x| x.active_file().cloned());
 
         let file = match file {
             // we were previously blocked, so re-use the file from the previous syscall invocation
@@ -182,8 +181,7 @@ impl SyscallHandler {
             .thread
             .syscall_condition()
             // if this was for a C descriptor, then there won't be an active file object
-            .map(|x| x.active_file().cloned())
-            .flatten();
+            .and_then(|x| x.active_file().cloned());
 
         let file = match file {
             // we were previously blocked, so re-use the file from the previous syscall invocation
@@ -277,8 +275,7 @@ impl SyscallHandler {
             .thread
             .syscall_condition()
             // if this was for a C descriptor, then there won't be an active file object
-            .map(|x| x.active_file().cloned())
-            .flatten();
+            .and_then(|x| x.active_file().cloned());
 
         let file = match file {
             // we were previously blocked, so re-use the file from the previous syscall invocation
@@ -316,8 +313,7 @@ impl SyscallHandler {
             .thread
             .syscall_condition()
             // if this was for a C descriptor, then there won't be an active file object
-            .map(|x| x.active_file().cloned())
-            .flatten();
+            .and_then(|x| x.active_file().cloned());
 
         let file = match file {
             // we were previously blocked, so re-use the file from the previous syscall invocation
@@ -475,7 +471,7 @@ impl SyscallHandler {
         let write_res = ctx
             .process
             .memory_mut()
-            .copy_to_ptr(TypedPluginPtr::new::<libc::c_int>(fd_ptr.into(), 2), &fds);
+            .copy_to_ptr(TypedPluginPtr::new::<libc::c_int>(fd_ptr, 2), &fds);
 
         // clean up in case of error
         match write_res {

--- a/src/main/host/syscall_types.rs
+++ b/src/main/host/syscall_types.rs
@@ -176,8 +176,8 @@ impl From<SysCallReg> for PluginPtr {
 }
 
 // Useful for syscalls whose strongly-typed wrappers return some Result<(), ErrType>
-impl Into<SysCallReg> for () {
-    fn into(self) -> SysCallReg {
+impl From<()> for SysCallReg {
+    fn from(_: ()) -> SysCallReg {
         SysCallReg { as_i64: 0 }
     }
 }
@@ -272,6 +272,10 @@ impl<T> TypedPluginPtr<T> {
         self.count
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
     pub fn is_null(&self) -> bool {
         self.base.is_null()
     }
@@ -355,7 +359,7 @@ impl From<c::SysCallReturn> for SyscallResult {
                 }) {
                     Ok(r) => Ok(r),
                     Err(e) => Err(SyscallError::Failed(Failed {
-                        errno: e.into(),
+                        errno: e,
                         restartable: unsafe { r.u.done.restartable },
                     })),
                 }
@@ -378,7 +382,7 @@ impl From<SyscallResult> for c::SysCallReturn {
                 state: c::SysCallReturnState_SYSCALL_DONE,
                 u: c::SysCallReturnBody {
                     done: c::SysCallReturnDone {
-                        retval: r.into(),
+                        retval: r,
                         // N/A for non-error result (and non-EINTR result in particular)
                         restartable: false,
                     },

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -18,7 +18,7 @@ impl ThreadRef {
         // below; we avoided it because argument evaluation order is currently a bit of a murky
         // issue, even though it'll *probably* always be left-to-right.
         // https://internals.rust-lang.org/t/rust-expression-order-of-evaluation/2605/16
-        let arg = |i| c::SysCallReg::from(args[i]);
+        let arg = |i| args[i];
         // Safety: self.cthread initialized in CThread::new.
         let raw_res = unsafe {
             match args.len() {

--- a/src/main/host/timer.rs
+++ b/src/main/host/timer.rs
@@ -82,11 +82,7 @@ impl Timer {
     /// armed, or None otherwise.
     pub fn remaining_time(&self) -> Option<SimulationTime> {
         self.magic.debug_check();
-        let t = if let Some(t) = self.internal.borrow().next_expire_time {
-            t
-        } else {
-            return None;
-        };
+        let t = self.internal.borrow().next_expire_time?;
         let now = Worker::current_time().unwrap();
         Some(t.saturating_duration_since(&now))
     }
@@ -127,7 +123,7 @@ impl Timer {
         let next_expire_time = internal_brw.next_expire_time.unwrap();
         if next_expire_time > Worker::current_time().unwrap() {
             // Hasn't expired yet. Check again later.
-            Self::schedule_new_expire_event(&mut *internal_brw, internal_weak.clone(), host);
+            Self::schedule_new_expire_event(&mut internal_brw, internal_weak.clone(), host);
             return;
         }
 
@@ -135,7 +131,7 @@ impl Timer {
         if internal_brw.expire_interval > SimulationTime::ZERO {
             internal_brw.next_expire_time =
                 Some(internal_brw.next_expire_time.unwrap() + internal_brw.expire_interval);
-            Self::schedule_new_expire_event(&mut *internal_brw, internal_weak.clone(), host);
+            Self::schedule_new_expire_event(&mut internal_brw, internal_weak.clone(), host);
         }
 
         // Re-borrow as an immutable reference while executing the callback.
@@ -174,7 +170,7 @@ impl Timer {
 
         let mut internal = self.internal.borrow_mut();
         internal.reset(Some(expire_time), expire_interval);
-        Self::schedule_new_expire_event(&mut *internal, Arc::downgrade(&self.internal), host);
+        Self::schedule_new_expire_event(&mut internal, Arc::downgrade(&self.internal), host);
     }
 }
 

--- a/src/main/lib.rs
+++ b/src/main/lib.rs
@@ -6,6 +6,11 @@
 // https://github.com/rust-lang/rfcs/blob/master/text/2585-unsafe-block-in-unsafe-fn.md
 #![deny(unsafe_op_in_unsafe_fn)]
 
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+#![allow(clippy::enum_variant_names)]
+#![allow(clippy::too_many_arguments)]
+
+
 /// cbindgen:ignore
 pub mod cshadow {
     #![allow(non_upper_case_globals)]

--- a/src/main/lib.rs
+++ b/src/main/lib.rs
@@ -5,11 +5,9 @@
 
 // https://github.com/rust-lang/rfcs/blob/master/text/2585-unsafe-block-in-unsafe-fn.md
 #![deny(unsafe_op_in_unsafe_fn)]
-
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 #![allow(clippy::enum_variant_names)]
 #![allow(clippy::too_many_arguments)]
-
 
 /// cbindgen:ignore
 pub mod cshadow {

--- a/src/main/network/graph/mod.rs
+++ b/src/main/network/graph/mod.rs
@@ -20,7 +20,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 type NetGraphError = Box<dyn Error + Send + Sync + 'static>;
 
 /// A graph node.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ShadowNode {
     pub id: u32,
     pub bandwidth_down: Option<units::BitsPerSec<units::SiPrefixUpper>>,
@@ -418,6 +418,12 @@ impl<T: Copy + Eq + Hash + std::fmt::Display> IpAssignment<T> {
             },
             std::net::IpAddr::V6(_) => unimplemented!(),
         }
+    }
+}
+
+impl<T: Copy + Eq + Hash + std::fmt::Display> Default for IpAssignment<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/main/network/packet.rs
+++ b/src/main/network/packet.rs
@@ -55,7 +55,6 @@ impl Packet {
 
     /// Transfers ownership of the given c_ptr reference into a new rust packet
     /// object.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn from_raw(c_ptr: *mut c::Packet) -> Self {
         assert!(!c_ptr.is_null());
         Self {

--- a/src/main/network/packet.rs
+++ b/src/main/network/packet.rs
@@ -55,6 +55,7 @@ impl Packet {
 
     /// Transfers ownership of the given c_ptr reference into a new rust packet
     /// object.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn from_raw(c_ptr: *mut c::Packet) -> Self {
         assert!(!c_ptr.is_null());
         Self {

--- a/src/main/network/relay/token_bucket.rs
+++ b/src/main/network/relay/token_bucket.rs
@@ -178,13 +178,10 @@ mod tests {
     fn test_new_valid_args() {
         let now = mock_time_millis(1000);
         assert!(TokenBucket::new_inner(1, 1, SimulationTime::from_nanos(1), now).is_some());
-        assert!(
-            TokenBucket::new_inner(1, 1, SimulationTime::from_millis(1), now).is_some()
-        );
+        assert!(TokenBucket::new_inner(1, 1, SimulationTime::from_millis(1), now).is_some());
         assert!(TokenBucket::new_inner(1, 1, SimulationTime::from_secs(1), now).is_some());
 
-        let tb = TokenBucket::new_inner(54321, 12345, SimulationTime::from_secs(1), now)
-            .unwrap();
+        let tb = TokenBucket::new_inner(54321, 12345, SimulationTime::from_secs(1), now).unwrap();
         assert_eq!(tb.capacity, 54321);
         assert_eq!(tb.refill_increment, 12345);
         assert_eq!(tb.refill_interval, SimulationTime::from_secs(1));
@@ -218,8 +215,7 @@ mod tests {
     #[test]
     fn test_refill_after_multiple_intervals() {
         let now = mock_time_millis(1000);
-        let mut tb =
-            TokenBucket::new_inner(100, 10, SimulationTime::from_millis(10), now).unwrap();
+        let mut tb = TokenBucket::new_inner(100, 10, SimulationTime::from_millis(10), now).unwrap();
 
         // Remove all tokens
         assert!(tb.conforming_remove_inner(100, &now).is_ok());
@@ -237,8 +233,7 @@ mod tests {
     #[test]
     fn test_capacity_limit() {
         let now = mock_time_millis(1000);
-        let mut tb =
-            TokenBucket::new_inner(100, 10, SimulationTime::from_millis(10), now).unwrap();
+        let mut tb = TokenBucket::new_inner(100, 10, SimulationTime::from_millis(10), now).unwrap();
 
         // Remove all tokens
         assert!(tb.conforming_remove_inner(100, &now).is_ok());

--- a/src/main/network/relay/token_bucket.rs
+++ b/src/main/network/relay/token_bucket.rs
@@ -169,21 +169,21 @@ mod tests {
     #[test]
     fn test_new_invalid_args() {
         let now = mock_time_millis(1000);
-        assert!(TokenBucket::new_inner(0, 1, SimulationTime::from_nanos(1), now.clone()).is_none());
-        assert!(TokenBucket::new_inner(1, 0, SimulationTime::from_nanos(1), now.clone()).is_none());
+        assert!(TokenBucket::new_inner(0, 1, SimulationTime::from_nanos(1), now).is_none());
+        assert!(TokenBucket::new_inner(1, 0, SimulationTime::from_nanos(1), now).is_none());
         assert!(TokenBucket::new_inner(1, 1, SimulationTime::ZERO, now).is_none());
     }
 
     #[test]
     fn test_new_valid_args() {
         let now = mock_time_millis(1000);
-        assert!(TokenBucket::new_inner(1, 1, SimulationTime::from_nanos(1), now.clone()).is_some());
+        assert!(TokenBucket::new_inner(1, 1, SimulationTime::from_nanos(1), now).is_some());
         assert!(
-            TokenBucket::new_inner(1, 1, SimulationTime::from_millis(1), now.clone()).is_some()
+            TokenBucket::new_inner(1, 1, SimulationTime::from_millis(1), now).is_some()
         );
-        assert!(TokenBucket::new_inner(1, 1, SimulationTime::from_secs(1), now.clone()).is_some());
+        assert!(TokenBucket::new_inner(1, 1, SimulationTime::from_secs(1), now).is_some());
 
-        let tb = TokenBucket::new_inner(54321, 12345, SimulationTime::from_secs(1), now.clone())
+        let tb = TokenBucket::new_inner(54321, 12345, SimulationTime::from_secs(1), now)
             .unwrap();
         assert_eq!(tb.capacity, 54321);
         assert_eq!(tb.refill_increment, 12345);
@@ -197,7 +197,7 @@ mod tests {
         let increment = 10;
         let now = mock_time_millis(1000);
 
-        let mut tb = TokenBucket::new_inner(capacity, increment, interval, now.clone()).unwrap();
+        let mut tb = TokenBucket::new_inner(capacity, increment, interval, now).unwrap();
         assert_eq!(tb.balance, capacity);
 
         // Remove all tokens
@@ -219,7 +219,7 @@ mod tests {
     fn test_refill_after_multiple_intervals() {
         let now = mock_time_millis(1000);
         let mut tb =
-            TokenBucket::new_inner(100, 10, SimulationTime::from_millis(10), now.clone()).unwrap();
+            TokenBucket::new_inner(100, 10, SimulationTime::from_millis(10), now).unwrap();
 
         // Remove all tokens
         assert!(tb.conforming_remove_inner(100, &now).is_ok());
@@ -238,7 +238,7 @@ mod tests {
     fn test_capacity_limit() {
         let now = mock_time_millis(1000);
         let mut tb =
-            TokenBucket::new_inner(100, 10, SimulationTime::from_millis(10), now.clone()).unwrap();
+            TokenBucket::new_inner(100, 10, SimulationTime::from_millis(10), now).unwrap();
 
         // Remove all tokens
         assert!(tb.conforming_remove_inner(100, &now).is_ok());
@@ -258,7 +258,7 @@ mod tests {
     fn test_remove_error() {
         let now = mock_time_millis(1000);
         let mut tb =
-            TokenBucket::new_inner(100, 10, SimulationTime::from_millis(123), now.clone()).unwrap();
+            TokenBucket::new_inner(100, 10, SimulationTime::from_millis(123), now).unwrap();
 
         // This many tokens are not available
         let result = tb.conforming_remove_inner(1000, &now);

--- a/src/main/network/router/codel_queue.rs
+++ b/src/main/network/router/codel_queue.rs
@@ -177,7 +177,7 @@ impl CoDelQueue {
         // Drop as many packets as the control law dictates.
         while item.is_some() && self.mode == CoDelMode::Drop && self.should_drop(now) {
             self.drop_packet(item.unwrap().packet);
-            self.current_drop_count = self.current_drop_count + 1;
+            self.current_drop_count += 1;
 
             item = self.codel_pop(now);
 
@@ -242,13 +242,10 @@ impl CoDelQueue {
             match self.interval_end {
                 Some(end) => {
                     // We were already in a bad state, and now we stayed in it.
-                    if now >= &end {
-                        // We have been in a bad state for a full interval worth
-                        // of time, so drop this packet.
-                        true
-                    } else {
-                        false
-                    }
+
+                    // if we have been in a bad state for a full interval worth
+                    // of time, drop this packet.
+                    now >= &end
                 }
                 None => {
                     // None means we were in a good state, but now we just
@@ -350,17 +347,17 @@ mod tests {
 
         for i in 1..=N {
             assert_eq!(cdq.len(), i - 1);
-            cdq.push(Packet::mock_new(), now.clone());
+            cdq.push(Packet::mock_new(), now);
             assert_eq!(cdq.len(), i);
         }
         for i in 1..=N {
             assert_eq!(cdq.len(), N - i + 1);
-            assert!(cdq.pop(now.clone()).is_some());
+            assert!(cdq.pop(now).is_some());
             assert_eq!(cdq.len(), N - i);
         }
         assert_eq!(cdq.len(), 0);
         assert!(cdq.is_empty());
-        assert!(cdq.pop(now.clone()).is_none());
+        assert!(cdq.pop(now).is_none());
     }
 
     #[test]
@@ -395,7 +392,7 @@ mod tests {
 
         let mut cdq = CoDelQueue::new();
         for _ in 0..5 {
-            cdq.push(Packet::mock_new(), start.clone());
+            cdq.push(Packet::mock_new(), start);
         }
         assert!(cdq.total_bytes_stored > c::CONFIG_MTU.try_into().unwrap());
 
@@ -444,7 +441,7 @@ mod tests {
         let mut cdq = CoDelQueue::new();
         const N: usize = 6;
         for _ in 0..N {
-            cdq.push(Packet::mock_new(), start.clone());
+            cdq.push(Packet::mock_new(), start);
         }
         assert!(cdq.total_bytes_stored > c::CONFIG_MTU.try_into().unwrap());
         assert_eq!(cdq.len(), N);
@@ -454,22 +451,22 @@ mod tests {
         // time in order to enter the drop state.
 
         // We didn't reach target yet.
-        cdq.pop((start + TARGET - one).clone());
+        cdq.pop(start + TARGET - one);
         assert_eq!(cdq.len(), N - 1);
         assert_eq!(cdq.mode, CoDelMode::Store);
 
         // We now reached target.
-        cdq.pop((start + TARGET).clone());
+        cdq.pop(start + TARGET);
         assert_eq!(cdq.len(), N - 2);
         assert_eq!(cdq.mode, CoDelMode::Store);
 
         // Still not above target for a full interval.
-        cdq.pop((start + TARGET + INTERVAL - one).clone());
+        cdq.pop(start + TARGET + INTERVAL - one);
         assert_eq!(cdq.len(), N - 3);
         assert_eq!(cdq.mode, CoDelMode::Store);
 
         // Now above target for interval, should enter drop mode and drop one packet.
-        cdq.pop((start + TARGET + INTERVAL).clone());
+        cdq.pop(start + TARGET + INTERVAL);
         assert_eq!(cdq.len(), N - 5);
         assert_eq!(cdq.mode, CoDelMode::Drop);
 
@@ -479,10 +476,10 @@ mod tests {
             // Add some low-delay packets
             cdq.push(
                 Packet::mock_new(),
-                (start + TARGET + INTERVAL * 2u64 - one).clone(),
+                start + TARGET + INTERVAL * 2u64 - one,
             );
         }
-        cdq.pop((start + TARGET + INTERVAL * 2u64).clone());
+        cdq.pop(start + TARGET + INTERVAL * 2u64);
         assert_eq!(cdq.mode, CoDelMode::Store);
     }
 
@@ -504,7 +501,7 @@ mod tests {
         let mut cdq = CoDelQueue::new();
         const N: usize = 20;
         for _ in 0..N {
-            cdq.push(Packet::mock_new(), start.clone());
+            cdq.push(Packet::mock_new(), start);
         }
         assert_eq!(cdq.len(), N);
 

--- a/src/main/network/router/codel_queue.rs
+++ b/src/main/network/router/codel_queue.rs
@@ -474,10 +474,7 @@ mod tests {
         // low-delay packets should put us back into store mode.
         for _ in 0..3 {
             // Add some low-delay packets
-            cdq.push(
-                Packet::mock_new(),
-                start + TARGET + INTERVAL * 2u64 - one,
-            );
+            cdq.push(Packet::mock_new(), start + TARGET + INTERVAL * 2u64 - one);
         }
         cdq.pop(start + TARGET + INTERVAL * 2u64);
         assert_eq!(cdq.mode, CoDelMode::Store);

--- a/src/main/network/router/mod.rs
+++ b/src/main/network/router/mod.rs
@@ -72,6 +72,12 @@ impl Router {
     }
 }
 
+impl Default for Router {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 mod export {
     use super::*;
 
@@ -146,15 +152,15 @@ mod tests {
         const N: usize = 10;
 
         for i in 1..=N {
-            assert_eq!(router.push_inner(Packet::mock_new(), now.clone()), i == 1);
+            assert_eq!(router.push_inner(Packet::mock_new(), now), i == 1);
             assert!(router.peek().is_some());
         }
         for _ in 1..=N {
             assert!(router.peek().is_some());
-            assert!(router.pop_inner(now.clone()).is_some());
+            assert!(router.pop_inner(now).is_some());
         }
 
         assert!(router.peek().is_none());
-        assert!(router.pop_inner(now.clone()).is_none());
+        assert!(router.pop_inner(now).is_none());
     }
 }

--- a/src/main/network/router/mod.rs
+++ b/src/main/network/router/mod.rs
@@ -22,6 +22,7 @@ pub struct Router {
 }
 
 impl Router {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Router {
         Router {
             magic: Magic::new(),
@@ -69,12 +70,6 @@ impl Router {
         // TODO: move _worker_runDeliverPacketTask to here.
         // Rob: Coming in future PR.
         todo!()
-    }
-}
-
-impl Default for Router {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/src/main/routing/packet.c
+++ b/src/main/routing/packet.c
@@ -628,7 +628,7 @@ gchar* packet_toString(Packet* packet) {
 
             g_string_append_printf(packetString, "%s:%u -> ",
                     sourceIPString, ntohs(header->sourcePort));
-            g_string_append_printf(packetString, "%s:%u seq=%u ack=%u sack=", 
+            g_string_append_printf(packetString, "%s:%u seq=%u ack=%u sack=",
                     destinationIPString, ntohs(header->destinationPort),
                     header->sequence, header->acknowledgment);
 
@@ -691,7 +691,7 @@ gchar* packet_toString(Packet* packet) {
             break;
         }
     }
-    
+
     guint statusLength = g_queue_get_length(packet->orderedStatus);
     if(statusLength > 0) {
         g_string_append_printf(packetString, " status=");

--- a/src/main/utility/byte_queue.rs
+++ b/src/main/utility/byte_queue.rs
@@ -57,7 +57,7 @@ impl ByteQueue {
 
     /// Returns true if the queue has data/chunks, which may include packets with 0 bytes.
     pub fn has_chunks(&self) -> bool {
-        self.bytes.len() > 0
+        !self.bytes.is_empty()
     }
 
     #[must_use]
@@ -88,12 +88,12 @@ impl ByteQueue {
 
             total_copied += bytes.len();
 
-            if unused.len() != 0 {
+            if !unused.is_empty() {
                 // restore the remaining unused buffer
                 self.unused_buffer = Some(unused);
             }
 
-            if bytes.len() == 0 {
+            if bytes.is_empty() {
                 break;
             }
 
@@ -149,7 +149,7 @@ impl ByteQueue {
 
         // we may have used up all of the space in 'unused_buffer'
         if let Some(ref unused_buffer) = self.unused_buffer {
-            if unused_buffer.len() == 0 {
+            if unused_buffer.is_empty() {
                 self.unused_buffer = None;
             }
         }
@@ -232,7 +232,7 @@ impl ByteQueue {
             self.length -= copied;
             total_copied += copied;
 
-            if bytes.len() == 0 {
+            if bytes.is_empty() {
                 self.bytes.pop_front();
             }
         }
@@ -294,7 +294,7 @@ impl ByteQueue {
                 let temp = chunk
                     .data
                     .split_to(std::cmp::min(chunk.data.len(), size_hint));
-                if chunk.data.len() == 0 {
+                if chunk.data.is_empty() {
                     self.bytes.pop_front();
                 }
                 temp
@@ -321,7 +321,7 @@ impl std::ops::Drop for ByteQueue {
 }
 
 /// The types of data that are supported by the [`ByteQueue`].
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ChunkType {
     Stream,
     Packet,
@@ -357,8 +357,8 @@ impl From<BytesWrapper> for Bytes {
 impl std::convert::AsRef<[u8]> for BytesWrapper {
     fn as_ref(&self) -> &[u8] {
         match self {
-            BytesWrapper::Mutable(x) => &x,
-            BytesWrapper::Immutable(x) => &x,
+            BytesWrapper::Mutable(x) => x,
+            BytesWrapper::Immutable(x) => x,
         }
     }
 }

--- a/src/main/utility/callback_queue.rs
+++ b/src/main/utility/callback_queue.rs
@@ -148,10 +148,7 @@ impl<T: Clone + Copy + 'static> Default for EventSource<T> {
 type Listener<T> = Arc<Box<dyn Fn(T, &mut CallbackQueue) + Send + Sync>>;
 
 struct EventSourceInner<T> {
-    listeners: std::vec::Vec<(
-        HandleId,
-        Listener<T>,
-    )>,
+    listeners: std::vec::Vec<(HandleId, Listener<T>)>,
     next_id: std::num::Wrapping<u32>,
 }
 

--- a/src/main/utility/callback_queue.rs
+++ b/src/main/utility/callback_queue.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Weak};
 
 /// A queue of events (functions/closures) which when run can add their own events to the queue.
 /// This allows events to be deferred and run later.
+#[allow(clippy::type_complexity)]
 pub struct CallbackQueue(std::collections::VecDeque<Box<dyn FnOnce(&mut Self)>>);
 
 impl CallbackQueue {
@@ -57,6 +58,12 @@ impl CallbackQueue {
         let rv = (f)(&mut cb_queue);
         cb_queue.run();
         rv
+    }
+}
+
+impl Default for CallbackQueue {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -132,10 +139,18 @@ impl<T: Clone + Copy + 'static> EventSource<T> {
     }
 }
 
+impl<T: Clone + Copy + 'static> Default for EventSource<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+type Listener<T> = Arc<Box<dyn Fn(T, &mut CallbackQueue) + Send + Sync>>;
+
 struct EventSourceInner<T> {
     listeners: std::vec::Vec<(
         HandleId,
-        Arc<Box<dyn Fn(T, &mut CallbackQueue) + Send + Sync>>,
+        Listener<T>,
     )>,
     next_id: std::num::Wrapping<u32>,
 }
@@ -151,15 +166,14 @@ impl<T> EventSourceInner<T> {
     fn get_unused_id(&mut self) -> HandleId {
         // it's very unlikely that there will be collisions, but we loop anyways since we
         // don't care about worst-case performance here
-        let handle_id = loop {
+        loop {
             let id = HandleId(self.next_id.0);
             self.next_id += std::num::Wrapping(1);
 
             if !self.listeners.iter().any(|x| x.0 == id) {
                 break id;
             }
-        };
-        handle_id
+        }
     }
 
     pub fn add_listener(

--- a/src/main/utility/childpid_watcher.rs
+++ b/src/main/utility/childpid_watcher.rs
@@ -123,7 +123,7 @@ impl ChildPidWatcher {
             let epoll = watcher.epoll;
             thread::Builder::new()
                 .name("child-pid-watcher".into())
-                .spawn(move || ChildPidWatcher::thread_loop(&*inner, epoll))
+                .spawn(move || ChildPidWatcher::thread_loop(&inner, epoll))
                 .unwrap()
         };
         watcher.inner.lock().unwrap().thread_handle = Some(thread_handle);
@@ -321,6 +321,12 @@ impl ChildPidWatcher {
         let pid_data = inner.pids.get_mut(&pid).unwrap();
         pid_data.callbacks.remove(&handle);
         inner.maybe_remove_pid(self.epoll, pid);
+    }
+}
+
+impl Default for ChildPidWatcher {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/main/utility/counter.rs
+++ b/src/main/utility/counter.rs
@@ -20,7 +20,7 @@ use std::ops::{Add, Sub};
 use serde::ser::SerializeMap;
 
 /// The main counter object that maps individual keys to count values.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Counter {
     // TODO: convert this so we could count generic types instead of Strings
     items: HashMap<String, i64>,
@@ -124,11 +124,11 @@ impl Counter {
 
     /// Get an iterator that returns elements in the order best suited for human-readable output
     /// (currently sorted by value with the largest value first).
-    fn sorted_for_display<'a>(
-        &'a self,
+    fn sorted_for_display(
+        &self,
     ) -> impl IntoIterator<
-        IntoIter = impl Iterator<Item = (&'a String, &'a i64)> + ExactSizeIterator + 'a,
-        Item = (&'a String, &'a i64),
+        IntoIter = impl Iterator<Item = (&String, &i64)> + ExactSizeIterator,
+        Item = (&String, &i64),
     > {
         // Get the items in a vector so we can sort them.
         let mut item_vec = Vec::from_iter(&self.items);
@@ -140,6 +140,12 @@ impl Counter {
         });
 
         item_vec
+    }
+}
+
+impl Default for Counter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/main/utility/interval_map.rs
+++ b/src/main/utility/interval_map.rs
@@ -269,7 +269,8 @@ impl<V: Clone> IntervalMap<V> {
 
     // Returns the entry of the interval containing `x`.
     pub fn get(&self, x: usize) -> Option<(Interval, &V)> {
-        self.get_index(x).map(|i| (self.starts[i]..self.ends[i], &self.vals[i]))
+        self.get_index(x)
+            .map(|i| (self.starts[i]..self.ends[i], &self.vals[i]))
     }
 
     // Returns the entry of the interval containing `x`.

--- a/src/main/utility/interval_map.rs
+++ b/src/main/utility/interval_map.rs
@@ -269,10 +269,7 @@ impl<V: Clone> IntervalMap<V> {
 
     // Returns the entry of the interval containing `x`.
     pub fn get(&self, x: usize) -> Option<(Interval, &V)> {
-        match self.get_index(x) {
-            None => None,
-            Some(i) => Some((self.starts[i]..self.ends[i], &self.vals[i])),
-        }
+        self.get_index(x).map(|i| (self.starts[i]..self.ends[i], &self.vals[i]))
     }
 
     // Returns the entry of the interval containing `x`.

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -84,6 +84,7 @@ impl<T> HostTreePointer<T> {
     /// SAFETY: Pointer must only be dereferenced while the configures Host is
     /// still active, in addition to the normal safety requirements for
     /// dereferencing a pointer.
+    #[allow(unused_must_use)]
     pub unsafe fn ptr(&self) -> *mut T {
         // While a caller might conceivably get the pointer without the lock
         // held but only dereference after it actually is held, better to be
@@ -149,6 +150,12 @@ impl<T> Magic<T> {
             // Ensure no other operations are performed on the object before validating.
             std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
         }
+    }
+}
+
+impl<T> Default for Magic<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -84,7 +84,6 @@ impl<T> HostTreePointer<T> {
     /// SAFETY: Pointer must only be dereferenced while the configures Host is
     /// still active, in addition to the normal safety requirements for
     /// dereferencing a pointer.
-    #[allow(unused_must_use)]
     pub unsafe fn ptr(&self) -> *mut T {
         // While a caller might conceivably get the pointer without the lock
         // held but only dereference after it actually is held, better to be

--- a/src/main/utility/pcap_writer.rs
+++ b/src/main/utility/pcap_writer.rs
@@ -206,7 +206,7 @@ mod export {
             return 1;
         }
 
-        return 0;
+        0
     }
 }
 

--- a/src/main/utility/perf_timer.rs
+++ b/src/main/utility/perf_timer.rs
@@ -43,3 +43,9 @@ impl PerfTimer {
         e
     }
 }
+
+impl Default for PerfTimer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/main/utility/proc_maps.rs
+++ b/src/main/utility/proc_maps.rs
@@ -157,7 +157,7 @@ impl FromStr for Mapping {
             // Undocumented whether this is actually base 10; change to 16 if we find
             // counter-examples.
             inode: parse_field(caps.get(10).unwrap().as_str(), "inode", |s| {
-                u64::from_str_radix(s, 10)
+                s.parse()
             })?,
             path: parse_field::<_, _, Box<dyn Error>>(
                 caps.get(11).unwrap().as_str(),

--- a/src/main/utility/proc_maps.rs
+++ b/src/main/utility/proc_maps.rs
@@ -156,9 +156,7 @@ impl FromStr for Mapping {
             })?,
             // Undocumented whether this is actually base 10; change to 16 if we find
             // counter-examples.
-            inode: parse_field(caps.get(10).unwrap().as_str(), "inode", |s| {
-                s.parse()
-            })?,
+            inode: parse_field(caps.get(10).unwrap().as_str(), "inode", |s| s.parse())?,
             path: parse_field::<_, _, Box<dyn Error>>(
                 caps.get(11).unwrap().as_str(),
                 "path",

--- a/src/main/utility/sockaddr.rs
+++ b/src/main/utility/sockaddr.rs
@@ -176,8 +176,8 @@ impl std::fmt::Debug for SockaddrStorage {
         let as_inet6 = self.as_inet6();
         let as_unix = self.as_unix();
 
-        let as_inet = as_inet.map(|x| &*x as &dyn std::fmt::Debug);
-        let as_inet6 = as_inet6.map(|x| &*x as &dyn std::fmt::Debug);
+        let as_inet = as_inet.map(|x| x as &dyn std::fmt::Debug);
+        let as_inet6 = as_inet6.map(|x| x as &dyn std::fmt::Debug);
         let as_unix = as_unix.as_ref().map(|x| x as &dyn std::fmt::Debug);
 
         // find a representation that is not None
@@ -287,7 +287,7 @@ where
             return None;
         }
 
-        return Some(&name[1..]);
+        Some(&name[1..])
     }
 
     /// Is the unix socket address unnamed? On Linux, unnamed unix sockets are unnamed if their

--- a/src/main/utility/synchronization/thread_parking.rs
+++ b/src/main/utility/synchronization/thread_parking.rs
@@ -68,6 +68,12 @@ impl ThreadUnparkerUnassigned {
     }
 }
 
+impl Default for ThreadUnparkerUnassigned {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ThreadUnparker {
     fn new(
         ready_flag: Arc<AtomicBool>,

--- a/src/main/utility/syscall.rs
+++ b/src/main/utility/syscall.rs
@@ -6,14 +6,14 @@ use nix::errno::Errno;
 const MAX_ERRNO: i64 = 4095;
 
 pub fn raw_return_value_to_errno(rv: i64) -> Result<SysCallReg, i32> {
-    if rv <= -1 && rv >= -MAX_ERRNO {
+    if (-MAX_ERRNO..=-1).contains(&rv) {
         return Err(-rv as i32);
     }
     Ok(rv.into())
 }
 
 pub fn raw_return_value_to_result(rv: i64) -> nix::Result<SysCallReg> {
-    if rv <= -1 && rv >= -MAX_ERRNO {
+    if (-MAX_ERRNO..=-1).contains(&rv) {
         return Err(Errno::from_i32(-rv as i32));
     }
     Ok(rv.into())

--- a/src/test/dup/test_dup.rs
+++ b/src/test/dup/test_dup.rs
@@ -25,16 +25,10 @@ fn main() -> Result<(), String> {
 
     let mut tests = get_tests();
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;

--- a/src/test/epoll/test_epoll.rs
+++ b/src/test/epoll/test_epoll.rs
@@ -126,20 +126,14 @@ fn main() -> anyhow::Result<()> {
     let all_envs = set![TestEnvironment::Libc, TestEnvironment::Shadow];
     let mut tests: Vec<test_utils::ShadowTest<(), anyhow::Error>> = vec![
         ShadowTest::new("threads-edge", test_threads_edge, all_envs.clone()),
-        ShadowTest::new("threads-level", test_threads_level, all_envs.clone()),
+        ShadowTest::new("threads-level", test_threads_level, all_envs),
     ];
 
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnvironment::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnvironment::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnvironment::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnvironment::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;

--- a/src/test/eventfd/test_eventfd.rs
+++ b/src/test/eventfd/test_eventfd.rs
@@ -44,17 +44,11 @@ fn main() -> Result<(), String> {
     ];
 
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
 
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;

--- a/src/test/ifaddrs/test_ifaddrs.rs
+++ b/src/test/ifaddrs/test_ifaddrs.rs
@@ -35,10 +35,10 @@ fn main() {
         let netmask: &nix::sys::socket::SockaddrIn = netmask.as_sockaddr_in().unwrap();
 
         let address_str = address.to_string();
-        let ip = address_str.split(":").collect::<Vec<&str>>()[0];
+        let ip = address_str.split(':').collect::<Vec<&str>>()[0];
 
         let netmask = netmask.to_string();
-        let netmask = netmask.split(":").collect::<Vec<&str>>()[0];
+        let netmask = netmask.split(':').collect::<Vec<&str>>()[0];
 
         println!(
             "found ifaddr interface {} address {} netmask {:?}",

--- a/src/test/itimer/test_itimer.rs
+++ b/src/test/itimer/test_itimer.rs
@@ -374,20 +374,14 @@ fn main() -> anyhow::Result<()> {
         // Must be last.
         // Validate proper cleanup for a timer that's still running when the
         // process exits.
-        ShadowTest::new("leave_running", test_leave_running, all_envs.clone()),
+        ShadowTest::new("leave_running", test_leave_running, all_envs),
     ];
 
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnvironment::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnvironment::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnvironment::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnvironment::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;

--- a/src/test/memory/test_unaligned.rs
+++ b/src/test/memory/test_unaligned.rs
@@ -85,16 +85,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         ),
     ];
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
     test_utils::run_tests(&tests, summarize)?;
     println!("Success.");

--- a/src/test/pipe/test_pipe.rs
+++ b/src/test/pipe/test_pipe.rs
@@ -19,16 +19,10 @@ fn main() -> Result<(), String> {
 
     let mut tests = get_tests();
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;
@@ -235,8 +229,7 @@ fn test_large_read_write() -> Result<(), String> {
             write_buf.push(random_value as u8)
         }
 
-        let mut read_buf = Vec::<u8>::with_capacity(write_buf.len());
-        read_buf.resize(read_buf.capacity(), 0);
+        let mut read_buf = vec![0u8; write_buf.len()];
 
         let mut bytes_written = 0;
         let mut bytes_read = 0;

--- a/src/test/poll/test_poll.rs
+++ b/src/test/poll/test_poll.rs
@@ -3,6 +3,8 @@
  * See LICENSE for licensing information
  */
 
+use std::cmp::Ordering;
+
 use nix::sys::signal;
 use nix::sys::signal::Signal;
 use std::time::Duration;
@@ -56,13 +58,17 @@ fn test_pipe() -> Result<(), String> {
 
         /* First make sure there's nothing there */
         let mut ready = unsafe { libc::poll(&mut read_poll as *mut libc::pollfd, 1, 100) };
-        if ready < 0 {
+        match ready.cmp(&0) {
+            Ordering::Less => {
             return Err("error: poll failed".to_string());
-        } else if ready > 0 {
-            return Err(format!(
-                "error: pipe marked readable. revents={}",
-                read_poll.revents
-            ));
+            }
+            Ordering::Greater => {
+                return Err(format!(
+                    "error: pipe marked readable. revents={}",
+                    read_poll.revents
+                ));
+            }
+            _ => (),
         }
 
         /* Now put information in pipe to be read */
@@ -95,20 +101,24 @@ fn test_regular_file() -> Result<(), String> {
     test_utils::run_and_close_fds(&[fd], || {
         /* poll will check when testpoll has info to read */
         let mut read_poll = libc::pollfd {
-            fd: fd,
+            fd,
             events: libc::POLLIN,
             revents: 0,
         };
         let ready = unsafe { libc::poll(&mut read_poll as *mut libc::pollfd, 1, 100) };
-        if ready < 0 {
-            return Err("error: poll on empty file failed".to_string());
-        } else if ready == 0 {
-            /* Note: Even though the file is 0 bytes, has no data inside of it, it is still instantly
-             * available for 'reading' the EOF. */
-            return Err(format!(
-                "error: expected EOF to be readable from empty file. revents={}",
-                read_poll.revents
-            ));
+        match ready.cmp(&0) {
+            Ordering::Less => {
+                return Err("error: poll on empty file failed".to_string());
+            }
+            Ordering::Equal => {
+                /* Note: Even though the file is 0 bytes, has no data inside of it, it is still instantly
+                 * available for 'reading' the EOF. */
+                return Err(format!(
+                    "error: expected EOF to be readable from empty file. revents={}",
+                    read_poll.revents
+                ));
+            }
+            _ => (),
         }
 
         /* write to file */
@@ -128,7 +138,7 @@ fn test_regular_file() -> Result<(), String> {
     test_utils::run_and_close_fds(&[fd], || {
         /* poll will check when testpoll has info to read */
         let mut read_poll = libc::pollfd {
-            fd: fd,
+            fd,
             events: libc::POLLIN,
             revents: 0,
         };
@@ -159,6 +169,7 @@ fn get_pollable_fd() -> Result<libc::c_int, String> {
     Ok(fd)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn test_poll_args_common(
     poll_fn: PollFn,
     pfd_null: bool,
@@ -176,8 +187,8 @@ fn test_poll_args_common(
     test_utils::run_and_close_fds(&[fd], || {
         // The main struct for the poll syscall
         let mut pfd = libc::pollfd {
-            fd: fd,
-            events: events,
+            fd,
+            events,
             revents: 0,
         };
         if fd_inval {
@@ -269,6 +280,7 @@ fn test_poll_args_common(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_poll_args_test(
     poll_fn: PollFn,
     pfd_null: bool,
@@ -375,16 +387,11 @@ fn main() -> Result<(), String> {
     }
 
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
+
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;

--- a/src/test/poll/test_poll.rs
+++ b/src/test/poll/test_poll.rs
@@ -2,6 +2,7 @@
  * The Shadow Simulator
  * See LICENSE for licensing information
  */
+#![allow(clippy::too_many_arguments)]
 
 use std::cmp::Ordering;
 
@@ -169,7 +170,6 @@ fn get_pollable_fd() -> Result<libc::c_int, String> {
     Ok(fd)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn test_poll_args_common(
     poll_fn: PollFn,
     pfd_null: bool,
@@ -280,7 +280,6 @@ fn test_poll_args_common(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 fn get_poll_args_test(
     poll_fn: PollFn,
     pfd_null: bool,

--- a/src/test/poll/test_poll.rs
+++ b/src/test/poll/test_poll.rs
@@ -60,7 +60,7 @@ fn test_pipe() -> Result<(), String> {
         let mut ready = unsafe { libc::poll(&mut read_poll as *mut libc::pollfd, 1, 100) };
         match ready.cmp(&0) {
             Ordering::Less => {
-            return Err("error: poll failed".to_string());
+                return Err("error: poll failed".to_string());
             }
             Ordering::Greater => {
                 return Err(format!(

--- a/src/test/random/test_random.rs
+++ b/src/test/random/test_random.rs
@@ -34,16 +34,10 @@ fn main() -> Result<(), String> {
         ),
     ];
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow))
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc))
     }
 
     test_utils::run_tests(&tests, summarize)?;
@@ -73,9 +67,9 @@ fn check_randomness(fracs: &[f64]) -> Result<(), String> {
     }
 
     if fail {
-        return Err("failed to get random values across entire range".to_string());
+        Err("failed to get random values across entire range".to_string())
     } else {
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -112,7 +106,7 @@ fn test_rand() -> Result<(), String> {
         let random_value = unsafe { libc::rand() };
 
         #[allow(clippy::absurd_extreme_comparisons)]
-        if random_value < 0 || random_value > libc::RAND_MAX {
+        if !(0..=libc::RAND_MAX).contains(&random_value) {
             return Err("error: rand returned bytes outside of expected range".to_string());
         }
 

--- a/src/test/random/test_random.rs
+++ b/src/test/random/test_random.rs
@@ -111,6 +111,7 @@ fn test_rand() -> Result<(), String> {
     for val in values.iter_mut() {
         let random_value = unsafe { libc::rand() };
 
+        #[allow(clippy::absurd_extreme_comparisons)]
         if random_value < 0 || random_value > libc::RAND_MAX {
             return Err("error: rand returned bytes outside of expected range".to_string());
         }

--- a/src/test/select/test_select.rs
+++ b/src/test/select/test_select.rs
@@ -2,6 +2,7 @@
  * The Shadow Simulator
  * See LICENSE for licensing information
  */
+#![allow(clippy::too_many_arguments)]
 
 use std::mem;
 use std::time::Duration;
@@ -221,7 +222,6 @@ fn get_selectable_fd() -> Result<libc::c_int, String> {
     Ok(fd)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn test_select_args_common(
     select_fn: SelectFn,
     readfds_null: bool,
@@ -380,7 +380,6 @@ fn test_select_args_common(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 fn get_select_args_test(
     select_fn: SelectFn,
     readfds_null: bool,

--- a/src/test/select/test_select.rs
+++ b/src/test/select/test_select.rs
@@ -67,7 +67,7 @@ fn test_pipe() -> Result<(), String> {
                 },
             )
         };
-        let mut fd_is_readable = unsafe { libc::FD_ISSET(pfd_read, &mut readfds) };
+        let mut fd_is_readable = unsafe { libc::FD_ISSET(pfd_read, &readfds) };
 
         if ready < 0 {
             return Err("error: select failed".to_string());
@@ -108,7 +108,7 @@ fn test_pipe() -> Result<(), String> {
         }
 
         // Make sure the event is set for the correct fd
-        fd_is_readable = unsafe { libc::FD_ISSET(pfd_read, &mut readfds) };
+        fd_is_readable = unsafe { libc::FD_ISSET(pfd_read, &readfds) };
 
         if !fd_is_readable {
             return Err(format!(
@@ -147,7 +147,7 @@ fn test_regular_file() -> Result<(), String> {
                 },
             )
         };
-        let fd_is_readable = unsafe { libc::FD_ISSET(fd, &mut readfds) };
+        let fd_is_readable = unsafe { libc::FD_ISSET(fd, &readfds) };
 
         if ready < 0 {
             return Err("error: select on empty file failed".to_string());
@@ -196,7 +196,7 @@ fn test_regular_file() -> Result<(), String> {
                 },
             )
         };
-        let fd_is_readable = unsafe { libc::FD_ISSET(fd, &mut readfds) };
+        let fd_is_readable = unsafe { libc::FD_ISSET(fd, &readfds) };
 
         if ready != 1 {
             return Err(format!("error: select returned {} instead of 1", ready));
@@ -221,6 +221,7 @@ fn get_selectable_fd() -> Result<libc::c_int, String> {
     Ok(fd)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn test_select_args_common(
     select_fn: SelectFn,
     readfds_null: bool,
@@ -379,6 +380,7 @@ fn test_select_args_common(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_select_args_test(
     select_fn: SelectFn,
     readfds_null: bool,
@@ -485,16 +487,10 @@ fn main() -> Result<(), String> {
     }
 
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;

--- a/src/test/sleep/test_sleep.rs
+++ b/src/test/sleep/test_sleep.rs
@@ -216,7 +216,7 @@ fn call_clock_gettime() -> Duration {
     }
     assert!(rv >= 0);
     // valid tv_nsec values are [0, 999999999], which fit in a u32
-    return Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32);
+    Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32)
 }
 
 fn syscall_clock_gettime() -> Duration {
@@ -230,5 +230,5 @@ fn syscall_clock_gettime() -> Duration {
     }
     assert!(rv >= 0);
     // valid tv_nsec values are [0, 999999999], which fit in a u32
-    return Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32);
+    Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32)
 }

--- a/src/test/socket/accept/test_accept.rs
+++ b/src/test/socket/accept/test_accept.rs
@@ -30,16 +30,10 @@ fn main() -> Result<(), String> {
 
     let mut tests = get_tests();
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;
@@ -296,7 +290,7 @@ fn test_invalid_sock_type(accept_fn: AcceptFn) -> Result<(), String> {
     assert!(fd >= 0);
 
     let mut args = AcceptArguments {
-        fd: fd,
+        fd,
         addr: None,
         addr_len: None,
         flags: 0,
@@ -324,7 +318,7 @@ fn test_non_listening_fd(
     assert!(fd >= 0);
 
     let mut args = AcceptArguments {
-        fd: fd,
+        fd,
         addr: None,
         addr_len: None,
         flags: accept_flag,
@@ -713,7 +707,7 @@ fn test_after_close(
 
     // accept() may mutate addr and addr_len
     let mut args = AcceptArguments {
-        fd: fd,
+        fd,
         addr: None,
         addr_len: None,
         flags: accept_flag,
@@ -1036,9 +1030,8 @@ fn check_accept_call(
     };
 
     let errno = test_utils::get_errno();
-    let fd;
 
-    match expected_errno {
+    let fd = match expected_errno {
         // if we expect the accept() call to return an error (rv should be -1)
         Some(expected_errno) => {
             if rv != -1 {
@@ -1053,7 +1046,7 @@ fn check_accept_call(
                     test_utils::get_errno_message(errno)
                 ));
             }
-            fd = None;
+            None
         }
         // if no error is expected (rv should be non-negative)
         None => {
@@ -1064,9 +1057,9 @@ fn check_accept_call(
                     test_utils::get_errno_message(errno)
                 ));
             }
-            fd = Some(rv);
+            Some(rv)
         }
-    }
+    };
 
     Ok(fd)
 }

--- a/src/test/socket/bind/test_bind.rs
+++ b/src/test/socket/bind/test_bind.rs
@@ -22,16 +22,10 @@ fn main() -> Result<(), String> {
 
     let mut tests = get_tests();
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;
@@ -69,8 +63,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
     let sock_types = &[libc::SOCK_STREAM, libc::SOCK_DGRAM, libc::SOCK_SEQPACKET];
     let sock_type_combinations: Vec<(libc::c_int, libc::c_int)> = sock_types
         .iter()
-        .map(|item_x| sock_types.iter().map(move |item_y| (*item_x, *item_y)))
-        .flatten()
+        .flat_map(|item_x| sock_types.iter().map(move |item_y| (*item_x, *item_y)))
         .collect();
 
     for &domain in [libc::AF_INET, libc::AF_UNIX].iter() {
@@ -262,7 +255,7 @@ fn test_null_addr(
     assert!(fd >= 0);
 
     let args = BindArguments {
-        fd: fd,
+        fd,
         addr: None,
         addr_len: 5,
     };
@@ -301,9 +294,9 @@ fn test_short_addr(
     };
 
     let args = BindArguments {
-        fd: fd,
+        fd,
         addr: Some(addr),
-        addr_len: addr_len,
+        addr_len,
     };
 
     test_utils::run_and_close_fds(&[fd], || check_bind_call(&args, Some(libc::EINVAL)))
@@ -324,7 +317,7 @@ fn test_ipv4(sock_type: libc::c_int, flag: libc::c_int) -> Result<(), String> {
     };
 
     let args = BindArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Inet(addr)),
         addr_len: std::mem::size_of_val(&addr) as u32,
     };
@@ -354,7 +347,7 @@ fn test_all_ports_used() -> Result<(), String> {
             };
 
             let args = BindArguments {
-                fd: fd,
+                fd,
                 addr: Some(SockAddr::Inet(addr)),
                 addr_len: std::mem::size_of_val(&addr) as u32,
             };
@@ -377,7 +370,7 @@ fn test_all_ports_used() -> Result<(), String> {
         };
 
         let args = BindArguments {
-            fd: fd,
+            fd,
             addr: Some(SockAddr::Inet(addr)),
             addr_len: std::mem::size_of_val(&addr) as u32,
         };
@@ -473,7 +466,7 @@ fn test_ipv6(sock_type: libc::c_int, flag: libc::c_int) -> Result<(), String> {
     };
 
     let args = BindArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Inet6(addr)),
         addr_len: std::mem::size_of_val(&addr) as u32,
     };
@@ -497,7 +490,7 @@ fn test_loopback(sock_type: libc::c_int, flag: libc::c_int) -> Result<(), String
     };
 
     let args = BindArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Inet(addr)),
         addr_len: std::mem::size_of_val(&addr) as u32,
     };
@@ -520,7 +513,7 @@ fn test_any_interface(sock_type: libc::c_int, flag: libc::c_int) -> Result<(), S
     };
 
     let args = BindArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Inet(addr)),
         addr_len: std::mem::size_of_val(&addr) as u32,
     };
@@ -563,7 +556,7 @@ fn test_double_bind_socket(
     };
 
     let args = BindArguments {
-        fd: fd,
+        fd,
         addr: Some(addr),
         addr_len,
     };
@@ -720,7 +713,7 @@ fn test_autobind(
     };
 
     let args = BindArguments {
-        fd: fd,
+        fd,
         addr: Some(addr),
         addr_len,
     };

--- a/src/test/socket/connect/test_connect.rs
+++ b/src/test/socket/connect/test_connect.rs
@@ -25,16 +25,10 @@ fn main() -> Result<(), String> {
 
     let mut tests = get_tests();
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;
@@ -316,7 +310,7 @@ fn test_null_addr() -> Result<(), String> {
     assert!(fd >= 0);
 
     let args = ConnectArguments {
-        fd: fd,
+        fd,
         addr: None,
         addr_len: std::mem::size_of::<libc::sockaddr_in>() as u32,
     };
@@ -339,7 +333,7 @@ fn test_short_len() -> Result<(), String> {
     };
 
     let args = ConnectArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Inet(addr)),
         addr_len: (std::mem::size_of_val(&addr) - 1) as u32,
     };
@@ -362,7 +356,7 @@ fn test_zero_len() -> Result<(), String> {
     };
 
     let args = ConnectArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Inet(addr)),
         addr_len: 0u32,
     };
@@ -386,7 +380,7 @@ fn test_non_existent_server(sock_type: libc::c_int, flag: libc::c_int) -> Result
     };
 
     let args = ConnectArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Inet(addr)),
         addr_len: std::mem::size_of_val(&addr) as u32,
     };
@@ -417,7 +411,7 @@ fn test_port_zero(sock_type: libc::c_int, flag: libc::c_int) -> Result<(), Strin
     };
 
     let args = ConnectArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Inet(addr)),
         addr_len: std::mem::size_of_val(&addr) as u32,
     };
@@ -453,7 +447,7 @@ fn test_after_close(sock_type: libc::c_int, flag: libc::c_int) -> Result<(), Str
     };
 
     let args = ConnectArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Inet(addr)),
         addr_len: std::mem::size_of_val(&addr) as u32,
     };
@@ -665,7 +659,7 @@ fn test_non_existent_path(sock_type: libc::c_int, flag: libc::c_int) -> Result<(
     };
 
     let args = ConnectArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Unix(addr)),
         addr_len: std::mem::size_of_val(&addr) as u32,
     };

--- a/src/test/socket/connect/test_connect.rs
+++ b/src/test/socket/connect/test_connect.rs
@@ -603,6 +603,7 @@ fn test_double_connect(
     };
 
     // expected errno for the second connect() call
+    #[allow(clippy::if_same_then_else)]
     let expected_errno_2 = if sock_type == libc::SOCK_DGRAM {
         None
     } else if flag & libc::SOCK_NONBLOCK != 0 {

--- a/src/test/socket/getpeername/test_getpeername.rs
+++ b/src/test/socket/getpeername/test_getpeername.rs
@@ -24,16 +24,11 @@ fn main() -> Result<(), String> {
 
     let mut tests = get_tests();
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
+
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;
@@ -255,7 +250,7 @@ fn test_non_connected_fd(domain: libc::c_int, sock_type: libc::c_int) -> Result<
 
     // getpeername() may mutate addr and addr_len
     let mut args = GetpeernameArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Generic(addr)),
         addr_len: Some(std::mem::size_of_val(&addr) as u32),
     };
@@ -481,7 +476,7 @@ fn test_unbound_socket(domain: libc::c_int, sock_type: libc::c_int) -> Result<()
 
     // getpeername() may mutate addr and addr_len
     let mut args = GetpeernameArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Generic(addr)),
         addr_len: Some(std::mem::size_of_val(&addr) as u32),
     };
@@ -503,7 +498,7 @@ fn test_bound_socket(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), 
 
     // getpeername() may mutate addr and addr_len
     let mut args = GetpeernameArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Generic(addr)),
         addr_len: Some(std::mem::size_of_val(&addr) as u32),
     };
@@ -556,7 +551,7 @@ fn test_connected_dgram_socket(domain: libc::c_int) -> Result<(), String> {
 
     // getpeername() may mutate addr and addr_len
     let mut args = GetpeernameArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Generic(addr)),
         addr_len: Some(std::mem::size_of_val(&addr) as u32),
     };

--- a/src/test/socket/getsockname/test_getsockname.rs
+++ b/src/test/socket/getsockname/test_getsockname.rs
@@ -24,16 +24,10 @@ fn main() -> Result<(), String> {
 
     let mut tests = get_tests();
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;
@@ -208,7 +202,7 @@ fn test_null_addr(method: SocketInitMethod, sock_type: libc::c_int) -> Result<()
 
     // getsockname() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
-        fd: fd,
+        fd,
         addr: None,
         addr_len: Some(5),
     };
@@ -226,7 +220,7 @@ fn test_null_len(method: SocketInitMethod, sock_type: libc::c_int) -> Result<(),
 
     // getsockname() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Generic(addr)),
         addr_len: None,
     };
@@ -264,7 +258,7 @@ fn test_short_len_inet() -> Result<(), String> {
 
     // getpeername() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
-        fd: fd,
+        fd,
         addr: Some(SockAddr::Inet(addr)),
         addr_len: Some((std::mem::size_of_val(&addr) - 1) as u32),
     };
@@ -295,7 +289,7 @@ fn test_zero_len(method: SocketInitMethod, sock_type: libc::c_int) -> Result<(),
 
     // getsockname() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
-        fd: fd,
+        fd,
         addr: Some(addr),
         addr_len: Some(0u32),
     };
@@ -335,7 +329,7 @@ fn test_unbound_socket(domain: libc::c_int, sock_type: libc::c_int) -> Result<()
 
     // getsockname() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
-        fd: fd,
+        fd,
         addr: Some(addr),
         addr_len: Some(addr.ptr_size()),
     };
@@ -430,7 +424,7 @@ fn test_bound_socket(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), 
 
     // getsockname() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
-        fd: fd,
+        fd,
         addr: Some(addr),
         addr_len: Some(addr.ptr_size()),
     };
@@ -495,7 +489,7 @@ fn test_autobound_socket(domain: libc::c_int, sock_type: libc::c_int) -> Result<
 
     // getsockname() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
-        fd: fd,
+        fd,
         addr: Some(addr),
         addr_len: Some(addr.ptr_size()),
     };
@@ -587,7 +581,7 @@ fn test_after_close(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), S
 
     // getsockname() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
-        fd: fd,
+        fd,
         addr: Some(addr),
         addr_len: Some(addr.ptr_size()),
     };
@@ -717,7 +711,7 @@ fn test_implicit_bind(domain: libc::c_int, sock_type: libc::c_int) -> Result<(),
 
     // getsockname() may mutate addr and addr_len
     let mut args = GetsocknameArguments {
-        fd: fd,
+        fd,
         addr: Some(addr),
         addr_len: Some(addr.ptr_size()),
     };

--- a/src/test/socket/ioctl/test_ioctl.rs
+++ b/src/test/socket/ioctl/test_ioctl.rs
@@ -15,16 +15,10 @@ fn main() -> Result<(), String> {
 
     let mut tests = get_tests();
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;

--- a/src/test/socket/listen/test_listen.rs
+++ b/src/test/socket/listen/test_listen.rs
@@ -276,10 +276,7 @@ fn test_negative_backlog(
         bind_fd(fd, address);
     }
 
-    let args = ListenArguments {
-        fd,
-        backlog: -1,
-    };
+    let args = ListenArguments { fd, backlog: -1 };
 
     let expected_errno = match (domain, sock_type, bind) {
         (libc::AF_INET, libc::SOCK_STREAM, _) => None,
@@ -302,10 +299,7 @@ fn test_negative_backlog_connect(
 
     let (bind_address, bind_len) = socket_utils::autobind_helper(fd, domain);
 
-    let args = ListenArguments {
-        fd,
-        backlog: -1,
-    };
+    let args = ListenArguments { fd, backlog: -1 };
 
     let expected_errno = match (domain, sock_type) {
         (libc::AF_INET, libc::SOCK_STREAM) => None,
@@ -389,10 +383,7 @@ fn test_listen_twice(
         bind_fd(fd, address);
     }
 
-    let args1 = ListenArguments {
-        fd,
-        backlog: 10,
-    };
+    let args1 = ListenArguments { fd, backlog: 10 };
 
     let args2 = ListenArguments { fd, backlog: 0 };
 
@@ -428,10 +419,7 @@ fn test_after_close(
     let rv = unsafe { libc::close(fd) };
     assert_eq!(rv, 0);
 
-    let args = ListenArguments {
-        fd,
-        backlog: 100,
-    };
+    let args = ListenArguments { fd, backlog: 100 };
 
     check_listen_call(&args, Some(libc::EBADF))
 }

--- a/src/test/socket/listen/test_listen.rs
+++ b/src/test/socket/listen/test_listen.rs
@@ -25,16 +25,10 @@ fn main() -> Result<(), String> {
 
     let mut tests = get_tests();
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;
@@ -236,7 +230,7 @@ fn test_invalid_sock_type() -> Result<(), String> {
     let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
     assert!(fd >= 0);
 
-    let args = ListenArguments { fd: fd, backlog: 0 };
+    let args = ListenArguments { fd, backlog: 0 };
 
     test_utils::run_and_close_fds(&[fd], || check_listen_call(&args, Some(libc::EOPNOTSUPP)))
 }
@@ -255,7 +249,7 @@ fn test_zero_backlog(
         bind_fd(fd, address);
     }
 
-    let args = ListenArguments { fd: fd, backlog: 0 };
+    let args = ListenArguments { fd, backlog: 0 };
 
     let expected_errno = match (domain, sock_type, bind) {
         (libc::AF_INET, libc::SOCK_STREAM, _) => None,
@@ -283,7 +277,7 @@ fn test_negative_backlog(
     }
 
     let args = ListenArguments {
-        fd: fd,
+        fd,
         backlog: -1,
     };
 
@@ -309,7 +303,7 @@ fn test_negative_backlog_connect(
     let (bind_address, bind_len) = socket_utils::autobind_helper(fd, domain);
 
     let args = ListenArguments {
-        fd: fd,
+        fd,
         backlog: -1,
     };
 
@@ -333,7 +327,7 @@ fn test_negative_backlog_connect(
             std::iter::repeat_with(|| unsafe { libc::socket(domain, sock_type, 0) })
                 .take(num_clients)
                 // make sure the fds are valid
-                .map(|x| (x >= 0).then(|| x))
+                .map(|x| (x >= 0).then_some(x))
                 .collect::<Option<_>>()
                 .unwrap();
 
@@ -366,7 +360,7 @@ fn test_large_backlog(
     }
 
     let args = ListenArguments {
-        fd: fd,
+        fd,
         backlog: libc::INT_MAX,
     };
 
@@ -396,11 +390,11 @@ fn test_listen_twice(
     }
 
     let args1 = ListenArguments {
-        fd: fd,
+        fd,
         backlog: 10,
     };
 
-    let args2 = ListenArguments { fd: fd, backlog: 0 };
+    let args2 = ListenArguments { fd, backlog: 0 };
 
     let expected_errno = match (domain, sock_type, bind) {
         (libc::AF_INET, libc::SOCK_STREAM, _) => None,
@@ -435,7 +429,7 @@ fn test_after_close(
     assert_eq!(rv, 0);
 
     let args = ListenArguments {
-        fd: fd,
+        fd,
         backlog: 100,
     };
 
@@ -453,7 +447,7 @@ fn test_listening_not_readable(
 
     socket_utils::autobind_helper(fd, domain);
 
-    let args = ListenArguments { fd: fd, backlog: 5 };
+    let args = ListenArguments { fd, backlog: 5 };
 
     test_utils::run_and_close_fds(&[fd], || {
         check_listen_call(&args, None)?;
@@ -479,7 +473,7 @@ fn test_listening_not_writable(
 
     socket_utils::autobind_helper(fd, domain);
 
-    let args = ListenArguments { fd: fd, backlog: 5 };
+    let args = ListenArguments { fd, backlog: 5 };
 
     test_utils::run_and_close_fds(&[fd], || {
         check_listen_call(&args, None)?;
@@ -514,7 +508,7 @@ fn test_backlog_size(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), 
                 // linux will support backlog+1 incoming connections
                 .take(*backlog as usize + 1)
                 // make sure the fds are valid
-                .map(|x| (x >= 0).then(|| x))
+                .map(|x| (x >= 0).then_some(x))
                 .collect::<Option<_>>()
                 .unwrap();
 
@@ -616,7 +610,10 @@ fn test_reduced_backlog(domain: libc::c_int, sock_type: libc::c_int) -> Result<(
 
     // the new backlog should be lower than the number of clients we plan to connect;
     // a listening socket with a backlog 'x' can queue 'x+1' sockets
-    assert!(NEW_BACKLOG + 1 < NUM_CLIENTS);
+    #[allow(clippy::assertions_on_constants)]
+    {
+        assert!(NEW_BACKLOG + 1 < NUM_CLIENTS);
+    }
 
     // bind the server socket
     let (addr, addr_len) = test_utils::socket_utils::autobind_helper(server_fd, domain);
@@ -631,7 +628,7 @@ fn test_reduced_backlog(domain: libc::c_int, sock_type: libc::c_int) -> Result<(
             // linux will support backlog+1 incoming connections
             .take(NUM_CLIENTS)
             // make sure the fds are valid
-            .map(|x| (x >= 0).then(|| x))
+            .map(|x| (x >= 0).then_some(x))
             .collect::<Option<_>>()
             .unwrap();
 

--- a/src/test/socket/shutdown/test_shutdown.rs
+++ b/src/test/socket/shutdown/test_shutdown.rs
@@ -20,16 +20,10 @@ fn main() -> Result<(), String> {
 
     let mut tests = get_tests();
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;
@@ -652,7 +646,7 @@ fn test_conn_reset(
             )?;
 
             // if it didn't return an error, make sure we successfully read the byte/message
-            if expected_errnos.len() == 0 {
+            if expected_errnos.is_empty() {
                 test_utils::result_assert_eq(rv, 1, "Unexpected return value when read()ing")?;
             }
         }
@@ -678,7 +672,7 @@ fn test_conn_reset(
             )?;
 
             // if it didn't return an error, we expect read() to signal EOF
-            if expected_errnos.len() == 0 {
+            if expected_errnos.is_empty() {
                 test_utils::result_assert_eq(
                     rv,
                     0,

--- a/src/test/socket/socket/test_socket.rs
+++ b/src/test/socket/socket/test_socket.rs
@@ -426,15 +426,14 @@ fn check_socket_call(
     };
 
     let errno = test_utils::get_errno();
-    let fd;
 
     // if we expect the socket creation to return an error
-    if should_error {
+    let fd = if should_error {
         if rv != -1 {
             return Err(format!("Expecting a return value of -1, received {}", rv));
         }
 
-        fd = None;
+        None
     } else {
         if rv < 0 {
             return Err(format!(
@@ -443,8 +442,8 @@ fn check_socket_call(
             ));
         }
 
-        fd = Some(rv);
-    }
+        Some(rv)
+    };
 
     // check the errno if we were given one
     if let Some(expected_errno) = expected_errno {

--- a/src/test/socket/sockopt/test_sockopt.rs
+++ b/src/test/socket/sockopt/test_sockopt.rs
@@ -70,16 +70,10 @@ fn main() -> Result<(), String> {
 
     let mut tests = get_tests();
     if filter_shadow_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Shadow))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Shadow));
     }
     if filter_libc_passing {
-        tests = tests
-            .into_iter()
-            .filter(|x| x.passing(TestEnv::Libc))
-            .collect()
+        tests.retain(|x| x.passing(TestEnv::Libc));
     }
 
     test_utils::run_tests(&tests, summarize)?;

--- a/src/test/socket_utils.rs
+++ b/src/test/socket_utils.rs
@@ -1,7 +1,7 @@
 use crate::get_errno;
 
 /// A container for different types of socket addresses.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SockAddr {
     Generic(libc::sockaddr_storage),
     Inet(libc::sockaddr_in),

--- a/src/test/threads/test_pthreads.rs
+++ b/src/test/threads/test_pthreads.rs
@@ -406,7 +406,10 @@ extern "C" fn thread_mutex_trylock(mx: *mut libc::c_void) -> *mut libc::c_void {
         unsafe { (*muxes).num_locked += 1 };
 
         let num_not_locked = unsafe { (*muxes).num_not_locked };
-        if num_not_locked == 0 && NUM_THREADS != 1 &&  unsafe { libc::pthread_cond_wait((*muxes).cond_ptr(), (*muxes).mux2_ptr()) } < 0 {
+        if num_not_locked == 0
+            && NUM_THREADS != 1
+            && unsafe { libc::pthread_cond_wait((*muxes).cond_ptr(), (*muxes).mux2_ptr()) } < 0
+        {
             rv = ThreadRetVal::CondWaitFailed;
         }
 


### PR DESCRIPTION
Clippy had many complains. I tried to fix those I could, and added explicit `allow(clippy::...)` for the others.

I left [`missing_safety_doc`](https://rust-lang.github.io/rust-clippy/master/#missing_safety_doc) alone: it triggers a lot, but in most case I'd lack the knowledge to actually do something intelligent about it.