### PR TITLE
Update network interface association/disassociation

### DIFF
--- a/src/main/host/descriptor/udp.c
+++ b/src/main/host/descriptor/udp.c
@@ -236,8 +236,18 @@ static void _udp_close(LegacyFile* descriptor, const Host* host) {
     MAGIC_ASSERT(udp);
     _udp_setState(udp, UDPS_CLOSED);
 
-    CompatSocket compat_socket = compatsocket_fromLegacySocket(&udp->super);
-    host_disassociateInterface(host, &compat_socket);
+    in_addr_t sock_ip = 0;
+    in_port_t sock_port = 0;
+    if (!legacysocket_getSocketName(&udp->super, &sock_ip, &sock_port)) {
+        /* socket isn't bound, so don't try to disassociate */
+        return;
+    }
+
+    in_addr_t peer_ip = 0;
+    in_port_t peer_port = 0;
+    legacysocket_getPeerName(&udp->super, &peer_ip, &peer_port);
+
+    host_disassociateInterface(host, PUDP, sock_ip, sock_port, peer_ip, peer_port);
 }
 
 gint udp_shutdown(UDP* udp, gint how) {

--- a/src/main/host/descriptor/udp.c
+++ b/src/main/host/descriptor/udp.c
@@ -243,11 +243,8 @@ static void _udp_close(LegacyFile* descriptor, const Host* host) {
         return;
     }
 
-    in_addr_t peer_ip = 0;
-    in_port_t peer_port = 0;
-    legacysocket_getPeerName(&udp->super, &peer_ip, &peer_port);
-
-    host_disassociateInterface(host, PUDP, sock_ip, sock_port, peer_ip, peer_port);
+    /* we associate/disassociate UDP sockets without a peer */
+    host_disassociateInterface(host, PUDP, sock_ip, sock_port, 0, 0);
 }
 
 gint udp_shutdown(UDP* udp, gint how) {

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -1090,25 +1090,41 @@ mod export {
     pub unsafe extern "C" fn host_associateInterface(
         hostrc: *const Host,
         socket: *const cshadow::CompatSocket,
-        bind_addr: in_addr_t,
+        protocol: cshadow::ProtocolType,
+        bind_ip: in_addr_t,
+        bind_port: in_port_t,
+        peer_ip: in_addr_t,
+        peer_port: in_port_t,
     ) {
         let hostrc = unsafe { hostrc.as_ref().unwrap() };
-        let ipv4 = Ipv4Addr::from(u32::from_be(bind_addr));
+
+        let bind_ip = Ipv4Addr::from(u32::from_be(bind_ip));
+        let peer_ip = Ipv4Addr::from(u32::from_be(peer_ip));
+        let bind_port = u16::from_be(bind_port);
+        let peer_port = u16::from_be(peer_port);
+
+        let bind_addr = SocketAddrV4::new(bind_ip, bind_port);
+        let peer_addr = SocketAddrV4::new(peer_ip, peer_port);
 
         // Associate the interfaces corresponding to bind_addr with socket
-        if ipv4.is_unspecified() {
+        if bind_addr.ip().is_unspecified() {
             // Need to associate all interfaces.
-            hostrc
-                .localhost
-                .borrow()
-                .as_ref()
-                .unwrap()
-                .associate(socket);
-            hostrc.internet.borrow().as_ref().unwrap().associate(socket);
+            hostrc.localhost.borrow().as_ref().unwrap().associate(
+                socket,
+                protocol,
+                bind_addr.port(),
+                peer_addr,
+            );
+            hostrc.internet.borrow().as_ref().unwrap().associate(
+                socket,
+                protocol,
+                bind_addr.port(),
+                peer_addr,
+            );
         } else {
             // TODO: return error if interface does not exist.
-            if let Some(iface) = hostrc.interface_mut(ipv4) {
-                iface.associate(socket);
+            if let Some(iface) = hostrc.interface_mut(*bind_addr.ip()) {
+                iface.associate(socket, protocol, bind_addr.port(), peer_addr);
             }
         }
     }
@@ -1116,37 +1132,40 @@ mod export {
     #[no_mangle]
     pub unsafe extern "C" fn host_disassociateInterface(
         hostrc: *const Host,
-        socket: *const cshadow::CompatSocket,
+        protocol: cshadow::ProtocolType,
+        sock_ip: in_addr_t,
+        sock_port: in_port_t,
+        peer_ip: in_addr_t,
+        peer_port: in_port_t,
     ) {
         let hostrc = unsafe { hostrc.as_ref().unwrap() };
 
-        let mut bind_addr = 0;
-        let found = unsafe {
-            cshadow::compatsocket_getSocketName(socket, &mut bind_addr, std::ptr::null_mut())
-        };
-        if found {
-            let ipv4 = Ipv4Addr::from(u32::from_be(bind_addr));
+        let sock_ip = Ipv4Addr::from(u32::from_be(sock_ip));
+        let peer_ip = Ipv4Addr::from(u32::from_be(peer_ip));
+        let sock_port = u16::from_be(sock_port);
+        let peer_port = u16::from_be(peer_port);
 
-            // Associate the interfaces corresponding to bind_addr with socket
-            if ipv4.is_unspecified() {
-                // Need to disassociate all interfaces.
-                hostrc
-                    .localhost
-                    .borrow()
-                    .as_ref()
-                    .unwrap()
-                    .disassociate(socket);
-                hostrc
-                    .internet
-                    .borrow()
-                    .as_ref()
-                    .unwrap()
-                    .disassociate(socket);
-            } else {
-                // TODO: return error if interface does not exist.
-                if let Some(iface) = hostrc.interface_mut(ipv4) {
-                    iface.disassociate(socket);
-                }
+        let sock_addr = SocketAddrV4::new(sock_ip, sock_port);
+        let peer_addr = SocketAddrV4::new(peer_ip, peer_port);
+
+        // Associate the interfaces corresponding to bind_addr with socket
+        if sock_addr.ip().is_unspecified() {
+            // Need to disassociate all interfaces.
+            hostrc.localhost.borrow().as_ref().unwrap().disassociate(
+                protocol,
+                sock_addr.port(),
+                peer_addr,
+            );
+
+            hostrc.internet.borrow().as_ref().unwrap().disassociate(
+                protocol,
+                sock_addr.port(),
+                peer_addr,
+            );
+        } else {
+            // TODO: return error if interface does not exist.
+            if let Some(iface) = hostrc.interface_mut(*sock_addr.ip()) {
+                iface.disassociate(protocol, sock_addr.port(), peer_addr);
             }
         }
     }

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -1179,14 +1179,17 @@ mod export {
         peer_port: in_port_t,
     ) -> in_port_t {
         let hostrc = unsafe { hostrc.as_ref().unwrap() };
-        let Some(port) = hostrc.get_random_free_port(
-            protocol_type,
-            Ipv4Addr::from(u32::from_be(interface_ip)),
-            SocketAddrV4::new(Ipv4Addr::from(u32::from_be(peer_ip)),
-            u16::from_be(peer_port))) else {
-                return 0;
-            };
-        port.to_be()
+
+        let interface_ip = Ipv4Addr::from(u32::from_be(interface_ip));
+        let peer_addr = SocketAddrV4::new(
+            Ipv4Addr::from(u32::from_be(peer_ip)),
+            u16::from_be(peer_port),
+        );
+
+        hostrc
+            .get_random_free_port(protocol_type, interface_ip, peer_addr)
+            .unwrap_or(0)
+            .to_be()
     }
 
     /// Returns a pointer to the Host's FutexTable.

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -787,27 +787,23 @@ impl Host {
         src: SocketAddrV4,
         dst: SocketAddrV4,
     ) -> bool {
-        let port = src.port().to_be();
-        let peer_addr = u32::from(*dst.ip()).to_be();
-        let peer_port = dst.port().to_be();
-
         if src.ip().is_unspecified() {
             // Check that all interfaces are available.
-            !self.localhost.borrow().as_ref().unwrap().is_associated(
-                protocol_type,
-                port,
-                peer_addr,
-                peer_port,
-            ) && !self.internet.borrow().as_ref().unwrap().is_associated(
-                protocol_type,
-                port,
-                peer_addr,
-                peer_port,
-            )
+            !self
+                .localhost
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .is_associated(protocol_type, src.port(), dst)
+                && !self.internet.borrow().as_ref().unwrap().is_associated(
+                    protocol_type,
+                    src.port(),
+                    dst,
+                )
         } else {
             // The interface is not available if it does not exist.
             match self.interface(*src.ip()) {
-                Some(i) => !i.is_associated(protocol_type, port, peer_addr, peer_port),
+                Some(i) => !i.is_associated(protocol_type, src.port(), dst),
                 None => false,
             }
         }

--- a/src/main/host/network_interface.h
+++ b/src/main/host/network_interface.h
@@ -26,8 +26,11 @@ void networkinterface_free(NetworkInterface* interface);
 gboolean networkinterface_isAssociated(NetworkInterface* interface, ProtocolType type,
         in_port_t port, in_addr_t peerAddr, in_port_t peerPort);
 
-void networkinterface_associate(NetworkInterface* interface, const CompatSocket* socket);
-void networkinterface_disassociate(NetworkInterface* interface, const CompatSocket* socket);
+void networkinterface_associate(NetworkInterface* interface, const CompatSocket* socket,
+                                ProtocolType type, in_port_t port, in_addr_t peerIP,
+                                in_port_t peerPort);
+void networkinterface_disassociate(NetworkInterface* interface, ProtocolType type, in_port_t port,
+                                   in_addr_t peerIP, in_port_t peerPort);
 
 void networkinterface_wantsSend(NetworkInterface* interface, const Host* host,
                                 const CompatSocket* socket);

--- a/src/main/host/network_interface.rs
+++ b/src/main/host/network_interface.rs
@@ -42,12 +42,43 @@ impl NetworkInterface {
         }
     }
 
-    pub fn associate(&self, socket_ptr: *const c::CompatSocket) {
-        unsafe { c::networkinterface_associate(self.c_ptr.ptr(), socket_ptr) };
+    pub fn associate(
+        &self,
+        socket_ptr: *const c::CompatSocket,
+        protocol_type: c::ProtocolType,
+        port: u16,
+        peer_addr: SocketAddrV4,
+    ) {
+        let port = port.to_be();
+        let peer_ip = u32::from(*peer_addr.ip()).to_be();
+        let peer_port = peer_addr.port().to_be();
+
+        unsafe {
+            c::networkinterface_associate(
+                self.c_ptr.ptr(),
+                socket_ptr,
+                protocol_type,
+                port,
+                peer_ip,
+                peer_port,
+            )
+        };
     }
 
-    pub fn disassociate(&self, socket_ptr: *const c::CompatSocket) {
-        unsafe { c::networkinterface_disassociate(self.c_ptr.ptr(), socket_ptr) };
+    pub fn disassociate(&self, protocol_type: c::ProtocolType, port: u16, peer_addr: SocketAddrV4) {
+        let port = port.to_be();
+        let peer_ip = u32::from(*peer_addr.ip()).to_be();
+        let peer_port = peer_addr.port().to_be();
+
+        unsafe {
+            c::networkinterface_disassociate(
+                self.c_ptr.ptr(),
+                protocol_type,
+                port,
+                peer_ip,
+                peer_port,
+            )
+        };
     }
 
     pub fn is_associated(&self, protocol: c::ProtocolType, port: u16, peer: SocketAddrV4) -> bool {

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -279,6 +279,14 @@ static int _syscallhandler_bindHelper(SysCallHandler* sys, LegacySocket* socket_
     legacysocket_setPeerName(socket_desc, peerAddr, peerPort);
     legacysocket_setSocketName(socket_desc, addr, port);
 
+    /* we associate/disassociate UDP sockets without a peer since if the peer is changed with
+     * `connect()`, we wouldn't be able to disassociate again later. See
+     * https://github.com/shadow/shadow/issues/2590 */
+    if (ptype == PUDP) {
+        peerAddr = 0;
+        peerPort = 0;
+    }
+
     /* set associations */
     CompatSocket compat_socket = compatsocket_fromLegacySocket(socket_desc);
     host_associateInterface(

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -281,7 +281,8 @@ static int _syscallhandler_bindHelper(SysCallHandler* sys, LegacySocket* socket_
 
     /* set associations */
     CompatSocket compat_socket = compatsocket_fromLegacySocket(socket_desc);
-    host_associateInterface(_syscallhandler_getHost(sys), &compat_socket, addr);
+    host_associateInterface(
+        _syscallhandler_getHost(sys), &compat_socket, ptype, addr, port, peerAddr, peerPort);
     return 0;
 }
 
@@ -745,7 +746,8 @@ SysCallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
 
             /* set netiface->socket associations */
             CompatSocket compat_socket = compatsocket_fromLegacySocket(socket_desc);
-            host_associateInterface(_syscallhandler_getHost(sys), &compat_socket, bindAddr);
+            host_associateInterface(
+                _syscallhandler_getHost(sys), &compat_socket, ptype, bindAddr, bindPort, 0, 0);
         }
     } else if (legacyfile_getType(desc) == DT_TCPSOCKET) {
         errcode = tcp_getConnectionError((TCP*)socket_desc);


### PR DESCRIPTION
The network interface's association and disassociation methods use `compatsocket_getSocketName` and `compatsocket_getPeerName` to get the local ip/port and peer ip/port when generating the key, but this can be confusing and lead to bugs. For example, the calling code needs to make to set the correct addresses using `compatsocket_setSocketName` and `compatsocket_setPeerName` before associating the socket (setting them after would be a bug), and it's not clear that this requirement exists. Some related issues that come up because of this indirection are https://github.com/shadow/shadow/issues/2590 and https://github.com/shadow/shadow/issues/2592.

This PR changes the network interface to take the ip/ports explicitly instead. This also makes the code more flexible, and makes it easier to implement Rust socket objects. It also adds an improvement for #2590 so that UDP sockets are always associated using a peer ip/port of 0/0, which means we shouldn't leak UDP sockets anymore when they use `connect()`.