### PR TITLE
Add initial version of the `TCP` wrapper

### DIFF
--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -35,6 +35,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
                 "main/bindings/c/bindings-opaque.h".into(),
                 "main/core/worker.h".into(),
                 "main/host/descriptor/descriptor_types.h".into(),
+                "main/host/descriptor/tcp.h".into(),
                 "main/host/futex_table.h".into(),
                 "main/host/network_interface.h".into(),
                 "main/host/protocol.h".into(),
@@ -132,11 +133,10 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .blocklist_function("thread_sharedMem")
         .allowlist_function("affinity_.*")
         .allowlist_function("thread_.*")
-        .allowlist_function("legacyfile_close")
-        .allowlist_function("legacyfile_(ref|unref)")
-        .allowlist_function("legacyfile_getHandle")
-        .allowlist_function("legacyfile_setHandle")
-        .allowlist_function("legacyfile_shutdownHelper")
+        .allowlist_function("tcp_.*")
+        .allowlist_function("legacyfile_.*")
+        .allowlist_function("legacysocket_.*")
+        .blocklist_function("legacysocket_init")
         .allowlist_function("networkinterface_.*")
         .allowlist_function("hostc_.*")
         // used by shadow's main function

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -223,7 +223,11 @@ static void _legacyfile_handleStatusChange(LegacyFile* descriptor, Status oldSta
 
         /* Call only if the listener is still in the table. */
         if (g_hash_table_contains(descriptor->listeners, listener)) {
-            statuslistener_onStatusChanged(listener, descriptor->status, statusesChanged);
+            /* First try adding to the global callback queue if it exists. */
+            if (!add_to_global_cb_queue(listener, descriptor->status, statusesChanged)) {
+                /* If there was no global callback queue, run the callback immediately. */
+                statuslistener_onStatusChanged(listener, descriptor->status, statusesChanged);
+            }
         }
 
         /* The above callback may have changes status again,

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use nix::sys::socket::SockaddrIn;
 
+use crate::core::worker::Worker;
 use crate::cshadow as c;
 use crate::host::descriptor::{
     FileMode, FileState, FileStatus, StateListenerFilter, SyscallResult,
@@ -110,7 +111,11 @@ impl TcpSocket {
     }
 
     pub fn close(&mut self, _cb_queue: &mut CallbackQueue) -> Result<(), SyscallError> {
-        todo!()
+        Worker::with_active_host(|h| {
+            unsafe { c::legacyfile_close(self.as_legacy_file(), h) };
+        })
+        .unwrap();
+        Ok(())
     }
 
     pub fn bind(

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -7,41 +7,94 @@ use crate::cshadow as c;
 use crate::host::descriptor::{
     FileMode, FileState, FileStatus, StateListenerFilter, SyscallResult,
 };
+use crate::host::host::Host;
 use crate::host::memory_manager::MemoryManager;
 use crate::host::syscall_types::{PluginPtr, SysCallReg, SyscallError};
 use crate::utility::callback_queue::{CallbackQueue, Handle};
 use crate::utility::sockaddr::SockaddrStorage;
-use crate::utility::HostTreePointer;
+use crate::utility::{HostTreePointer, ObjectCounter};
 
-pub struct TcpSocket {}
+pub struct TcpSocket {
+    socket: HostTreePointer<c::TCP>,
+    // should only be used by `OpenFile` to make sure there is only ever one `OpenFile` instance for
+    // this file
+    has_open_file: bool,
+    _counter: ObjectCounter,
+}
 
 impl TcpSocket {
-    pub fn new() -> Arc<AtomicRefCell<Self>> {
-        todo!()
+    pub fn new(status: FileStatus, host: &Host) -> Arc<AtomicRefCell<Self>> {
+        let recv_buf_size = host.params.init_sock_recv_buf_size.try_into().unwrap();
+        let send_buf_size = host.params.init_sock_send_buf_size.try_into().unwrap();
+
+        let tcp = unsafe { c::tcp_new(host, recv_buf_size, send_buf_size) };
+        let tcp = unsafe { Self::new_from_legacy(tcp) };
+
+        tcp.borrow_mut().set_status(status);
+
+        tcp
+    }
+
+    /// Takes ownership of the [`TCP`](c::TCP) reference.
+    pub unsafe fn new_from_legacy(legacy_tcp: *mut c::TCP) -> Arc<AtomicRefCell<Self>> {
+        assert!(!legacy_tcp.is_null());
+
+        let socket = Self {
+            socket: HostTreePointer::new(legacy_tcp),
+            has_open_file: false,
+            _counter: ObjectCounter::new("TcpSocket"),
+        };
+
+        Arc::new(AtomicRefCell::new(socket))
+    }
+
+    /// Get the [`c::TCP`] pointer.
+    pub fn as_legacy_tcp(&self) -> *mut c::TCP {
+        unsafe { self.socket.ptr() }
+    }
+
+    /// Get the [`c::TCP`] pointer as a [`c::LegacySocket`] pointer.
+    pub fn as_legacy_socket(&self) -> *mut c::LegacySocket {
+        self.as_legacy_tcp() as *mut c::LegacySocket
+    }
+
+    /// Get the [`c::TCP`] pointer as a [`c::LegacyFile`] pointer.
+    pub fn as_legacy_file(&self) -> *mut c::LegacyFile {
+        self.as_legacy_tcp() as *mut c::LegacyFile
     }
 
     pub fn get_status(&self) -> FileStatus {
-        todo!()
+        let o_flags = unsafe { c::legacyfile_getFlags(self.as_legacy_file()) };
+        let o_flags =
+            nix::fcntl::OFlag::from_bits(o_flags).expect("Not a valid OFlag: {o_flags:?}");
+        let (status, extra_flags) = FileStatus::from_o_flags(o_flags);
+        assert!(
+            extra_flags.is_empty(),
+            "Rust wrapper doesn't support {extra_flags:?} flags",
+        );
+        status
     }
 
-    pub fn set_status(&mut self, _status: FileStatus) {
-        todo!();
+    pub fn set_status(&mut self, status: FileStatus) {
+        let o_flags = status.as_o_flags().bits();
+        unsafe { c::legacyfile_setFlags(self.as_legacy_file(), o_flags) };
     }
 
     pub fn mode(&self) -> FileMode {
-        todo!()
+        FileMode::READ | FileMode::WRITE
     }
 
     pub fn has_open_file(&self) -> bool {
-        todo!()
+        self.has_open_file
     }
 
     pub fn supports_sa_restart(&self) -> bool {
-        todo!()
+        // TODO: false if a timeout has been set via setsockopt
+        true
     }
 
-    pub fn set_has_open_file(&mut self, _val: bool) {
-        todo!();
+    pub fn set_has_open_file(&mut self, val: bool) {
+        self.has_open_file = val;
     }
 
     pub fn getsockname(&self) -> Result<Option<SockaddrIn>, SyscallError> {
@@ -53,7 +106,7 @@ impl TcpSocket {
     }
 
     pub fn address_family(&self) -> nix::sys::socket::AddressFamily {
-        todo!()
+        nix::sys::socket::AddressFamily::Inet
     }
 
     pub fn close(&mut self, _cb_queue: &mut CallbackQueue) -> Result<(), SyscallError> {
@@ -162,15 +215,21 @@ impl TcpSocket {
         todo!()
     }
 
-    pub fn add_legacy_listener(&mut self, _ptr: HostTreePointer<c::StatusListener>) {
-        todo!();
+    pub fn add_legacy_listener(&mut self, ptr: HostTreePointer<c::StatusListener>) {
+        unsafe { c::legacyfile_addListener(self.as_legacy_file(), ptr.ptr()) };
     }
 
-    pub fn remove_legacy_listener(&mut self, _ptr: *mut c::StatusListener) {
-        todo!();
+    pub fn remove_legacy_listener(&mut self, ptr: *mut c::StatusListener) {
+        unsafe { c::legacyfile_removeListener(self.as_legacy_file(), ptr) };
     }
 
     pub fn state(&self) -> FileState {
-        todo!()
+        unsafe { c::legacyfile_getStatus(self.as_legacy_file()) }.into()
+    }
+}
+
+impl std::ops::Drop for TcpSocket {
+    fn drop(&mut self) {
+        unsafe { c::legacyfile_unref(self.socket.ptr() as *mut libc::c_void) };
     }
 }

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -2019,8 +2019,7 @@ static void _tcp_processPacket(LegacySocket* socket, const Host* host, Packet* p
 
                 /* we need to multiplex a new child */
                 TCP* multiplexed = tcp_new(host, recvBufSize, sendBufSize);
-                Descriptor* desc =
-                    descriptor_fromLegacyFile((LegacyFile*)multiplexed, /* flags= */ 0);
+                Descriptor* desc = descriptor_fromLegacyTcp(multiplexed, /* flags= */ 0);
                 int handle = process_registerDescriptor(registerInProcess, desc);
 
                 multiplexed->child =

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -120,7 +120,7 @@ pub struct Host {
     #[cfg(feature = "perf_timers")]
     execution_timer: RefCell<PerfTimer>,
 
-    params: HostParameters,
+    pub params: HostParameters,
 
     cpu: RefCell<Option<Cpu>>,
 

--- a/src/main/host/syscall/handler/ioctl.rs
+++ b/src/main/host/syscall/handler/ioctl.rs
@@ -1,5 +1,8 @@
 use crate::cshadow as c;
 use crate::host::context::ThreadContext;
+use crate::host::descriptor::socket::inet::InetSocket;
+use crate::host::descriptor::socket::Socket;
+use crate::host::descriptor::File;
 use crate::host::descriptor::{CompatFile, DescriptorFlags, FileStatus};
 use crate::host::syscall::handler::SyscallHandler;
 use crate::host::syscall_types::{PluginPtr, SysCallArgs, SyscallResult, TypedPluginPtr};
@@ -47,6 +50,11 @@ impl SyscallHandler {
         };
 
         let file = file.inner_file().clone();
+
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file {
+            return Self::legacy_syscall(c::syscallhandler_ioctl, ctx, args);
+        }
+
         let mut file = file.borrow_mut();
 
         // all file types that shadow implements should support non-blocking operation

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -2,6 +2,7 @@ use std::mem::MaybeUninit;
 
 use crate::cshadow as c;
 use crate::host::context::ThreadContext;
+use crate::host::descriptor::socket::inet::InetSocket;
 use crate::host::descriptor::socket::unix::{UnixSocket, UnixSocketType};
 use crate::host::descriptor::socket::Socket;
 use crate::host::descriptor::{
@@ -108,6 +109,10 @@ impl SyscallHandler {
 
         let file = file.inner_file().clone();
 
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file {
+            return Self::legacy_syscall(c::syscallhandler_bind, ctx, args);
+        }
+
         let File::Socket(ref socket) = file else {
             return Err(Errno::ENOTSOCK.into());
         };
@@ -151,6 +156,10 @@ impl SyscallHandler {
                 }
             },
         };
+
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_sendto, ctx, args);
+        }
 
         self.sendto_helper(ctx, file, buf_ptr, buf_len, flags, addr_ptr, addr_len)
     }
@@ -258,6 +267,10 @@ impl SyscallHandler {
             },
         };
 
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_recvfrom, ctx, args);
+        }
+
         self.recvfrom_helper(ctx, file, buf_ptr, buf_len, flags, addr_ptr, addr_len_ptr)
     }
 
@@ -358,6 +371,10 @@ impl SyscallHandler {
             return Err(Errno::ENOTSOCK.into());
         };
 
+        if let Socket::Inet(InetSocket::Tcp(_)) = socket {
+            return Self::legacy_syscall(c::syscallhandler_getsockname, ctx, args);
+        }
+
         // linux will return an EFAULT before other errors
         if addr_ptr.is_null() || addr_len_ptr.is_null() {
             return Err(Errno::EFAULT.into());
@@ -399,6 +416,10 @@ impl SyscallHandler {
             return Err(Errno::ENOTSOCK.into());
         };
 
+        if let Socket::Inet(InetSocket::Tcp(_)) = socket {
+            return Self::legacy_syscall(c::syscallhandler_getpeername, ctx, args);
+        }
+
         // linux will return an EFAULT before other errors like ENOTCONN
         if addr_ptr.is_null() || addr_len_ptr.is_null() {
             return Err(Errno::EFAULT.into());
@@ -432,6 +453,10 @@ impl SyscallHandler {
                 return Self::legacy_syscall(c::syscallhandler_listen, ctx, args);
             }
         };
+
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_listen, ctx, args);
+        }
 
         let File::Socket(socket) = file.inner_file() else {
             return Err(Errno::ENOTSOCK.into());
@@ -470,6 +495,10 @@ impl SyscallHandler {
             },
         };
 
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_accept, ctx, args);
+        }
+
         self.accept_helper(ctx, file, addr_ptr, addr_len_ptr, 0)
     }
 
@@ -501,6 +530,10 @@ impl SyscallHandler {
                 }
             },
         };
+
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_accept4, ctx, args);
+        }
 
         self.accept_helper(ctx, file, addr_ptr, addr_len_ptr, flags)
     }
@@ -608,6 +641,10 @@ impl SyscallHandler {
             },
         };
 
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_connect, ctx, args);
+        }
+
         let File::Socket(socket) = file.inner_file() else {
             return Err(Errno::ENOTSOCK.into());
         };
@@ -642,6 +679,10 @@ impl SyscallHandler {
                 return Self::legacy_syscall(c::syscallhandler_shutdown, ctx, args);
             }
         };
+
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_shutdown, ctx, args);
+        }
 
         let File::Socket(socket) = file.inner_file() else {
             return Err(Errno::ENOTSOCK.into());
@@ -771,6 +812,10 @@ impl SyscallHandler {
             }
         };
 
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_getsockopt, ctx, args);
+        }
+
         let File::Socket(socket) = file.inner_file() else {
             return Err(Errno::ENOTSOCK.into());
         };
@@ -800,6 +845,10 @@ impl SyscallHandler {
                 return Self::legacy_syscall(c::syscallhandler_setsockopt, ctx, args);
             }
         };
+
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_setsockopt, ctx, args);
+        }
 
         let File::Socket(socket) = file.inner_file() else {
             return Err(Errno::ENOTSOCK.into());

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -41,9 +41,11 @@ impl SyscallHandler {
 
         // if there are still valid descriptors to the open file, close() will do nothing
         // and return None
-        CallbackQueue::queue_and_run(|cb_queue| desc.close(ctx.host, cb_queue))
-            .unwrap_or(Ok(()))
-            .map(|()| 0.into())
+        crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
+            CallbackQueue::queue_and_run(|cb_queue| desc.close(ctx.host, cb_queue))
+                .unwrap_or(Ok(()))
+                .map(|()| 0.into())
+        })
     }
 
     #[log_syscall(/* rv */ libc::c_int, /* oldfd */ libc::c_int)]

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -2,6 +2,8 @@ use crate::cshadow as c;
 use crate::host::context::ThreadContext;
 use crate::host::descriptor::pipe;
 use crate::host::descriptor::shared_buf::SharedBuf;
+use crate::host::descriptor::socket::inet::InetSocket;
+use crate::host::descriptor::socket::Socket;
 use crate::host::descriptor::{
     CompatFile, Descriptor, DescriptorFlags, File, FileMode, FileState, FileStatus, OpenFile,
 };
@@ -158,6 +160,10 @@ impl SyscallHandler {
             },
         };
 
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_read, ctx, args);
+        }
+
         self.read_helper(ctx, fd, file, buf_ptr, buf_size, offset)
     }
 
@@ -189,6 +195,10 @@ impl SyscallHandler {
                 }
             },
         };
+
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_pread64, ctx, args);
+        }
 
         self.read_helper(ctx, fd, file, buf_ptr, buf_size, offset)
     }
@@ -278,6 +288,10 @@ impl SyscallHandler {
             },
         };
 
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_write, ctx, args);
+        }
+
         self.write_helper(ctx, fd, file, buf_ptr, buf_size, offset)
     }
 
@@ -309,6 +323,10 @@ impl SyscallHandler {
                 }
             },
         };
+
+        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+            return Self::legacy_syscall(c::syscallhandler_pwrite64, ctx, args);
+        }
 
         self.write_helper(ctx, fd, file, buf_ptr, buf_size, offset)
     }

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -1363,12 +1363,13 @@ SysCallReturn syscallhandler_socket(SysCallHandler* sys,
     guint64 recvBufSize = host_getConfiguredRecvBufSize(_syscallhandler_getHost(sys));
     guint64 sendBufSize = host_getConfiguredSendBufSize(_syscallhandler_getHost(sys));
 
-    LegacySocket* sock_desc = NULL;
     if (type_no_flags == SOCK_STREAM) {
-        sock_desc = (LegacySocket*)tcp_new(_syscallhandler_getHost(sys), recvBufSize, sendBufSize);
-    } else {
-        sock_desc = (LegacySocket*)udp_new(_syscallhandler_getHost(sys), recvBufSize, sendBufSize);
+        panic("TCP sockets should be created by the rust socket() syscall handler");
     }
+
+    utility_alwaysAssert(type_no_flags == SOCK_DGRAM);
+    LegacySocket* sock_desc = sock_desc =
+        (LegacySocket*)udp_new(_syscallhandler_getHost(sys), recvBufSize, sendBufSize);
 
     int descFlags = 0;
     if (type & SOCK_CLOEXEC) {

--- a/src/main/utility/legacy_callback_queue.rs
+++ b/src/main/utility/legacy_callback_queue.rs
@@ -1,0 +1,124 @@
+use std::cell::RefCell;
+use std::ops::DerefMut;
+
+use crate::cshadow as c;
+
+thread_local! {
+    static C_CALLBACK_QUEUE: RefCell<Option<LegacyCallbackQueue>> = RefCell::new(None);
+}
+
+/// Similar to [`CallbackQueue`](crate::utility::callback_queue::CallbackQueue), but with some
+/// tweaks to work with C code.
+struct LegacyCallbackQueue(std::collections::VecDeque<Box<dyn FnOnce()>>);
+
+impl LegacyCallbackQueue {
+    pub fn new() -> Self {
+        Self(std::collections::VecDeque::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn add(&mut self, f: impl FnOnce() + 'static) {
+        self.0.push_back(Box::new(f));
+    }
+
+    /// The `Option` must be `Some`.
+    pub fn run(queue: &RefCell<Option<Self>>) {
+        // loop until there are no more events
+        let mut count = 0;
+
+        // the mutable borrow is short-lived so that new callbacks can be added to the queue while
+        // running `f`
+        while let Some(f) = queue.borrow_mut().as_mut().unwrap().0.pop_front() {
+            // run the event and allow it to add new events
+            (f)();
+
+            count += 1;
+            if count == 200 {
+                log::trace!("Possible infinite loop of event callbacks.");
+            } else if count == 10_000 {
+                log::warn!("Very likely an infinite loop of event callbacks.");
+            }
+        }
+    }
+}
+
+impl std::ops::Drop for LegacyCallbackQueue {
+    fn drop(&mut self) {
+        // don't show the following warning message if panicking
+        if std::thread::panicking() {
+            return;
+        }
+
+        if !self.is_empty() {
+            // panic in debug builds since the backtrace will be helpful for debugging
+            debug_panic!("Dropping LegacyEventQueue while it still has events pending.");
+        }
+    }
+}
+
+/// Helper function to initialize and run a global thread-local callback queue. This is a hack so
+/// that C [`LegacyFile`](crate::cshadow::LegacyFile)s can queue listener callbacks using
+/// `add_to_global_cb_queue`. This is primarily for [`TCP`](crate::cshadow::TCP) objects, and should
+/// not be used with Rust file objects.
+///
+/// Just like
+/// [`CallbackQueue::queue_and_run`](crate::utility::callback_queue::CallbackQueue::queue_and_run),
+/// the closure should make any borrows of the file object, rather than making any borrows outside
+/// of the closure.
+pub fn with_global_cb_queue<T>(f: impl FnOnce() -> T) -> T {
+    C_CALLBACK_QUEUE.with(|cb_queue| {
+        if cb_queue.borrow().is_some() {
+            // we seem to be in a nested `with_global_cb_queue()` call, so just run the closure with
+            // the existing queue
+            return f();
+        }
+
+        // set the global queue
+        assert!(cb_queue
+            .borrow_mut()
+            .replace(LegacyCallbackQueue::new())
+            .is_none());
+
+        let rv = f();
+
+        // run and drop the global queue
+        LegacyCallbackQueue::run(&cb_queue);
+        assert!(cb_queue.borrow_mut().take().is_some());
+
+        rv
+    })
+}
+
+mod export {
+    use super::*;
+
+    /// Returns `true` if successfully added to the queue, or `false` if there was no queue.
+    #[no_mangle]
+    pub unsafe extern "C" fn add_to_global_cb_queue(
+        listener: *mut c::StatusListener,
+        status: c::Status,
+        changed: c::Status,
+    ) -> bool {
+        C_CALLBACK_QUEUE.with(|cb_queue| {
+            let mut cb_queue = cb_queue.borrow_mut();
+
+            if let Some(cb_queue) = cb_queue.deref_mut() {
+                unsafe { c::statuslistener_ref(listener) };
+                cb_queue.add(move || {
+                    unsafe { c::statuslistener_onStatusChanged(listener, status, changed) };
+                    unsafe { c::statuslistener_unref(listener) };
+                });
+                true
+            } else {
+                false
+            }
+        })
+    }
+}

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -10,6 +10,7 @@ pub mod childpid_watcher;
 pub mod counter;
 pub mod give;
 pub mod interval_map;
+pub mod legacy_callback_queue;
 pub mod notnull;
 pub mod pcap_writer;
 pub mod perf_timer;


### PR DESCRIPTION
For most syscalls, we simply call the C syscall handler from the rust syscall handler just like we did before. This lets us incrementally add support for individual syscalls for this `TcpSocket` wrapper.

The `LegacyCallbackQueue` prevents circular borrows when running event listeners. For the `close()` syscall, this prevents a panic where the syscall handler mutably borrows the `TcpSocket`, the inner C `TCP` object changes to the `CLOSED` state, an epoll event listener callback is run, and the callback takes a shared borrow of the `TcpSocket`. Just like we do with the rust file objects, the callback queue allows us to delay callbacks until later.

A temporary `LegacyCallbackQueue` is stored as a thread-local so that the `LegacyDescriptor` can access it without us having to update large amounts of C code to pass it through to everywhere we need it. Since we're deprecating/removing the C code, it's not worth the effort / possible breakage to update it.