### PR TITLE
Support `ioctl()` for tcp wrapper

### DIFF
--- a/src/main/host/syscall/handler/ioctl.rs
+++ b/src/main/host/syscall/handler/ioctl.rs
@@ -1,8 +1,5 @@
 use crate::cshadow as c;
 use crate::host::context::ThreadContext;
-use crate::host::descriptor::socket::inet::InetSocket;
-use crate::host::descriptor::socket::Socket;
-use crate::host::descriptor::File;
 use crate::host::descriptor::{CompatFile, DescriptorFlags, FileStatus};
 use crate::host::syscall::handler::SyscallHandler;
 use crate::host::syscall_types::{PluginPtr, SysCallArgs, SyscallResult, TypedPluginPtr};
@@ -50,10 +47,6 @@ impl SyscallHandler {
         };
 
         let file = file.inner_file().clone();
-
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file {
-            return Self::legacy_syscall(c::syscallhandler_ioctl, ctx, args);
-        }
 
         let mut file = file.borrow_mut();
 


### PR DESCRIPTION
The forced generic type on `TypedPluginPtr::new` was useful here since originally I didn't specify it, and since functions like `tcp_getInputBufferLength` return an `i64` and the plugin memory is a `i32`, it would have overwritten too many bytes without any kind of warning or error. But since `TypedPluginPtr::new` has the `NoTypeInference` requirement, it failed to compile.