### PR TITLE
Don't refcount Process

### DIFF
--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -681,7 +681,7 @@ impl Host {
         let processes = std::mem::take(&mut *self.processes.borrow_mut());
         for (_id, process) in processes.into_iter() {
             unsafe { cshadow::process_stop(process.ptr()) };
-            unsafe { cshadow::process_unref(process.ptr()) };
+            unsafe { cshadow::process_free(process.ptr()) };
         }
         trace!("done freeing application for host '{}'", self.name());
     }

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -79,7 +79,7 @@ struct _Process {
     HostId hostId;
 
     /* unique id of the program that this process should run */
-    guint processID;
+    pid_t processID;
     GString* processName;
 
     /* All of the descriptors opened by this process. */
@@ -216,7 +216,7 @@ const char* process_getWorkingDir(Process* proc) {
     return proc->workingDir;
 }
 
-guint process_getProcessID(Process* proc) {
+pid_t process_getProcessID(Process* proc) {
     MAGIC_ASSERT(proc);
     return proc->processID;
 }

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -991,11 +991,6 @@ static void _process_free(Process* proc) {
     g_free(proc);
 }
 
-void process_ref(Process* proc) {
-    MAGIC_ASSERT(proc);
-    (proc->referenceCount)++;
-}
-
 void process_unref(Process* proc) {
     MAGIC_ASSERT(proc);
     (proc->referenceCount)--;

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -157,7 +157,6 @@ struct _Process {
     /* Pause shadow after launching this process, to give the user time to attach gdb */
     bool pause_for_debugging;
 
-    gint referenceCount;
     MAGIC_DECLARE;
 };
 
@@ -899,7 +898,6 @@ Process* process_new(const Host* host, guint processID, CSimulationTime startTim
     proc->threads =
         g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, _thread_gpointer_unref);
 
-    proc->referenceCount = 1;
     proc->isExiting = false;
 
     proc->straceLoggingMode = _strace_logging_mode;
@@ -924,7 +922,7 @@ Process* process_new(const Host* host, guint processID, CSimulationTime startTim
     return proc;
 }
 
-static void _process_free(Process* proc) {
+void process_free(Process* proc) {
     MAGIC_ASSERT(proc);
 
     process_freePtrsWithoutFlushing(proc);
@@ -989,15 +987,6 @@ static void _process_free(Process* proc) {
 
     MAGIC_CLEAR(proc);
     g_free(proc);
-}
-
-void process_unref(Process* proc) {
-    MAGIC_ASSERT(proc);
-    (proc->referenceCount)--;
-    utility_debugAssert(proc->referenceCount >= 0);
-    if(proc->referenceCount == 0) {
-        _process_free(proc);
-    }
 }
 
 MemoryManager* process_getMemoryManager(Process* proc) {

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -44,7 +44,7 @@ Process* process_new(const Host* host, guint processID, CSimulationTime startTim
                      CSimulationTime stopTime, const gchar* hostName, const gchar* pluginName,
                      const gchar* pluginPath, const gchar* const* envv, const gchar* const* argv,
                      bool pause_for_debugging);
-void process_unref(Process* proc);
+void process_free(Process* proc);
 
 void process_schedule(Process* proc, const Host* host);
 void process_continue(Process* proc, Thread* thread);

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -86,7 +86,7 @@ int process_getStraceFd(Process* proc);
 const gchar* process_getPluginName(Process* proc);
 
 /* Returns the processID that was assigned to us in process_new */
-guint process_getProcessID(Process* proc);
+pid_t process_getProcessID(Process* proc);
 
 /* Returns the native pid of the process */
 pid_t process_getNativePid(const Process* proc);

--- a/src/main/host/process.h
+++ b/src/main/host/process.h
@@ -44,7 +44,6 @@ Process* process_new(const Host* host, guint processID, CSimulationTime startTim
                      CSimulationTime stopTime, const gchar* hostName, const gchar* pluginName,
                      const gchar* pluginPath, const gchar* const* envv, const gchar* const* argv,
                      bool pause_for_debugging);
-void process_ref(Process* proc);
 void process_unref(Process* proc);
 
 void process_schedule(Process* proc, const Host* host);

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -66,7 +66,7 @@ impl Process {
     }
 
     pub fn id(&self) -> ProcessId {
-        ProcessId(unsafe { cshadow::process_getProcessID(self.cprocess) })
+        ProcessId::try_from(unsafe { cshadow::process_getProcessID(self.cprocess) }).unwrap()
     }
 
     pub fn host_id(&self) -> HostId {

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -90,7 +90,6 @@ SysCallHandler* syscallhandler_new(const Host* host, Process* process, Thread* t
 
     MAGIC_INIT(sys);
 
-    process_ref(process);
     thread_ref(thread);
 
     worker_count_allocation(SysCallHandler);
@@ -120,9 +119,6 @@ static void _syscallhandler_free(SysCallHandler* sys) {
         counter_free(sys->syscall_counter);
     }
 
-    if (sys->process) {
-        process_unref(sys->process);
-    }
     if (sys->thread) {
         thread_unref(sys->thread);
     }

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -93,11 +93,10 @@ impl<T> HostTreePointer<T> {
         // This function is still `unsafe` since it's now the caller's
         // responsibility to not release the lock and *then* dereference the
         // pointer.
-        //
-        // FIXME: unwrap result. See https://github.com/shadow/shadow/issues/2514
         Worker::with_active_host(|h| {
             assert_eq!(self.host_id, h.info().id);
-        });
+        })
+        .unwrap();
         self.ptr
     }
 }

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -158,6 +158,10 @@ name = "test_itimer"
 path = "itimer/test_itimer.rs"
 
 [[bin]]
+name = "test_itimer_scheduled_after_exit"
+path = "itimer/test_itimer_scheduled_after_exit.rs"
+
+[[bin]]
 name = "test_stdio"
 path = "stdio/test_stdio.rs"
 

--- a/src/test/itimer/CMakeLists.txt
+++ b/src/test/itimer/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_linux_tests(BASENAME itimer COMMAND sh -c "../../target/debug/test_itimer")
 add_shadow_tests(BASENAME itimer)
+
+add_linux_tests(BASENAME itimer_scheduled_after_exit COMMAND sh -c "../../target/debug/test_itimer_scheduled_after_exit")
+add_shadow_tests(BASENAME itimer_scheduled_after_exit)

--- a/src/test/itimer/itimer_scheduled_after_exit.yaml
+++ b/src/test/itimer/itimer_scheduled_after_exit.yaml
@@ -1,0 +1,11 @@
+general:
+  stop_time: 30
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  testnode:
+    network_node_id: 0
+    processes:
+    - path: ../../target/debug/test_itimer_scheduled_after_exit
+      start_time: 1

--- a/src/test/itimer/test_itimer_scheduled_after_exit.rs
+++ b/src/test/itimer/test_itimer_scheduled_after_exit.rs
@@ -1,0 +1,39 @@
+use nix::sys::signal;
+use test_utils::setitimer;
+
+pub fn main() {
+    // Ignore SIGALRM, so that it doesn't inadvertently kill
+    // the process if the timer fires before this process exits.
+    unsafe {
+        signal::sigaction(
+            signal::Signal::SIGALRM,
+            &signal::SigAction::new(
+                signal::SigHandler::SigIgn,
+                signal::SaFlags::empty(),
+                signal::SigSet::empty(),
+            ),
+        )
+        .unwrap()
+    };
+
+    // Set a timer to run forever.
+    setitimer(
+        libc::ITIMER_REAL,
+        &libc::itimerval {
+            it_value: libc::timeval {
+                tv_sec: 0,
+                tv_usec: 1_000,
+            },
+            // Repeat every ms indefinitely
+            it_interval: libc::timeval {
+                tv_sec: 0,
+                tv_usec: 1_000,
+            },
+        },
+    )
+    .unwrap();
+
+    // exit, with the timer still scheduled.
+    // This is to validate the behavior in Shadow when the process no longer
+    // exists at the time that the timer event fires.
+}


### PR DESCRIPTION
This simplifies the migration of Process to Rust.

I had initially planned to used `RootedRc`, and to store `RootedRcWeak` in tasks and to avoid circular references, but I realized the *only* strong reference would currently be in the `Host`. It'll be simpler to avoid exposing the `RootedRc` and `RootedRcWeak` wrappers around `Process` to the C code, and this allows us to do it.

This adds some `BTreeTable` lookups to fetch `Process*`'s from the `Host`'s process table, but these should be quite fast, especially since most simulations use fairly few processes per host. I'll do a benchmark run to verify, though.