### PR TITLE
Remove `Host::setup()`

### DIFF
--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -594,8 +594,8 @@ impl<'a> Manager<'a> {
                 unblocked_vdso_latency: self.config.unblocked_vdso_latency(),
             };
 
-            let host = Box::new(Host::new(params, &self.hosts_path, self.raw_frequency));
-            unsafe { host.setup(dns) };
+            let host =
+                Box::new(unsafe { Host::new(params, &self.hosts_path, self.raw_frequency, dns) });
 
             host
         };

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -594,8 +594,8 @@ impl<'a> Manager<'a> {
                 unblocked_vdso_latency: self.config.unblocked_vdso_latency(),
             };
 
-            let host = Box::new(Host::new(params, &self.hosts_path));
-            unsafe { host.setup(dns, self.raw_frequency) };
+            let host = Box::new(Host::new(params, &self.hosts_path, self.raw_frequency));
+            unsafe { host.setup(dns) };
 
             host
         };

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -594,8 +594,8 @@ impl<'a> Manager<'a> {
                 unblocked_vdso_latency: self.config.unblocked_vdso_latency(),
             };
 
-            let host = Box::new(Host::new(params));
-            unsafe { host.setup(dns, self.raw_frequency, &self.hosts_path) };
+            let host = Box::new(Host::new(params, &self.hosts_path));
+            unsafe { host.setup(dns, self.raw_frequency) };
 
             host
         };


### PR DESCRIPTION
I wanted to move around some of the host's network objects, but it was a little complicated with the `setup()` function, so I moved the code from the `Host::setup()` into `Host::new()`. Hopefully this doesn't overlap with any other WIP changes.