### PR TITLE
Move host networking to new `NetworkNamespace` object

### DIFF
--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -434,6 +434,10 @@ impl Host {
         self.router.borrow_mut()
     }
 
+    pub fn network_namespace(&self) -> impl Deref<Target = NetworkNamespace> + '_ {
+        Ref::map(self.net_ns.borrow(), |x| x.as_ref().unwrap())
+    }
+
     #[track_caller]
     pub fn tracker_mut(&self) -> Option<impl Deref<Target = cshadow::Tracker> + DerefMut + '_> {
         let tracker = self.tracker.borrow_mut();

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -75,7 +75,7 @@ impl SyscallHandler {
                 Socket::Unix(UnixSocket::new(
                     file_flags,
                     socket_type,
-                    ctx.host.abstract_unix_namespace(),
+                    &ctx.host.abstract_unix_namespace(),
                 ))
             }
             libc::AF_INET => match socket_type {
@@ -751,7 +751,7 @@ impl SyscallHandler {
             UnixSocket::pair(
                 file_flags,
                 socket_type,
-                ctx.host.abstract_unix_namespace(),
+                &ctx.host.abstract_unix_namespace(),
                 cb_queue,
             )
         });

--- a/src/main/network/mod.rs
+++ b/src/main/network/mod.rs
@@ -1,4 +1,5 @@
 pub mod graph;
+pub mod net_namespace;
 pub mod packet;
 mod relay;
 pub mod router;

--- a/src/main/network/net_namespace.rs
+++ b/src/main/network/net_namespace.rs
@@ -183,16 +183,7 @@ impl NetworkNamespace {
         // to a linear search to make sure we get a free port if we have one.
         // but start from a random port instead of the min.
         let start = rng.gen_range(MIN_RANDOM_PORT..=u16::MAX);
-        let mut port = start;
-        loop {
-            port = if port == u16::MAX {
-                MIN_RANDOM_PORT
-            } else {
-                port + 1
-            };
-            if port == start {
-                break;
-            }
+        for port in (start..=u16::MAX).chain(MIN_RANDOM_PORT..start) {
             if self.is_interface_available(
                 protocol_type,
                 SocketAddrV4::new(interface_ip, port),

--- a/src/main/network/net_namespace.rs
+++ b/src/main/network/net_namespace.rs
@@ -1,0 +1,127 @@
+use std::ffi::CString;
+use std::net::Ipv4Addr;
+use std::num::NonZeroU8;
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use shadow_shim_helper_rs::HostId;
+
+use crate::core::support::configuration::QDiscMode;
+use crate::core::worker::Worker;
+use crate::cshadow;
+use crate::host::descriptor::socket::abstract_unix_ns::AbstractUnixNamespace;
+use crate::host::network_interface::{NetworkInterface, PcapOptions};
+use crate::utility::SyncSendPointer;
+
+/// Represents a network namespace. Can be thought of as roughly equivalent to a Linux `struct net`.
+/// Shadow doesn't support multiple network namespaces, but this `NetworkNamespace` allows us to
+/// consolidate the host's networking objects, and hopefully might make it easier to support
+/// multiple network namespaces if we want to in the future.
+pub struct NetworkNamespace {
+    // map abstract socket addresses to unix sockets
+    pub unix: Arc<AtomicRefCell<AbstractUnixNamespace>>,
+
+    pub localhost: NetworkInterface,
+    pub internet: NetworkInterface,
+
+    // TODO: use a Rust address type
+    pub default_address: SyncSendPointer<cshadow::Address>,
+}
+
+impl NetworkNamespace {
+    /// SAFETY: `dns` must be a valid pointer.
+    pub unsafe fn new(
+        host_id: HostId,
+        hostname: Vec<NonZeroU8>,
+        public_ip: Ipv4Addr,
+        pcap: Option<PcapOptions>,
+        qdisc: QDiscMode,
+        dns: *mut cshadow::DNS,
+    ) -> Self {
+        let (localhost, local_addr) = unsafe {
+            Self::setup_net_interface(
+                &InterfaceOptions {
+                    host_id,
+                    hostname: hostname.clone(),
+                    ip: Ipv4Addr::LOCALHOST,
+                    uses_router: false,
+                    pcap: pcap.clone(),
+                    qdisc,
+                },
+                dns,
+            )
+        };
+
+        unsafe { cshadow::address_unref(local_addr) };
+
+        let (internet, public_addr) = unsafe {
+            Self::setup_net_interface(
+                &InterfaceOptions {
+                    host_id,
+                    hostname: hostname,
+                    ip: public_ip,
+                    uses_router: true,
+                    pcap,
+                    qdisc,
+                },
+                dns,
+            )
+        };
+
+        Self {
+            unix: Arc::new(AtomicRefCell::new(AbstractUnixNamespace::new())),
+            localhost,
+            internet,
+            default_address: unsafe { SyncSendPointer::new(public_addr) },
+        }
+    }
+
+    /// Must free the returned `*mut cshadow::Address` using [`cshadow::address_unref`].
+    unsafe fn setup_net_interface(
+        options: &InterfaceOptions,
+        dns: *mut cshadow::DNS,
+    ) -> (NetworkInterface, *mut cshadow::Address) {
+        let ip = u32::from(options.ip).to_be();
+
+        // hostname is shadowed so that we can't accidentally drop the CString before the end of the
+        // scope
+        let hostname: CString = options.hostname.clone().into();
+        let hostname = hostname.as_ptr();
+
+        let addr = unsafe { cshadow::dns_register(dns, options.host_id, hostname, ip) };
+        assert!(!addr.is_null());
+
+        let interface = unsafe {
+            NetworkInterface::new(
+                options.host_id,
+                addr,
+                options.pcap.clone(),
+                options.qdisc,
+                options.uses_router,
+            )
+        };
+
+        (interface, addr)
+    }
+}
+
+impl std::ops::Drop for NetworkNamespace {
+    fn drop(&mut self) {
+        // deregistering localhost is a no-op, so we skip it
+        Worker::with_dns(|dns| unsafe {
+            let dns = dns as *const cshadow::DNS;
+            cshadow::dns_deregister(dns.cast_mut(), self.default_address.ptr())
+        });
+
+        unsafe { cshadow::address_unref(self.default_address.ptr()) };
+    }
+}
+
+struct InterfaceOptions {
+    pub host_id: HostId,
+    pub hostname: Vec<NonZeroU8>,
+    pub ip: Ipv4Addr,
+    pub uses_router: bool,
+    pub pcap: Option<PcapOptions>,
+    pub qdisc: QDiscMode,
+}


### PR DESCRIPTION
This serves two main purposes:

1. Consolidate the host's networking-related code into a new structure.
2. When we have a function like `Socket::bind()` that needs to be able to associate the socket with a network interface, we can pass it just this `NetworkNamespace` object instead of needing to pass the entire `Host`. This provides better encapsulation.