### PR TITLE
Changed systemctl TasksMax Parameter

### DIFF
--- a/docs/system_configuration.md
+++ b/docs/system_configuration.md
@@ -90,7 +90,7 @@ tasks.
 If this task limit is too small, it can be removed with the following command:
 
 ```
-$ sudo systemctl set-property user-$UID.slice TasksMax=-1
+$ sudo systemctl set-property user-$UID.slice TasksMax=infinity
 ```
 
 ## Number of Maps


### PR DESCRIPTION
The parameter "-1" is no longer supported, instead "infinity" should be used. 

From SYSTEMD.RESOURCE-CONTROL(5)   
>  TasksMax=N
>            Specify the maximum number of tasks that may be created in the unit. This ensures that the number of tasks accounted for the unit (see above) stays below a specific limit. This either takes an
>            absolute number of tasks or a percentage value that is taken relative to the configured maximum number of tasks on the system. If assigned the special value "infinity", no tasks limit is
>            applied. This controls the "pids.max" control group attribute. For details about this control group attribute, see Process Number Controller[7].
> 
>            The system default for this setting may be controlled with DefaultTasksMax= in systemd-system.conf(5).