### PR TITLE
Support `bind()` for tcp wrapper

### DIFF
--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -6,6 +6,7 @@ use crate::cshadow as c;
 use crate::host::descriptor::{FileMode, FileState, FileStatus, SyscallResult};
 use crate::host::memory_manager::MemoryManager;
 use crate::host::syscall_types::{PluginPtr, SysCallReg, SyscallError};
+use crate::network::net_namespace::NetworkNamespace;
 use crate::utility::callback_queue::CallbackQueue;
 use crate::utility::sockaddr::SockaddrStorage;
 use crate::utility::HostTreePointer;
@@ -59,10 +60,15 @@ impl Socket {
         }
     }
 
-    pub fn bind(&self, addr: Option<&SockaddrStorage>, rng: impl rand::Rng) -> SyscallResult {
+    pub fn bind(
+        &self,
+        addr: Option<&SockaddrStorage>,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
+    ) -> SyscallResult {
         match self {
-            Self::Unix(socket) => UnixSocket::bind(socket, addr, rng),
-            Self::Inet(socket) => InetSocket::bind(socket, addr, rng),
+            Self::Unix(socket) => UnixSocket::bind(socket, addr, net_ns, rng),
+            Self::Inet(socket) => InetSocket::bind(socket, addr, net_ns, rng),
         }
     }
 

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -17,6 +17,7 @@ use crate::host::memory_manager::MemoryManager;
 use crate::host::syscall::Trigger;
 use crate::host::syscall_condition::SysCallCondition;
 use crate::host::syscall_types::{Blocked, PluginPtr, SysCallReg, SyscallError};
+use crate::network::net_namespace::NetworkNamespace;
 use crate::utility::callback_queue::{CallbackQueue, Handle};
 use crate::utility::sockaddr::{SockaddrStorage, SockaddrUnix};
 use crate::utility::stream_len::StreamLen;
@@ -134,6 +135,7 @@ impl UnixSocket {
     pub fn bind(
         socket: &Arc<AtomicRefCell<Self>>,
         addr: Option<&SockaddrStorage>,
+        _net_ns: &NetworkNamespace,
         rng: impl rand::Rng,
     ) -> SyscallResult {
         let socket_ref = &mut *socket.borrow_mut();


### PR DESCRIPTION
This passes the network namespace to the socket during the bind call, which isn't how Linux does it (in Linux, sockets hold a reference-counted reference to the network namespace in it's inode), but in Shadow we don't use reference counting on the network namespace and we don't support multiple network namespaces so we need to pass it here.