### PR TITLE
Rename borrowing accessors

### DIFF
--- a/src/lib/syscall-logger/src/lib.rs
+++ b/src/lib/syscall-logger/src/lib.rs
@@ -98,7 +98,7 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
             use crate::host::syscall::format::{{SyscallArgsFmt, SyscallResultFmt, write_syscall}};
 
             let syscall_args = {{
-                let memory = ctx.process.memory();
+                let memory = ctx.process.memory_borrow();
                 let syscall_args = <SyscallArgsFmt::<{syscall_args}>>::new(args, strace_fmt_options, &*memory);
                 // need to convert to a string so that we read the plugin's memory before we potentially
                 // modify it during the syscall
@@ -109,7 +109,7 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
             let rv = self.{syscall_name}_original(ctx, args);
 
             // format the result (returns None if the syscall didn't complete)
-            let memory = ctx.process.memory();
+            let memory = ctx.process.memory_borrow();
             let syscall_rv = SyscallResultFmt::<{syscall_rv}>::new(&rv, strace_fmt_options, &*memory);
 
             if let Some(ref syscall_rv) = syscall_rv {{

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -353,7 +353,7 @@ impl Worker {
             let packet = packet.take().expect("Packet task ran twice");
 
             let became_nonempty = {
-                let mut router = host.upstream_router_mut();
+                let mut router = host.upstream_router_borrow_mut();
                 unsafe { crate::network::router::router_enqueue(&mut *router, packet.into_inner()) }
             };
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -447,6 +447,7 @@ impl Host {
         self.router.borrow_mut()
     }
 
+    #[track_caller]
     pub fn network_namespace_borrow(&self) -> impl Deref<Target = NetworkNamespace> + '_ {
         Ref::map(self.net_ns.borrow(), |x| x.as_ref().unwrap())
     }

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -699,7 +699,7 @@ where
         // Allocate through the MemoryManager, so that it knows about this region.
         let ptr = PluginPtr::from(
             ctx.process
-                .memory_mut()
+                .memory_borrow_mut()
                 .do_mmap(
                     ctx.thread,
                     PluginPtr::from(0usize),
@@ -725,7 +725,7 @@ where
 
     pub fn free(mut self, ctx: &mut ThreadContext) {
         ctx.process
-            .memory_mut()
+            .memory_borrow_mut()
             .do_munmap(ctx.thread, self.ptr.ptr(), self.ptr.len())
             .unwrap();
         self.freed = true;

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -144,10 +144,12 @@ impl Process {
         unsafe { cshadow::process_getHostId(self.cprocess.ptr()) }
     }
 
+    #[track_caller]
     pub fn memory_borrow_mut(&self) -> impl Deref<Target = MemoryManager> + DerefMut + '_ {
         RefMut::map(self.memory_manager.borrow_mut(), |mm| mm.as_mut().unwrap())
     }
 
+    #[track_caller]
     pub fn memory_borrow(&self) -> impl Deref<Target = MemoryManager> + '_ {
         Ref::map(self.memory_manager.borrow(), |mm| mm.as_ref().unwrap())
     }
@@ -170,10 +172,12 @@ impl Process {
         Some(rv)
     }
 
+    #[track_caller]
     pub fn descriptor_table_borrow(&self) -> impl Deref<Target = DescriptorTable> + '_ {
         self.desc_table.borrow()
     }
 
+    #[track_caller]
     pub fn descriptor_table_borrow_mut(
         &self,
     ) -> impl Deref<Target = DescriptorTable> + DerefMut + '_ {
@@ -185,10 +189,12 @@ impl Process {
         Pid::from_raw(pid)
     }
 
+    #[track_caller]
     pub fn realtime_timer_borrow(&self) -> impl Deref<Target = Timer> + '_ {
         self.itimer_real.borrow()
     }
 
+    #[track_caller]
     pub fn realtime_timer_borrow_mut(&self) -> impl Deref<Target = Timer> + DerefMut + '_ {
         self.itimer_real.borrow_mut()
     }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -65,7 +65,7 @@ pub struct Process {
 }
 
 fn itimer_real_expiration(host: &Host, pid: ProcessId) {
-    let Some(process) = host.process(pid) else {
+    let Some(process) = host.process_borrow(pid) else {
         debug!("Process {:?} no longer exists", pid);
         return;
     };
@@ -144,11 +144,11 @@ impl Process {
         unsafe { cshadow::process_getHostId(self.cprocess.ptr()) }
     }
 
-    pub fn memory_mut(&self) -> impl Deref<Target = MemoryManager> + DerefMut + '_ {
+    pub fn memory_borrow_mut(&self) -> impl Deref<Target = MemoryManager> + DerefMut + '_ {
         RefMut::map(self.memory_manager.borrow_mut(), |mm| mm.as_mut().unwrap())
     }
 
-    pub fn memory(&self) -> impl Deref<Target = MemoryManager> + '_ {
+    pub fn memory_borrow(&self) -> impl Deref<Target = MemoryManager> + '_ {
         Ref::map(self.memory_manager.borrow(), |mm| mm.as_ref().unwrap())
     }
 
@@ -170,11 +170,13 @@ impl Process {
         Some(rv)
     }
 
-    pub fn descriptor_table(&self) -> impl Deref<Target = DescriptorTable> + '_ {
+    pub fn descriptor_table_borrow(&self) -> impl Deref<Target = DescriptorTable> + '_ {
         self.desc_table.borrow()
     }
 
-    pub fn descriptor_table_mut(&self) -> impl Deref<Target = DescriptorTable> + DerefMut + '_ {
+    pub fn descriptor_table_borrow_mut(
+        &self,
+    ) -> impl Deref<Target = DescriptorTable> + DerefMut + '_ {
         self.desc_table.borrow_mut()
     }
 
@@ -183,11 +185,11 @@ impl Process {
         Pid::from_raw(pid)
     }
 
-    pub fn realtime_timer(&self) -> impl Deref<Target = Timer> + '_ {
+    pub fn realtime_timer_borrow(&self) -> impl Deref<Target = Timer> + '_ {
         self.itimer_real.borrow()
     }
 
-    pub fn realtime_timer_mut(&self) -> impl Deref<Target = Timer> + DerefMut + '_ {
+    pub fn realtime_timer_borrow_mut(&self) -> impl Deref<Target = Timer> + DerefMut + '_ {
         self.itimer_real.borrow_mut()
     }
 }
@@ -228,7 +230,7 @@ mod export {
 
         let fd = Worker::with_active_host(|h| {
             proc.borrow(h.root())
-                .descriptor_table_mut()
+                .descriptor_table_borrow_mut()
                 .register_descriptor(*desc)
         })
         .unwrap();
@@ -251,12 +253,12 @@ mod export {
             }
         };
 
-        Worker::with_active_host(
-            |h| match proc.borrow(h.root()).descriptor_table().get(handle) {
+        Worker::with_active_host(|h| {
+            match proc.borrow(h.root()).descriptor_table_borrow().get(handle) {
                 Some(d) => d as *const Descriptor,
                 None => std::ptr::null(),
-            },
-        )
+            }
+        })
         .unwrap()
     }
 
@@ -277,7 +279,11 @@ mod export {
         };
 
         Worker::with_active_host(|h| {
-            match proc.borrow(h.root()).descriptor_table_mut().get_mut(handle) {
+            match proc
+                .borrow(h.root())
+                .descriptor_table_borrow_mut()
+                .get_mut(handle)
+            {
                 Some(d) => d as *mut Descriptor,
                 None => std::ptr::null_mut(),
             }
@@ -301,7 +307,7 @@ mod export {
             }
         };
 
-        Worker::with_active_host(|h| match proc.borrow(h.root()).descriptor_table().get(handle).map(|x| x.file()) {
+        Worker::with_active_host(|h| match proc.borrow(h.root()).descriptor_table_borrow().get(handle).map(|x| x.file()) {
             Some(CompatFile::Legacy(file)) => unsafe { file.ptr() },
             Some(CompatFile::New(file)) => {
                 // we have a special case for the legacy C TCP objects
@@ -330,15 +336,19 @@ mod export {
         let src = TypedPluginPtr::new::<u8>(src.into(), n);
         let dst = unsafe { std::slice::from_raw_parts_mut(notnull_mut_debug(dst) as *mut u8, n) };
 
-        Worker::with_active_host(
-            |h| match proc.borrow(h.root()).memory().copy_from_ptr(dst, src) {
+        Worker::with_active_host(|h| {
+            match proc
+                .borrow(h.root())
+                .memory_borrow()
+                .copy_from_ptr(dst, src)
+            {
                 Ok(_) => 0,
                 Err(e) => {
                     trace!("Couldn't read {:?} into {:?}: {:?}", src, dst, e);
                     -(e as i32)
                 }
-            },
-        )
+            }
+        })
         .unwrap()
     }
 
@@ -354,7 +364,11 @@ mod export {
         let dst = TypedPluginPtr::new::<u8>(dst.into(), n);
         let src = unsafe { std::slice::from_raw_parts(notnull_debug(src) as *const u8, n) };
         Worker::with_active_host(|h| {
-            match proc.borrow(h.root()).memory_mut().copy_to_ptr(dst, src) {
+            match proc
+                .borrow(h.root())
+                .memory_borrow_mut()
+                .copy_to_ptr(dst, src)
+            {
                 Ok(_) => 0,
                 Err(e) => {
                     trace!("Couldn't write {:?} into {:?}: {:?}", src, dst, e);
@@ -377,7 +391,7 @@ mod export {
         let plugin_src: PluginPtr = plugin_src.into();
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let memory = proc.memory();
+            let memory = proc.memory_borrow();
             let memory_ref = memory.memory_ref(TypedPluginPtr::new::<u8>(plugin_src, n));
             match memory_ref {
                 Ok(mr) => {
@@ -404,7 +418,7 @@ mod export {
         let proc = unsafe { cshadow::process_getRustProcess(proc).as_ref().unwrap() };
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let mut memory_manager = proc.memory_mut();
+            let mut memory_manager = proc.memory_borrow_mut();
             let plugin_src = TypedPluginPtr::new::<u8>(PluginPtr::from(plugin_src), n);
             let memory_ref = memory_manager.memory_ref_mut_uninit(plugin_src);
             match memory_ref {
@@ -438,7 +452,7 @@ mod export {
         let proc = unsafe { proc.as_ref().unwrap() };
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let mut memory_manager = proc.memory_mut();
+            let mut memory_manager = proc.memory_borrow_mut();
             let plugin_src = TypedPluginPtr::new::<u8>(PluginPtr::from(plugin_src), n);
             let memory_ref = memory_manager.memory_ref_mut(plugin_src);
             match memory_ref {
@@ -472,7 +486,7 @@ mod export {
         let proc = unsafe { proc.as_ref().unwrap() };
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let memory_manager = proc.memory();
+            let memory_manager = proc.memory_borrow();
             let buf = unsafe {
                 std::slice::from_raw_parts_mut(notnull_mut_debug(strbuf) as *mut u8, maxlen)
             };
@@ -493,7 +507,7 @@ mod export {
         let proc = unsafe { proc.as_ref().unwrap() };
         Worker::with_active_host(|h| {
             proc.borrow(h.root())
-                .descriptor_table_mut()
+                .descriptor_table_borrow_mut()
                 .shutdown_helper();
         })
         .unwrap();
@@ -505,7 +519,10 @@ mod export {
     pub unsafe extern "C" fn _process_descriptorTableRemoveAndCloseAll(proc: *const RustProcess) {
         let proc = unsafe { proc.as_ref().unwrap() };
         Worker::with_active_host(|host| {
-            let descriptors = proc.borrow(host.root()).descriptor_table_mut().remove_all();
+            let descriptors = proc
+                .borrow(host.root())
+                .descriptor_table_borrow_mut()
+                .remove_all();
             CallbackQueue::queue_and_run(|cb_queue| {
                 for desc in descriptors {
                     desc.close(host, cb_queue);
@@ -531,7 +548,7 @@ mod export {
 
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let mut table = proc.descriptor_table_mut();
+            let mut table = proc.descriptor_table_borrow_mut();
             match table.set(index.try_into().unwrap(), *descriptor.unwrap()) {
                 Some(d) => Descriptor::into_raw(Box::new(d)),
                 None => std::ptr::null_mut(),
@@ -568,7 +585,7 @@ mod export {
         let proc = unsafe { proc.as_ref().unwrap() };
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let memory_manager = proc.memory();
+            let memory_manager = proc.memory_borrow();
             match memory_manager
                 .memory_ref_prefix(TypedPluginPtr::new::<u8>(PluginPtr::from(plugin_src), n))
             {
@@ -599,7 +616,7 @@ mod export {
         let proc = unsafe { cshadow::process_getRustProcess(proc).as_ref().unwrap() };
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let mut memory_manager = proc.memory_mut();
+            let mut memory_manager = proc.memory_borrow_mut();
             let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             memory_manager
                 .do_mmap(
@@ -627,7 +644,7 @@ mod export {
         let proc = unsafe { cshadow::process_getRustProcess(proc).as_ref().unwrap() };
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let mut memory_manager = proc.memory_mut();
+            let mut memory_manager = proc.memory_borrow_mut();
             let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             memory_manager
                 .handle_munmap(&mut thread, PluginPtr::from(addr), len)
@@ -649,7 +666,7 @@ mod export {
         let proc = unsafe { cshadow::process_getRustProcess(proc).as_ref().unwrap() };
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let mut memory_manager = proc.memory_mut();
+            let mut memory_manager = proc.memory_borrow_mut();
             let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             memory_manager
                 .handle_mremap(
@@ -676,7 +693,7 @@ mod export {
         let proc = unsafe { cshadow::process_getRustProcess(proc).as_ref().unwrap() };
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let mut memory_manager = proc.memory_mut();
+            let mut memory_manager = proc.memory_borrow_mut();
             let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             memory_manager
                 .handle_mprotect(&mut thread, PluginPtr::from(addr), size, prot)
@@ -695,7 +712,7 @@ mod export {
         let proc = unsafe { cshadow::process_getRustProcess(proc).as_ref().unwrap() };
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let mut memory_manager = proc.memory_mut();
+            let mut memory_manager = proc.memory_borrow_mut();
             let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             memory_manager
                 .handle_brk(&mut thread, PluginPtr::from(plugin_src))
@@ -714,7 +731,7 @@ mod export {
         let proc = unsafe { cshadow::process_getRustProcess(proc).as_ref().unwrap() };
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
-            let mut memory_manager = proc.memory_mut();
+            let mut memory_manager = proc.memory_borrow_mut();
             if !memory_manager.has_mapper() {
                 let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
                 memory_manager.init_mapper(&mut thread)

--- a/src/main/host/syscall/format.rs
+++ b/src/main/host/syscall/format.rs
@@ -613,7 +613,7 @@ mod export {
             let proc = proc.borrow(host.root());
 
             // we don't know the type, so just show it as an int
-            let memory = proc.memory();
+            let memory = proc.memory_borrow();
             let rv = SyscallResultFmt::<libc::c_long>::new(&result, logging_mode, &memory);
 
             if let Some(ref rv) = rv {

--- a/src/main/host/syscall/handler/eventfd.rs
+++ b/src/main/host/syscall/handler/eventfd.rs
@@ -75,7 +75,10 @@ impl SyscallHandler {
         let mut desc = Descriptor::new(CompatFile::New(OpenFile::new(File::EventFd(file))));
         desc.set_flags(descriptor_flags);
 
-        let fd = ctx.process.descriptor_table_mut().register_descriptor(desc);
+        let fd = ctx
+            .process
+            .descriptor_table_borrow_mut()
+            .register_descriptor(desc);
 
         log::trace!("eventfd() returning fd {}", fd);
 

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -25,7 +25,7 @@ impl SyscallHandler {
         };
 
         // get the descriptor, or return early if it doesn't exist
-        let mut desc_table = ctx.process.descriptor_table_mut();
+        let mut desc_table = ctx.process.descriptor_table_borrow_mut();
         let desc = Self::get_descriptor_mut(&mut desc_table, fd)?;
 
         Ok(match cmd {

--- a/src/main/host/syscall/handler/ioctl.rs
+++ b/src/main/host/syscall/handler/ioctl.rs
@@ -17,7 +17,7 @@ impl SyscallHandler {
 
         // get the descriptor, or return early if it doesn't exist
         let file = {
-            let mut desc_table = ctx.process.descriptor_table_mut();
+            let mut desc_table = ctx.process.descriptor_table_borrow_mut();
             let desc = Self::get_descriptor_mut(&mut desc_table, fd)?;
 
             // add the CLOEXEC flag
@@ -57,7 +57,7 @@ impl SyscallHandler {
         // all file types that shadow implements should support non-blocking operation
         if request == libc::FIONBIO {
             let arg_ptr = TypedPluginPtr::new::<libc::c_int>(arg_ptr, 1);
-            let arg = ctx.process.memory_mut().read_vals::<_, 1>(arg_ptr)?[0];
+            let arg = ctx.process.memory_borrow_mut().read_vals::<_, 1>(arg_ptr)?[0];
 
             let mut status = file.get_status();
             status.set(FileStatus::NONBLOCK, arg != 0);
@@ -67,6 +67,6 @@ impl SyscallHandler {
         }
 
         // handle file-specific ioctls
-        file.ioctl(request, arg_ptr, &mut ctx.process.memory_mut())
+        file.ioctl(request, arg_ptr, &mut ctx.process.memory_borrow_mut())
     }
 }

--- a/src/main/host/syscall/handler/random.rs
+++ b/src/main/host/syscall/handler/random.rs
@@ -22,7 +22,7 @@ impl SyscallHandler {
 
         // Get a native-process mem buffer where we can copy the random bytes.
         let dst_ptr = TypedPluginPtr::new::<u8>(buf_ptr, count);
-        let mut memory = ctx.process.memory_mut();
+        let mut memory = ctx.process.memory_borrow_mut();
         let mut mem_ref = match memory.memory_ref_mut_uninit(dst_ptr) {
             Ok(m) => m,
             Err(e) => {

--- a/src/main/host/syscall/handler/sched.rs
+++ b/src/main/host/syscall/handler/sched.rs
@@ -34,7 +34,7 @@ impl SyscallHandler {
         let mask_ptr = TypedPluginPtr::new::<u8>(unsafe { args.get(2).as_ptr }.into(), cpusetsize);
 
         let pid = ProcessId::try_from(pid_t).map_err(|_| Errno::ESRCH)?;
-        if ctx.host.process(pid).is_none() && pid_t != 0 {
+        if ctx.host.process_borrow(pid).is_none() && pid_t != 0 {
             return Err(Errno::ESRCH.into());
         };
 
@@ -44,7 +44,7 @@ impl SyscallHandler {
             return Err(Errno::EINVAL.into());
         }
 
-        let mut mem = ctx.process.memory_mut();
+        let mut mem = ctx.process.memory_borrow_mut();
         let mut mask = mem.memory_ref_mut(mask_ptr)?;
 
         // this assumes little endian
@@ -64,7 +64,7 @@ impl SyscallHandler {
         let mask_ptr = TypedPluginPtr::new::<u8>(unsafe { args.get(2).as_ptr }.into(), cpusetsize);
 
         let pid = ProcessId::try_from(pid_t).map_err(|_| Errno::ESRCH)?;
-        if ctx.host.process(pid).is_none() && pid_t != 0 {
+        if ctx.host.process_borrow(pid).is_none() && pid_t != 0 {
             return Err(Errno::ESRCH.into());
         };
 
@@ -74,7 +74,7 @@ impl SyscallHandler {
             return Err(Errno::EINVAL.into());
         }
 
-        let mem = ctx.process.memory_mut();
+        let mem = ctx.process.memory_borrow_mut();
         let mask = mem.memory_ref(mask_ptr)?;
 
         // this assumes little endian
@@ -130,7 +130,7 @@ impl SyscallHandler {
             //   state.
             return Ok(0.into());
         }
-        let mut mem = ctx.process.memory_mut();
+        let mut mem = ctx.process.memory_borrow_mut();
         let mut rseq = mem.memory_ref_mut(rseq_ptr)?;
 
         // rseq is mostly unimplemented, but also mostly unneeded in Shadow.

--- a/src/main/host/syscall/handler/sysinfo.rs
+++ b/src/main/host/syscall/handler/sysinfo.rs
@@ -42,7 +42,9 @@ impl SyscallHandler {
         info.mem_unit = 1024 * 1024 * 1024; // GiB
 
         // Write the result to plugin memory.
-        ctx.process.memory_mut().copy_to_ptr(info_ptr, &[info])?;
+        ctx.process
+            .memory_borrow_mut()
+            .copy_to_ptr(info_ptr, &[info])?;
         Ok(0.into())
     }
 }


### PR DESCRIPTION
Follow-up to @stevenengler's feedback on https://github.com/shadow/shadow/pull/2612.

* Rename APIs that return borrow-counted objects
* add `#[track_caller]` to borrowing APIs