### PR TITLE
Add rust `TcpSocket` to network interface as `LegacySocket`

### DIFF
--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -333,7 +333,9 @@ fn associate_socket(
         return Err(Errno::EADDRINUSE.into());
     }
 
-    let socket = unsafe { c::compatsocket_fromInetSocket(&socket) };
+    // TODO: create the CompatSocket from the InetSocket
+    let InetSocket::Tcp(socket) = socket;
+    let socket = unsafe { c::compatsocket_fromLegacySocket(socket.borrow().as_legacy_socket()) };
 
     // associate the interfaces corresponding to addr with socket
     unsafe { net_ns.associate_interface(&socket, protocol, local_addr, peer_addr) };


### PR DESCRIPTION
When #2611 was merged, it added the first use of rust `InetSocket` objects in the network interface. This seems to have affected the graphs in the tgen benchmark.

![1671657833_grim](https://user-images.githubusercontent.com/3708797/209005575-aabf3fa0-ed41-4fab-8902-423528f53208.png)
![1671657857_grim](https://user-images.githubusercontent.com/3708797/209005585-9abc67ad-166b-43dd-b7d5-925a78da3513.png)

I don't think the simulation itself changed, just the tracker ~was~ became broken since only metrics that came from [Shadow](https://github.com/shadow/benchmark-results/blob/master/tgen/2022-12-20-T03-10-21/plots/shadow.results.pdf) changed, but not metrics that came from [tgen](https://github.com/shadow/benchmark-results/blob/master/tgen/2022-12-20-T03-10-21/plots/tgen.viz.pdf).

This PR changes it back to adding the C `LegacySocket` to the network interface instead, which causes the shadow metrics to go back to how they were before.

![1671658236_grim](https://user-images.githubusercontent.com/3708797/209006273-b565f3ac-6f69-4b02-bae2-40a4ffaa7d2f.png)
![1671658261_grim](https://user-images.githubusercontent.com/3708797/209006285-be38e5ed-3449-442b-afc5-402c258b63d5.png)



