### PR TITLE
Migrate packet forwarding functionality to rust

### DIFF
--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -361,15 +361,9 @@ impl Worker {
 
         let packet_task = TaskRef::new(move |host| {
             let packet = packet.take().expect("Packet task ran twice");
-
-            let became_nonempty = {
-                let mut router = host.upstream_router_borrow_mut();
-                router.push(packet)
-            };
-
-            if became_nonempty {
-                host.packets_are_available_to_receive();
-            }
+            host.upstream_router_borrow_mut()
+                .route_incoming_packet(packet);
+            host.notify_router_has_packets();
         });
 
         let mut packet_event = Event::new(packet_task, deliver_time, src_host, dst_host_id);

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -652,13 +652,6 @@ mod export {
         Worker::with(|w| w.shared.child_pid_watcher() as *const _).unwrap()
     }
 
-    // TODO: move to Router::_route_outgoing_packet
-    #[no_mangle]
-    pub extern "C" fn worker_sendPacket(src_host: *const Host, packet: *mut cshadow::Packet) {
-        let src_host = unsafe { src_host.as_ref() }.unwrap();
-        unsafe { Worker::send_packet(src_host, packet) };
-    }
-
     /// Implementation for counting allocated objects. Do not use this function directly.
     /// Use worker_count_allocation instead from the call site.
     #[no_mangle]
@@ -703,11 +696,6 @@ mod export {
     #[no_mangle]
     pub extern "C" fn worker_getCurrentEmulatedTime() -> CEmulatedTime {
         EmulatedTime::to_c_emutime(Worker::current_time())
-    }
-
-    #[no_mangle]
-    pub extern "C" fn worker_isBootstrapActive() -> bool {
-        Worker::with(|w| w.clock.borrow().now.unwrap() < w.shared.bootstrap_end_time).unwrap()
     }
 
     #[no_mangle]

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -456,6 +456,13 @@ impl Worker {
     pub fn increment_plugin_error_count() {
         Worker::with(|w| w.shared.increment_plugin_error_count()).unwrap()
     }
+
+    /// Shadow allows configuration of a "bootstrapping" interval, during which
+    /// hosts' network activity does not consume bandwidth. Returns `true` if we
+    /// are still within this preliminary interval, or `false` otherwise.
+    pub fn is_bootstrapping() -> bool {
+        Worker::with(|w| w.clock.borrow().now.unwrap() < w.shared.bootstrap_end_time).unwrap()
+    }
 }
 
 #[derive(Debug)]

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -10,6 +10,7 @@ use crate::host::process::Process;
 use crate::host::thread::ThreadId;
 use crate::network::net_namespace::NetworkNamespace;
 use crate::network::router::Router;
+use crate::network::PacketDevice;
 use crate::utility::{self, SyncSendPointer};
 use atomic_refcell::AtomicRefCell;
 use log::{debug, info, trace};
@@ -782,6 +783,10 @@ impl Host {
     /// the native Timestamp Counter, if we were able to find it.
     pub fn tsc(&self) -> &Tsc {
         &self.tsc
+    }
+
+    pub fn get_packet_device(&self, _address: Ipv4Addr) -> Ref<dyn PacketDevice> {
+        todo!()
     }
 }
 

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -330,31 +330,6 @@ Packet* networkinterface_pop(NetworkInterface* interface) {
     return packet;
 }
 
-const Packet* networkinterface_peek(NetworkInterface* interface) {
-    MAGIC_ASSERT(interface);
-
-    CompatSocket socket = {0};
-    bool found = false;
-
-    switch (interface->qdisc) {
-        case Q_DISC_MODE_ROUND_ROBIN: {
-            found = rrsocketqueue_peek(&interface->rrQueue, &socket);
-            break;
-        }
-        case Q_DISC_MODE_FIFO:
-        default: {
-            found = fifosocketqueue_peek(&interface->fifoQueue, &socket);
-            break;
-        }
-    }
-
-    if (found) {
-        return compatsocket_peekNextOutPacket(&socket);
-    } else {
-        return NULL;
-    }
-}
-
 // Add the socket to the list of sockets that have data ready for us to send
 // out to the network.
 void networkinterface_wantsSend(NetworkInterface* interface, const CompatSocket* socket) {

--- a/src/main/host/network_interface.h
+++ b/src/main/host/network_interface.h
@@ -17,9 +17,10 @@ typedef struct _NetworkInterface NetworkInterface;
 #include "main/host/descriptor/socket.h"
 #include "main/host/protocol.h"
 #include "main/routing/address.h"
+#include "main/routing/packet.minimal.h"
 
 NetworkInterface* networkinterface_new(Address* address, const gchar* pcapDir,
-                                       guint32 pcapCaptureSize, QDiscMode qdisc, bool uses_router);
+                                       guint32 pcapCaptureSize, QDiscMode qdisc);
 void networkinterface_free(NetworkInterface* interface);
 
 /* The address and ports must be in network byte order. */
@@ -32,12 +33,9 @@ void networkinterface_associate(NetworkInterface* interface, const CompatSocket*
 void networkinterface_disassociate(NetworkInterface* interface, ProtocolType type, in_port_t port,
                                    in_addr_t peerIP, in_port_t peerPort);
 
-void networkinterface_wantsSend(NetworkInterface* interface, const Host* host,
-                                const CompatSocket* socket);
+void networkinterface_wantsSend(NetworkInterface* interface, const CompatSocket* socket);
 
-void networkinterface_startRefillingTokenBuckets(NetworkInterface* interface, uint64_t bwDownKiBps,
-                                                 uint64_t bwUpKiBps);
-
-void networkinterface_receivePackets(NetworkInterface* interface, const Host* host);
+Packet* networkinterface_pop(NetworkInterface* interface);
+void networkinterface_push(NetworkInterface* interface, Packet* packet);
 
 #endif /* SHD_NETWORK_INTERFACE_H_ */

--- a/src/main/host/network_queuing_disciplines.c
+++ b/src/main/host/network_queuing_disciplines.c
@@ -47,19 +47,6 @@ bool rrsocketqueue_isEmpty(RrSocketQueue* self) {
     return g_queue_is_empty(self->queue);
 }
 
-bool rrsocketqueue_peek(RrSocketQueue* self, CompatSocket* socket) {
-    utility_debugAssert(self != NULL);
-    utility_debugAssert(self->queue != NULL);
-
-    uintptr_t taggedSocket = (uintptr_t)g_queue_peek_head(self->queue);
-    if (taggedSocket == 0) {
-        return false;
-    }
-
-    *socket = compatsocket_fromTagged(taggedSocket);
-    return true;
-}
-
 bool rrsocketqueue_pop(RrSocketQueue* self, CompatSocket* socket) {
     utility_debugAssert(self != NULL);
     utility_debugAssert(self->queue != NULL);
@@ -143,19 +130,6 @@ bool fifosocketqueue_isEmpty(FifoSocketQueue* self) {
     utility_debugAssert(self != NULL);
     utility_debugAssert(self->queue != NULL);
     return priorityqueue_isEmpty(self->queue);
-}
-
-bool fifosocketqueue_peek(FifoSocketQueue* self, CompatSocket* socket) {
-    utility_debugAssert(self != NULL);
-    utility_debugAssert(self->queue != NULL);
-
-    uintptr_t taggedSocket = (uintptr_t)priorityqueue_peek(self->queue);
-    if (taggedSocket == 0) {
-        return false;
-    }
-
-    *socket = compatsocket_fromTagged(taggedSocket);
-    return true;
 }
 
 bool fifosocketqueue_pop(FifoSocketQueue* self, CompatSocket* socket) {

--- a/src/main/host/network_queuing_disciplines.h
+++ b/src/main/host/network_queuing_disciplines.h
@@ -28,7 +28,6 @@ void rrsocketqueue_init(RrSocketQueue* self);
 void rrsocketqueue_destroy(RrSocketQueue* self, void (*fn_processItem)(const CompatSocket*));
 
 bool rrsocketqueue_isEmpty(RrSocketQueue* self);
-bool rrsocketqueue_peek(RrSocketQueue* self, CompatSocket* socket);
 bool rrsocketqueue_pop(RrSocketQueue* self, CompatSocket* socket);
 void rrsocketqueue_push(RrSocketQueue* self, const CompatSocket* socket);
 bool rrsocketqueue_find(RrSocketQueue* self, const CompatSocket* socket);
@@ -37,7 +36,6 @@ void fifosocketqueue_init(FifoSocketQueue* self);
 void fifosocketqueue_destroy(FifoSocketQueue* self, void (*fn_processItem)(const CompatSocket*));
 
 bool fifosocketqueue_isEmpty(FifoSocketQueue* self);
-bool fifosocketqueue_peek(FifoSocketQueue* self, CompatSocket* socket);
 bool fifosocketqueue_pop(FifoSocketQueue* self, CompatSocket* socket);
 void fifosocketqueue_push(FifoSocketQueue* self, const CompatSocket* socket);
 bool fifosocketqueue_find(FifoSocketQueue* self, const CompatSocket* socket);

--- a/src/main/network/mod.rs
+++ b/src/main/network/mod.rs
@@ -1,8 +1,18 @@
+use std::net::Ipv4Addr;
+
+use crate::network::packet::Packet;
+
 pub mod graph;
 pub mod net_namespace;
 pub mod packet;
-mod relay;
+pub mod relay;
 pub mod router;
+
+pub trait PacketDevice {
+    fn get_address(&self) -> Ipv4Addr;
+    fn pop(&self) -> Option<Packet>;
+    fn push(&self, packet: Packet);
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/main/network/net_namespace.rs
+++ b/src/main/network/net_namespace.rs
@@ -55,7 +55,6 @@ impl NetworkNamespace {
                     host_id,
                     hostname: hostname.clone(),
                     ip: Ipv4Addr::LOCALHOST,
-                    uses_router: false,
                     pcap: pcap.clone(),
                     qdisc,
                 },
@@ -71,7 +70,6 @@ impl NetworkNamespace {
                     host_id,
                     hostname,
                     ip: public_ip,
-                    uses_router: true,
                     pcap,
                     qdisc,
                 },
@@ -105,13 +103,7 @@ impl NetworkNamespace {
         assert!(!addr.is_null());
 
         let interface = unsafe {
-            NetworkInterface::new(
-                options.host_id,
-                addr,
-                options.pcap.clone(),
-                options.qdisc,
-                options.uses_router,
-            )
+            NetworkInterface::new(options.host_id, addr, options.pcap.clone(), options.qdisc)
         };
 
         (interface, addr)
@@ -297,7 +289,6 @@ struct InterfaceOptions {
     pub host_id: HostId,
     pub hostname: Vec<NonZeroU8>,
     pub ip: Ipv4Addr,
-    pub uses_router: bool,
     pub pcap: Option<PcapOptions>,
     pub qdisc: QDiscMode,
 }

--- a/src/main/network/relay/mod.rs
+++ b/src/main/network/relay/mod.rs
@@ -1,1 +1,314 @@
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+use std::sync::Weak;
+
+use crate::core::work::task::TaskRef;
+use crate::core::worker::Worker;
+use crate::cshadow as c;
+use crate::host::host::Host;
+use crate::network::packet::PacketStatus;
+use crate::network::relay::token_bucket::TokenBucket;
+use crate::network::Packet;
+use crate::utility::ObjectCounter;
+use atomic_refcell::AtomicRefCell;
+use crossbeam::atomic::AtomicCell;
+use shadow_shim_helper_rs::simulation_time::SimulationTime;
+
 mod token_bucket;
+
+/// A `Relay` forwards `Packet`s between `PacketDevice`s, optionally enforcing a
+/// bandwidth limit on the rate at which we forward `Packet`s between devices.
+/// The `Relay` is considered the "active" part of the `Packet` forwarding
+/// process: it initiates `Packet` forwarding and internally schedules tasks to
+/// ensure that `Packet`s are continually forwarded over time without exceeding
+/// the configured `RateLimit`.
+///
+/// An `Ipv4Addr` associated with a source `PacketDevice` object is supplied
+/// when creating a `Relay`. This `Ipv4Addr` is only meaningful to the extent
+/// that the `Host` understands how to map this `Ipv4Addr` to the intended
+/// `PacketDevice` when `Host::get_packet_device(Ipv4Addr)` is called. This
+/// source `PacketDevice` supplies the `Relay` with a stream of `Packet`s
+/// (through its implementation of `PacketDevice::pop()`) that the `Relay` will
+/// forward to a destination.
+///
+/// `Relay::notify()` must be called whenever the source `PacketDevice` changes
+/// state from empty to non-empty, to trigger an idle `Relay` to start
+/// forwarding `Packet`s again.
+///
+/// For each `Packet` that needs to be forwarded, the `Relay` uses the
+/// `Packet`'s destination `Ipv4Addr` to obtain the destination `PacketDevice`
+/// from the `Host` by calling its `Host::get_packet_device(Ipv4Addr)` function.
+/// The `Packet` is forwarded to the destination through the destination
+/// `PacketDevice`'s implementation of `PacketDevice::push()`.
+///
+/// This design allows the `Host` to use `Host::get_packet_device` to define its
+/// own routing table.
+///
+/// Note that `Packet`s forwarded between identical source and destination
+/// `PacketDevices` are considered "local" to that device and exempt from any
+/// configured `RateLimit`.
+pub struct Relay {
+    /// Allow for internal mutability. It as assumed that this will never be
+    /// mutably borrowed outside of `Relay::forward_until_blocked()`.
+    internal: AtomicRefCell<RelayInternal>,
+}
+
+struct RelayInternal {
+    _counter: ObjectCounter,
+    rate_limiter: Option<TokenBucket>,
+    src_dev_address: Ipv4Addr,
+    state: RelayState,
+    next_packet: Option<Packet>,
+}
+
+/// Track's the `Relay`s state, which typically moves from Idle to Pending to
+/// Forwarding, and then back to either Idle or Pending.
+#[derive(PartialEq, Copy, Clone, Debug)]
+enum RelayState {
+    /// Relay is idle (is not currently forwarding packets) and has not
+    /// scheduled a forwarding event.
+    Idle,
+    /// A forwarding event has been scheduled, and we are waiting for it to be
+    /// executed before we start forwarding packets.
+    Pending,
+    /// We are currently running our packet forwarding loop.
+    Forwarding,
+}
+
+/// Specifies a throughput limit the relay should enforce when forwarding packets.
+pub enum RateLimit {
+    BytesPerSecond(u64),
+    Unlimited,
+}
+
+impl Relay {
+    /// Creates a new `Relay` that will forward `Packet`s following the given
+    /// `RateLimit` from the `PacketDevice` returned by the `Host` when passing
+    /// the given `src_dev_address` to `Host::get_packet_device()`. The `Relay`
+    /// internally schedules tasks as needed to ensure packets continue to be
+    /// forwarded over time without exceeding the configured `RateLimit`.
+    pub fn new(rate: RateLimit, src_dev_address: Ipv4Addr) -> Self {
+        let rate_limiter = match rate {
+            RateLimit::BytesPerSecond(bytes) => Some(create_token_bucket(bytes)),
+            RateLimit::Unlimited => None,
+        };
+
+        Self {
+            internal: AtomicRefCell::new(RelayInternal {
+                _counter: ObjectCounter::new("Relay"),
+                rate_limiter,
+                src_dev_address,
+                state: RelayState::Idle,
+                next_packet: None,
+            }),
+        }
+    }
+
+    /// Notify the relay that its packet source now has packets available for
+    /// relaying to the packet sink. This must be called when the source changes
+    /// state from empty to non-empty to signal the relay to resume forwarding.
+    pub fn notify(self: &Arc<Self>, host: &Host) {
+        // The only time we hold a mutable borrow of our internals while
+        // executing outside of this module is when we're running our forwarding
+        // loop, and forwarding packets can certainly cause a call to
+        // Relay::notify(). Thus, it's safe to assume that we are in the
+        // Forwarding state if the borrow fails.
+        let state = match self.internal.try_borrow() {
+            Ok(internal) => internal.state,
+            Err(_) => RelayState::Forwarding,
+        };
+
+        #[allow(dead_code)]
+        match state {
+            RelayState::Idle => {
+                // FIXME: For now we emulate the old C forwarding code, which
+                // immediately forwarded one packet at a time as soon as one is
+                // available. We should delete the forward_now call and swap to
+                // forward_later intead, which lets packets accumulate and
+                // unwinds the stack to forward them, once we better understand
+                // its effect on performance.
+                self.forward_now(host);
+                // self.forward_later(SimulationTime::ZERO, host);
+            }
+            RelayState::Pending => {
+                log::trace!("Relay forward task already scheduled; skipping forward request.");
+            }
+            RelayState::Forwarding => {
+                log::trace!("Relay forward task currently running; skipping forward request.");
+            }
+        }
+    }
+
+    /// Schedule an event to trigger us to run the forwarding loop later, and
+    /// changes our state to `RelayState::Pending`. This allows us to run the
+    /// forwarding loop after unwinding the current stack, and allows socket
+    /// data to accumulate so we can forward multiple packets at once.
+    ///
+    /// Must not be called if our state is already `RelayState::Pending`, to
+    /// avoid scheduling multiple forwarding events simultaneously.
+    fn forward_later(self: &Arc<Self>, delay: SimulationTime, host: &Host) {
+        // We should not already be waiting for a scheduled forwarding task.
+        {
+            let mut internal = self.internal.borrow_mut();
+            assert_ne!(internal.state, RelayState::Pending);
+            internal.state = RelayState::Pending;
+        }
+
+        // Schedule a forwarding task using a weak reference to allow the relay
+        // to be dropped before the forwarding task is executed.
+        let weak_self = Arc::downgrade(self);
+        let task = TaskRef::new(move |host| Self::run_forward_task(&weak_self, host));
+        host.schedule_task_with_delay(task, delay);
+    }
+
+    /// The initial entry point for the forwarding event executed by the scheduler.
+    fn run_forward_task(weak_self: &Weak<Self>, host: &Host) {
+        // Ignore the task if the relay was dropped while the task was pending.
+        let Some(strong_self) = Weak::upgrade(weak_self) else {
+            log::trace!("Relay no longer exists; skipping forward task.");
+            return;
+        };
+
+        // Relay still exists, and task is no longer pending.
+        strong_self.internal.borrow_mut().state = RelayState::Idle;
+
+        // Run the main packet forwarding loop.
+        strong_self.forward_now(host);
+    }
+
+    /// Runs the forward loop, and then schedules a task to run it again if needed.
+    fn forward_now(self: &Arc<Self>, host: &Host) {
+        if let Some(blocking_dur) = self.forward_until_blocked(host) {
+            // Block until we have enough tokens to forward the next packet.
+            // Our state will be changed to `RelayState::Pending`.
+            self.forward_later(blocking_dur, host);
+        }
+    }
+
+    /// Run our main packet forwarding loop that continues forwarding packets
+    /// from the source device to the destination device until we run out of
+    /// either tokens or packets.
+    ///
+    /// Causes our state to change to `RelayState::Forwarding` during execution
+    /// of the loop, and then either `RelayState::Idle` if we run out of
+    /// packets, or `RelayState::Pending` if we run out of tokens before all
+    /// available packets are forwarded and we scheduled an event to resume
+    /// forwarding later.
+    ///
+    /// The duration until we have enough tokens to forward the next packet is
+    /// returned in case we run out of tokens in the forwarding loop.
+    fn forward_until_blocked(self: &Arc<Self>, host: &Host) -> Option<SimulationTime> {
+        // We don't enforce rate limits during bootstrapping.
+        let is_bootstrapping = Worker::is_bootstrapping();
+
+        // Get a mutable reference to internals, which we'll continuously hold
+        // for the rest of this function (for the entire time that we remain in
+        // the Forwarding state).
+        let mut internal = self.internal.borrow_mut();
+        internal.state = RelayState::Forwarding;
+
+        // The source device supplies us with the stream of packets to forward.
+        let src = host.get_packet_device(internal.src_dev_address);
+
+        // Continue forwarding until we run out of either packets or tokens.
+        loop {
+            // Get next packet from our local cache, or from the source device.
+            let Some(mut packet) = internal.next_packet.take().or_else(|| src.pop()) else {
+                // Ran out of packets to forward.
+                internal.state = RelayState::Idle;
+                return None;
+            };
+
+            // Get the destination device to which this packet should be forwarded.
+            let dst = host.get_packet_device(packet.dst_address());
+
+            // The packet is local if the src and dst refer to the same device.
+            // This can happen for the loopback device, and for the inet device
+            // if both sockets use the public ip to communicate over localhost.
+            let is_local = src.get_address() == dst.get_address();
+
+            // Check if we have enough tokens for forward the packet. Rate
+            // limits do not apply during bootstrapping, or if the source and
+            // destination are the same device.
+            if !is_bootstrapping && !is_local {
+                // Rate limit applies only if we have a token bucket.
+                if let Some(tb) = internal.rate_limiter.as_mut() {
+                    // Try to remove tokens for this packet.
+                    if let Err(blocking_dur) = tb.comforming_remove(packet.size() as u64) {
+                        // Too few tokens, cache the packet until we can forward it later.
+                        packet.add_status(PacketStatus::RelayCached);
+                        assert!(internal.next_packet.is_none());
+                        internal.next_packet = Some(packet);
+                        internal.state = RelayState::Idle;
+
+                        // Call Relay::forward_later() after dropping the mutable borrow.
+                        return Some(blocking_dur);
+                    }
+                }
+            }
+
+            // Forward the packet to the destination device now.
+            packet.add_status(PacketStatus::RelayForwarded);
+            // FIXME: For now we emulate the old C forwarding code, which
+            // scheduled a 1 nanosecond callback to deliver local packets. We
+            // should delete this entire block once we better understand how
+            // removing it affects the simulation.
+            if is_local {
+                let packet = Arc::new(AtomicCell::new(Some(packet)));
+                let task = TaskRef::new(move |host| {
+                    let packet = packet.take().expect("Packet task ran twice");
+                    let dst = host.get_packet_device(packet.dst_address());
+                    dst.push(packet);
+                });
+                host.schedule_task_with_delay(task, SimulationTime::from_nanos(1));
+                continue;
+            }
+            dst.push(packet);
+        }
+    }
+}
+
+/// Configures a token bucket according the the given bytes_per_second rate
+/// limit. We always refill at least 1 byte per millisecond.
+fn create_token_bucket(bytes_per_second: u64) -> TokenBucket {
+    let refill_interval = SimulationTime::from_millis(1);
+    let refill_size = std::cmp::max(1, bytes_per_second / 1000);
+
+    // Only the `capacity` of the bucket is increased by the burst allowance,
+    // not the `refill_size`. Therefore, the long term rate limit enforced by
+    // the token bucket (configured by `refill_size`) is not affected much.
+    let capacity = refill_size + get_burst_allowance();
+
+    TokenBucket::new(capacity, refill_size, refill_interval).unwrap()
+}
+
+/// Returns the "burst allowance" we use in our token buckets.
+///
+/// What the burst allowance ensures is that we don't lose tokens that are
+/// unused because we don't fragment packets. If we set the capacity of the
+/// bucket to exactly the refill size (i.e., without the `CONFIG_MTU` burst
+/// allowance) and there are only 1499 tokens left in this sending round, a full
+/// packet would not fit. The next time the bucket refills, it adds
+/// `refill_size` tokens but in doing so 1499 tokens would fall over the top of
+/// the bucket; these tokens would represent wasted bandwidth, and could
+/// potentially accumulate in every refill interval leading to a significantly
+/// lower achievable bandwidth.
+///
+/// A downside of the `CONFIG_MTU` burst allowance is that the sending rate
+/// could possibly become "bursty" with a behavior such as:
+/// - interval 1: send `refill_size` + `CONFIG_MTU` bytes, sending over the
+///      allowance by 1500 bytes
+/// - refill: `refill_size` token gets added to the bucket
+/// - interval 2: send `refill_size` - `CONFIG_MTU` bytes, sending under the
+///       allowance by 1500 bytes
+/// - refill: `refill_size` token gets added to the bucket
+/// - interval 3: send `refill_size` + `CONFIG_MTU` bytes, sending over the
+///      allowance by 1500 bytes
+/// - repeat
+///
+/// So it could become less smooth and more "bursty" even though the long term
+/// average is maintained. But I don't think this would happen much in practice,
+/// and we are batching sends for performance reasons.
+fn get_burst_allowance() -> u64 {
+    c::CONFIG_MTU.try_into().unwrap()
+}

--- a/src/main/network/router/codel_queue.rs
+++ b/src/main/network/router/codel_queue.rs
@@ -94,11 +94,13 @@ impl CoDelQueue {
     }
 
     /// Returns the total number of packets stored in the queue.
+    #[cfg(test)]
     pub fn len(&self) -> usize {
         self.elements.len()
     }
 
     /// Returns true if the queue is holding zero packets, false otherwise.
+    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -107,6 +109,7 @@ impl CoDelQueue {
     /// empty. Note that there is no gurantee that a subsequent `pop()`
     /// operation will return the same packet, since it could be dropped by the
     /// queue between the `peek()` and `pop()` operations.
+    #[cfg(test)]
     pub fn peek(&self) -> Option<&Packet> {
         self.elements.front().map(|x| &x.packet)
     }

--- a/src/main/network/router/mod.rs
+++ b/src/main/network/router/mod.rs
@@ -1,7 +1,10 @@
+use std::cell::RefCell;
+use std::net::Ipv4Addr;
+
 use crate::core::worker::Worker;
 use crate::cshadow as c;
-use crate::host::host::Host;
 use crate::network::packet::Packet;
+use crate::network::PacketDevice;
 use crate::utility::{Magic, ObjectCounter};
 
 use self::codel_queue::CoDelQueue;
@@ -14,89 +17,64 @@ use shadow_shim_helper_rs::emulated_time::EmulatedTime;
 pub struct Router {
     magic: Magic<Self>,
     _counter: ObjectCounter,
+    address: Ipv4Addr,
     /// Packets inbound to the host from the simulated network.
-    inbound_packets: CoDelQueue,
+    inbound_packets: RefCell<CoDelQueue>,
 }
 
 impl Router {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Router {
+    /// Create a new router for a host that will help route packets between it
+    /// and other hosts. The `address` must uniquely identify this router to the
+    /// host that owns it.
+    pub fn new(address: Ipv4Addr) -> Router {
         Router {
             magic: Magic::new(),
+            address,
             _counter: ObjectCounter::new("Router"),
-            inbound_packets: CoDelQueue::new(),
+            inbound_packets: RefCell::new(CoDelQueue::new()),
         }
     }
 
-    // Return true if the router changed from empty to non-empty.
-    // TODO: This will eventually not return anything once we have
-    // PacketDevice signaling implemented in rust.
-    // Rob: Coming in future PR.
-    pub fn push(&mut self, packet: Packet) -> bool {
+    fn push_inner(&self, packet: Packet, now: EmulatedTime) {
+        self.magic.debug_check();
+        self.inbound_packets.borrow_mut().push(packet, now);
+    }
+
+    fn pop_inner(&self, now: EmulatedTime) -> Option<Packet> {
+        self.magic.debug_check();
+        self.inbound_packets.borrow_mut().pop(now)
+    }
+
+    /// Routes the packet from the source host through the virtual internet to
+    /// the destination host.
+    fn route_outgoing_packet(&self, packet: Packet) {
+        // TODO: move Worker::send_packet to here?
+        let cpacket = packet.into_inner();
+        Worker::with_active_host(|src_host| unsafe { Worker::send_packet(src_host, cpacket) })
+            .unwrap();
+        unsafe { c::packet_unref(cpacket) };
+    }
+
+    /// Routes the packet from the virtual internet into our CoDel queue, which
+    /// can then be received by the destiantion host by calling pop().
+    pub fn route_incoming_packet(&self, packet: Packet) {
         self.push_inner(packet, Worker::current_time().unwrap())
-    }
-
-    fn push_inner(&mut self, packet: Packet, now: EmulatedTime) -> bool {
-        self.magic.debug_check();
-        let was_empty = self.inbound_packets.is_empty();
-        self.inbound_packets.push(packet, now);
-        was_empty && !self.inbound_packets.is_empty()
-    }
-
-    pub fn peek(&self) -> Option<&Packet> {
-        self.magic.debug_check();
-        self.inbound_packets.peek()
-    }
-
-    pub fn pop(&mut self) -> Option<Packet> {
-        self.pop_inner(Worker::current_time().unwrap())
-    }
-
-    fn pop_inner(&mut self, now: EmulatedTime) -> Option<Packet> {
-        self.magic.debug_check();
-        self.inbound_packets.pop(now)
-    }
-
-    fn _route_outgoing_packet(_src_host: &Host, _packet: Packet) {
-        // TODO: move worker_sendPacket to here.
-        // Rob: Coming in future PR.
-        todo!()
-    }
-
-    fn _route_incoming_packet(_dst_host: &Host, _packet: Packet) {
-        // TODO: move _worker_runDeliverPacketTask to here.
-        // Rob: Coming in future PR.
-        todo!()
     }
 }
 
-mod export {
-    use super::*;
-
-    /// # Safety
-    ///
-    /// The returned `c::Packet` must not live longer than the next time the
-    /// router is modified; when the router is modified, the returned packet
-    /// pointer becomes invalid/dangling.
-    #[no_mangle]
-    pub unsafe extern "C" fn router_peek(router_ptr: *const Router) -> *const c::Packet {
-        let router = unsafe { router_ptr.as_ref() }.unwrap();
-        match router.peek() {
-            Some(packet) => packet.borrow_inner(),
-            None => std::ptr::null(),
-        }
+impl PacketDevice for Router {
+    fn get_address(&self) -> Ipv4Addr {
+        self.address
     }
 
-    /// # Safety
-    ///
-    /// Pointer args must be safely dereferenceable.
-    #[no_mangle]
-    pub unsafe extern "C" fn router_dequeue(router_ptr: *mut Router) -> *mut c::Packet {
-        let router = unsafe { router_ptr.as_mut() }.unwrap();
-        match router.pop() {
-            Some(packet) => packet.into_inner(),
-            None => std::ptr::null_mut(),
-        }
+    fn pop(&self) -> Option<Packet> {
+        // When the host calls pop, we provide the next packet from the CoDel queue.
+        self.pop_inner(Worker::current_time().unwrap())
+    }
+
+    fn push(&self, packet: Packet) {
+        // When the host calls push, we send to the virtual internet.
+        self.route_outgoing_packet(packet);
     }
 }
 
@@ -108,8 +86,8 @@ mod tests {
     #[test]
     fn empty() {
         let now = mock_time_millis(1000);
-        let mut router = Router::new();
-        assert!(router.peek().is_none());
+        let router = Router::new(Ipv4Addr::UNSPECIFIED);
+        assert!(router.inbound_packets.borrow().peek().is_none());
         assert!(router.pop_inner(now).is_none());
     }
 
@@ -118,20 +96,20 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn push_pop_simple() {
         let now = mock_time_millis(1000);
-        let mut router = Router::new();
+        let router = Router::new(Ipv4Addr::UNSPECIFIED);
 
         const N: usize = 10;
 
-        for i in 1..=N {
-            assert_eq!(router.push_inner(Packet::mock_new(), now), i == 1);
-            assert!(router.peek().is_some());
+        for _ in 1..=N {
+            router.push_inner(Packet::mock_new(), now);
+            assert!(router.inbound_packets.borrow().peek().is_some());
         }
         for _ in 1..=N {
-            assert!(router.peek().is_some());
+            assert!(router.inbound_packets.borrow().peek().is_some());
             assert!(router.pop_inner(now).is_some());
         }
 
-        assert!(router.peek().is_none());
+        assert!(router.inbound_packets.borrow().peek().is_none());
         assert!(router.pop_inner(now).is_none());
     }
 }

--- a/src/main/routing/packet.c
+++ b/src/main/routing/packet.c
@@ -583,6 +583,8 @@ static const gchar* _packet_deliveryStatusToAscii(PacketDeliveryStatusFlags stat
         case PDS_RCV_SOCKET_BUFFERED: return "RCV_SOCKET_BUFFERED";
         case PDS_RCV_SOCKET_DELIVERED: return "RCV_SOCKET_DELIVERED";
         case PDS_DESTROYED: return "PDS_DESTROYED";
+        case PDS_RELAY_CACHED: return "RELAY_CACHED";
+        case PDS_RELAY_FORWARDED: return "RELAY_FORWARDED";
         default: return "UKNOWN";
     }
 }

--- a/src/main/routing/packet.minimal.h
+++ b/src/main/routing/packet.minimal.h
@@ -32,6 +32,8 @@ enum _PacketDeliveryStatusFlags {
     PDS_RCV_SOCKET_BUFFERED = 1 << 18,
     PDS_RCV_SOCKET_DELIVERED = 1 << 19,
     PDS_DESTROYED = 1 << 20,
+    PDS_RELAY_CACHED = 1 << 21,
+    PDS_RELAY_FORWARDED = 1 << 22,
 };
 
 typedef struct _PacketTCPHeader PacketTCPHeader;


### PR DESCRIPTION
Adds a new relay module that simplifies and encompasses the packet forwarding logic that was previously embedded inside of the network interface module.

closes #1727
closes #1728