### PR TITLE
TGen speed test threshold

### DIFF
--- a/docs/extra_tests.md
+++ b/docs/extra_tests.md
@@ -17,7 +17,11 @@ not complete before the timeout.
 ./setup build --test --extra
 ./setup test --extra
 # To exclude the TGen and Tor tests (for example if you built Shadow in debug mode)
-./setup test --extra -- --label-exclude tgen|tor
+./setup test --extra -- --label-exclude "tgen|tor"
+# To include only the TGen tests
+./setup test --extra tgen
+# To run a specific TGen test
+./setup test --extra tgen-duration-1mbit_300ms-1000streams-shadow
 ```
 
 If you change the version of tor located at `~/.local/bin/tor`, make sure to

--- a/src/test/tgen/fixed_duration/verify.sh
+++ b/src/test/tgen/fixed_duration/verify.sh
@@ -29,23 +29,23 @@ client_Bps_read="$(grep -r --include="client.tgen.*.stdout" "driver-heartbeat" \
 printf "Server bytes per second=${server_Bps_read}\n"
 printf "Client bytes per second=${client_Bps_read}\n"
 
-# Test passes if tgen application achieves >= 89% of configured speed, allowing
+# Test passes if tgen application achieves >= 85% of configured speed, allowing
 # for TCP overhead. We use a 89% threshold since it's the highest that allowed
 # all tgen tests to pass at time of writing. We can increase this in the future
 # as we improve our stack.
 #
 # The 111250 value below comes from:
 #   1Mbit/s = 125000 bytes/s
-#   125000 bytes/s * 0.89 = 111250 bytes/s
+#   125000 bytes/s * 0.85 = 106250 bytes/s
 expected=0
 if [[ "${network}" == "1mbit"* ]]; then
-    expected=111250
+    expected=106250
 elif [[ "${network}" == "10mbit"* ]]; then
-    expected=1112500
+    expected=1062500
 elif [[ "${network}" == "100mbit"* ]]; then
-    expected=11125000
+    expected=10625000
 elif [[ "${network}" == "1gbit"* ]]; then
-    expected=111250000
+    expected=106250000
 else
     printf "Verification ${RED}failed${NC}: unable to determine expected connection speed\n"
     exit 1


### PR DESCRIPTION
Lowers the threshold since @stevenengler found that running the tests slightly differently (e.g. changing the host id sort order) will require a lower threshold to pass all of the TGen tests. (I think the only one that requires a lower threshold is `tgen-duration-1mbit_300ms-1000streams-shadow`.)