### PR TITLE
Add example (and test) for etcd

### DIFF
--- a/.github/workflows/extra_tests.yml
+++ b/.github/workflows/extra_tests.yml
@@ -450,6 +450,7 @@ jobs:
           cd shadow
           # dependencies for examples
           ./examples/curl/install_deps.sh
+          ./examples/etcd/install_deps.sh
           ./examples/http-server/install_deps.sh
           ./examples/iperf-2/install_deps.sh
           ./examples/nginx/install_deps.sh

--- a/docs/compatibility_notes.md
+++ b/docs/compatibility_notes.md
@@ -162,84 +162,14 @@ with Shadow and will cause Shadow to deadlock. A workaround is to use the
 
 ### Example
 
-Example for etcd version 3.5.x.
+Example for etcd version 3.3.x.
 
 ```yaml
-general:
-  stop_time: 30s
-  model_unblocked_syscall_latency: true
-
-network:
-  graph:
-    type: gml
-    inline: |
-      graph [
-        node [
-          id 0
-          host_bandwidth_down "20 Mbit"
-          host_bandwidth_up "20 Mbit"
-        ]
-        edge [
-          source 0
-          target 0
-          latency "150 ms"
-          packet_loss 0.01
-        ]
-      ]
-
-hosts:
-  server1:
-    network_node_id: 0
-    processes:
-    - path: /usr/bin/etcd
-      args:
-        --name server1
-        --log-outputs=stdout
-        --initial-cluster-token etcd-cluster-1
-        --initial-cluster 'server1=http://server1:2380,server2=http://server2:2380,server3=http://server3:2380'
-        --listen-client-urls http://0.0.0.0:2379
-        --advertise-client-urls http://server1:2379
-        --listen-peer-urls http://0.0.0.0:2380
-        --initial-advertise-peer-urls http://server1:2380
-    - path: /usr/bin/etcdctl
-      args: put my-key my-value
-      start_time: 10s
-  server2:
-    network_node_id: 0
-    processes:
-    - path: /usr/bin/etcd
-      args:
-        --name server2
-        --log-outputs=stdout
-        --initial-cluster-token etcd-cluster-1
-        --initial-cluster 'server1=http://server1:2380,server2=http://server2:2380,server3=http://server3:2380'
-        --listen-client-urls http://0.0.0.0:2379
-        --advertise-client-urls http://server2:2379
-        --listen-peer-urls http://0.0.0.0:2380
-        --initial-advertise-peer-urls http://server2:2380
-    - path: /usr/bin/etcdctl
-      args: get my-key
-      start_time: 12s
-  server3:
-    network_node_id: 0
-    processes:
-    - path: /usr/bin/etcd
-      args:
-        --name server3
-        --log-outputs=stdout
-        --initial-cluster-token etcd-cluster-1
-        --initial-cluster 'server1=http://server1:2380,server2=http://server2:2380,server3=http://server3:2380'
-        --listen-client-urls http://0.0.0.0:2379
-        --advertise-client-urls http://server3:2379
-        --listen-peer-urls http://0.0.0.0:2380
-        --initial-advertise-peer-urls http://server3:2380
-    - path: /usr/bin/etcdctl
-      args: get my-key
-      start_time: 12s
+{{#include ../examples/etcd/shadow.yaml}}
 ```
 
 ```bash
-rm -rf shadow.data; shadow shadow.yaml > shadow.log
+{{#include ../examples/etcd/run.sh:body}}
 ```
 
 ### Notes

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(curl)
+add_subdirectory(etcd)
 add_subdirectory(http-server)
 add_subdirectory(iperf-2)
 add_subdirectory(nginx)

--- a/examples/etcd/CMakeLists.txt
+++ b/examples/etcd/CMakeLists.txt
@@ -1,0 +1,13 @@
+file(COPY
+       ${CMAKE_CURRENT_SOURCE_DIR}/run.sh
+       ${CMAKE_CURRENT_SOURCE_DIR}/shadow.yaml
+     DESTINATION
+       ${CMAKE_CURRENT_BINARY_DIR})
+
+add_test(
+  NAME etcd-example
+  COMMAND bash run.sh ${CMAKE_BINARY_DIR}/src/main
+  CONFIGURATIONS extra
+)
+
+set_property(TEST etcd-example PROPERTY LABELS shadow example)

--- a/examples/etcd/install_deps.sh
+++ b/examples/etcd/install_deps.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+apt-get install -y etcd

--- a/examples/etcd/run.sh
+++ b/examples/etcd/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# first argument is the path to shadow
+if [ "$#" -ge 1 ]; then
+    echo "Prepending $1 to PATH"
+    export PATH="$1:${PATH}"
+fi
+
+# ANCHOR: body
+rm -rf shadow.data; shadow shadow.yaml > shadow.log
+cat shadow.data/hosts/*/*.etcdctl.*.stdout
+# ANCHOR_END: body

--- a/examples/etcd/shadow.yaml
+++ b/examples/etcd/shadow.yaml
@@ -1,0 +1,70 @@
+general:
+  stop_time: 30s
+
+network:
+  graph:
+    type: gml
+    inline: |
+      graph [
+        node [
+          id 0
+          host_bandwidth_down "20 Mbit"
+          host_bandwidth_up "20 Mbit"
+        ]
+        edge [
+          source 0
+          target 0
+          latency "150 ms"
+          packet_loss 0.01
+        ]
+      ]
+
+hosts:
+  server1:
+    network_node_id: 0
+    processes:
+    - path: etcd
+      args:
+        --name server1
+        --log-output=stdout
+        --initial-cluster-token etcd-cluster-1
+        --initial-cluster 'server1=http://server1:2380,server2=http://server2:2380,server3=http://server3:2380'
+        --listen-client-urls http://0.0.0.0:2379
+        --advertise-client-urls http://server1:2379
+        --listen-peer-urls http://0.0.0.0:2380
+        --initial-advertise-peer-urls http://server1:2380
+    - path: etcdctl
+      args: set my-key my-value
+      start_time: 10s
+  server2:
+    network_node_id: 0
+    processes:
+    - path: etcd
+      args:
+        --name server2
+        --log-output=stdout
+        --initial-cluster-token etcd-cluster-1
+        --initial-cluster 'server1=http://server1:2380,server2=http://server2:2380,server3=http://server3:2380'
+        --listen-client-urls http://0.0.0.0:2379
+        --advertise-client-urls http://server2:2379
+        --listen-peer-urls http://0.0.0.0:2380
+        --initial-advertise-peer-urls http://server2:2380
+    - path: etcdctl
+      args: get my-key
+      start_time: 12s
+  server3:
+    network_node_id: 0
+    processes:
+    - path: etcd
+      args:
+        --name server3
+        --log-output=stdout
+        --initial-cluster-token etcd-cluster-1
+        --initial-cluster 'server1=http://server1:2380,server2=http://server2:2380,server3=http://server3:2380'
+        --listen-client-urls http://0.0.0.0:2379
+        --advertise-client-urls http://server3:2379
+        --listen-peer-urls http://0.0.0.0:2380
+        --initial-advertise-peer-urls http://server3:2380
+    - path: etcdctl
+      args: get my-key
+      start_time: 12s


### PR DESCRIPTION
This required small changes to the sim since Ubuntu uses etcd 3.3.x.

- `--log-outputs` to `--log-output`
- `etcdctl put` to `etcdctl set`
- removed `model_unblocked_syscall_latency: true` (this option exacerbates non-determinism issues in shadow, causing the sim to fail sporadically)