### PR TITLE
Show nanoseconds in strace log

### DIFF
--- a/src/main/host/syscall/formatter.rs
+++ b/src/main/host/syscall/formatter.rs
@@ -236,7 +236,7 @@ pub fn write_syscall(
 ) -> std::io::Result<()> {
     let sim_time = sim_time.duration_since(&EmulatedTime::SIMULATION_START);
     let sim_time = TimeParts::from_nanos(sim_time.as_nanos());
-    let sim_time = sim_time.fmt_hr_min_sec_milli();
+    let sim_time = sim_time.fmt_hr_min_sec_nano();
 
     writeln!(writer, "{sim_time} [tid {tid}] {name}({args}) = {rv}")
 }

--- a/src/main/utility/time.rs
+++ b/src/main/utility/time.rs
@@ -41,6 +41,11 @@ impl TimeParts {
     pub fn fmt_hr_min_sec_milli(&self) -> TimePartsFmtHrMinSecMilli {
         TimePartsFmtHrMinSecMilli { time: self }
     }
+
+    /// Format as HH:MM:SS.nnnnnnnnn.
+    pub fn fmt_hr_min_sec_nano(&self) -> TimePartsFmtHrMinSecNano {
+        TimePartsFmtHrMinSecNano { time: self }
+    }
 }
 
 pub struct TimePartsFmtHrMinSec<'a> {
@@ -70,6 +75,20 @@ impl std::fmt::Display for TimePartsFmtHrMinSecMilli<'_> {
             self.time.mins,
             self.time.secs,
             self.time.nanos / 1_000_000
+        )
+    }
+}
+
+pub struct TimePartsFmtHrMinSecNano<'a> {
+    time: &'a TimeParts,
+}
+
+impl std::fmt::Display for TimePartsFmtHrMinSecNano<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:02}:{:02}:{:02}.{:09}",
+            self.time.hours, self.time.mins, self.time.secs, self.time.nanos,
         )
     }
 }


### PR DESCRIPTION
This can be useful when matching the strace log with the shadow log, or for seeing where syscall latency is applied.

Before:

```
00:00:01.000 [tid 1000] socket(Inet, 1, 0) = 3
00:00:01.000 [tid 1000] socket(Inet, 1, 0) = 4
00:00:01.000 [tid 1000] bind(3, 0x7fffffffdc88, 16) = 0
00:00:01.000 [tid 1000] getsockname(3, 0x7fffffffdc88, 16 (0x7fffffffdcf0)) = 0
00:00:01.000 [tid 1000] listen(3, 10) = 0
00:00:01.000 [tid 1000] connect(4, 0x7fffffffddec, 16) = 0
00:00:01.002 [tid 1000] nanosleep(...) = 0
00:00:01.002 [tid 1000] connect(4, 0x7fffffffe14c, 16) = -106 (EISCONN: Transport endpoint is already connected)
00:00:01.002 [tid 1000] close(4) = 0
00:00:01.002 [tid 1000] close(3) = 0
```

After:

```
00:00:01.000097028 [tid 1000] socket(Inet, 1, 0) = 3
00:00:01.000099028 [tid 1000] socket(Inet, 1, 0) = 4
00:00:01.000099028 [tid 1000] bind(3, 0x7fffffffdc88, 16) = 0
00:00:01.000101028 [tid 1000] getsockname(3, 0x7fffffffdc88, 16 (0x7fffffffdcf0)) = 0
00:00:01.000101028 [tid 1000] listen(3, 10) = 0
00:00:01.000103030 [tid 1000] connect(4, 0x7fffffffddec, 16) = 0
00:00:01.002103030 [tid 1000] nanosleep(...) = 0
00:00:01.002103030 [tid 1000] connect(4, 0x7fffffffe14c, 16) = -106 (EISCONN: Transport endpoint is already connected)
00:00:01.002105030 [tid 1000] close(4) = 0
00:00:01.002105030 [tid 1000] close(3) = 0
```