### PR TITLE
Allow higher-level host log levels

### DIFF
--- a/src/main/core/logger/log_wrapper.c
+++ b/src/main/core/logger/log_wrapper.c
@@ -12,7 +12,7 @@ static void _flush(Logger* logger) { rustlogger_flush(); }
 
 static bool _isEnabled(Logger* logger, LogLevel level) { return rustlogger_isEnabled(level); }
 
-static void _setLevel(Logger* logger, LogLevel level) { rustlogger_setLevel(level); }
+static void _setLevel(Logger* logger, LogLevel level) { warning("Setting the log level is not supported"); }
 
 Logger* rustlogger_new() {
     Logger* logger = malloc(sizeof(*logger));

--- a/src/main/core/logger/log_wrapper.rs
+++ b/src/main/core/logger/log_wrapper.rs
@@ -36,13 +36,6 @@ pub fn c_to_rust_log_level(level: logger::LogLevel) -> Option<log::Level> {
     }
 }
 
-/// Set the max (noisiest) logging level to `level`.
-#[no_mangle]
-pub extern "C" fn rustlogger_setLevel(level: logger::LogLevel) {
-    let level = c_to_rust_log_level(level).unwrap();
-    log::set_max_level(level.to_level_filter());
-}
-
 /// Whether logging is currently enabled for `level`.
 #[no_mangle]
 pub extern "C" fn rustlogger_isEnabled(level: logger::LogLevel) -> c_int {


### PR DESCRIPTION
Previously if a host had a log level higher than the simulation log level, the host log level wouldn't take effect. Now you can specify higher host log levels (for example "trace") even if you specify a lower simulation log level (for example "info").

Closes #2643.

This doesn't appear to have any effect on runtime.

https://github.com/shadow/benchmark-results/tree/master/tor/2023-01-06-T17-24-59

![run_time](https://user-images.githubusercontent.com/3708797/211125228-3cf6deef-a7b1-46f9-8181-e77f6bafbc4a.png)