### PR TITLE
Log syscalls that are handled in the shim

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -414,8 +414,6 @@ The logs will be stored at
 
 Limitations:
 
-- Syscalls handled within Shadow's preloaded "shim" library will not be logged
-  (for example `SYS_gettimeofday`).
 - Syscalls run natively will not log the syscall arguments or return value (for
   example `SYS_getcwd`).
 - Syscalls processed within Shadow's C code will not log the syscall arguments.

--- a/src/lib/shadow-shim-helper-rs/src/lib.rs
+++ b/src/lib/shadow-shim-helper-rs/src/lib.rs
@@ -7,6 +7,7 @@ use vasi::VirtualAddressSpaceIndependent;
 
 pub mod emulated_time;
 pub mod notnull;
+pub mod option;
 pub mod rootedcell;
 pub mod shim_shmem;
 pub mod signals;

--- a/src/lib/shadow-shim-helper-rs/src/option.rs
+++ b/src/lib/shadow-shim-helper-rs/src/option.rs
@@ -1,0 +1,63 @@
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(C)]
+pub enum FfiOption<T> {
+    #[default]
+    None,
+    Some(T),
+}
+
+unsafe impl<T> vasi::VirtualAddressSpaceIndependent for FfiOption<T> where
+    T: vasi::VirtualAddressSpaceIndependent
+{
+}
+
+impl<T> FfiOption<T> {
+    pub fn unwrap(self) -> T {
+        match self {
+            Self::Some(x) => x,
+            Self::None => panic!("called `FfiOption::unwrap()` on a `None` value"),
+        }
+    }
+
+    pub fn unwrap_or(self, default: T) -> T {
+        match self {
+            Self::Some(x) => x,
+            Self::None => default,
+        }
+    }
+
+    pub fn take(&mut self) -> Self {
+        let mut other = Self::None;
+        std::mem::swap(self, &mut other);
+        other
+    }
+
+    pub fn replace(&mut self, value: T) -> Self {
+        let mut other = Self::Some(value);
+        std::mem::swap(self, &mut other);
+        other
+    }
+
+    pub fn as_ref(&self) -> FfiOption<&T> {
+        match *self {
+            Self::Some(ref x) => FfiOption::Some(x),
+            Self::None => FfiOption::None,
+        }
+    }
+
+    pub fn as_mut(&mut self) -> FfiOption<&mut T> {
+        match *self {
+            Self::Some(ref mut x) => FfiOption::Some(x),
+            Self::None => FfiOption::None,
+        }
+    }
+}
+
+impl<T> From<Option<T>> for FfiOption<T> {
+    fn from(x: Option<T>) -> Self {
+        match x {
+            Some(x) => Self::Some(x),
+            None => Self::None,
+        }
+    }
+}

--- a/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
@@ -500,20 +500,6 @@ pub mod export {
     ///
     /// Pointer args must be safely dereferenceable.
     #[no_mangle]
-    pub unsafe extern "C" fn shimshmemprocess_init(
-        process_mem: *mut ShimShmemProcess,
-        lock: *const ShimShmemHostLock,
-    ) {
-        let lock = unsafe { lock.as_ref().unwrap() };
-        let m = ProcessShmem::new(&lock.root, lock.host_id);
-        assert_shmem_safe!(ProcessShmem, _test_process_shmem);
-        unsafe { process_mem.write(m) }
-    }
-
-    /// # Safety
-    ///
-    /// Pointer args must be safely dereferenceable.
-    #[no_mangle]
     pub unsafe extern "C" fn shimshmem_getEmulatedTime(
         host_mem: *const ShimShmemHost,
     ) -> CEmulatedTime {

--- a/src/main/host/managed_thread.h
+++ b/src/main/host/managed_thread.h
@@ -10,7 +10,7 @@ typedef struct _ManagedThread ManagedThread;
 ManagedThread* managedthread_new(Thread* thread);
 void managedthread_free(ManagedThread* mthread);
 void managedthread_run(ManagedThread* methread, const char* pluginPath, const char* const* argv,
-                       const char* const* envv, const char* workingDir);
+                       const char* const* envv, const char* workingDir, int straceFd);
 SysCallCondition* managedthread_resume(ManagedThread* mthread);
 void managedthread_handleProcessExit(ManagedThread* mthread);
 int managedthread_getReturnCode(ManagedThread* mthread);

--- a/src/main/host/process.c
+++ b/src/main/host/process.c
@@ -436,7 +436,7 @@ void process_start(Process* proc, const char* const* argv, const char* const* en
     _process_setSharedTime(proc);
     /* exec the process */
     thread_run(mainThread, _process_getPluginPath(proc->rustProcess), argv,
-               (const char* const*)envv, process_getWorkingDir(proc));
+               (const char* const*)envv, process_getWorkingDir(proc), process_getStraceFd(proc));
     g_strfreev(envv);
     const pid_t nativePid = thread_getNativePid(mainThread);
     _process_setNativePid(proc->rustProcess, nativePid);

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -61,7 +61,7 @@ Thread* thread_new(const Host* host, Process* process, int threadID) {
     thread->sys = syscallhandler_new(host, process, thread);
     thread->mthread = managedthread_new(thread);
 
-    shimshmemthread_init(thread_sharedMem(thread), host_getShimShmemLock(host));
+    shimshmemthread_init(thread_sharedMem(thread), host_getShimShmemLock(host), threadID);
 
     return thread;
 }

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -98,9 +98,9 @@ void thread_unref(Thread* thread) {
 }
 
 void thread_run(Thread* thread, const char* pluginPath, const char* const* argv,
-                const char* const* envv, const char* workingDir) {
+                const char* const* envv, const char* workingDir, int straceFd) {
     MAGIC_ASSERT(thread);
-    managedthread_run(thread->mthread, pluginPath, argv, envv, workingDir);
+    managedthread_run(thread->mthread, pluginPath, argv, envv, workingDir, straceFd);
 }
 
 void thread_resume(Thread* thread) {

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -24,7 +24,7 @@ void thread_ref(Thread* thread);
 void thread_unref(Thread* thread);
 
 void thread_run(Thread* thread, const char* pluginPath, const char* const* argv,
-                const char* const* envv, const char* workingDir);
+                const char* const* envv, const char* workingDir, int straceFd);
 void thread_resume(Thread* thread);
 void thread_handleProcessExit(Thread* thread);
 int thread_getReturnCode(Thread* thread);

--- a/src/test/golang/CMakeLists.txt
+++ b/src/test/golang/CMakeLists.txt
@@ -92,5 +92,7 @@ add_shadow_tests(
     # Trace level logging logs quite a bit in the "busy" loop here,
     # causing timeouts in debug builds.
     LOGLEVEL debug
+    ARGS
+      --strace-logging-mode off
     PROPERTIES
       LABELS golang)


### PR DESCRIPTION
Examples of shim-handled syscalls:

```
00:10:00.301000001 [tid 1000] epoll_wait(...) = 1
00:10:00.301000001 [tid 1000] read(7, 0x7ffffffee6d0, 65536) = 1460
000000600301000001 [tid 1000] clock_gettime(...) = 0
00:10:00.301000001 [tid 1000] epoll_wait(...) = 1
00:10:00.301000001 [tid 1000] epoll_wait(...) = 1
00:10:00.301000001 [tid 1000] read(7, 0x7ffffffee6d0, 65536) = 1460
000000600301000001 [tid 1000] clock_gettime(...) = 0
00:10:00.301000001 [tid 1000] epoll_wait(...) = 1
00:10:00.301000001 [tid 1000] epoll_wait(...) = 1
00:10:00.301000001 [tid 1000] read(7, 0x7ffffffee6d0, 65536) = 1460
000000600301000001 [tid 1000] clock_gettime(...) = 0
00:10:00.301000001 [tid 1000] epoll_wait(...) = 1
00:10:00.301000001 [tid 1000] epoll_wait(...) = 1
```

Examples of native syscalls:

```
00:10:00.000000000 [tid 1000] munmap(0x7ffff7ffb000, 118) = 0
000000600000000000 [tid 1000] gettimeofday(...) = 0
00:10:00.000000000 [tid 1000] access(...) = <native>
000000600000000000 [tid 1000] ^^^ = 0
00:10:00.000000000 [tid 1000] access(...) = <native>
000000600000000000 [tid 1000] ^^^ = 0
00:10:00.000000000 [tid 1000] openat(-100, "../../../conf/tgen.client.graphml.xml", O_LARGEFILE | O_RDONLY, (empty)) = 3
00:10:00.000000000 [tid 1000] readlink(...) = <native>
000000600000000000 [tid 1000] ^^^ = 27
```

The time isn't formatted properly in these log lines, but I'll leave that for a future PR.