### PR TITLE
Support displaying more-complex syscall arguments

### DIFF
--- a/src/lib/syscall-logger/src/lib.rs
+++ b/src/lib/syscall-logger/src/lib.rs
@@ -114,7 +114,7 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
 
             let syscall_args = {
                 let memory = ctx.process.memory_borrow();
-                let syscall_args = <SyscallArgsFmt::<#(#arg_types)*>>::new(args, strace_fmt_options, &*memory);
+                let syscall_args = <SyscallArgsFmt::<#(#arg_types)*>>::new(args.args, strace_fmt_options, &*memory);
                 // need to convert to a string so that we read the plugin's memory before we potentially
                 // modify it during the syscall
                 format!("{}", syscall_args)
@@ -133,7 +133,7 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
 
             // format the result (returns None if the syscall didn't complete)
             let memory = ctx.process.memory_borrow();
-            let syscall_rv = SyscallResultFmt::<#(#rv_type)*>::new(&rv, strace_fmt_options, &*memory);
+            let syscall_rv = SyscallResultFmt::<#(#rv_type)*>::new(&rv, args.args, strace_fmt_options, &*memory);
 
             if let Some(ref syscall_rv) = syscall_rv {
                 ctx.process.with_strace_file(|file| {

--- a/src/main/host/syscall/handler/file.rs
+++ b/src/main/host/syscall/handler/file.rs
@@ -3,16 +3,17 @@ use syscall_logger::log_syscall;
 use crate::cshadow;
 use crate::host::context::ThreadContext;
 use crate::host::syscall::handler::SyscallHandler;
+use crate::host::syscall::type_formatting::SyscallStringArg;
 use crate::host::syscall_types::{SysCallArgs, SyscallResult};
 
 impl SyscallHandler {
-    #[log_syscall(/* rv */ libc::c_int, /* pathname */ *const libc::c_char,
+    #[log_syscall(/* rv */ libc::c_int, /* pathname */ SyscallStringArg,
                   /* flags */ nix::fcntl::OFlag, /* mode */ nix::sys::stat::Mode)]
     pub fn open(&self, ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
         Self::legacy_syscall(cshadow::syscallhandler_open, ctx, args)
     }
 
-    #[log_syscall(/* rv */ libc::c_int, /* dirfd */ libc::c_int, /* pathname */ *const libc::c_char,
+    #[log_syscall(/* rv */ libc::c_int, /* dirfd */ libc::c_int, /* pathname */ SyscallStringArg,
                   /* flags */ nix::fcntl::OFlag, /* mode */ nix::sys::stat::Mode)]
     pub fn openat(&self, ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
         Self::legacy_syscall(cshadow::syscallhandler_openat, ctx, args)

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -11,6 +11,7 @@ use crate::host::descriptor::{
 };
 use crate::host::memory_manager::MemoryManager;
 use crate::host::syscall::handler::SyscallHandler;
+use crate::host::syscall::type_formatting::SyscallBufferArg;
 use crate::host::syscall::Trigger;
 use crate::host::syscall_condition::SysCallCondition;
 use crate::host::syscall_types::{Blocked, PluginPtr, SysCallArgs, TypedPluginPtr};
@@ -141,9 +142,10 @@ impl SyscallHandler {
         Socket::bind(socket, addr.as_ref(), &net_ns, &mut *rng)
     }
 
-    #[log_syscall(/* rv */ libc::ssize_t, /* sockfd */ libc::c_int, /* buf */ *const libc::c_char,
-                  /* len */ libc::size_t, /* flags */ nix::sys::socket::MsgFlags,
-                  /* dest_addr */ *const libc::sockaddr, /* addrlen */ libc::socklen_t)]
+    #[log_syscall(/* rv */ libc::ssize_t, /* sockfd */ libc::c_int,
+                  /* buf */ SyscallBufferArg</* len */ 2>, /* len */ libc::size_t,
+                  /* flags */ nix::sys::socket::MsgFlags, /* dest_addr */ *const libc::sockaddr,
+                  /* addrlen */ libc::socklen_t)]
     pub fn sendto(&self, ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
         let fd: libc::c_int = args.get(0).into();
         let buf_ptr: PluginPtr = args.get(1).into();

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -8,6 +8,7 @@ use crate::host::descriptor::{
     CompatFile, Descriptor, DescriptorFlags, File, FileMode, FileState, FileStatus, OpenFile,
 };
 use crate::host::syscall::handler::SyscallHandler;
+use crate::host::syscall::type_formatting::SyscallBufferArg;
 use crate::host::syscall::Trigger;
 use crate::host::syscall_condition::SysCallCondition;
 use crate::host::syscall_types::{Blocked, PluginPtr, SysCallArgs, TypedPluginPtr};
@@ -273,8 +274,8 @@ impl SyscallHandler {
         result
     }
 
-    #[log_syscall(/* rv */ libc::ssize_t, /* fd */ libc::c_int, /* buf */ *const libc::c_char,
-                  /* count */ libc::size_t)]
+    #[log_syscall(/* rv */ libc::ssize_t, /* fd */ libc::c_int,
+                  /* buf */ SyscallBufferArg</* count */ 2>, /* count */ libc::size_t)]
     pub fn write(&self, ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
         let fd = libc::c_int::from(args.get(0));
         let buf_ptr = PluginPtr::from(args.get(1));
@@ -313,8 +314,9 @@ impl SyscallHandler {
         self.write_helper(ctx, fd, file, buf_ptr, buf_size, offset)
     }
 
-    #[log_syscall(/* rv */ libc::ssize_t, /* fd */ libc::c_int, /* buf */ *const libc::c_char,
-                  /* count */ libc::size_t, /* offset */ libc::off_t)]
+    #[log_syscall(/* rv */ libc::ssize_t, /* fd */ libc::c_int,
+                  /* buf */ SyscallBufferArg</* count */ 2>, /* count */ libc::size_t,
+                  /* offset */ libc::off_t)]
     pub fn pwrite64(&self, ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
         let fd = libc::c_int::from(args.get(0));
         let buf_ptr = PluginPtr::from(args.get(1));

--- a/src/main/host/syscall/type_formatting.rs
+++ b/src/main/host/syscall/type_formatting.rs
@@ -205,8 +205,7 @@ impl TryFromSyscallReg for nix::sys::mman::MRemapFlags {
 simple_display_impl!(i8, i16, i32, i64, isize);
 simple_display_impl!(u8, u16, u32, u64, usize);
 
-// skip *const i8 since we have a custom string format impl below
-deref_pointer_impl!(i16, i32, i64, isize);
+deref_pointer_impl!(i8, i16, i32, i64, isize);
 deref_pointer_impl!(u8, u16, u32, u64, usize);
 
 deref_array_impl!(i8, i16, i32, i64, isize);
@@ -274,7 +273,10 @@ fn fmt_string(
     }
 }
 
-impl SyscallDisplay for SyscallVal<'_, *const i8> {
+/// Displays a nul-terminated string syscall argument.
+pub struct SyscallStringArg {}
+
+impl SyscallDisplay for SyscallVal<'_, SyscallStringArg> {
     fn fmt(
         &self,
         f: &mut std::fmt::Formatter<'_>,

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -239,8 +239,8 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number,
         scr = syscallhandler_##s(sys, args);                                                       \
         _syscallhandler_post_syscall(sys, args->number, #s, &scr);                                 \
         if (straceLoggingMode != STRACE_FMT_MODE_OFF) {                                            \
-            scr = log_syscall(                                                                     \
-                sys->process, straceLoggingMode, thread_getID(sys->thread), #s, "...", scr);       \
+            scr = log_syscall(sys->process, straceLoggingMode, thread_getID(sys->thread), #s,      \
+                              "...", &args->args, scr);                                            \
         }                                                                                          \
         break
 #define NATIVE(s)                                                                                  \
@@ -248,8 +248,8 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number,
         trace("native syscall %ld " #s, args->number);                                             \
         scr = syscallreturn_makeNative();                                                          \
         if (straceLoggingMode != STRACE_FMT_MODE_OFF) {                                            \
-            scr = log_syscall(                                                                     \
-                sys->process, straceLoggingMode, thread_getID(sys->thread), #s, "...", scr);       \
+            scr = log_syscall(sys->process, straceLoggingMode, thread_getID(sys->thread), #s,      \
+                              "...", &args->args, scr);                                            \
         }                                                                                          \
         break
 #define UNSUPPORTED(s)                                                                             \
@@ -257,8 +257,8 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number,
         error("Returning error ENOSYS for explicitly unsupported syscall %ld " #s, args->number);  \
         scr = syscallreturn_makeDoneErrno(ENOSYS);                                                 \
         if (straceLoggingMode != STRACE_FMT_MODE_OFF) {                                            \
-            scr = log_syscall(                                                                     \
-                sys->process, straceLoggingMode, thread_getID(sys->thread), #s, "...", scr);       \
+            scr = log_syscall(sys->process, straceLoggingMode, thread_getID(sys->thread), #s,      \
+                              "...", &args->args, scr);                                            \
         }                                                                                          \
         break
 #define HANDLE_RUST(s)                                                                             \
@@ -561,7 +561,7 @@ SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
                     char arg_str[20] = {0};
                     snprintf(arg_str, sizeof(arg_str), "%ld, ...", args->number);
                     scr = log_syscall(sys->process, straceLoggingMode, thread_getID(sys->thread),
-                                      "syscall", arg_str, scr);
+                                      "syscall", arg_str, &args->args, scr);
                 }
 
                 break;


### PR DESCRIPTION
In order to display syscall arguments in strace logging, we sometimes need to know the values of multiple syscall arguments. For example to display the byte buffer for `write()`, we need to know both `const void *buf` and `size_t count`. Shadow previously would just read bytes until a nul or a memory access error, but this wasn't correct since the buffer is often not nul-terminated.

To print a byte buffer like the one in `write()`, instead of using `*const libc::c_char` in the `log_syscall()` macro, we now have two types `SyscallStringArg` and `SyscallBufferArg<const LEN_INDEX: usize>` depending on whether the syscall takes a buffer (as in `write()`) or a nul-terminated string (as in `open()`). The constant generic in `SyscallBufferArg` allows us to specify the index of the `count` argument. This is a little weird, but allows us to continue using rust's type system for specifying how to display syscall arguments.

In the future we can use the same method to display other types of syscall arguments, like socket addresses or socket/ioctl options.