### PR TITLE
Simplify strace logging in `Process`

### DIFF
--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -594,7 +594,7 @@ impl<'a> Manager<'a> {
                 unblocked_vdso_latency: self.config.unblocked_vdso_latency(),
                 use_legacy_working_dir: self.config.use_legacy_working_dir(),
                 use_shim_syscall_handler: self.config.use_shim_syscall_handler(),
-                strace_logging_mode: self.config.strace_logging_mode(),
+                strace_logging_options: self.config.strace_logging_mode(),
             };
 
             Box::new(unsafe { Host::new(params, &self.hosts_path, self.raw_frequency, dns) })

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use super::units::{self, Unit};
 use crate::cshadow as c;
-use crate::host::syscall::formatter::StraceFmtMode;
+use crate::host::syscall::formatter::FmtOptions;
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
 
 use logger as c_log;
@@ -159,11 +159,11 @@ impl ConfigOptions {
         self.experimental.use_shim_syscall_handler.unwrap()
     }
 
-    pub fn strace_logging_mode(&self) -> StraceFmtMode {
+    pub fn strace_logging_mode(&self) -> Option<FmtOptions> {
         match self.experimental.strace_logging_mode.as_ref().unwrap() {
-            StraceLoggingMode::Standard => StraceFmtMode::Standard,
-            StraceLoggingMode::Deterministic => StraceFmtMode::Deterministic,
-            StraceLoggingMode::Off => StraceFmtMode::Off,
+            StraceLoggingMode::Standard => Some(FmtOptions::Standard),
+            StraceLoggingMode::Deterministic => Some(FmtOptions::Deterministic),
+            StraceLoggingMode::Off => None,
         }
     }
 }
@@ -1358,12 +1358,5 @@ mod export {
         assert!(!config.is_null());
         let config = unsafe { &*config };
         config.use_legacy_working_dir()
-    }
-
-    #[no_mangle]
-    pub extern "C" fn config_getStraceLoggingMode(config: *const ConfigOptions) -> StraceFmtMode {
-        assert!(!config.is_null());
-        let config = unsafe { &*config };
-        config.strace_logging_mode()
     }
 }

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -72,12 +72,12 @@ pub struct HostParameters {
     pub unblocked_vdso_latency: SimulationTime,
     pub use_legacy_working_dir: bool,
     pub use_shim_syscall_handler: bool,
-    pub strace_logging_mode: StraceFmtMode,
+    pub strace_logging_options: Option<FmtOptions>,
 }
 
 use super::cpu::Cpu;
 use super::process::ProcessId;
-use super::syscall::formatter::StraceFmtMode;
+use super::syscall::formatter::FmtOptions;
 
 /// Immutable information about the Host.
 #[derive(Debug, Clone)]
@@ -381,7 +381,7 @@ impl Host {
                 pause_for_debugging,
                 self.params.use_legacy_working_dir,
                 self.params.use_shim_syscall_handler,
-                self.params.strace_logging_mode,
+                self.params.strace_logging_options,
             )
         };
 

--- a/src/main/host/syscall/formatter.rs
+++ b/src/main/host/syscall/formatter.rs
@@ -34,6 +34,16 @@ impl From<StraceFmtMode> for Option<FmtOptions> {
     }
 }
 
+impl From<Option<FmtOptions>> for StraceFmtMode {
+    fn from(x: Option<FmtOptions>) -> Self {
+        match x {
+            None => StraceFmtMode::Off,
+            Some(FmtOptions::Standard) => StraceFmtMode::Standard,
+            Some(FmtOptions::Deterministic) => StraceFmtMode::Deterministic,
+        }
+    }
+}
+
 pub trait SyscallDisplay {
     fn fmt(
         &self,


### PR DESCRIPTION
The `StraceFmtMode` type exists for compatibility with C code (it's better to represent the "off" state as an `Option::None`), so its use has been replaced with `Option<FmtOptions>` in the process, host, and manager code. The `strace_logging_options: Option<FmtOptions>` and `strace_file: Option<File>` fields have been merged into a single `strace_logging: Option<StraceLogging>` field.