### PR TITLE
Bump Rust to 1.66.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,5 @@
 # This file overrides rustup's default toolchain, but can itself be overridden
 # locally if desired.
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
-#
-# This is the version that will be used in CI when building
-# shadow, running lints, etc.
 [toolchain]
-channel = "1.66.0"
+channel = "1.66.1"


### PR DESCRIPTION
This is a point release fixing a security vulnerability. https://blog.rust-lang.org/2023/01/10/Rust-1.66.1.html