### PR TITLE
Changed register-to-int conversions from `From` to `TryFrom`

### DIFF
--- a/src/main/host/syscall/handler/eventfd.rs
+++ b/src/main/host/syscall/handler/eventfd.rs
@@ -18,7 +18,7 @@ use syscall_logger::log_syscall;
 impl SyscallHandler {
     #[log_syscall(/* rv */ libc::c_int, /* initval */ libc::c_uint)]
     pub fn eventfd(&self, ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
-        let init_val: libc::c_uint = args.get(0).into();
+        let init_val: libc::c_uint = args.get(0).try_into()?;
 
         self.eventfd_helper(ctx, init_val, 0)
     }
@@ -26,8 +26,8 @@ impl SyscallHandler {
     #[log_syscall(/* rv */ libc::c_int, /* initval */ libc::c_uint,
                   /* flags */ nix::sys::eventfd::EfdFlags)]
     pub fn eventfd2(&self, ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
-        let init_val: libc::c_uint = args.get(0).into();
-        let flags: libc::c_int = args.get(1).into();
+        let init_val: libc::c_uint = args.get(0).try_into()?;
+        let flags: libc::c_int = args.get(1).try_into()?;
 
         self.eventfd_helper(ctx, init_val, flags)
     }

--- a/src/main/host/syscall/handler/ioctl.rs
+++ b/src/main/host/syscall/handler/ioctl.rs
@@ -9,7 +9,7 @@ use syscall_logger::log_syscall;
 impl SyscallHandler {
     #[log_syscall(/* rv */ libc::c_int, /* fd */ libc::c_int, /* request */ libc::c_ulong)]
     pub fn ioctl(&self, ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
-        let fd: libc::c_int = args.get(0).into();
+        let fd: libc::c_int = args.get(0).try_into()?;
         let request: libc::c_ulong = args.get(1).into();
         let arg_ptr: PluginPtr = args.get(2).into(); // type depends on request
 

--- a/src/main/host/syscall/handler/random.rs
+++ b/src/main/host/syscall/handler/random.rs
@@ -13,7 +13,7 @@ impl SyscallHandler {
                   /* flags */ libc::c_uint)]
     pub fn getrandom(&self, ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
         let buf_ptr: PluginPtr = args.get(0).into(); // char*
-        let count: libc::size_t = args.get(1).into();
+        let count: libc::size_t = args.get(1).try_into()?;
 
         // We ignore the flags arg, because we use the same random source for both
         // random and urandom, and it never blocks anyway.

--- a/src/main/host/syscall/handler/time.rs
+++ b/src/main/host/syscall/handler/time.rs
@@ -25,7 +25,7 @@ fn itimerval_from_timer(timer: &Timer) -> libc::itimerval {
 impl SyscallHandler {
     #[log_syscall(/* rv */ libc::c_int, /* which */ libc::c_int, /*curr_value*/ *const libc::c_void)]
     pub fn getitimer(&self, ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
-        let which = libc::c_int::from(args.get(0));
+        let which = libc::c_int::try_from(args.get(0))?;
         let curr_value_ptr = TypedPluginPtr::new::<libc::itimerval>(args.get(1).into(), 1);
 
         if which != libc::ITIMER_REAL {
@@ -43,7 +43,7 @@ impl SyscallHandler {
 
     #[log_syscall(/* rv */ libc::c_int, /* which */ libc::c_int, /* new_value */ *const libc::c_void, /* old_value */ *const libc::c_void)]
     pub fn setitimer(&self, ctx: &mut ThreadContext, args: &SysCallArgs) -> SyscallResult {
-        let which = libc::c_int::from(args.get(0));
+        let which = libc::c_int::try_from(args.get(0))?;
         let new_value_ptr = TypedPluginPtr::new::<libc::itimerval>(args.get(1).into(), 1);
         let old_value_ptr = TypedPluginPtr::new::<libc::itimerval>(args.get(2).into(), 1);
 

--- a/src/main/host/syscall/type_formatting.rs
+++ b/src/main/host/syscall/type_formatting.rs
@@ -155,49 +155,49 @@ macro_rules! deref_array_impl {
 
 impl TryFromSyscallReg for nix::fcntl::OFlag {
     fn try_from_reg(reg: SysCallReg) -> Option<Self> {
-        Self::from_bits(reg.into())
+        Self::from_bits(reg.try_into().ok()?)
     }
 }
 
 impl TryFromSyscallReg for nix::sys::eventfd::EfdFlags {
     fn try_from_reg(reg: SysCallReg) -> Option<Self> {
-        Self::from_bits(reg.into())
+        Self::from_bits(reg.try_into().ok()?)
     }
 }
 
 impl TryFromSyscallReg for nix::sys::socket::AddressFamily {
     fn try_from_reg(reg: SysCallReg) -> Option<Self> {
-        Self::from_i32(reg.into())
+        Self::from_i32(reg.try_into().ok()?)
     }
 }
 
 impl TryFromSyscallReg for nix::sys::socket::MsgFlags {
     fn try_from_reg(reg: SysCallReg) -> Option<Self> {
-        Self::from_bits(reg.into())
+        Self::from_bits(reg.try_into().ok()?)
     }
 }
 
 impl TryFromSyscallReg for nix::sys::stat::Mode {
     fn try_from_reg(reg: SysCallReg) -> Option<Self> {
-        Self::from_bits(reg.into())
+        Self::from_bits(reg.try_into().ok()?)
     }
 }
 
 impl TryFromSyscallReg for nix::sys::mman::ProtFlags {
     fn try_from_reg(reg: SysCallReg) -> Option<Self> {
-        Self::from_bits(reg.into())
+        Self::from_bits(reg.try_into().ok()?)
     }
 }
 
 impl TryFromSyscallReg for nix::sys::mman::MapFlags {
     fn try_from_reg(reg: SysCallReg) -> Option<Self> {
-        Self::from_bits(reg.into())
+        Self::from_bits(reg.try_into().ok()?)
     }
 }
 
 impl TryFromSyscallReg for nix::sys::mman::MRemapFlags {
     fn try_from_reg(reg: SysCallReg) -> Option<Self> {
-        Self::from_bits(reg.into())
+        Self::from_bits(reg.try_into().ok()?)
     }
 }
 
@@ -330,7 +330,9 @@ impl<const LEN_INDEX: usize> SyscallDisplay for SyscallVal<'_, SyscallBufferArg<
         mem: &MemoryManager,
     ) -> std::fmt::Result {
         let ptr = self.reg.into();
-        let len: libc::size_t = self.args[LEN_INDEX].into();
+        let Ok(len) = self.args[LEN_INDEX].try_into() else {
+            return write!(f, "{ptr:p}");
+        };
         fmt_buffer(f, ptr, len, options, mem)
     }
 }
@@ -364,7 +366,9 @@ impl<const LEN_INDEX: usize> SyscallDisplay for SyscallVal<'_, SyscallSockAddrAr
         }
 
         let ptr = self.reg.into();
-        let len = self.args[LEN_INDEX].into();
+        let Ok(len) = self.args[LEN_INDEX].try_into() else {
+            return write!(f, "{ptr:p}");
+        };
 
         let Ok(Some(addr)) = read_sockaddr(mem, ptr, len) else {
             return write!(f, "{ptr:p}");

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -179,7 +179,7 @@ impl ThreadRef {
                 SysCallReg::from(mode),
             ],
         );
-        Ok(i32::from(res?))
+        Ok(i32::try_from(res?).unwrap())
     }
 
     /// Natively execute close(2) on the given thread.


### PR DESCRIPTION
This PR changes the (for example) `impl From<SysCallReg> for u32 { ... }` implementations to `impl TryFrom<SysCallReg> for u32 { ... }`. Previously, the `From` implementations would just cast the register value to the corresponding type. This can be error-prone if we accidentally cast to a different type than what the Linux syscall actually accepts. Since when we write syscall handlers we tend to follow the libc API rather than the syscall API, we could accidentally have our syscall handler accept an `i32` argument if the libc wrapper takes an `i32`, but maybe the actual syscall takes a `i64` instead. This could also occur if we originally accepted a `i64`, but then we changed something else in the syscall handler which changed rust's type inference, which changed what type we cast the register to (like what `NoTypeInference` with `TypedPluginPointer` is supposed to protect against).

There are two cases to consider:

1. Shadow reads a larger-width value: If the application writes an `-1i32` to a syscall register, and Shadow's syscall handler does a `i64::from(reg)`, Shadow will get a value of `4_294_967_295i64`, not `-1i64` since it won't be sign extended.
2. Shadow reads a smaller-width value: If the application writes a `u32::MAX as u64 + 1` to a syscall register, and Shadow's syscall handler does a `u32::from(reg)`, Shadow will get a value of `0`, not `u32::MAX + 1`.

There's no way we can catch (1), but we can try to catch (2) by checking if there are non-zero bits outside of the range that we're casting to. For example in the `u32::MAX as u64 + 1` case, we could check if the bits outside of the `u32` range are non-zero.

@sporksmith What do you think about this? I have two concerns: (1) Maybe it's better to not check this in release mode for performance reasons, but this probably isn't a big deal. (2) Maybe we should leave this as only `From`, but show a warning instead of a `Result::Err`.