### PR TITLE
 Remove unneeded workaround in `syscallhandler_epoll_ctl`

### DIFF
--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -2324,6 +2324,7 @@ static void _tcp_endOfFileSignalled(TCP* tcp, enum TCPFlags flags) {
 
     if((tcp->flags & TCPF_EOF_RD_SIGNALED) && (tcp->flags & TCPF_EOF_WR_SIGNALED)) {
         /* user can no longer access socket */
+        /* FIXME: a file should not be closed if there are still file handles (fds) to it */
         legacyfile_adjustStatus(&(tcp->super.super), STATUS_FILE_CLOSED, TRUE);
         legacyfile_adjustStatus(&(tcp->super.super), STATUS_FILE_ACTIVE, FALSE);
     }

--- a/src/main/host/syscall/epoll.c
+++ b/src/main/host/syscall/epoll.c
@@ -106,12 +106,7 @@ SysCallReturn syscallhandler_epoll_ctl(SysCallHandler* sys,
     LegacyFile* legacyDescriptor = descriptor_asLegacyFile(descriptor);
 
     // Make sure the child is not closed only if it's a legacy file
-    // FIXME: for now we allow child fds to be closed on EPOLL_CTL_DEL operations,
-    // because libevent frequently closes before issuing the EPOLL_CTL_DEL op.
-    // Once #1101 is fixed, and we correctly clean up closed watch fds, then we can
-    // error out here on EPOLL_CTL_DEL ops too.
-    // See: https://github.com/shadow/shadow/issues/1101
-    if (legacyDescriptor != NULL && op != EPOLL_CTL_DEL) {
+    if (legacyDescriptor != NULL) {
         errorCode = _syscallhandler_validateLegacyFile(legacyDescriptor, DT_NONE);
 
         if (errorCode) {

--- a/src/main/host/syscall/protected.c
+++ b/src/main/host/syscall/protected.c
@@ -49,6 +49,12 @@ int _syscallhandler_validateLegacyFile(LegacyFile* descriptor, LegacyFileType ex
         Status status = legacyfile_getStatus(descriptor);
 
         if (status & STATUS_FILE_CLOSED) {
+            // A file that is referenced in the descriptor table should never
+            // be a closed file. File handles (fds) are handles to open files,
+            // so if we have a file handle to a closed file, then there's an
+            // error somewhere in Shadow. Shadow's TCP sockets do close
+            // themselves even if there are still file handles (see
+            // `_tcp_endOfFileSignalled`), so we can't make this a panic.
             warning("descriptor %p is closed", descriptor);
             return -EBADF;
         }


### PR DESCRIPTION
See https://github.com/shadow/shadow/issues/1101#issuecomment-1376485378. Also adds a check for closed files in `epoll_control()` since TCP sockets are no longer always treated as `LegacyFile`s (they are now sometimes wrapped as rust file objects).