### PR TITLE
Set 40s timeout for 'bind-shadow' test

### DIFF
--- a/src/test/socket/bind/CMakeLists.txt
+++ b/src/test/socket/bind/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_linux_tests(BASENAME bind COMMAND sh -c "../../../target/debug/test_bind --libc-passing")
-add_shadow_tests(BASENAME bind LOGLEVEL debug ARGS --strace-logging-mode off)
+add_shadow_tests(BASENAME bind LOGLEVEL debug ARGS --strace-logging-mode off PROPERTIES TIMEOUT 40)
 
 add_shadow_tests(BASENAME bind_in_new_process CHECK_RETVAL false)


### PR DESCRIPTION
The 'bind-shadow' test has been failing in the CI recently for debug builds. In the last month we've moved more code from C to Rust, and this test has become faster in release builds and slower in debug builds.