### PR TITLE
bind-shadow test: extend timeout

### DIFF
--- a/src/test/socket/bind/CMakeLists.txt
+++ b/src/test/socket/bind/CMakeLists.txt
@@ -2,6 +2,10 @@ add_linux_tests(BASENAME bind COMMAND sh -c "../../../target/debug/test_bind --l
 add_shadow_tests(
     BASENAME bind
     LOGLEVEL debug
-    ARGS --strace-logging-mode off)
+    ARGS --strace-logging-mode off
+    PROPERTIES
+      # This test can take a bit longer, especially on debug builds of shadow
+      TIMEOUT 30
+    )
 
 add_shadow_tests(BASENAME bind_in_new_process CHECK_RETVAL false)

--- a/src/test/socket/bind/CMakeLists.txt
+++ b/src/test/socket/bind/CMakeLists.txt
@@ -1,4 +1,7 @@
 add_linux_tests(BASENAME bind COMMAND sh -c "../../../target/debug/test_bind --libc-passing")
-add_shadow_tests(BASENAME bind LOGLEVEL debug ARGS --strace-logging-mode off)
+add_shadow_tests(
+    BASENAME bind
+    LOGLEVEL debug
+    ARGS --strace-logging-mode off)
 
 add_shadow_tests(BASENAME bind_in_new_process CHECK_RETVAL false)


### PR DESCRIPTION
This has been timing out occasionally in CI on debug builds. It doesn't seem to have gotten slower in release builds, and doesn't have any obvious culprits in `perf`.