### PR TITLE
Support `InetSocket` in the tracker

### DIFF
--- a/src/main/host/descriptor/compat_socket.c
+++ b/src/main/host/descriptor/compat_socket.c
@@ -67,6 +67,16 @@ void compatsocket_unref(const CompatSocket* socket) {
     compatsockettypes_assertValid(socket->type);
 }
 
+uintptr_t compatsocket_getCanonicalHandle(const CompatSocket* socket) {
+    switch (socket->type) {
+        case CST_LEGACY_SOCKET: return (uintptr_t)(void*)socket->object.as_legacy_socket;
+        case CST_INET_SOCKET: return inetsocket_getCanonicalHandle(socket->object.as_inet_socket);
+        case CST_NONE: utility_panic("Unexpected CompatSocket type");
+    }
+
+    utility_panic("Invalid CompatSocket type");
+}
+
 uintptr_t compatsocket_toTagged(const CompatSocket* socket) {
     CompatSocketTypes type = socket->type;
     CompatSocketObject object = socket->object;

--- a/src/main/host/descriptor/compat_socket.h
+++ b/src/main/host/descriptor/compat_socket.h
@@ -37,6 +37,9 @@ CompatSocket compatsocket_fromInetSocket(const InetSocket* socket);
 CompatSocket compatsocket_refAs(const CompatSocket* socket);
 void compatsocket_unref(const CompatSocket* socket);
 
+/* handle to the socket object */
+uintptr_t compatsocket_getCanonicalHandle(const CompatSocket* socket);
+
 /* converting between a CompatSocket and a tagged pointer */
 uintptr_t compatsocket_toTagged(const CompatSocket* socket);
 CompatSocket compatsocket_fromTagged(uintptr_t ptr);

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -81,7 +81,8 @@ static void _legacysocket_close(LegacyFile* descriptor, const Host* host) {
 
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
-        tracker_removeSocket(tracker, socket);
+        CompatSocket compatSocket = compatsocket_fromLegacySocket(socket);
+        tracker_removeSocket(tracker, &compatSocket);
     }
 
     socket->vtable->close((LegacyFile*)socket, host);
@@ -124,8 +125,9 @@ void legacysocket_init(LegacySocket* socket, const Host* host, SocketFunctionTab
 
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
-        tracker_addSocket(
-            tracker, socket, socket->protocol, socket->inputBufferSize, socket->outputBufferSize);
+        CompatSocket compatSocket = compatsocket_fromLegacySocket(socket);
+        tracker_addSocket(tracker, &compatSocket, socket->protocol, socket->inputBufferSize,
+                          socket->outputBufferSize);
     }
 }
 
@@ -149,7 +151,8 @@ gint legacysocket_connectToPeer(LegacySocket* socket, const Host* host, in_addr_
 
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
-        tracker_updateSocketPeer(tracker, socket, ip, ntohs(port));
+        CompatSocket compatSocket = compatsocket_fromLegacySocket(socket);
+        tracker_updateSocketPeer(tracker, &compatSocket, ip, ntohs(port));
     }
 
     return socket->vtable->connectToPeer(socket, host, ip, port, family);
@@ -355,8 +358,9 @@ gboolean legacysocket_addToInputBuffer(LegacySocket* socket, const Host* host, P
     /* update the tracker input buffer stats */
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
+        CompatSocket compatSocket = compatsocket_fromLegacySocket(socket);
         tracker_updateSocketInputBuffer(
-            tracker, socket, socket->inputBufferLength, socket->inputBufferSize);
+            tracker, &compatSocket, socket->inputBufferLength, socket->inputBufferSize);
     }
 
     /* we just added a packet, so we are readable */
@@ -385,8 +389,9 @@ Packet* legacysocket_removeFromInputBuffer(LegacySocket* socket, const Host* hos
         /* update the tracker input buffer stats */
         Tracker* tracker = host_getTracker(host);
         if (tracker != NULL) {
+            CompatSocket compatSocket = compatsocket_fromLegacySocket(socket);
             tracker_updateSocketInputBuffer(
-                tracker, socket, socket->inputBufferLength, socket->inputBufferSize);
+                tracker, &compatSocket, socket->inputBufferLength, socket->inputBufferSize);
         }
 
         /* we are not readable if we are now empty */
@@ -434,8 +439,9 @@ gboolean legacysocket_addToOutputBuffer(LegacySocket* socket, const Host* host, 
     /* update the tracker input buffer stats */
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
+        CompatSocket compatSocket = compatsocket_fromLegacySocket(socket);
         tracker_updateSocketOutputBuffer(
-            tracker, socket, socket->outputBufferLength, socket->outputBufferSize);
+            tracker, &compatSocket, socket->outputBufferLength, socket->outputBufferSize);
     }
 
     /* we just added a packet, we are no longer writable if full */
@@ -471,8 +477,9 @@ Packet* legacysocket_removeFromOutputBuffer(LegacySocket* socket, const Host* ho
         /* update the tracker input buffer stats */
         Tracker* tracker = host_getTracker(host);
         if (tracker != NULL) {
+            CompatSocket compatSocket = compatsocket_fromLegacySocket(socket);
             tracker_updateSocketOutputBuffer(
-                tracker, socket, socket->outputBufferLength, socket->outputBufferSize);
+                tracker, &compatSocket, socket->outputBufferLength, socket->outputBufferSize);
         }
 
         /* we are writable if we now have space */

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -58,6 +58,12 @@ impl TcpSocket {
         Arc::new(AtomicRefCell::new(socket))
     }
 
+    /// Get a canonical handle for this socket. We use the address of the `TCP` object so that the
+    /// rust socket and legacy socket have the same handle.
+    pub fn canonical_handle(&self) -> usize {
+        self.as_legacy_tcp() as usize
+    }
+
     /// Get the [`c::TCP`] pointer.
     pub fn as_legacy_tcp(&self) -> *mut c::TCP {
         unsafe { self.socket.ptr() }

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -1364,10 +1364,11 @@ static void _tcp_flush(TCP* tcp, const Host* host) {
     gsize inSize = legacysocket_getInputBufferSize(&(tcp->super));
     gsize outSize = legacysocket_getOutputBufferSize(&(tcp->super));
     if (tracker != NULL) {
+        CompatSocket compatSocket = compatsocket_fromLegacySocket(socket);
         tracker_updateSocketInputBuffer(
-            tracker, socket, inSize - _tcp_getBufferSpaceIn(tcp), inSize);
+            tracker, &compatSocket, inSize - _tcp_getBufferSpaceIn(tcp), inSize);
         tracker_updateSocketOutputBuffer(
-            tracker, socket, outSize - _tcp_getBufferSpaceOut(tcp), outSize);
+            tracker, &compatSocket, outSize - _tcp_getBufferSpaceOut(tcp), outSize);
     }
 
     /* should we send a fin after clearing the output buffer */
@@ -1711,8 +1712,8 @@ gint tcp_acceptServerPeer(TCP* tcp, const Host* host, in_addr_t* ip, in_port_t* 
 
     Tracker* tracker = host_getTracker(host);
     if (tracker != NULL) {
-        tracker_updateSocketPeer(
-            tracker, &tcpChild->child->parent->super, *ip, ntohs(tcpChild->super.peerPort));
+        CompatSocket compatSocket = compatsocket_fromLegacySocket(&tcpChild->child->parent->super);
+        tracker_updateSocketPeer(tracker, &compatSocket, *ip, ntohs(tcpChild->super.peerPort));
     }
 
     return 0;

--- a/src/main/host/tracker.c
+++ b/src/main/host/tracker.c
@@ -125,7 +125,9 @@ static void _socketstats_free(SocketStats* ss) {
     }
 }
 
-static guintptr _tracker_socketHandle(LegacySocket* sock) { return (guintptr)sock; }
+static guintptr _tracker_socketHandle(const CompatSocket* sock) {
+    return compatsocket_getCanonicalHandle(sock);
+}
 
 Tracker* tracker_new(const Host* host, CSimulationTime interval, LogLevel loglevel,
                      LogInfoFlags loginfo) {
@@ -215,7 +217,7 @@ static void _tracker_updateCounters(Counters* c, gsize header, gsize payload,
     }
 }
 
-void tracker_addInputBytes(Tracker* tracker, Packet* packet, LegacySocket* socket) {
+void tracker_addInputBytes(Tracker* tracker, Packet* packet, const CompatSocket* socket) {
     MAGIC_ASSERT(tracker);
     guintptr handle = _tracker_socketHandle(socket);
 
@@ -248,7 +250,7 @@ void tracker_addInputBytes(Tracker* tracker, Packet* packet, LegacySocket* socke
     }
 }
 
-void tracker_addOutputBytes(Tracker* tracker, Packet* packet, LegacySocket* socket) {
+void tracker_addOutputBytes(Tracker* tracker, Packet* packet, const CompatSocket* socket) {
     MAGIC_ASSERT(tracker);
     guintptr handle = _tracker_socketHandle(socket);
 
@@ -309,7 +311,7 @@ void tracker_removeAllocatedBytes(Tracker* tracker, gpointer location) {
     }
 }
 
-void tracker_addSocket(Tracker* tracker, LegacySocket* socket, ProtocolType type,
+void tracker_addSocket(Tracker* tracker, const CompatSocket* socket, ProtocolType type,
                        gsize inputBufferSize, gsize outputBufferSize) {
     MAGIC_ASSERT(tracker);
     guintptr handle = _tracker_socketHandle(socket);
@@ -320,7 +322,7 @@ void tracker_addSocket(Tracker* tracker, LegacySocket* socket, ProtocolType type
     }
 }
 
-void tracker_updateSocketPeer(Tracker* tracker, LegacySocket* socket, in_addr_t peerIP,
+void tracker_updateSocketPeer(Tracker* tracker, const CompatSocket* socket, in_addr_t peerIP,
                               in_port_t peerPort) {
     MAGIC_ASSERT(tracker);
     guintptr handle = _tracker_socketHandle(socket);
@@ -353,7 +355,7 @@ void tracker_updateSocketPeer(Tracker* tracker, LegacySocket* socket, in_addr_t 
     }
 }
 
-void tracker_updateSocketInputBuffer(Tracker* tracker, LegacySocket* socket,
+void tracker_updateSocketInputBuffer(Tracker* tracker, const CompatSocket* socket,
                                      gsize inputBufferLength, gsize inputBufferSize) {
     MAGIC_ASSERT(tracker);
     guintptr handle = _tracker_socketHandle(socket);
@@ -367,7 +369,7 @@ void tracker_updateSocketInputBuffer(Tracker* tracker, LegacySocket* socket,
     }
 }
 
-void tracker_updateSocketOutputBuffer(Tracker* tracker, LegacySocket* socket,
+void tracker_updateSocketOutputBuffer(Tracker* tracker, const CompatSocket* socket,
                                       gsize outputBufferLength, gsize outputBufferSize) {
     MAGIC_ASSERT(tracker);
     guintptr handle = _tracker_socketHandle(socket);
@@ -381,7 +383,7 @@ void tracker_updateSocketOutputBuffer(Tracker* tracker, LegacySocket* socket,
     }
 }
 
-void tracker_removeSocket(Tracker* tracker, LegacySocket* socket) {
+void tracker_removeSocket(Tracker* tracker, const CompatSocket* socket) {
     MAGIC_ASSERT(tracker);
     guintptr handle = _tracker_socketHandle(socket);
 

--- a/src/main/host/tracker.h
+++ b/src/main/host/tracker.h
@@ -22,15 +22,15 @@ void tracker_free(Tracker* tracker);
 
 void tracker_addProcessingTimeNanos(Tracker* tracker, CSimulationTime processingTime);
 void tracker_addVirtualProcessingDelay(Tracker* tracker, CSimulationTime delay);
-void tracker_addInputBytes(Tracker* tracker, Packet* packet, LegacySocket* socket);
-void tracker_addOutputBytes(Tracker* tracker, Packet* packet, LegacySocket* socket);
+void tracker_addInputBytes(Tracker* tracker, Packet* packet, const CompatSocket* socket);
+void tracker_addOutputBytes(Tracker* tracker, Packet* packet, const CompatSocket* socket);
 void tracker_addAllocatedBytes(Tracker* tracker, gpointer location, gsize allocatedBytes);
 void tracker_removeAllocatedBytes(Tracker* tracker, gpointer location);
-void tracker_addSocket(Tracker* tracker, LegacySocket* socket, ProtocolType type, gsize inputBufferSize, gsize outputBufferSize);
-void tracker_updateSocketPeer(Tracker* tracker, LegacySocket* socket, in_addr_t peerIP, in_port_t peerPort);
-void tracker_updateSocketInputBuffer(Tracker* tracker, LegacySocket* socket, gsize inputBufferLength, gsize inputBufferSize);
-void tracker_updateSocketOutputBuffer(Tracker* tracker, LegacySocket* socket, gsize outputBufferLength, gsize outputBufferSize);
-void tracker_removeSocket(Tracker* tracker, LegacySocket* socket);
+void tracker_addSocket(Tracker* tracker, const CompatSocket* socket, ProtocolType type, gsize inputBufferSize, gsize outputBufferSize);
+void tracker_updateSocketPeer(Tracker* tracker, const CompatSocket* socket, in_addr_t peerIP, in_port_t peerPort);
+void tracker_updateSocketInputBuffer(Tracker* tracker, const CompatSocket* socket, gsize inputBufferLength, gsize inputBufferSize);
+void tracker_updateSocketOutputBuffer(Tracker* tracker, const CompatSocket* socket, gsize outputBufferLength, gsize outputBufferSize);
+void tracker_removeSocket(Tracker* tracker, const CompatSocket* socket);
 void tracker_heartbeat(Tracker* tracker, const Host* host);
 static inline void tracker_heartbeatTask(const Host* host, gpointer tracker, gpointer userData) {
     tracker_heartbeat(tracker, host);


### PR DESCRIPTION
This adds support for `InetSocket` in the tracker, ~and reverts the change from #2626~.