### PR TITLE
Change log msg level from info to debug

### DIFF
--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -602,7 +602,7 @@ impl Process {
             info!("process '{}' ran for {:?}", self.name(), delay);
         }
         #[cfg(not(feature = "perf_timers"))]
-        info!("process '{}' done continuing", self.name());
+        debug!("process '{}' done continuing", self.name());
 
         if self.is_exiting.get() {
             self.handle_process_exit(host);


### PR DESCRIPTION
This was changed from debug to info in the rust migration, which causes a slowdown in tor sims and tornettools processing.