### PR TITLE
WIP Edge-triggered epoll

### DIFF
--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -109,6 +109,9 @@ bitflags::bitflags! {
         const WRITABLE = c::_Status_STATUS_FILE_WRITABLE;
         /// User already called close.
         const CLOSED = c::_Status_STATUS_FILE_CLOSED;
+        /// Flipped when the size of the input buffer changes
+        // TODO: Currently this one is only implemented in sockets and eventfd.
+        const INPUT_BUFFER_PARITY = c::_Status_STATUS_FILE_INPUT_BUFFER_PARITY;
         /// A wakeup operation occurred on a futex.
         const FUTEX_WAKEUP = c::_Status_STATUS_FUTEX_WAKEUP;
         /// A listening socket is allowing connections. Only applicable to connection-oriented unix

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -370,6 +370,11 @@ gboolean legacysocket_addToInputBuffer(LegacySocket* socket, const Host* host, P
     if(socket->inputBufferLength > 0) {
         legacyfile_adjustStatus((LegacyFile*)socket, STATUS_FILE_READABLE, TRUE);
     }
+    /* the size of input buffer changes, so we flip the flag */
+    if (length > 0) {
+        gboolean parity = (legacyfile_getStatus((LegacyFile*)socket) & STATUS_FILE_INPUT_BUFFER_PARITY) != 0;
+        legacyfile_adjustStatus((LegacyFile*)socket, STATUS_FILE_INPUT_BUFFER_PARITY, !parity);
+    }
 
     return TRUE;
 }
@@ -399,6 +404,11 @@ Packet* legacysocket_removeFromInputBuffer(LegacySocket* socket, const Host* hos
         /* we are not readable if we are now empty */
         if(socket->inputBufferLength <= 0) {
             legacyfile_adjustStatus((LegacyFile*)socket, STATUS_FILE_READABLE, FALSE);
+        }
+        /* the size of input buffer changes, so we flip the flag */
+        if (length > 0) {
+            gboolean parity = (legacyfile_getStatus((LegacyFile*)socket) & STATUS_FILE_INPUT_BUFFER_PARITY) != 0;
+            legacyfile_adjustStatus((LegacyFile*)socket, STATUS_FILE_INPUT_BUFFER_PARITY, !parity);
         }
     }
 

--- a/src/main/host/status.h
+++ b/src/main/host/status.h
@@ -20,11 +20,14 @@ enum _Status {
     STATUS_FILE_WRITABLE = 1 << 2,
     /* user already called close */
     STATUS_FILE_CLOSED = 1 << 3,
+    /* flipped when the size of the input buffer changes */
+    // TODO: Currently this one is only implemented in sockets and eventfd.
+    STATUS_FILE_INPUT_BUFFER_PARITY = 1 << 4,
     /* a wakeup operation occurred on a futex */
-    STATUS_FUTEX_WAKEUP = 1 << 4,
+    STATUS_FUTEX_WAKEUP = 1 << 5,
     /* a listening socket is allowing connections; only applicable to connection-oriented unix
      * sockets */
-    STATUS_SOCKET_ALLOWING_CONNECT = 1 << 5,
+    STATUS_SOCKET_ALLOWING_CONNECT = 1 << 6,
 };
 
 #endif // SRC_MAIN_HOST_STATUS_H


### PR DESCRIPTION
Since edge-triggered epoll events in Shadow don't work similarly to Linux as discussed in https://github.com/shadow/shadow/issues/2673, I fixed it in this PR.

You can see that the patch is quite short. However, I haven't implemented the tests for this yet since I don't have bandwidth to do so. If you are interested in applying this patch, you can continue the work. (I will come back and do the tests when I have bandwidth to do so)

This PR fixes the edge-triggered epoll only for legacy sockets and eventfd, so there will probably be other types of file descriptors that don't work similarly to Linux.