### PR TITLE
Multithread death

### DIFF
--- a/src/lib/shadow-shim-helper-rs/ipc.cc
+++ b/src/lib/shadow-shim-helper-rs/ipc.cc
@@ -70,7 +70,7 @@ void shimevent_recvEventFromShadow(struct IPCData* data, ShimEvent* e, bool spin
 void shimevent_recvEventFromPlugin(struct IPCData* data, ShimEvent* e) {
     data->xfer_ctrl_to_shadow.wait();
     if (data->plugin_died.load(std::memory_order_relaxed)) {
-        e->event_id = SHD_SHIM_EVENT_STOP;
+        e->event_id = SHD_SHIM_EVENT_PROCESS_DEATH;
     } else {
         *e = data->plugin_to_shadow;
     }
@@ -91,7 +91,7 @@ int shimevent_tryRecvEventFromPlugin(struct IPCData* data, ShimEvent* e) {
         return rv;
     }
     if (data->plugin_died.load(std::memory_order_relaxed)) {
-        e->event_id = SHD_SHIM_EVENT_STOP;
+        e->event_id = SHD_SHIM_EVENT_PROCESS_DEATH;
         return 0;
     }
 

--- a/src/lib/shadow-shim-helper-rs/ipc.h
+++ b/src/lib/shadow-shim-helper-rs/ipc.h
@@ -25,7 +25,7 @@ void ipcData_destroy(struct IPCData* ipc_data);
 
 // After calling this function, the next (or current) call to
 // `shimevent_recvEventFromPlugin` or `shimevent_tryRecvEventFromPlugin` will
-// return SHD_SHIM_EVENT_STOP.
+// return SHD_SHIM_EVENT_PROCESS_DEATH.
 //
 // This function is thread-safe, and is safe to call at any point in this APIs
 // state-machine, e.g. even if the last method called was

--- a/src/lib/shadow-shim-helper-rs/shim_event.h
+++ b/src/lib/shadow-shim-helper-rs/shim_event.h
@@ -12,7 +12,10 @@ typedef enum {
     // Next val: 13
     SHD_SHIM_EVENT_NULL = 0,
     SHD_SHIM_EVENT_START = 1,
-    SHD_SHIM_EVENT_STOP = 2,
+    // The whole process has died.
+    // We inject this event to trigger cleanup after we've detected that the
+    // native process has died.
+    SHD_SHIM_EVENT_PROCESS_DEATH = 2,
     SHD_SHIM_EVENT_SYSCALL = 3,
     SHD_SHIM_EVENT_SYSCALL_COMPLETE = 4,
     SHD_SHIM_EVENT_SYSCALL_DO_NATIVE = 8,

--- a/src/main/host/managed_thread.c
+++ b/src/main/host/managed_thread.c
@@ -294,7 +294,10 @@ SysCallCondition* managedthread_resume(ManagedThread* mthread) {
                 _managedthread_continuePlugin(mthread, &mthread->currentEvent);
                 break;
             }
-                // the plugin stopped running
+            case SHD_SHIM_EVENT_PROCESS_DEATH: {
+                // The native threads are all dead or zombies. Nothing to do but
+                // clean up.
+                process_markAsExiting(thread_getProcess(mthread->base));
                 _managedthread_cleanup(mthread);
 
                 // it will not be sending us any more events
@@ -464,6 +467,7 @@ long managedthread_nativeSyscall(ManagedThread* mthread, long n, va_list args) {
     _managedthread_waitForNextEvent(mthread, &res);
     if (res.event_id == SHD_SHIM_EVENT_PROCESS_DEATH) {
         trace("Plugin exited while executing native syscall %ld", n);
+        process_markAsExiting(thread_getProcess(mthread->base));
         _managedthread_cleanup(mthread);
 
         // We have to return *something* here. Probably doesn't matter much what.

--- a/src/main/host/managed_thread.c
+++ b/src/main/host/managed_thread.c
@@ -294,7 +294,6 @@ SysCallCondition* managedthread_resume(ManagedThread* mthread) {
                 _managedthread_continuePlugin(mthread, &mthread->currentEvent);
                 break;
             }
-            case SHD_SHIM_EVENT_STOP: {
                 // the plugin stopped running
                 _managedthread_cleanup(mthread);
 
@@ -463,7 +462,7 @@ long managedthread_nativeSyscall(ManagedThread* mthread, long n, va_list args) {
 
     ShimEvent res;
     _managedthread_waitForNextEvent(mthread, &res);
-    if (res.event_id == SHD_SHIM_EVENT_STOP) {
+    if (res.event_id == SHD_SHIM_EVENT_PROCESS_DEATH) {
         trace("Plugin exited while executing native syscall %ld", n);
         _managedthread_cleanup(mthread);
 


### PR DESCRIPTION
* Rename SHD_SHIM_EVENT_STOP to SHD_SHIM_EVENT_PROCESS_DEATH
* Handling SHD_SHIM_EVENT_PROCESS_DEATH: mark whole process as dead

We inject a SHD_SHIM_EVENT_PROCESS_DEATH event into each individual
managed thread when we detect the process has died.

In https://github.com/shadow/shadow/issues/2674, this ended up causing
the memory write inside Process::reap_thread to fail. Since the process
has died, we don't need to do that write at all; marking the process as
dead correctly skips this step.

I tried to write a regression test but was unable to reproduce the
issue. As in the mongodb case, I set it up so that a child thread
called `abort` while the thread group leader was blocked. In both cases,
we end up trying to use the thread group leader to do the write, but it
is in a zombie state since we already natively raised SIGABRT, which
kills the whole process. In my test that write *works*, even though the
thread group leader is in a zombie state.

I did verify that this change fixes the problem in the mongodb example,
though.