### PR TITLE
Disable delayed and quick ACKs for localhost connections

### DIFF
--- a/src/test/regression/2683/CMakeLists.txt
+++ b/src/test/regression/2683/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(COPY
+       ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+     DESTINATION
+       ${CMAKE_CURRENT_BINARY_DIR})
+
+add_shadow_tests(BASENAME regression_2683)
+add_linux_tests(BASENAME regression_2683 COMMAND sh -c "python3 -u test.py 127.0.0.1")

--- a/src/test/regression/2683/regression_2683.yaml
+++ b/src/test/regression/2683/regression_2683.yaml
@@ -1,0 +1,18 @@
+general:
+  stop_time: 5
+
+network:
+  graph:
+    type: 1_gbit_switch
+
+hosts:
+  loopback:
+    network_node_id: 0
+    processes:
+    - path: python3
+      args: -u ../../../test.py 127.0.0.1
+  internet:
+    network_node_id: 0
+    processes:
+    - path: python3
+      args: -u ../../../test.py internet

--- a/src/test/regression/2683/test.py
+++ b/src/test/regression/2683/test.py
@@ -1,0 +1,39 @@
+import socket
+import sys
+import time
+
+connect_to = sys.argv[1];
+
+client_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+server_sock.bind(('0.0.0.0', 8000))
+server_sock.listen()
+print("Server listening")
+
+# asynchronously connect the client to the server
+client_sock.setblocking(0)
+try:
+    client_sock.connect((connect_to, 8000))
+except BlockingIOError:
+    pass
+client_sock.setblocking(1)
+print("Client connecting")
+
+(child_sock, _) = server_sock.accept()
+print("Connection accepted")
+
+# send a bunch of packets back-and-forth, and make sure the rtt is close to 0
+for i in range(200):
+    start_time = time.time()
+
+    client_sock.sendall(b"Hello, world")
+    assert len(child_sock.recv(1024)) == 12
+
+    duration = time.time() - start_time
+    print(f"({i}) Send-recv duration: {duration*1000*1000*1000:.0f} ns")
+
+    # on a laptop on Linux (no Shadow) the duration ranges from around 6 us to 130 us
+    assert duration < 0.0005 # 500 us
+
+print("Done")

--- a/src/test/regression/CMakeLists.txt
+++ b/src/test/regression/CMakeLists.txt
@@ -34,3 +34,11 @@ add_shadow_tests(
       # the full timeout to fail otherwise.
       TIMEOUT 5
     )
+
+# Make sure tests in subdirs append to previously collected tests.
+set(ALL_SHADOW_TESTS "${ALL_SHADOW_TESTS}")
+
+add_subdirectory(2683)
+
+# Now set the variable in the parent scope to ours, which includes subdir tests.
+set(ALL_SHADOW_TESTS "${ALL_SHADOW_TESTS}" PARENT_SCOPE)


### PR DESCRIPTION
This was meant to fix #2683, but it breaks a shutdown test (`shutdown-shadow: test_read_after_peer_shutdown`) and an autotuning test (`sockbuf-shadow: test_autotune_increases_size`). It's not worth trying to debug those.