### PR TITLE
Add `DescriptorHandle` and return `Result` from descriptor table methods 

### DIFF
--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -5,9 +5,12 @@ use std::collections::{BTreeSet, HashMap};
 
 use log::*;
 
+/// POSIX requires fds to be assigned as `libc::c_int`, so we can't allow any fds larger than this.
+pub const FD_MAX: u32 = i32::MAX as u32;
+
 /// Map of file handles to file descriptors. Typically owned by a Process.
 pub struct DescriptorTable {
-    descriptors: HashMap<u32, Descriptor>,
+    descriptors: HashMap<DescriptorHandle, Descriptor>,
 
     // Indices less than `next_index` known to be available.
     available_indices: BTreeSet<u32>,
@@ -26,9 +29,14 @@ impl DescriptorTable {
         }
     }
 
-    /// Add the descriptor at an unused index, and return the index.
-    fn add(&mut self, descriptor: Descriptor, min_index: u32) -> u32 {
-        let idx = if let Some(idx) = self.available_indices.range(min_index..).next() {
+    /// Add the descriptor at an unused index, and return the index. If the descriptor could not be
+    /// added, the descriptor is returned in the `Err`.
+    fn add(
+        &mut self,
+        descriptor: Descriptor,
+        min_index: DescriptorHandle,
+    ) -> Result<DescriptorHandle, Descriptor> {
+        let idx = if let Some(idx) = self.available_indices.range(min_index.val()..).next() {
             // Un-borrow from `available_indices`.
             let idx = *idx;
             // Take from `available_indices`
@@ -38,7 +46,12 @@ impl DescriptorTable {
         } else {
             // Start our search at either the next likely available index or the minimum index,
             // whichever is larger.
-            let mut idx = std::cmp::max(self.next_index, min_index);
+            let mut idx = std::cmp::max(self.next_index, min_index.val());
+
+            // Check if this index out of range.
+            if idx > FD_MAX {
+                return Err(descriptor);
+            }
 
             // Only update next_index if we started at it, otherwise there may be other
             // available indexes lower than idx.
@@ -46,8 +59,18 @@ impl DescriptorTable {
 
             // Skip past any indexes that are in use. This can happen after
             // calling `set` with a value greater than `next_index`.
-            while self.descriptors.contains_key(&idx) {
+            while self
+                .descriptors
+                .contains_key(&DescriptorHandle::new(idx).unwrap())
+            {
                 trace!("Skipping past in-use index {}", idx);
+
+                // Check if the next index is out of range.
+                if idx >= FD_MAX {
+                    return Err(descriptor);
+                }
+
+                // Won't overflow because of the check above.
                 idx += 1;
             }
 
@@ -60,10 +83,12 @@ impl DescriptorTable {
             idx
         };
 
-        let prev = self.descriptors.insert(idx, descriptor);
-        debug_assert!(prev.is_none(), "Already a descriptor at {}", idx);
+        let idx = DescriptorHandle::new(idx).unwrap();
 
-        idx
+        let prev = self.descriptors.insert(idx, descriptor);
+        assert!(prev.is_none(), "Already a descriptor at {}", idx);
+
+        Ok(idx)
     }
 
     // Call after inserting to `available_indices`, to free any that are contiguous
@@ -82,23 +107,24 @@ impl DescriptorTable {
     }
 
     /// Get the descriptor at `idx`, if any.
-    pub fn get(&self, idx: u32) -> Option<&Descriptor> {
+    pub fn get(&self, idx: DescriptorHandle) -> Option<&Descriptor> {
         self.descriptors.get(&idx)
     }
 
     /// Get the descriptor at `idx`, if any.
-    pub fn get_mut(&mut self, idx: u32) -> Option<&mut Descriptor> {
+    pub fn get_mut(&mut self, idx: DescriptorHandle) -> Option<&mut Descriptor> {
         self.descriptors.get_mut(&idx)
     }
 
-    /// Insert a descriptor at `index`. If a descriptor is already present at
-    /// that index, it is unregistered from that index and returned.
-    fn set(&mut self, index: u32, descriptor: Descriptor) -> Option<Descriptor> {
+    /// Insert a descriptor at `index`. If a descriptor is already present at that index, it is
+    /// unregistered from that index and returned.
+    #[must_use]
+    fn set(&mut self, index: DescriptorHandle, descriptor: Descriptor) -> Option<Descriptor> {
         // We ensure the index is no longer in `self.available_indices`. We *don't* ensure
         // `self.next_index` is > `index`, since that'd require adding the indices in between to
         // `self.available_indices`. It uses less memory and is no more expensive to iterate when
         // *using* `self.available_indices` instead.
-        self.available_indices.remove(&index);
+        self.available_indices.remove(&index.val());
 
         if let Some(prev) = self.descriptors.insert(index, descriptor) {
             trace!("Overwriting index {}", index);
@@ -109,29 +135,45 @@ impl DescriptorTable {
         }
     }
 
-    /// Register a descriptor and return its fd handle.
-    pub fn register_descriptor(&mut self, desc: Descriptor) -> u32 {
-        self.add(desc, 0)
+    /// Register a descriptor and return its fd handle. Equivalent to
+    /// `register_descriptor_with_min_fd(desc, 0)`. If the descriptor could not be added, the
+    /// descriptor is returned in the `Err`.
+    pub fn register_descriptor(
+        &mut self,
+        desc: Descriptor,
+    ) -> Result<DescriptorHandle, Descriptor> {
+        const ZERO: DescriptorHandle = match DescriptorHandle::new(0) {
+            Some(x) => x,
+            None => unreachable!(),
+        };
+        self.add(desc, ZERO)
     }
 
-    /// Register a descriptor and return its fd handle.
-    pub fn register_descriptor_with_min_fd(&mut self, desc: Descriptor, min_fd: u32) -> u32 {
+    /// Register a descriptor and return its fd handle. If the descriptor could not be added, the
+    /// descriptor is returned in the `Err`.
+    pub fn register_descriptor_with_min_fd(
+        &mut self,
+        desc: Descriptor,
+        min_fd: DescriptorHandle,
+    ) -> Result<DescriptorHandle, Descriptor> {
         self.add(desc, min_fd)
     }
 
     /// Register a descriptor with a given fd handle and return the descriptor that it replaced.
+    #[must_use]
     pub fn register_descriptor_with_fd(
         &mut self,
         desc: Descriptor,
-        new_fd: u32,
+        new_fd: DescriptorHandle,
     ) -> Option<Descriptor> {
         self.set(new_fd, desc)
     }
 
     /// Deregister the descriptor with the given fd handle and return it.
-    pub fn deregister_descriptor(&mut self, fd: u32) -> Option<Descriptor> {
+    #[must_use]
+    pub fn deregister_descriptor(&mut self, fd: DescriptorHandle) -> Option<Descriptor> {
         let maybe_descriptor = self.descriptors.remove(&fd);
-        self.available_indices.insert(fd);
+        self.available_indices.insert(fd.val());
         self.trim_tail();
         maybe_descriptor
     }
@@ -164,3 +206,71 @@ impl Default for DescriptorTable {
         Self::new()
     }
 }
+
+/// A handle for a file descriptor.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DescriptorHandle(u32);
+
+impl DescriptorHandle {
+    /// Returns `Some` if `fd` is less than [`FD_MAX`]. Can be used in `const` contexts.
+    pub const fn new(fd: u32) -> Option<Self> {
+        if fd > FD_MAX {
+            return None;
+        }
+
+        Some(DescriptorHandle(fd))
+    }
+
+    pub fn val(&self) -> u32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for DescriptorHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<DescriptorHandle> for u32 {
+    fn from(x: DescriptorHandle) -> u32 {
+        x.0
+    }
+}
+
+impl From<DescriptorHandle> for i32 {
+    fn from(x: DescriptorHandle) -> i32 {
+        const _: () = assert!(FD_MAX <= i32::MAX as u32);
+        // the constructor makes sure this won't panic
+        x.0.try_into().unwrap()
+    }
+}
+
+impl TryFrom<u32> for DescriptorHandle {
+    type Error = DescriptorHandleError;
+    fn try_from(x: u32) -> Result<Self, Self::Error> {
+        DescriptorHandle::new(x).ok_or(DescriptorHandleError())
+    }
+}
+
+impl TryFrom<i32> for DescriptorHandle {
+    type Error = DescriptorHandleError;
+    fn try_from(x: i32) -> Result<Self, Self::Error> {
+        x.try_into()
+            .ok()
+            .and_then(DescriptorHandle::new)
+            .ok_or(DescriptorHandleError())
+    }
+}
+
+/// The handle is not valid.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct DescriptorHandleError();
+
+impl std::fmt::Display for DescriptorHandleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Not a valid descriptor handle")
+    }
+}
+
+impl std::error::Error for DescriptorHandleError {}

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -93,7 +93,7 @@ impl DescriptorTable {
 
     /// Insert a descriptor at `index`. If a descriptor is already present at
     /// that index, it is unregistered from that index and returned.
-    pub fn set(&mut self, index: u32, descriptor: Descriptor) -> Option<Descriptor> {
+    fn set(&mut self, index: u32, descriptor: Descriptor) -> Option<Descriptor> {
         // We ensure the index is no longer in `self.available_indices`. We *don't* ensure
         // `self.next_index` is > `index`, since that'd require adding the indices in between to
         // `self.available_indices`. It uses less memory and is no more expensive to iterate when

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -740,7 +740,9 @@ impl Process {
         let desc = unsafe {
             Descriptor::from_legacy_file(stdfile as *mut cshadow::LegacyFile, OFlag::empty())
         };
-        let prev = self.descriptor_table_borrow_mut().set(fd, desc);
+        let prev = self
+            .descriptor_table_borrow_mut()
+            .register_descriptor_with_fd(desc, fd);
         assert!(prev.is_none());
         trace!(
             "Successfully opened fd {} at {}",

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -32,7 +32,7 @@ use crate::host::syscall::formatter::FmtOptions;
 use crate::utility::callback_queue::CallbackQueue;
 use crate::utility::pathbuf_to_nul_term_cstring;
 
-use super::descriptor::descriptor_table::DescriptorTable;
+use super::descriptor::descriptor_table::{DescriptorHandle, DescriptorTable};
 use super::host::Host;
 use super::memory_manager::{MemoryManager, ProcessMemoryRef, ProcessMemoryRefMut};
 use super::syscall::formatter::StraceFmtMode;
@@ -422,16 +422,24 @@ impl Process {
         assert!(!self.is_running());
 
         self.open_stdio_file_helper(
-            libc::STDIN_FILENO as u32,
+            libc::STDIN_FILENO.try_into().unwrap(),
             "/dev/null".into(),
             OFlag::O_RDONLY,
         );
 
         let name = self.output_file_name(host, "stdout");
-        self.open_stdio_file_helper(libc::STDOUT_FILENO as u32, name, OFlag::O_WRONLY);
+        self.open_stdio_file_helper(
+            libc::STDOUT_FILENO.try_into().unwrap(),
+            name,
+            OFlag::O_WRONLY,
+        );
 
         let name = self.output_file_name(host, "stderr");
-        self.open_stdio_file_helper(libc::STDERR_FILENO as u32, name, OFlag::O_WRONLY);
+        self.open_stdio_file_helper(
+            libc::STDERR_FILENO.try_into().unwrap(),
+            name,
+            OFlag::O_WRONLY,
+        );
 
         // Create the main thread and add it to our thread list.
         let tid = self.thread_group_leader_id();
@@ -713,7 +721,7 @@ impl Process {
 
     fn open_stdio_file_helper(
         &self,
-        fd: u32,
+        fd: DescriptorHandle,
         path: PathBuf,
         access_mode: OFlag,
     ) -> *mut cshadow::RegularFile {
@@ -1444,9 +1452,10 @@ mod export {
             proc.borrow(h.root())
                 .descriptor_table_borrow_mut()
                 .register_descriptor(*desc)
+                .unwrap()
         })
         .unwrap();
-        fd.try_into().unwrap()
+        fd.into()
     }
 
     /// Get a temporary reference to a descriptor.
@@ -1457,7 +1466,7 @@ mod export {
     ) -> *const Descriptor {
         let proc = unsafe { proc.as_ref().unwrap() };
 
-        let handle: u32 = match handle.try_into() {
+        let handle = match handle.try_into() {
             Ok(i) => i,
             Err(_) => {
                 log::debug!("Attempted to get a descriptor with handle {}", handle);
@@ -1482,7 +1491,7 @@ mod export {
     ) -> *mut Descriptor {
         let proc = unsafe { proc.as_ref().unwrap() };
 
-        let handle: u32 = match handle.try_into() {
+        let handle = match handle.try_into() {
             Ok(i) => i,
             Err(_) => {
                 log::debug!("Attempted to get a descriptor with handle {}", handle);
@@ -1511,7 +1520,7 @@ mod export {
     ) -> *mut cshadow::LegacyFile {
         let proc = unsafe { proc.as_ref().unwrap() };
 
-        let handle: u32 = match handle.try_into() {
+        let handle = match handle.try_into() {
             Ok(i) => i,
             Err(_) => {
                 log::debug!("Attempted to get a descriptor with handle {}", handle);

--- a/src/main/host/syscall/handler/eventfd.rs
+++ b/src/main/host/syscall/handler/eventfd.rs
@@ -78,10 +78,11 @@ impl SyscallHandler {
         let fd = ctx
             .process
             .descriptor_table_borrow_mut()
-            .register_descriptor(desc);
+            .register_descriptor(desc)
+            .or(Err(Errno::ENFILE))?;
 
         log::trace!("eventfd() returning fd {}", fd);
 
-        Ok(fd.into())
+        Ok(fd.val().into())
     }
 }

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -2,7 +2,7 @@ use std::mem::MaybeUninit;
 
 use crate::cshadow as c;
 use crate::host::context::{ThreadContext, ThreadContextObjs};
-use crate::host::descriptor::descriptor_table::DescriptorTable;
+use crate::host::descriptor::descriptor_table::{DescriptorHandle, DescriptorTable};
 use crate::host::descriptor::Descriptor;
 use crate::host::memory_manager::MemoryManager;
 use crate::host::syscall_types::{
@@ -96,10 +96,10 @@ impl SyscallHandler {
     /// EBADF.
     fn get_descriptor(
         descriptor_table: &DescriptorTable,
-        fd: impl TryInto<u32>,
+        fd: impl TryInto<DescriptorHandle>,
     ) -> Result<&Descriptor, nix::errno::Errno> {
         // check that fd is within bounds
-        let fd: u32 = fd.try_into().map_err(|_| nix::errno::Errno::EBADF)?;
+        let fd = fd.try_into().or(Err(nix::errno::Errno::EBADF))?;
 
         match descriptor_table.get(fd) {
             Some(desc) => Ok(desc),
@@ -111,10 +111,10 @@ impl SyscallHandler {
     /// EBADF.
     fn get_descriptor_mut(
         descriptor_table: &mut DescriptorTable,
-        fd: impl TryInto<u32>,
+        fd: impl TryInto<DescriptorHandle>,
     ) -> Result<&mut Descriptor, nix::errno::Errno> {
         // check that fd is within bounds
-        let fd: u32 = fd.try_into().map_err(|_| nix::errno::Errno::EBADF)?;
+        let fd = fd.try_into().or(Err(nix::errno::Errno::EBADF))?;
 
         match descriptor_table.get_mut(fd) {
             Some(desc) => Ok(desc),


### PR DESCRIPTION
The descriptor table shouldn't ever allow descriptors to be registered with a handle larger than `libc::c_int::MAX`. The old code also had a loop that could wrap around unexpectedly in release builds.

While the libc API uses `int` values for file handles, the Linux syscall API uses `unsigned int` for file handles. This means that when you pass a file handle of -1 to a `close()` call for example, Linux will see this as 4,294,967,295. If we read file handles in Shadow's syscall handlers as `libc::c_uint` values, we run into problems in these edge cases (for example with `dup2(fd, -1)`). We can continue reading them as signed integers and casting them to unsigned for now, but I think it's nicer to force us to handle these edge cases.

The public API to `DescriptorTable` now uses `DescriptorHandle` objects. The `register_descriptor` and `register_descriptor_with_min_fd` methods also now return results if the descriptor could not be added.