### PR TITLE
Simplify the host's networking cleanup

### DIFF
--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -300,7 +300,7 @@ fn associate_socket(
 ) -> Result<SocketAddrV4, SyscallError> {
     log::trace!("Trying to associate socket with addresses (local={local_addr}, peer={peer_addr})");
 
-    if !local_addr.ip().is_unspecified() && net_ns.interface(*local_addr.ip()).is_none() {
+    if !local_addr.ip().is_unspecified() && net_ns.interface_borrow(*local_addr.ip()).is_none() {
         log::debug!(
             "No network interface exists for the provided local address {}",
             local_addr.ip(),

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -612,10 +612,14 @@ impl Host {
         }
     }
 
+    /// Shut down the host. This should be called while `Worker` has the active host set.
     pub fn shutdown(&self) {
         self.continue_execution_timer();
 
         debug!("shutting down host {}", self.name());
+
+        // the network namespace object needs to be cleaned up before it's dropped
+        Worker::with_dns(|dns| self.net_ns.borrow().as_ref().unwrap().cleanup(dns));
 
         // Need to drop the interfaces early because they trigger worker accesses
         // that will not be valid at the normal drop time. The interfaces will

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -127,8 +127,7 @@ pub struct Host {
 
     cpu: RefCell<Cpu>,
 
-    // TODO: rearrange our shutdown process so we don't need an `Option` type here
-    net_ns: RefCell<Option<NetworkNamespace>>,
+    net_ns: NetworkNamespace,
 
     // Store as a CString so that we can return a borrowed pointer to C code
     // instead of having to allocate a new string.
@@ -271,7 +270,7 @@ impl Host {
             shim_shmem,
             shim_shmem_lock: RefCell::new(None),
             cpu,
-            net_ns: RefCell::new(Some(net_ns)),
+            net_ns,
             data_dir_path,
             data_dir_path_cstring,
             process_id_counter,
@@ -429,7 +428,7 @@ impl Host {
     }
 
     pub fn default_ip(&self) -> Ipv4Addr {
-        let addr = self.net_ns.borrow().as_ref().unwrap().default_address.ptr();
+        let addr = self.net_ns.default_address.ptr();
         let addr = unsafe { cshadow::address_toNetworkIP(addr) };
         u32::from_be(addr).into()
     }
@@ -437,7 +436,7 @@ impl Host {
     pub fn abstract_unix_namespace(
         &self,
     ) -> impl Deref<Target = Arc<AtomicRefCell<AbstractUnixNamespace>>> + '_ {
-        Ref::map(self.net_ns.borrow(), |x| &x.as_ref().unwrap().unix)
+        &self.net_ns.unix
     }
 
     pub fn log_level(&self) -> Option<log::LevelFilter> {
@@ -452,7 +451,7 @@ impl Host {
 
     #[track_caller]
     pub fn network_namespace_borrow(&self) -> impl Deref<Target = NetworkNamespace> + '_ {
-        Ref::map(self.net_ns.borrow(), |x| x.as_ref().unwrap())
+        &self.net_ns
     }
 
     #[track_caller]
@@ -490,25 +489,21 @@ impl Host {
     /// Returns `None` if there is no such interface.
     ///
     /// Panics if we have shut down.
-    #[track_caller]
     pub fn interface_borrow_mut(
         &self,
         addr: Ipv4Addr,
     ) -> Option<impl Deref<Target = NetworkInterface> + DerefMut + '_> {
-        let borrow = self.net_ns.borrow_mut();
-        RefMut::filter_map(borrow, |x| x.as_mut().unwrap().interface_mut(addr)).ok()
+        self.net_ns.interface_borrow_mut(addr)
     }
 
     /// Returns `None` if there is no such interface.
     ///
     /// Panics if we have shut down.
-    #[track_caller]
     pub fn interface_borrow(
         &self,
         addr: Ipv4Addr,
     ) -> Option<impl Deref<Target = NetworkInterface> + '_> {
-        let borrow = self.net_ns.borrow();
-        Ref::filter_map(borrow, |x| x.as_ref().unwrap().interface(addr)).ok()
+        self.net_ns.interface_borrow(addr)
     }
 
     #[track_caller]
@@ -582,16 +577,12 @@ impl Host {
         let bw_down = self.bw_down_kiBps();
         let bw_up = self.bw_up_kiBps();
         self.net_ns
-            .borrow()
-            .as_ref()
-            .unwrap()
             .localhost
+            .borrow()
             .start_refilling_token_buckets(bw_down, bw_up);
         self.net_ns
-            .borrow()
-            .as_ref()
-            .unwrap()
             .internet
+            .borrow()
             .start_refilling_token_buckets(bw_down, bw_up);
 
         // must be done after the default IP exists so tracker_heartbeat works
@@ -619,15 +610,7 @@ impl Host {
         debug!("shutting down host {}", self.name());
 
         // the network namespace object needs to be cleaned up before it's dropped
-        Worker::with_dns(|dns| self.net_ns.borrow().as_ref().unwrap().cleanup(dns));
-
-        // Need to drop the interfaces early because they trigger worker accesses
-        // that will not be valid at the normal drop time. The interfaces will
-        // become None after this and should not be unwrapped anymore.
-        // TODO: clean this up when removing the interface's C internals.
-        {
-            self.net_ns.replace(None);
-        }
+        Worker::with_dns(|dns| self.net_ns.cleanup(dns));
 
         assert!(self.processes.borrow().is_empty());
 
@@ -707,13 +690,7 @@ impl Host {
         //   `self.net_ns.borrow().as_ref().unwrap().internet.receive_packets(self);`
         // but that causes a double-borrow loop. See `host_socketWantsToSend()`.
         unsafe {
-            let netif_ptr = self
-                .net_ns
-                .borrow()
-                .as_ref()
-                .unwrap()
-                .internet
-                .borrow_inner();
+            let netif_ptr = self.net_ns.internet.borrow().borrow_inner();
             cshadow::networkinterface_receivePackets(netif_ptr, self)
         };
     }
@@ -901,13 +878,7 @@ mod export {
     #[no_mangle]
     pub unsafe extern "C" fn host_getDefaultAddress(hostrc: *const Host) -> *mut cshadow::Address {
         let hostrc = unsafe { hostrc.as_ref().unwrap() };
-        hostrc
-            .net_ns
-            .borrow()
-            .as_ref()
-            .unwrap()
-            .default_address
-            .ptr()
+        hostrc.net_ns.default_address.ptr()
     }
 
     #[no_mangle]
@@ -1019,9 +990,6 @@ mod export {
         );
         hostrc
             .net_ns
-            .borrow()
-            .as_ref()
-            .unwrap()
             .is_interface_available(protocol_type, src, dst)
     }
 
@@ -1049,9 +1017,6 @@ mod export {
         unsafe {
             hostrc
                 .net_ns
-                .borrow()
-                .as_ref()
-                .unwrap()
                 .associate_interface(socket, protocol, bind_addr, peer_addr)
         };
     }
@@ -1078,9 +1043,6 @@ mod export {
         // associate the interfaces corresponding to bind_addr with socket
         hostrc
             .net_ns
-            .borrow()
-            .as_ref()
-            .unwrap()
             .disassociate_interface(protocol, bind_addr, peer_addr);
     }
 
@@ -1102,9 +1064,6 @@ mod export {
 
         hostrc
             .net_ns
-            .borrow()
-            .as_ref()
-            .unwrap()
             .get_random_free_port(
                 protocol_type,
                 interface_ip,

--- a/src/main/host/network_interface.rs
+++ b/src/main/host/network_interface.rs
@@ -138,7 +138,8 @@ impl NetworkInterface {
 
 impl Drop for NetworkInterface {
     fn drop(&mut self) {
-        unsafe { c::networkinterface_free(self.c_ptr.ptr()) };
+        // don't check the active host since we're in the middle of dropping the host
+        unsafe { c::networkinterface_free(self.c_ptr.ptr_unchecked()) };
     }
 }
 

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -114,6 +114,17 @@ impl<T> HostTreePointer<T> {
         assert_eq!(self.host_id, host.info().id);
         self.ptr
     }
+
+    /// Get the pointer without checking the active host.
+    ///
+    /// # Safety
+    ///
+    /// Pointer must only be dereferenced while the configures Host is still
+    /// active, in addition to the normal safety requirements for dereferencing
+    /// a pointer.
+    pub unsafe fn ptr_unchecked(&self) -> *mut T {
+        self.ptr
+    }
 }
 
 /// A trait we can use as a compile-time check to make sure that an object is Send.


### PR DESCRIPTION
This changes the host's `net_ns: RefCell<Option<NetworkNamespace>>` to `net_ns: NetworkNamespace` by adding a `NetworkNamespace::cleanup` function that has to be run while the worker has an active host. The network namespace objects have also been wrapped in a `RefCell`. The network interface objects don't have any `&mut` methods so this `RefCell` isn't currently needed, but we'll likely want to give them `&mut` methods in the future.

@robgjansen This can be merged either before or after your changes, whichever makes it easier for your PR.