### PR TITLE
Close the `LegacyFile` when the last `LegacyFileCounter` is dropped

### DIFF
--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -754,10 +754,7 @@ impl LegacyFileCounter {
         }
     }
 
-    /// # Safety
-    ///
-    /// TODO
-    pub unsafe fn ptr(&self) -> *mut c::LegacyFile {
+    pub fn ptr(&self) -> *mut c::LegacyFile {
         unsafe { self.file.ptr() }
     }
 
@@ -871,7 +868,7 @@ mod export {
         let descriptor = unsafe { &*descriptor };
 
         if let CompatFile::Legacy(d) = descriptor.file() {
-            unsafe { d.ptr() }
+            d.ptr()
         } else {
             std::ptr::null_mut()
         }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1529,7 +1529,7 @@ mod export {
         };
 
         Worker::with_active_host(|h| match proc.borrow(h.root()).descriptor_table_borrow().get(handle).map(|x| x.file()) {
-            Some(CompatFile::Legacy(file)) => unsafe { file.ptr() },
+            Some(CompatFile::Legacy(file)) => file.ptr(),
             Some(CompatFile::New(file)) => {
                 // we have a special case for the legacy C TCP objects
                 if let File::Socket(Socket::Inet(InetSocket::Tcp(tcp))) = file.inner_file() {


### PR DESCRIPTION
This makes `LegacyFileCounter` more closely match `OpenFile`, so that if a descriptor is dropped, it may run the file's close method.

See discussion in https://github.com/shadow/shadow/pull/2691#discussion_r1086194738.