### PR TITLE
process_continue: take thread id instead of thread*

### DIFF
--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -2130,12 +2130,9 @@ mod export {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn process_continue(
-        proc: *const ProcessRefCell,
-        thread: *mut cshadow::Thread,
-    ) {
+    pub unsafe extern "C" fn process_continue(proc: *const ProcessRefCell, thread_id: libc::pid_t) {
         let proc = unsafe { proc.as_ref().unwrap() };
-        let tid = ThreadId::try_from(unsafe { cshadow::thread_getID(thread) }).unwrap();
+        let tid = ThreadId::try_from(thread_id).unwrap();
         Worker::with_active_host(|host| {
             let proc = proc.borrow(host.root());
             proc.resume(host, tid)

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -355,7 +355,7 @@ static void _syscallcondition_trigger(const Host* host, void* obj, void* arg) {
 #endif
 
         /* Wake up the thread. */
-        process_continue(proc, cond->thread);
+        process_continue(proc, thread_getID(cond->thread));
     } else {
         // Spurious wakeup. Just return without running the process. The
         // condition's listeners should still be installed, and now that we've


### PR DESCRIPTION
Simplifies API and implementation