### PR TITLE
Reordered line styles in `plot-shadow.py`

### DIFF
--- a/src/tools/plot-shadow.py
+++ b/src/tools/plot-shadow.py
@@ -53,7 +53,7 @@ try: pylab.rcParams.update({'legend.ncol':1.0})
 except: pass
 
 LINE_COLORS = ['k', 'r', 'b', 'g', 'c', 'm', 'y']
-LINE_STYLES = ['-', '--', ':', '-.']
+LINE_STYLES = ['-', '--', '-.', ':']
 
 # since there are 7 colors and 4 styles (no common factor), there will be 28
 # distinct color/style combinations before it repeats


### PR DESCRIPTION
The `:` style is not visible underneath `-.`, so they've been reordered. For example, see the old version:

![1674833247_grim](https://user-images.githubusercontent.com/3708797/215123593-4dee688e-d231-4507-810d-063496ef1e6f.png)