### PR TITLE
Plan for interior mutability in Thread / ThreadRef

### DIFF
--- a/src/main/host/context.rs
+++ b/src/main/host/context.rs
@@ -66,7 +66,7 @@ impl<'a> ProcessContext<'a> {
         Self { host, process }
     }
 
-    pub fn with_thread(&'a mut self, thread: &'a mut ThreadRef) -> ThreadContext<'a> {
+    pub fn with_thread(&'a mut self, thread: &'a ThreadRef) -> ThreadContext<'a> {
         ThreadContext::new(self.host, self.process, thread)
     }
 }
@@ -75,11 +75,11 @@ impl<'a> ProcessContext<'a> {
 pub struct ThreadContext<'a> {
     pub host: &'a Host,
     pub process: &'a Process,
-    pub thread: &'a mut ThreadRef,
+    pub thread: &'a ThreadRef,
 }
 
 impl<'a> ThreadContext<'a> {
-    pub fn new(host: &'a Host, process: &'a Process, thread: &'a mut ThreadRef) -> Self {
+    pub fn new(host: &'a Host, process: &'a Process, thread: &'a ThreadRef) -> Self {
         Self {
             host,
             process,
@@ -125,7 +125,7 @@ impl<'a> ThreadContextObjs<'a> {
         F: FnOnce(&mut ThreadContext) -> R,
     {
         let process = self.process.borrow(self.host.root());
-        let mut ctx = ThreadContext::new(self.host, &process, &mut self.thread);
+        let mut ctx = ThreadContext::new(self.host, &process, &self.thread);
         f(&mut ctx)
     }
 }

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -1111,7 +1111,7 @@ mod export {
         for process in host.processes.borrow().values() {
             let process = process.borrow(host.root());
             if let Some(thread) = process.thread_borrow(tid) {
-                return unsafe { thread.borrow(host.root()).cthread() };
+                return unsafe { thread.cthread() };
             };
         }
         std::ptr::null_mut()

--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -166,7 +166,7 @@ impl ShmFile {
     }
 
     /// Map the given range of the file into the plugin's address space.
-    fn mmap_into_plugin(&self, thread: &mut ThreadRef, interval: &Interval, prot: i32) {
+    fn mmap_into_plugin(&self, thread: &ThreadRef, interval: &Interval, prot: i32) {
         thread
             .native_mmap(
                 PluginPtr::from(interval.start),
@@ -212,7 +212,7 @@ fn get_regions(pid: Pid) -> IntervalMap<Region> {
 /// Find the heap range, and map it if non-empty.
 fn get_heap(
     shm_file: &mut ShmFile,
-    thread: &mut ThreadRef,
+    thread: &ThreadRef,
     memory_manager: &MemoryManager,
     regions: &mut IntervalMap<Region>,
 ) -> Interval {
@@ -252,7 +252,7 @@ fn get_heap(
 /// stack size.
 fn map_stack(
     memory_manager: &mut MemoryManager,
-    thread: &mut ThreadRef,
+    thread: &ThreadRef,
     shm_file: &mut ShmFile,
     regions: &mut IntervalMap<Region>,
 ) {
@@ -365,7 +365,7 @@ fn coalesce_regions(regions: IntervalMap<Region>) -> IntervalMap<Region> {
 }
 
 impl MemoryMapper {
-    pub fn new(memory_manager: &mut MemoryManager, thread: &mut ThreadRef) -> MemoryMapper {
+    pub fn new(memory_manager: &mut MemoryManager, thread: &ThreadRef) -> MemoryMapper {
         let shm_path = format!(
             "/dev/shm/shadow_memory_manager_{}_{:?}_{}",
             process::id(),
@@ -528,7 +528,7 @@ impl MemoryMapper {
     /// mappings are remapped.
     pub fn handle_mmap_result(
         &mut self,
-        thread: &mut ThreadRef,
+        thread: &ThreadRef,
         ptr: TypedPluginPtr<u8>,
         prot: i32,
         flags: i32,
@@ -616,7 +616,7 @@ impl MemoryMapper {
     /// if applicable.
     pub fn handle_mremap(
         &mut self,
-        thread: &mut ThreadRef,
+        thread: &ThreadRef,
         old_address: PluginPtr,
         old_size: usize,
         new_size: usize,
@@ -742,7 +742,7 @@ impl MemoryMapper {
     /// Execute the requested `brk` and update our mappings accordingly. May invalidate outstanding
     /// pointers. (Rust won't allow mutable methods such as this one to be called with outstanding
     /// borrowed references).
-    pub fn handle_brk(&mut self, thread: &mut ThreadRef, ptr: PluginPtr) -> SyscallResult {
+    pub fn handle_brk(&mut self, thread: &ThreadRef, ptr: PluginPtr) -> SyscallResult {
         let requested_brk = usize::from(ptr);
 
         // On error, brk syscall returns current brk (end of heap). The only errors we specifically
@@ -862,7 +862,7 @@ impl MemoryMapper {
     /// memory in a way that the plugin itself can't.
     pub fn handle_mprotect(
         &mut self,
-        thread: &mut ThreadRef,
+        thread: &ThreadRef,
         addr: PluginPtr,
         size: usize,
         prot: i32,

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -566,7 +566,7 @@ impl MemoryManager {
 
     /// Initialize the MemoryMapper, allowing for more efficient access. Needs a
     /// running thread.
-    pub fn init_mapper(&mut self, thread: &mut ThreadRef) {
+    pub fn init_mapper(&mut self, thread: &ThreadRef) {
         assert!(self.memory_mapper.is_none());
         self.memory_mapper = Some(MemoryMapper::new(self, thread));
     }
@@ -585,7 +585,7 @@ impl MemoryManager {
         }
     }
 
-    pub fn handle_brk(&mut self, thread: &mut ThreadRef, ptr: PluginPtr) -> SyscallResult {
+    pub fn handle_brk(&mut self, thread: &ThreadRef, ptr: PluginPtr) -> SyscallResult {
         match &mut self.memory_mapper {
             Some(mm) => mm.handle_brk(thread, ptr),
             None => Err(SyscallError::Native),
@@ -594,7 +594,7 @@ impl MemoryManager {
 
     pub fn do_mmap(
         &mut self,
-        thread: &mut ThreadRef,
+        thread: &ThreadRef,
         addr: PluginPtr,
         length: usize,
         prot: i32,
@@ -617,7 +617,7 @@ impl MemoryManager {
 
     pub fn handle_munmap(
         &mut self,
-        thread: &mut ThreadRef,
+        thread: &ThreadRef,
         addr: PluginPtr,
         length: usize,
     ) -> SyscallResult {
@@ -633,12 +633,7 @@ impl MemoryManager {
         }
     }
 
-    fn do_munmap(
-        &mut self,
-        thread: &mut ThreadRef,
-        addr: PluginPtr,
-        length: usize,
-    ) -> nix::Result<()> {
+    fn do_munmap(&mut self, thread: &ThreadRef, addr: PluginPtr, length: usize) -> nix::Result<()> {
         thread.native_munmap(addr, length)?;
         if let Some(mm) = &mut self.memory_mapper {
             mm.handle_munmap_result(addr, length);
@@ -648,7 +643,7 @@ impl MemoryManager {
 
     pub fn handle_mremap(
         &mut self,
-        thread: &mut ThreadRef,
+        thread: &ThreadRef,
         old_address: PluginPtr,
         old_size: usize,
         new_size: usize,
@@ -665,7 +660,7 @@ impl MemoryManager {
 
     pub fn handle_mprotect(
         &mut self,
-        thread: &mut ThreadRef,
+        thread: &ThreadRef,
         addr: PluginPtr,
         size: usize,
         prot: i32,

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -694,7 +694,7 @@ impl Process {
         let mut host_shmem_protected = host.shim_shmem_lock_borrow_mut().unwrap();
         let threads = self.threads.borrow();
         for thread in threads.values() {
-            let mut thread = thread.borrow_mut(host.root());
+            let thread = thread.borrow_mut(host.root());
             {
                 let thread_shmem = thread.shmem();
                 let thread_shmem_protected = thread_shmem

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -576,7 +576,6 @@ impl Process {
         // can drop the borrow of the thread list, and pass a borrowed mutable reference
         // to `thread` so that it doesn't need to be re-borrowed.
         let cthread = unsafe { thread.cthread() };
-        drop(thread);
         drop(threads);
 
         unsafe { cshadow::thread_resume(cthread) };
@@ -1736,17 +1735,9 @@ mod export {
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
             let mut memory_manager = proc.memory_borrow_mut();
-            let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
+            let thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             memory_manager
-                .do_mmap(
-                    &mut thread,
-                    PluginPtr::from(addr),
-                    len,
-                    prot,
-                    flags,
-                    fd,
-                    offset,
-                )
+                .do_mmap(&thread, PluginPtr::from(addr), len, prot, flags, fd, offset)
                 .into()
         })
         .unwrap()
@@ -1764,9 +1755,9 @@ mod export {
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
             let mut memory_manager = proc.memory_borrow_mut();
-            let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
+            let thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             memory_manager
-                .handle_munmap(&mut thread, PluginPtr::from(addr), len)
+                .handle_munmap(&thread, PluginPtr::from(addr), len)
                 .into()
         })
         .unwrap()
@@ -1786,10 +1777,10 @@ mod export {
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
             let mut memory_manager = proc.memory_borrow_mut();
-            let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
+            let thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             memory_manager
                 .handle_mremap(
-                    &mut thread,
+                    &thread,
                     PluginPtr::from(old_addr),
                     old_size,
                     new_size,
@@ -1813,9 +1804,9 @@ mod export {
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
             let mut memory_manager = proc.memory_borrow_mut();
-            let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
+            let thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             memory_manager
-                .handle_mprotect(&mut thread, PluginPtr::from(addr), size, prot)
+                .handle_mprotect(&thread, PluginPtr::from(addr), size, prot)
                 .into()
         })
         .unwrap()
@@ -1832,9 +1823,9 @@ mod export {
         Worker::with_active_host(|h| {
             let proc = proc.borrow(h.root());
             let mut memory_manager = proc.memory_borrow_mut();
-            let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
+            let thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
             memory_manager
-                .handle_brk(&mut thread, PluginPtr::from(plugin_src))
+                .handle_brk(&thread, PluginPtr::from(plugin_src))
                 .into()
         })
         .unwrap()
@@ -1852,8 +1843,8 @@ mod export {
             let proc = proc.borrow(h.root());
             let mut memory_manager = proc.memory_borrow_mut();
             if !memory_manager.has_mapper() {
-                let mut thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
-                memory_manager.init_mapper(&mut thread)
+                let thread = unsafe { ThreadRef::new(notnull_mut_debug(thread)) };
+                memory_manager.init_mapper(&thread)
             }
         })
         .unwrap()


### PR DESCRIPTION
At a high level, I think we're going to need interior mutability in Thread/ThreadRef for similar reasons as in Process and Host - it'd be difficult to avoid incompatible borrows of Thread itself without it.

More concretely, I ran into a problem when changing SysCallCondition to store a tid instead of a `Thread*`: some `SysCallCondition` methods need to act on the `Thread`. Since the condition itself is a member of the `Thread`, it'll be impossible to simultaneously hold a `&mut Thread` and a reference to the condition. Using a `&Thread` instead of a `&mut Thread` works around this.

I went a bit further here than strictly necessary and removed the `RootedRefCell` wrapper around `Process`'s `ThreadRef`s altogether. I think as with `Process` we'll end up making ~all methods take `&self` instead of `&mut self`, so will never need to get a `&mut` reference to the `ThreadRef`.

We *could* leave the `RootedRefCell` in place to make things easier in case we want to get `&mut` references later, but after working through the analagous problem in `Process` I think I'm leaning towards following the [yagni](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it) principle here. Better to make the code simpler now and only support as much functionality as we know we need.