### PR TITLE
Support rust `InetSocket`s in the network interface

### DIFF
--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -335,9 +335,7 @@ fn associate_socket(
         return Err(Errno::EADDRINUSE.into());
     }
 
-    // TODO: create the CompatSocket from the InetSocket
-    let InetSocket::Tcp(socket) = socket;
-    let socket = unsafe { c::compatsocket_fromLegacySocket(socket.borrow().as_legacy_socket()) };
+    let socket = unsafe { c::compatsocket_fromInetSocket(&socket) };
 
     // associate the interfaces corresponding to addr with socket
     unsafe { net_ns.associate_interface(&socket, protocol, local_addr, peer_addr) };

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -360,6 +360,18 @@ void networkinterface_wantsSend(NetworkInterface* interface, const CompatSocket*
     }
 }
 
+void networkinterface_removeAllSockets(NetworkInterface* interface) {
+    /* we want to unref all sockets, but also want to keep the network interface in a valid state */
+
+    rrsocketqueue_destroy(&interface->rrQueue, compatsocket_unref);
+    fifosocketqueue_destroy(&interface->fifoQueue, compatsocket_unref);
+
+    rrsocketqueue_init(&interface->rrQueue);
+    fifosocketqueue_init(&interface->fifoQueue);
+
+    g_hash_table_remove_all(interface->boundSockets);
+}
+
 NetworkInterface* networkinterface_new(Address* address, const gchar* pcapDir,
                                        guint32 pcapCaptureSize, QDiscMode qdisc) {
     NetworkInterface* interface = g_new0(NetworkInterface, 1);

--- a/src/main/host/network_interface.h
+++ b/src/main/host/network_interface.h
@@ -38,4 +38,7 @@ void networkinterface_wantsSend(NetworkInterface* interface, const CompatSocket*
 Packet* networkinterface_pop(NetworkInterface* interface);
 void networkinterface_push(NetworkInterface* interface, Packet* packet);
 
+/* Disassociate all bound sockets and remove sockets from the sending queue. */
+void networkinterface_removeAllSockets(NetworkInterface* interface);
+
 #endif /* SHD_NETWORK_INTERFACE_H_ */

--- a/src/main/host/network_interface.rs
+++ b/src/main/host/network_interface.rs
@@ -114,6 +114,12 @@ impl NetworkInterface {
     pub fn add_data_source(&self, socket_ptr: *const c::CompatSocket) {
         unsafe { c::networkinterface_wantsSend(self.c_ptr.ptr(), socket_ptr) };
     }
+
+    /// Disassociate all bound sockets and remove sockets from the sending queue. This should be
+    /// called as part of the host's cleanup procedure.
+    pub fn remove_all_sockets(&self) {
+        unsafe { c::networkinterface_removeAllSockets(self.c_ptr.ptr()) };
+    }
 }
 
 impl Drop for NetworkInterface {

--- a/src/main/host/network_queuing_disciplines.c
+++ b/src/main/host/network_queuing_disciplines.c
@@ -13,6 +13,19 @@
 #include "main/utility/priority_queue.h"
 #include "main/utility/utility.h"
 
+// returns 0 if the sockets' canonical handles are equal, otherwise returns 1
+static gint _compareTaggedSocket(gconstpointer a, gconstpointer b) {
+    if (a == b) {
+        // they must have equal canonical handles
+        return 0;
+    }
+
+    CompatSocket sa = compatsocket_fromTagged((uintptr_t)a);
+    CompatSocket sb = compatsocket_fromTagged((uintptr_t)b);
+
+    return compatsocket_getCanonicalHandle(&sa) != compatsocket_getCanonicalHandle(&sb);
+}
+
 void rrsocketqueue_init(RrSocketQueue* self) {
     utility_debugAssert(self != NULL);
     utility_debugAssert(self->queue == NULL);
@@ -70,7 +83,8 @@ void rrsocketqueue_push(RrSocketQueue* self, const CompatSocket* socket) {
 bool rrsocketqueue_find(RrSocketQueue* self, const CompatSocket* socket) {
     utility_debugAssert(self != NULL);
     utility_debugAssert(self->queue != NULL);
-    return g_queue_find(self->queue, (void*)compatsocket_toTagged(socket));
+    return g_queue_find_custom(
+        self->queue, (void*)compatsocket_toTagged(socket), _compareTaggedSocket);
 }
 
 static gint _compareSocket(const CompatSocket* sa, const CompatSocket* sb) {
@@ -155,5 +169,6 @@ void fifosocketqueue_push(FifoSocketQueue* self, const CompatSocket* socket) {
 bool fifosocketqueue_find(FifoSocketQueue* self, const CompatSocket* socket) {
     utility_debugAssert(self != NULL);
     utility_debugAssert(self->queue != NULL);
-    return priorityqueue_find(self->queue, (void*)compatsocket_toTagged(socket));
+    return priorityqueue_find_custom(
+        self->queue, (void*)compatsocket_toTagged(socket), _compareTaggedSocket);
 }

--- a/src/main/network/net_namespace.rs
+++ b/src/main/network/net_namespace.rs
@@ -121,6 +121,11 @@ impl NetworkNamespace {
             cshadow::dns_deregister(dns.cast_mut(), self.default_address.ptr());
         }
 
+        // we need to unref all sockets and free them before we drop the host, otherwise they'll try
+        // to access the global host and panic since there is no host
+        self.localhost.borrow().remove_all_sockets();
+        self.internet.borrow().remove_all_sockets();
+
         self.has_run_cleanup.set(true);
     }
 

--- a/src/main/utility/priority_queue.h
+++ b/src/main/utility/priority_queue.h
@@ -21,6 +21,7 @@ gboolean priorityqueue_isEmpty(PriorityQueue *q);
 gboolean priorityqueue_push(PriorityQueue *q, gpointer data);
 gpointer priorityqueue_peek(PriorityQueue *q);
 gpointer priorityqueue_find(PriorityQueue *q, gpointer data);
+gpointer priorityqueue_find_custom(PriorityQueue* q, gpointer data, GCompareFunc compareFunc);
 gpointer priorityqueue_pop(PriorityQueue *q);
 
 #endif /* SHD_PRIORITY_QUEUE_H */


### PR DESCRIPTION
Changes:
- add a `remove_all_sockets` method to the network interface — since sockets might access the global host when they're freed/dropped, we should free/drop the sockets while the global host is still set (so before we drop the host)
- when adding a socket to the qdisc, check for the canonical handle rather than the pointer address (involves a hash table iteration unfortunately) — closes #2704 
- add the tcp socket to the network interface as a rust `InetSocket` rather than as a `LegacySocket`

The benchmark results change slightly for some reason, but they're very similar in both the tgen and tor benchmarks.

### [tgen](https://github.com/shadow/benchmark-results/tree/master/tgen/2023-02-01-T21-58-59)

![1675355279_grim](https://user-images.githubusercontent.com/3708797/216383838-e60e0e9a-a76d-4473-bf92-28653cf01cfe.png)
![1675355309_grim](https://user-images.githubusercontent.com/3708797/216383859-071fe076-d088-4eca-8b5f-e9f9e27af08c.png)
![bytes_read_count_timeseries](https://user-images.githubusercontent.com/3708797/216383885-1aafe0bc-3f0a-40e3-9691-7e4cbe1dd2d6.png)
![time_to_last_byte_recv_1048576_timeseries](https://user-images.githubusercontent.com/3708797/216383910-153a0e4f-0a9a-4019-b60b-e8073fc9d354.png)

### [tor](https://github.com/shadow/benchmark-results/tree/master/tor/2023-02-02-T01-42-18)

![run_time](https://user-images.githubusercontent.com/3708797/216384615-b15e4861-c531-487b-ac03-61963a6e929c.png)
![transfer_time_5242880 exit](https://user-images.githubusercontent.com/3708797/216384632-f2d6f828-35da-4f29-81ad-20a9d37ce7bd.png)