### PR TITLE
Support Rust listeners on C `LegacyFile`s

### DIFF
--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -20,6 +20,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
             "Tsc".into(),
         ]);
         c.add_opaque_types(&["ProcessRefCell"]);
+        c.add_opaque_types(&["RootedRefCell_StateEventSource"]);
         c
     };
 

--- a/src/main/host/descriptor/descriptor_types.h
+++ b/src/main/host/descriptor/descriptor_types.h
@@ -48,7 +48,7 @@ struct _LegacyFile {
     LegacyFileFunctionTable* funcTable;
     LegacyFileType type;
     Status status;
-    GHashTable* listeners;
+    RootedRefCell_StateEventSource* event_source;
     gint refCountStrong;
     gint refCountWeak;
     gint flags;

--- a/src/main/utility/callback_queue.rs
+++ b/src/main/utility/callback_queue.rs
@@ -145,7 +145,7 @@ impl<T: Clone + Copy + 'static> Default for EventSource<T> {
     }
 }
 
-type Listener<T> = Arc<Box<dyn Fn(T, &mut CallbackQueue) + Send + Sync>>;
+type Listener<T> = Arc<dyn Fn(T, &mut CallbackQueue) + Send + Sync>;
 
 struct EventSourceInner<T> {
     listeners: std::vec::Vec<(HandleId, Listener<T>)>,
@@ -180,8 +180,7 @@ impl<T> EventSourceInner<T> {
     ) -> Handle<T> {
         let handle_id = self.get_unused_id();
 
-        self.listeners
-            .push((handle_id, Arc::new(Box::new(notify_fn))));
+        self.listeners.push((handle_id, Arc::new(notify_fn)));
 
         Handle::new(handle_id, inner)
     }


### PR DESCRIPTION
This should allow us to add rust state/status listener callback closures to `LegacyFile`s in the future. This means that we can write rust objects that add listeners to `LegacyFile`s. For example, we can write a rust epoll file object that listens for events on C `TCP` or `RegularFile` objects using rust closures.