### PR TITLE
Don't run workflows on merge to main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,8 +9,6 @@ defaults:
     shell: bash
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/extra_tests.yml
+++ b/.github/workflows/extra_tests.yml
@@ -9,8 +9,6 @@ defaults:
     shell: bash
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,6 @@ name: Lint Checks
 permissions: read-all
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,8 +9,6 @@ defaults:
     shell: bash
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/run_tests_incremental.yml
+++ b/.github/workflows/run_tests_incremental.yml
@@ -9,8 +9,6 @@ defaults:
     shell: bash
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize]
   workflow_dispatch:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -5,8 +5,6 @@ name: Rust Sanitizers
 permissions: read-all
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # The Shadow Simulator
 
-[![Shadow Tests](https://github.com/shadow/shadow/actions/workflows/run_tests_incremental.yml/badge.svg?branch=main&event=push)](https://github.com/shadow/shadow/actions/workflows/run_tests_incremental.yml?query=branch:main+event:push)
-
 ## Quickstart
 
 After installing the [dependencies](https://shadow.github.io/docs/guide/install_dependencies.html): build, test, and install Shadow into `~/.local`:


### PR DESCRIPTION
We don't need to run our CI on commits to main since main is already a protected branch that only allows merging from a PR that is up to date with main and has already passed the CI.