### PR TITLE
Set shim's stdout/stderr to the shim log file

### DIFF
--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -226,12 +226,13 @@ static void _shim_parent_init_logging() {
         logger_set_global_start_time_micros(logger_start_time);
     }
 
-    // Redirect logger to specified log file.
+    // Redirect logger to stdout (shadow sets stdout and stderr to the shim log).
     {
-        const char* name = getenv("SHADOW_LOG_FILE");
-        FILE* log_file = fopen(name, "w");
+        // the FILE takes ownership of the fd, so give it its own fd
+        int shimlog_fd = dup(STDOUT_FILENO);
+        FILE* log_file = fdopen(shimlog_fd, "w");
         if (log_file == NULL) {
-            panic("fopen: %s", strerror(errno));
+            panic("fdopen: %s", strerror(errno));
         }
         logger_setDefault(shimlogger_new(log_file));
     }

--- a/src/main/host/managed_thread.h
+++ b/src/main/host/managed_thread.h
@@ -10,7 +10,8 @@ typedef struct _ManagedThread ManagedThread;
 ManagedThread* managedthread_new(Thread* thread);
 void managedthread_free(ManagedThread* mthread);
 void managedthread_run(ManagedThread* methread, const char* pluginPath, const char* const* argv,
-                       const char* const* envv, const char* workingDir, int straceFd);
+                       const char* const* envv, const char* workingDir, int straceFd,
+                       const char* logPath);
 SysCallCondition* managedthread_resume(ManagedThread* mthread);
 void managedthread_handleProcessExit(ManagedThread* mthread);
 int managedthread_getReturnCode(ManagedThread* mthread);

--- a/src/main/host/thread.c
+++ b/src/main/host/thread.c
@@ -87,7 +87,8 @@ void thread_free(Thread* thread) {
 }
 
 void thread_run(Thread* thread, const char* pluginPath, const char* const* argv,
-                const char* const* envv_in, const char* workingDir, int straceFd) {
+                const char* const* envv_in, const char* workingDir, int straceFd,
+                const char* logPath) {
     MAGIC_ASSERT(thread);
 
     gchar** envv = g_strdupv((gchar**)envv_in);
@@ -105,7 +106,7 @@ void thread_run(Thread* thread, const char* pluginPath, const char* const* argv,
     }
 
     managedthread_run(
-        thread->mthread, pluginPath, argv, (const char* const*)envv, workingDir, straceFd);
+        thread->mthread, pluginPath, argv, (const char* const*)envv, workingDir, straceFd, logPath);
 
     g_strfreev(envv);
 }

--- a/src/main/host/thread.h
+++ b/src/main/host/thread.h
@@ -24,7 +24,7 @@ Thread* thread_new(const Host* host, const ProcessRefCell* process, int threadID
 void thread_free(Thread* thread);
 
 void thread_run(Thread* thread, const char* pluginPath, const char* const* argv,
-                const char* const* envv, const char* workingDir, int straceFd);
+                const char* const* envv, const char* workingDir, int straceFd, const char* logPath);
 void thread_resume(Thread* thread);
 void thread_handleProcessExit(Thread* thread);
 int thread_getReturnCode(Thread* thread);


### PR DESCRIPTION
Shadow now uses an fd passed through fork/exec for the shim log rather than passing a filename using `SHADOW_LOG_FILE`, and also uses this fd for stdout and stderr.

If the shim writes to stdout/stderr (or the plugin disables interposition and writes to stdout/stderr), it should be written to the shim log rather than to shadow's stdout/stderr (which may be the terminal or some other file).

@sporksmith If this overlaps with your `Thread` migration let me know and I'll hold off on merging.