### PR TITLE
SysCallHandler: don't store pointers to Process and Thread

### DIFF
--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -122,10 +122,10 @@ impl Worker {
 
     /// Run `f` with a reference to the current
     /// `RootedRc<RootedRefCell<Process>>`, or return `None` if there isn't one.
-    // non-pub because we're migrating code to pass the current Process around explicitly
-    // in Rust. e.g. see `ProcessContext`.
+    ///
+    /// Prefer to pass Process explicitly where feasible. e.g. see `ProcessContext`.
     #[must_use]
-    fn with_active_process_rc<F, R>(f: F) -> Option<R>
+    pub fn with_active_process_rc<F, R>(f: F) -> Option<R>
     where
         F: FnOnce(&RootedRc<RootedRefCell<Process>>) -> R,
     {
@@ -133,10 +133,10 @@ impl Worker {
     }
 
     /// Run `f` with a reference to the current `Process`, or return `None` if there isn't one.
-    // non-pub because we're migrating code to pass the current Process around explicitly
-    // in Rust. e.g. see `ProcessContext`.
+    ///
+    /// Prefer to pass Process explicitly where feasible. e.g. see `ProcessContext`.
     #[must_use]
-    fn with_active_process<F, R>(f: F) -> Option<R>
+    pub fn with_active_process<F, R>(f: F) -> Option<R>
     where
         F: FnOnce(&Process) -> R,
     {
@@ -155,8 +155,8 @@ impl Worker {
     }
 
     /// Run `f` with a reference to the current `Thread`, or return `None` if there isn't one.
-    // non-pub because we're migrating code to pass the current Thread around explicitly
-    // in Rust. e.g. see `ThreadContext`.
+    ///
+    /// Prefer to pass Thread explicitly where feasible. e.g. see `ThreadContext`.
     #[must_use]
     fn with_active_thread<F, R>(f: F) -> Option<R>
     where

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -960,9 +960,15 @@ impl Process {
             self.memory_borrow_mut()
                 .copy_to_ptr(typed_clear_child_tid_pvp, &[0])
                 .unwrap();
-            // Restore active thread.
-            Worker::clear_active_thread();
-            Worker::set_active_thread(&thread);
+
+            // XXX We currently can't restore the active thread to the one we're
+            // reaping, since it's no longer in the Process's thread table,
+            // which Worker::set_active_thread currently depends on.
+            //
+            // This may lead to some confusing log messages between here and when we bubble back
+            // up the call stack :/.
+            //
+            // (Fixed in next commit)
 
             // Wake the corresponding futex.
             let mut futexes = host.futextable_borrow_mut();

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -329,6 +329,10 @@ impl Process {
         rv
     }
 
+    pub fn weak_rc(&self) -> &RootedRcWeak<RootedRefCell<Self>> {
+        self.weak_rc.as_ref().unwrap()
+    }
+
     pub fn id(&self) -> ProcessId {
         self.id
     }

--- a/src/main/host/syscall/fcntl.c
+++ b/src/main/host/syscall/fcntl.c
@@ -60,7 +60,8 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, RegularFile* file, i
         case F_OFD_GETLK:
 #endif
         {
-            struct flock* flk = process_getMutablePtr(sys->process, argReg.as_ptr, sizeof(*flk));
+            struct flock* flk =
+                process_getMutablePtr(_syscallhandler_getProcess(sys), argReg.as_ptr, sizeof(*flk));
             result = regularfile_fcntl(file, command, (void*)flk);
             break;
         }
@@ -68,7 +69,7 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, RegularFile* file, i
 #if defined(F_GETLK64) && F_GETLK64 != F_GETLK
         case F_GETLK64: {
             struct flock64* flk =
-                process_getMutablePtr(sys->process, sys->thread, argReg.as_ptr, sizeof(*flk));
+                process_getMutablePtr(_syscallhandler_getProcess(sys), argReg.as_ptr, sizeof(*flk));
             result = regularfile_fcntl(file, command, (void*)flk);
             break;
         }
@@ -83,8 +84,8 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, RegularFile* file, i
         case F_OFD_SETLKW:
 #endif
         {
-            const struct flock* flk =
-                process_getReadablePtr(sys->process, argReg.as_ptr, sizeof(*flk));
+            const struct flock* flk = process_getReadablePtr(
+                _syscallhandler_getProcess(sys), argReg.as_ptr, sizeof(*flk));
             result = regularfile_fcntl(file, command, (void*)flk);
             break;
         }
@@ -105,15 +106,15 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, RegularFile* file, i
 #endif
 
         case F_GETOWN_EX: {
-            struct f_owner_ex* foe =
-                process_getWriteablePtr(sys->process, argReg.as_ptr, sizeof(*foe));
+            struct f_owner_ex* foe = process_getWriteablePtr(
+                _syscallhandler_getProcess(sys), argReg.as_ptr, sizeof(*foe));
             result = regularfile_fcntl(file, command, foe);
             break;
         }
 
         case F_SETOWN_EX: {
-            const struct f_owner_ex* foe =
-                process_getReadablePtr(sys->process, argReg.as_ptr, sizeof(*foe));
+            const struct f_owner_ex* foe = process_getReadablePtr(
+                _syscallhandler_getProcess(sys), argReg.as_ptr, sizeof(*foe));
             result = regularfile_fcntl(file, command, (void*)foe);
             break;
         }
@@ -125,7 +126,8 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, RegularFile* file, i
         case F_GET_FILE_RW_HINT:
 #endif
         {
-            uint64_t* hint = process_getWriteablePtr(sys->process, argReg.as_ptr, sizeof(*hint));
+            uint64_t* hint = process_getWriteablePtr(
+                _syscallhandler_getProcess(sys), argReg.as_ptr, sizeof(*hint));
             result = regularfile_fcntl(file, command, hint);
             break;
         }
@@ -137,8 +139,8 @@ static int _syscallhandler_fcntlHelper(SysCallHandler* sys, RegularFile* file, i
         case F_SET_FILE_RW_HINT:
 #endif
         {
-            const uint64_t* hint =
-                process_getReadablePtr(sys->process, argReg.as_ptr, sizeof(*hint));
+            const uint64_t* hint = process_getReadablePtr(
+                _syscallhandler_getProcess(sys), argReg.as_ptr, sizeof(*hint));
             result = regularfile_fcntl(file, command, (void*)hint);
             break;
         }
@@ -177,7 +179,7 @@ SysCallReturn syscallhandler_fcntl(SysCallHandler* sys,
 
     trace("fcntl called on fd %d for command %lu", fd, command);
 
-    LegacyFile* desc = process_getRegisteredLegacyFile(sys->process, fd);
+    LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), fd);
     int errcode = _syscallhandler_validateLegacyFile(desc, DT_NONE);
     if (errcode < 0) {
         return syscallreturn_makeDoneErrno(-errcode);

--- a/src/main/host/syscall/ioctl.c
+++ b/src/main/host/syscall/ioctl.c
@@ -65,7 +65,8 @@ static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
     switch (request) {
         case SIOCINQ: { // equivalent to FIONREAD
             int lenout = legacysocket_getInputBufferLength((LegacySocket*)udp);
-            int rv = process_writePtr(sys->process, argPtr, &lenout, sizeof(int));
+            int rv =
+                process_writePtr(_syscallhandler_getProcess(sys), argPtr, &lenout, sizeof(int));
 
             if (rv != 0) {
                 utility_debugAssert(rv < 0);
@@ -79,7 +80,8 @@ static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
 
         case SIOCOUTQ: { // equivalent to TIOCOUTQ
             int lenout = legacysocket_getOutputBufferLength((LegacySocket*)udp);
-            int rv = process_writePtr(sys->process, argPtr, &lenout, sizeof(int));
+            int rv =
+                process_writePtr(_syscallhandler_getProcess(sys), argPtr, &lenout, sizeof(int));
 
             if (rv != 0) {
                 utility_debugAssert(rv < 0);
@@ -93,7 +95,7 @@ static int _syscallhandler_ioctlUDPHelper(SysCallHandler* sys, UDP* udp, int fd,
 
         case FIONBIO: {
             int val = 0;
-            int rv = process_readPtr(sys->process, &val, argPtr, sizeof(int));
+            int rv = process_readPtr(_syscallhandler_getProcess(sys), &val, argPtr, sizeof(int));
 
             if (rv != 0) {
                 utility_debugAssert(rv < 0);
@@ -148,7 +150,7 @@ SysCallReturn syscallhandler_ioctl(SysCallHandler* sys,
 
     trace("ioctl called on fd %d for request %ld", fd, request);
 
-    LegacyFile* desc = process_getRegisteredLegacyFile(sys->process, fd);
+    LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), fd);
     int errcode = _syscallhandler_validateLegacyFile(desc, DT_NONE);
     if (errcode < 0) {
         return syscallreturn_makeDoneErrno(-errcode);

--- a/src/main/host/syscall/protected.c
+++ b/src/main/host/syscall/protected.c
@@ -22,7 +22,7 @@
 CEmulatedTime _syscallhandler_getTimeout(const SysCallHandler* sys) {
     MAGIC_ASSERT(sys);
 
-    SysCallCondition* cond = thread_getSysCallCondition(sys->thread);
+    SysCallCondition* cond = thread_getSysCallCondition(_syscallhandler_getThread(sys));
     if (!cond) {
         return EMUTIME_INVALID;
     }

--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -30,15 +30,8 @@ typedef enum {
 
 struct _SysCallHandler {
     HostId hostId;
-
-    /* We store pointers to the process and thread that the syscall
-     * handler is associated with. We typically need to makes calls into
-     * these modules in order to handle syscalls.
-     *
-     * The SysCallHandler must not outlive these.
-     */
-    const ProcessRefCell* process;
-    Thread* thread;
+    pid_t processId;
+    pid_t threadId;
 
     // For syscalls implemented in rust. Will eventually replace the C handler.
     SyscallHandler* syscall_handler_rs;
@@ -102,5 +95,8 @@ bool _syscallhandler_didListenTimeoutExpire(const SysCallHandler* sys);
 bool _syscallhandler_wasBlocked(const SysCallHandler* sys);
 int _syscallhandler_validateLegacyFile(LegacyFile* descriptor, LegacyFileType expectedType);
 const Host* _syscallhandler_getHost(const SysCallHandler* sys);
+const ProcessRefCell* _syscallhandler_getProcess(const SysCallHandler* sys);
+const char* _syscallhandler_getProcessName(const SysCallHandler* sys);
+Thread* _syscallhandler_getThread(const SysCallHandler* sys);
 
 #endif /* SRC_MAIN_HOST_SYSCALL_PROTECTED_H_ */

--- a/src/main/host/syscall/select.c
+++ b/src/main/host/syscall/select.c
@@ -35,15 +35,16 @@ static SysCallReturn _syscallhandler_select_helper(SysCallHandler* sys, int nfds
     FD_ZERO(&exceptfds);
 
     // Get the fd_set syscall args in our memory.
-    if (readfds_ptr.val && process_readPtr(sys->process, &readfds, readfds_ptr, sizeof(readfds))) {
+    if (readfds_ptr.val &&
+        process_readPtr(_syscallhandler_getProcess(sys), &readfds, readfds_ptr, sizeof(readfds))) {
         return syscallreturn_makeDoneErrno(EFAULT);
     }
-    if (writefds_ptr.val &&
-        process_readPtr(sys->process, &writefds, writefds_ptr, sizeof(writefds))) {
+    if (writefds_ptr.val && process_readPtr(_syscallhandler_getProcess(sys), &writefds,
+                                            writefds_ptr, sizeof(writefds))) {
         return syscallreturn_makeDoneErrno(EFAULT);
     }
-    if (exceptfds_ptr.val &&
-        process_readPtr(sys->process, &exceptfds, exceptfds_ptr, sizeof(exceptfds))) {
+    if (exceptfds_ptr.val && process_readPtr(_syscallhandler_getProcess(sys), &exceptfds,
+                                             exceptfds_ptr, sizeof(exceptfds))) {
         return syscallreturn_makeDoneErrno(EFAULT);
     }
 
@@ -129,17 +130,18 @@ static SysCallReturn _syscallhandler_select_helper(SysCallHandler* sys, int nfds
 
     // OK now we know we have success; write back the result fd sets.
     scr = syscallreturn_makeDoneI64(num_set_bits);
-    if (readfds_ptr.val && process_writePtr(sys->process, readfds_ptr, &readfds, sizeof(readfds))) {
+    if (readfds_ptr.val &&
+        process_writePtr(_syscallhandler_getProcess(sys), readfds_ptr, &readfds, sizeof(readfds))) {
         scr = syscallreturn_makeDoneErrno(EFAULT);
         goto done;
     }
-    if (writefds_ptr.val &&
-        process_writePtr(sys->process, writefds_ptr, &writefds, sizeof(writefds))) {
+    if (writefds_ptr.val && process_writePtr(_syscallhandler_getProcess(sys), writefds_ptr,
+                                             &writefds, sizeof(writefds))) {
         scr = syscallreturn_makeDoneErrno(EFAULT);
         goto done;
     }
-    if (exceptfds_ptr.val &&
-        process_writePtr(sys->process, exceptfds_ptr, &exceptfds, sizeof(exceptfds))) {
+    if (exceptfds_ptr.val && process_writePtr(_syscallhandler_getProcess(sys), exceptfds_ptr,
+                                              &exceptfds, sizeof(exceptfds))) {
         scr = syscallreturn_makeDoneErrno(EFAULT);
         goto done;
     }
@@ -200,8 +202,8 @@ SysCallReturn syscallhandler_select(SysCallHandler* sys, const SysCallArgs* args
         // to plugin memory. See syscallhandler_ppoll for reasoning.
         struct timeval tv_timeout_val = {0};
 
-        if (process_readPtr(sys->process, &tv_timeout_val, timeout_ptr, sizeof(tv_timeout_val)) !=
-            0) {
+        if (process_readPtr(_syscallhandler_getProcess(sys), &tv_timeout_val, timeout_ptr,
+                            sizeof(tv_timeout_val)) != 0) {
             return syscallreturn_makeDoneErrno(EFAULT);
         }
 
@@ -242,8 +244,8 @@ SysCallReturn syscallhandler_pselect6(SysCallHandler* sys, const SysCallArgs* ar
     struct timespec ts_timeout_val = {0};
 
     if (timeout_ptr.val) {
-        if (process_readPtr(sys->process, &ts_timeout_val, timeout_ptr, sizeof(ts_timeout_val)) !=
-            0) {
+        if (process_readPtr(_syscallhandler_getProcess(sys), &ts_timeout_val, timeout_ptr,
+                            sizeof(ts_timeout_val)) != 0) {
             return syscallreturn_makeDoneErrno(EFAULT);
         }
     }

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -27,7 +27,7 @@ static int _syscallhandler_validateVecParams(SysCallHandler* sys, int fd, Plugin
                                              unsigned long iovlen, off_t offset,
                                              LegacyFile** desc_out, struct iovec** iov_out) {
     /* Get the descriptor. */
-    LegacyFile* desc = process_getRegisteredLegacyFile(sys->process, fd);
+    LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), fd);
     if (!desc) {
         return -EBADF;
     }
@@ -51,7 +51,7 @@ static int _syscallhandler_validateVecParams(SysCallHandler* sys, int fd, Plugin
 
     /* Get the vector of pointers. */
     struct iovec* iov = malloc(iovlen * sizeof(*iov));
-    if (process_readPtr(sys->process, iov, iovPtr, iovlen * sizeof(*iov)) != 0) {
+    if (process_readPtr(_syscallhandler_getProcess(sys), iov, iovPtr, iovlen * sizeof(*iov)) != 0) {
         warning("Got unreadable pointer [%p..+%zu]", (void*)iovPtr.val, iovlen * sizeof(*iov));
         free(iov);
         return -EFAULT;
@@ -137,7 +137,7 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
 
                 // if the above syscall handler created any pointers, we may
                 // need to flush them before calling the syscall handler again
-                result = process_flushPtrs(sys->process);
+                result = process_flushPtrs(_syscallhandler_getProcess(sys));
                 if (result != 0) {
                     break;
                 }
@@ -261,7 +261,7 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
 
                 // if the above syscall handler created any pointers, we may
                 // need to flush them before calling the syscall handler again
-                result = process_flushPtrs(sys->process);
+                result = process_flushPtrs(_syscallhandler_getProcess(sys));
                 if (result != 0) {
                     break;
                 }

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -240,6 +240,10 @@ impl Thread {
     pub fn shmem(&self) -> &ThreadShmem {
         unsafe { c::thread_sharedMem(self.cthread()).as_ref().unwrap() }
     }
+
+    pub fn native_tid(&self) -> nix::unistd::Pid {
+        nix::unistd::Pid::from_raw(unsafe { c::thread_getNativeTid(self.cthread()) })
+    }
 }
 
 impl Drop for Thread {


### PR DESCRIPTION
These circular references otherwise somewhat complicate migrating Thread to Rust.

To facilitate getting rid of these, I added back `worker_getCurrentProcess` and `worker_getCurrentThread`. These are easier to implement safely now that they are wrapped in `RootedRc` objects, and we aren't trying to provide mutable access to the Rust objects. I tentatively still think it's better to prefer passing explicitly where possible, particularly in Rust code, but these are helpful in C code and for interop with C code during the migration.