### PR TITLE
Add a Rust PluginPhysicalPtr type

### DIFF
--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -9,6 +9,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
         c.export.exclude.extend_from_slice(&[
             "LogLevel".into(),
             "PluginPtr".into(),
+            "PluginPhysicalPtr".into(),
             "SysCallReg".into(),
             "SysCallArgs".into(),
             "Packet".into(),

--- a/src/main/host/syscall_types.rs
+++ b/src/main/host/syscall_types.rs
@@ -10,7 +10,7 @@ use std::mem::size_of;
 /// Represents a pointer to a virtual address in plugin memory.
 #[derive(Copy, Clone, Debug)]
 pub struct PluginPtr {
-    ptr: c::PluginPtr,
+    ptr: usize,
 }
 
 impl PluginPtr {
@@ -19,53 +19,55 @@ impl PluginPtr {
     }
 
     pub fn is_null(&self) -> bool {
-        self.ptr.val == 0
+        self.ptr == 0
     }
 }
 
 impl From<PluginPtr> for c::PluginPtr {
     fn from(v: PluginPtr) -> c::PluginPtr {
-        v.ptr
+        c::PluginPtr {
+            val: v.ptr.try_into().unwrap(),
+        }
     }
 }
 
 impl From<c::PluginPtr> for PluginPtr {
     fn from(v: c::PluginPtr) -> PluginPtr {
-        PluginPtr { ptr: v }
+        PluginPtr {
+            ptr: v.val.try_into().unwrap(),
+        }
     }
 }
 
 impl From<PluginPtr> for usize {
     fn from(v: PluginPtr) -> usize {
-        v.ptr.val as usize
+        v.ptr
     }
 }
 
 impl From<usize> for PluginPtr {
     fn from(v: usize) -> PluginPtr {
-        PluginPtr {
-            ptr: c::PluginPtr { val: v as u64 },
-        }
+        PluginPtr { ptr: v }
     }
 }
 
 impl From<u64> for PluginPtr {
     fn from(v: u64) -> PluginPtr {
         PluginPtr {
-            ptr: c::PluginPtr { val: v },
+            ptr: v.try_into().unwrap(),
         }
     }
 }
 
 impl From<PluginPtr> for u64 {
     fn from(v: PluginPtr) -> u64 {
-        v.ptr.val
+        v.ptr.try_into().unwrap()
     }
 }
 
 impl std::fmt::Pointer for PluginPtr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let ptr = self.ptr.val as *const libc::c_void;
+        let ptr = self.ptr as *const libc::c_void;
         std::fmt::Pointer::fmt(&ptr, f)
     }
 }
@@ -248,9 +250,7 @@ impl From<PluginPtr> for SysCallReg {
 
 impl From<SysCallReg> for PluginPtr {
     fn from(v: SysCallReg) -> PluginPtr {
-        PluginPtr {
-            ptr: unsafe { v.as_ptr },
-        }
+        PluginPtr::from(unsafe { v.as_ptr })
     }
 }
 
@@ -396,9 +396,7 @@ impl<T> TypedPluginPtr<T> {
         assert!(included_start <= self.count);
         TypedPluginPtr {
             base: PluginPtr {
-                ptr: c::PluginPtr {
-                    val: (self.base.ptr.val as usize + included_start * size_of::<T>()) as u64,
-                },
+                ptr: (self.base.ptr + included_start * size_of::<T>()),
             },
             count: excluded_end - included_start,
             _phantom: PhantomData,

--- a/src/main/host/syscall_types.rs
+++ b/src/main/host/syscall_types.rs
@@ -75,46 +75,48 @@ impl std::fmt::Pointer for PluginPtr {
 /// Represents a pointer to a *physical* address in plugin memory.
 #[derive(Copy, Clone, Debug)]
 pub struct PluginPhysicalPtr {
-    ptr: c::PluginPhysicalPtr,
+    ptr: usize,
 }
 
 impl From<PluginPhysicalPtr> for c::PluginPhysicalPtr {
     fn from(v: PluginPhysicalPtr) -> c::PluginPhysicalPtr {
-        v.ptr
+        c::PluginPhysicalPtr {
+            val: v.ptr.try_into().unwrap(),
+        }
     }
 }
 
 impl From<c::PluginPhysicalPtr> for PluginPhysicalPtr {
     fn from(v: c::PluginPhysicalPtr) -> PluginPhysicalPtr {
-        PluginPhysicalPtr { ptr: v }
+        PluginPhysicalPtr {
+            ptr: v.val.try_into().unwrap(),
+        }
     }
 }
 
 impl From<PluginPhysicalPtr> for usize {
     fn from(v: PluginPhysicalPtr) -> usize {
-        v.ptr.val as usize
+        v.ptr
     }
 }
 
 impl From<usize> for PluginPhysicalPtr {
     fn from(v: usize) -> PluginPhysicalPtr {
-        PluginPhysicalPtr {
-            ptr: c::PluginPhysicalPtr { val: v as u64 },
-        }
+        PluginPhysicalPtr { ptr: v }
     }
 }
 
 impl From<u64> for PluginPhysicalPtr {
     fn from(v: u64) -> PluginPhysicalPtr {
         PluginPhysicalPtr {
-            ptr: c::PluginPhysicalPtr { val: v },
+            ptr: v.try_into().unwrap(),
         }
     }
 }
 
 impl From<PluginPhysicalPtr> for u64 {
     fn from(v: PluginPhysicalPtr) -> u64 {
-        v.ptr.val
+        v.ptr.try_into().unwrap()
     }
 }
 

--- a/src/main/host/syscall_types.rs
+++ b/src/main/host/syscall_types.rs
@@ -7,6 +7,7 @@ use std::convert::From;
 use std::marker::PhantomData;
 use std::mem::size_of;
 
+/// Represents a pointer to a virtual address in plugin memory.
 #[derive(Copy, Clone, Debug)]
 pub struct PluginPtr {
     ptr: c::PluginPtr,
@@ -66,6 +67,52 @@ impl std::fmt::Pointer for PluginPtr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let ptr = self.ptr.val as *const libc::c_void;
         std::fmt::Pointer::fmt(&ptr, f)
+    }
+}
+
+/// Represents a pointer to a *physical* address in plugin memory.
+#[derive(Copy, Clone, Debug)]
+pub struct PluginPhysicalPtr {
+    ptr: c::PluginPhysicalPtr,
+}
+
+impl From<PluginPhysicalPtr> for c::PluginPhysicalPtr {
+    fn from(v: PluginPhysicalPtr) -> c::PluginPhysicalPtr {
+        v.ptr
+    }
+}
+
+impl From<c::PluginPhysicalPtr> for PluginPhysicalPtr {
+    fn from(v: c::PluginPhysicalPtr) -> PluginPhysicalPtr {
+        PluginPhysicalPtr { ptr: v }
+    }
+}
+
+impl From<PluginPhysicalPtr> for usize {
+    fn from(v: PluginPhysicalPtr) -> usize {
+        v.ptr.val as usize
+    }
+}
+
+impl From<usize> for PluginPhysicalPtr {
+    fn from(v: usize) -> PluginPhysicalPtr {
+        PluginPhysicalPtr {
+            ptr: c::PluginPhysicalPtr { val: v as u64 },
+        }
+    }
+}
+
+impl From<u64> for PluginPhysicalPtr {
+    fn from(v: u64) -> PluginPhysicalPtr {
+        PluginPhysicalPtr {
+            ptr: c::PluginPhysicalPtr { val: v },
+        }
+    }
+}
+
+impl From<PluginPhysicalPtr> for u64 {
+    fn from(v: PluginPhysicalPtr) -> u64 {
+        v.ptr.val
     }
 }
 


### PR DESCRIPTION
This also changes both PhysicalPtr and PluginPhysicalPtr to directly store a usize internally instead of their C counterparts. This is a step towards removing the C counterparts and making the Rust types be the single canonical type. Actually doing that requires detangling circular dependencies in the generated C headers though, so I'm deferring it for the moment.