### PR TITLE
Rename `TcpSocket` to `LegacyTcpSocket`

### DIFF
--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -836,7 +836,7 @@ mod export {
 
     use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 
-    use crate::host::descriptor::socket::inet::tcp::TcpSocket;
+    use crate::host::descriptor::socket::inet::tcp::LegacyTcpSocket;
     use crate::host::descriptor::socket::inet::InetSocket;
     use crate::utility::legacy_callback_queue::RootedRefCell_StateEventSource;
 
@@ -868,9 +868,9 @@ mod export {
     ) -> *mut Descriptor {
         assert!(!legacy_tcp.is_null());
 
-        let tcp = unsafe { TcpSocket::new_from_legacy(legacy_tcp) };
+        let tcp = unsafe { LegacyTcpSocket::new_from_legacy(legacy_tcp) };
         let mut descriptor = Descriptor::new(CompatFile::New(OpenFile::new(File::Socket(
-            Socket::Inet(InetSocket::Tcp(tcp)),
+            Socket::Inet(InetSocket::LegacyTcp(tcp)),
         ))));
 
         let descriptor_flags = OFlag::from_bits(descriptor_flags).unwrap();

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1505,7 +1505,7 @@ mod export {
             Some(CompatFile::Legacy(file)) => file.ptr(),
             Some(CompatFile::New(file)) => {
                 // we have a special case for the legacy C TCP objects
-                if let File::Socket(Socket::Inet(InetSocket::Tcp(tcp))) = file.inner_file() {
+                if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(tcp))) = file.inner_file() {
                     tcp.borrow().as_legacy_file()
                 } else {
                     log::warn!(

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -1,5 +1,5 @@
 use crate::cshadow as c;
-use crate::host::descriptor::socket::inet::tcp::TcpSocket;
+use crate::host::descriptor::socket::inet::tcp::LegacyTcpSocket;
 use crate::host::descriptor::socket::inet::InetSocket;
 use crate::host::descriptor::socket::unix::{UnixSocket, UnixSocketType};
 use crate::host::descriptor::socket::Socket;
@@ -84,7 +84,10 @@ impl SyscallHandler {
                         warn!("Unsupported inet stream socket protocol {protocol}");
                         return Err(Errno::EPROTONOSUPPORT.into());
                     }
-                    Socket::Inet(InetSocket::Tcp(TcpSocket::new(file_flags, ctx.objs.host)))
+                    Socket::Inet(InetSocket::LegacyTcp(LegacyTcpSocket::new(
+                        file_flags,
+                        ctx.objs.host,
+                    )))
                 }
                 _ => panic!("Should have called the C syscall handler"),
             },
@@ -184,7 +187,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             return Self::legacy_syscall(c::syscallhandler_sendto, ctx);
         }
 
@@ -300,7 +303,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             return Self::legacy_syscall(c::syscallhandler_recvfrom, ctx);
         }
 
@@ -496,7 +499,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             drop(desc_table);
             return Self::legacy_syscall(c::syscallhandler_listen, ctx);
         }
@@ -545,7 +548,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             return Self::legacy_syscall(c::syscallhandler_accept, ctx);
         }
 
@@ -587,7 +590,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             return Self::legacy_syscall(c::syscallhandler_accept4, ctx);
         }
 
@@ -707,7 +710,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             return Self::legacy_syscall(c::syscallhandler_connect, ctx);
         }
 
@@ -747,7 +750,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             drop(desc_table);
             return Self::legacy_syscall(c::syscallhandler_shutdown, ctx);
         }
@@ -891,7 +894,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             drop(desc_table);
             return Self::legacy_syscall(c::syscallhandler_getsockopt, ctx);
         }
@@ -933,7 +936,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             drop(desc_table);
             return Self::legacy_syscall(c::syscallhandler_setsockopt, ctx);
         }

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -174,7 +174,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             return Self::legacy_syscall(c::syscallhandler_read, ctx);
         }
 
@@ -216,7 +216,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             return Self::legacy_syscall(c::syscallhandler_pread64, ctx);
         }
 
@@ -314,7 +314,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             return Self::legacy_syscall(c::syscallhandler_write, ctx);
         }
 
@@ -357,7 +357,7 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::Tcp(_))) = file.inner_file() {
+        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
             return Self::legacy_syscall(c::syscallhandler_pwrite64, ctx);
         }
 


### PR DESCRIPTION
This is to make room for an eventual all-rust `TcpSocket` object.