### PR TITLE
Support `shutdown()` for tcp wrapper

### DIFF
--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use nix::errno::Errno;
+use nix::sys::socket::Shutdown;
 
 use crate::cshadow as c;
 use crate::host::descriptor::{FileMode, FileState, FileStatus, SyscallResult};
@@ -263,6 +264,10 @@ impl InetSocketRefMut<'_> {
             Self::LegacyTcp(socket) => socket.accept(cb_queue).map(InetSocket::LegacyTcp),
         }
     }
+
+    enum_passthrough!(self, (how, cb_queue), LegacyTcp;
+        pub fn shutdown(&mut self, how: Shutdown, cb_queue: &mut CallbackQueue) -> Result<(), SyscallError>
+    );
 }
 
 // inet socket-specific functions

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use nix::sys::socket::Shutdown;
 
 use crate::cshadow as c;
 use crate::host::descriptor::{FileMode, FileState, FileStatus, SyscallResult};
@@ -267,6 +268,10 @@ impl SocketRefMut<'_> {
             Self::Inet(socket) => socket.accept(cb_queue).map(Socket::Inet),
         }
     }
+
+    enum_passthrough!(self, (how, cb_queue), Unix, Inet;
+        pub fn shutdown(&mut self, how: Shutdown, cb_queue: &mut CallbackQueue) -> Result<(), SyscallError>
+    );
 }
 
 impl std::fmt::Debug for SocketRef<'_> {

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Weak};
 
 use atomic_refcell::AtomicRefCell;
 use nix::errno::Errno;
+use nix::sys::socket::Shutdown;
 
 use crate::cshadow as c;
 use crate::host::descriptor::shared_buf::{
@@ -234,6 +235,15 @@ impl UnixSocket {
         cb_queue: &mut CallbackQueue,
     ) -> Result<Arc<AtomicRefCell<UnixSocket>>, SyscallError> {
         self.protocol_state.accept(&mut self.common, cb_queue)
+    }
+
+    pub fn shutdown(
+        &mut self,
+        _how: Shutdown,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<(), SyscallError> {
+        log::warn!("shutdown() syscall not yet supported for unix sockets; Returning ENOSYS");
+        Err(Errno::ENOSYS.into())
     }
 
     pub fn getsockopt(


### PR DESCRIPTION
The logic for generally follows the logic from `src/main/host/syscall/socket.c`.

https://github.com/shadow/shadow/blob/8638dc4acd92b194215701c669259f23a29738b2/src/main/host/syscall/socket.c#L1179-L1211