### PR TITLE
Rooted*: make public APIs inline

### DIFF
--- a/src/lib/shadow-shim-helper-rs/src/rootedcell/cell.rs
+++ b/src/lib/shadow-shim-helper-rs/src/rootedcell/cell.rs
@@ -24,6 +24,7 @@ unsafe impl<T> VirtualAddressSpaceIndependent for RootedCell<T> where
 
 impl<T> RootedCell<T> {
     /// Create a RootedCell associated with `root`.
+    #[inline]
     pub fn new(root: &Root, val: T) -> Self {
         Self {
             tag: root.tag(),
@@ -31,16 +32,19 @@ impl<T> RootedCell<T> {
         }
     }
 
+    #[inline]
     pub fn get_mut(&mut self) -> &mut T {
         // Since we have the only reference to `self`, we don't need to check the root.
         unsafe { &mut *self.val.get() }
     }
 
+    #[inline]
     pub fn set(&self, root: &Root, val: T) {
         // Replace the current value, and just drop the old value.
         drop(self.replace(root, val))
     }
 
+    #[inline]
     pub fn replace(&self, root: &Root, val: T) -> T {
         // Prove that the root is held for this tag.
         assert_eq!(
@@ -52,12 +56,14 @@ impl<T> RootedCell<T> {
         unsafe { self.val.get().replace(val) }
     }
 
+    #[inline]
     pub fn into_inner(self) -> T {
         self.val.into_inner()
     }
 }
 
 impl<T: Copy> RootedCell<T> {
+    #[inline]
     pub fn get(&self, root: &Root) -> T {
         // Prove that the root is held for this tag.
         assert_eq!(

--- a/src/lib/shadow-shim-helper-rs/src/rootedcell/rc.rs
+++ b/src/lib/shadow-shim-helper-rs/src/rootedcell/rc.rs
@@ -124,6 +124,7 @@ impl<T> RootedRcCommon<T> {
 }
 
 impl<T> Drop for RootedRcCommon<T> {
+    #[inline]
     fn drop(&mut self) {
         if self.internal.is_some() {
             log::error!("Dropped without calling `safely_drop`");
@@ -170,6 +171,7 @@ pub struct RootedRc<T> {
 
 impl<T> RootedRc<T> {
     /// Creates a new object associated with `root`.
+    #[inline]
     pub fn new(root: &Root, val: T) -> Self {
         Self {
             common: RootedRcCommon::new(root, val),
@@ -180,6 +182,7 @@ impl<T> RootedRc<T> {
     ///
     /// We use fully qualified syntax here for consistency with Rc and Arc and
     /// to avoid name conflicts with `T`'s methods.
+    #[inline]
     pub fn downgrade(this: &Self, root: &Root) -> RootedRcWeak<T> {
         RootedRcWeak {
             common: this.common.clone(root, RefType::Weak),
@@ -191,6 +194,7 @@ impl<T> RootedRc<T> {
     /// Intentionally named clone to shadow Self::deref()::clone().
     ///
     /// Panics if `root` is not the associated [Root].
+    #[inline]
     pub fn clone(&self, root: &Root) -> Self {
         Self {
             common: self.common.clone(root, RefType::Strong),
@@ -204,6 +208,7 @@ impl<T> RootedRc<T> {
     /// safely cleaned up. In debug builds this will result in a `panic`.
     /// Otherwise the underlying reference count will simply not be decremented,
     /// ultimately resulting in the enclosed value never being dropped.
+    #[inline]
     pub fn safely_drop(self, root: &Root) {
         self.common.safely_drop(root, RefType::Strong);
     }
@@ -212,6 +217,7 @@ impl<T> RootedRc<T> {
 impl<T> std::ops::Deref for RootedRc<T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         // No need to require a reference to `Root` here since we're not
         // touching the counts, only the value itself, which we already required
@@ -345,6 +351,7 @@ pub struct RootedRcWeak<T> {
 }
 
 impl<T> RootedRcWeak<T> {
+    #[inline]
     pub fn upgrade(&self, root: &Root) -> Option<RootedRc<T>> {
         let internal = self.common.borrow_internal(root);
 
@@ -362,12 +369,14 @@ impl<T> RootedRcWeak<T> {
     /// Intentionally named clone to shadow Self::deref()::clone().
     ///
     /// Panics if `root` is not the associated [Root].
+    #[inline]
     pub fn clone(&self, root: &Root) -> Self {
         Self {
             common: self.common.clone(root, RefType::Weak),
         }
     }
 
+    #[inline]
     pub fn safely_drop(self, root: &Root) {
         self.common.safely_drop(root, RefType::Weak)
     }

--- a/src/lib/shadow-shim-helper-rs/src/rootedcell/refcell.rs
+++ b/src/lib/shadow-shim-helper-rs/src/rootedcell/refcell.rs
@@ -27,6 +27,7 @@ unsafe impl<T> VirtualAddressSpaceIndependent for RootedRefCell<T> where
 
 impl<T> RootedRefCell<T> {
     /// Create a RootedRefCell associated with `root`.
+    #[inline]
     pub fn new(root: &Root, val: T) -> Self {
         Self {
             tag: root.tag(),
@@ -38,6 +39,7 @@ impl<T> RootedRefCell<T> {
 
     /// Borrow a reference. Panics if `root` is for the wrong [Root], or
     /// if this object is alread mutably borrowed.
+    #[inline]
     pub fn borrow<'a>(&'a self, root: &'a Root) -> RootedRefCellRef<'a, T> {
         // Prove that the root is held for this tag.
         assert_eq!(
@@ -55,6 +57,7 @@ impl<T> RootedRefCell<T> {
 
     /// Borrow a mutable reference. Panics if `root` is for the wrong
     /// [Root], or if this object is already borrowed.
+    #[inline]
     pub fn borrow_mut<'a>(&'a self, root: &'a Root) -> RootedRefCellRefMut<'a, T> {
         // Prove that the root is held for this tag.
         assert_eq!(
@@ -71,6 +74,7 @@ impl<T> RootedRefCell<T> {
         RootedRefCellRefMut { guard: self }
     }
 
+    #[inline]
     pub fn into_inner(self) -> T {
         self.val.into_inner()
     }
@@ -86,12 +90,14 @@ pub struct RootedRefCellRef<'a, T> {
 impl<'a, T> std::ops::Deref for RootedRefCellRef<'a, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         unsafe { self.guard.val.get().as_ref().unwrap() }
     }
 }
 
 impl<'a, T> Drop for RootedRefCellRef<'a, T> {
+    #[inline]
     fn drop(&mut self) {
         self.guard
             .reader_count
@@ -106,18 +112,21 @@ pub struct RootedRefCellRefMut<'a, T> {
 impl<'a, T> std::ops::Deref for RootedRefCellRefMut<'a, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         unsafe { self.guard.val.get().as_ref().unwrap() }
     }
 }
 
 impl<'a, T> std::ops::DerefMut for RootedRefCellRefMut<'a, T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { self.guard.val.get().as_mut().unwrap() }
     }
 }
 
 impl<'a, T> Drop for RootedRefCellRefMut<'a, T> {
+    #[inline]
     fn drop(&mut self) {
         self.guard.writer.set(false);
     }


### PR DESCRIPTION
By default, Rust doesn't inline calls across crate boundaries. Since these functions are small, called frequently, and from across a crate boundary, we probably want them to be inline. We force this by marking them `#[inline]`, which is also done in the analogous functions in `std`.

A quick local benchmark using the tor minimal test shows there might be a measurable improvement here, though it's inconclusive since the confidence intervals overlap substantially:

Before:

```
Benchmark 1: ./setup test --extra tor-minimal
  Time (mean ± σ):     17.424 s ±  0.455 s    [User: 18.446 s, System: 6.024 s]
  Range (min … max):   16.818 s … 18.123 s    10 runs
```

After:

```
Benchmark 1: ./setup test --extra tor-minimal
  Time (mean ± σ):     17.119 s ±  0.482 s    [User: 18.211 s, System: 5.993 s]
  Range (min … max):   16.534 s … 18.020 s    10 runs
```