### PR TITLE
Fix backwards timeout condition

### DIFF
--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -294,7 +294,7 @@ static bool _syscallcondition_statusIsValid(SysCallCondition* cond) {
 
 static bool _syscallcondition_satisfied(SysCallCondition* cond, const Host* host, const Thread* thread) {
     if (cond->timeoutExpiration != EMUTIME_INVALID &&
-        cond->timeoutExpiration >= worker_getCurrentEmulatedTime()) {
+        worker_getCurrentEmulatedTime() >= cond->timeoutExpiration) {
         // Timed out.
         return true;
     }


### PR DESCRIPTION
The timeout condition in the `SysCallCondition` is backwards, causing the process to wake up before its timeout has expired. (And maybe not wake up at all when it does exceed the timeout?)

(This doesn't fix our tor onion service stream timeout issue.)