### PR TITLE
Support explicit return types in the syscall handlers

### DIFF
--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -248,75 +248,83 @@ pub trait SyscallHandlerFn<T> {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult;
 }
 
-impl<F> SyscallHandlerFn<()> for F
+impl<F, T0> SyscallHandlerFn<()> for F
 where
-    F: Fn(&mut SyscallContext) -> SyscallResult,
+    F: Fn(&mut SyscallContext) -> Result<T0, SyscallError>,
+    T0: Into<SysCallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
-        self(ctx)
+        self(ctx).map(Into::into)
     }
 }
 
-impl<F, T> SyscallHandlerFn<(T,)> for F
+impl<F, T0, T1> SyscallHandlerFn<(T1,)> for F
 where
-    F: Fn(&mut SyscallContext, T) -> SyscallResult,
-    T: From<SysCallReg>,
+    F: Fn(&mut SyscallContext, T1) -> Result<T0, SyscallError>,
+    T0: Into<SysCallReg>,
+    T1: From<SysCallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
-        (self)(ctx, ctx.args.get(0).into())
+        self(ctx, ctx.args.get(0).into()).map(Into::into)
     }
 }
 
-impl<F, T1, T2> SyscallHandlerFn<(T1, T2)> for F
+impl<F, T0, T1, T2> SyscallHandlerFn<(T1, T2)> for F
 where
-    F: Fn(&mut SyscallContext, T1, T2) -> SyscallResult,
+    F: Fn(&mut SyscallContext, T1, T2) -> Result<T0, SyscallError>,
+    T0: Into<SysCallReg>,
     T1: From<SysCallReg>,
     T2: From<SysCallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
-        (self)(ctx, ctx.args.get(0).into(), ctx.args.get(1).into())
+        self(ctx, ctx.args.get(0).into(), ctx.args.get(1).into()).map(Into::into)
     }
 }
 
-impl<F, T1, T2, T3> SyscallHandlerFn<(T1, T2, T3)> for F
+impl<F, T0, T1, T2, T3> SyscallHandlerFn<(T1, T2, T3)> for F
 where
-    F: Fn(&mut SyscallContext, T1, T2, T3) -> SyscallResult,
+    F: Fn(&mut SyscallContext, T1, T2, T3) -> Result<T0, SyscallError>,
+    T0: Into<SysCallReg>,
     T1: From<SysCallReg>,
     T2: From<SysCallReg>,
     T3: From<SysCallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
-        (self)(
+        self(
             ctx,
             ctx.args.get(0).into(),
             ctx.args.get(1).into(),
             ctx.args.get(2).into(),
         )
+        .map(Into::into)
     }
 }
 
-impl<F, T1, T2, T3, T4> SyscallHandlerFn<(T1, T2, T3, T4)> for F
+impl<F, T0, T1, T2, T3, T4> SyscallHandlerFn<(T1, T2, T3, T4)> for F
 where
-    F: Fn(&mut SyscallContext, T1, T2, T3, T4) -> SyscallResult,
+    F: Fn(&mut SyscallContext, T1, T2, T3, T4) -> Result<T0, SyscallError>,
+    T0: Into<SysCallReg>,
     T1: From<SysCallReg>,
     T2: From<SysCallReg>,
     T3: From<SysCallReg>,
     T4: From<SysCallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
-        (self)(
+        self(
             ctx,
             ctx.args.get(0).into(),
             ctx.args.get(1).into(),
             ctx.args.get(2).into(),
             ctx.args.get(3).into(),
         )
+        .map(Into::into)
     }
 }
 
-impl<F, T1, T2, T3, T4, T5> SyscallHandlerFn<(T1, T2, T3, T4, T5)> for F
+impl<F, T0, T1, T2, T3, T4, T5> SyscallHandlerFn<(T1, T2, T3, T4, T5)> for F
 where
-    F: Fn(&mut SyscallContext, T1, T2, T3, T4, T5) -> SyscallResult,
+    F: Fn(&mut SyscallContext, T1, T2, T3, T4, T5) -> Result<T0, SyscallError>,
+    T0: Into<SysCallReg>,
     T1: From<SysCallReg>,
     T2: From<SysCallReg>,
     T3: From<SysCallReg>,
@@ -324,7 +332,7 @@ where
     T5: From<SysCallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
-        (self)(
+        self(
             ctx,
             ctx.args.get(0).into(),
             ctx.args.get(1).into(),
@@ -332,12 +340,14 @@ where
             ctx.args.get(3).into(),
             ctx.args.get(4).into(),
         )
+        .map(Into::into)
     }
 }
 
-impl<F, T1, T2, T3, T4, T5, T6> SyscallHandlerFn<(T1, T2, T3, T4, T5, T6)> for F
+impl<F, T0, T1, T2, T3, T4, T5, T6> SyscallHandlerFn<(T1, T2, T3, T4, T5, T6)> for F
 where
-    F: Fn(&mut SyscallContext, T1, T2, T3, T4, T5, T6) -> SyscallResult,
+    F: Fn(&mut SyscallContext, T1, T2, T3, T4, T5, T6) -> Result<T0, SyscallError>,
+    T0: Into<SysCallReg>,
     T1: From<SysCallReg>,
     T2: From<SysCallReg>,
     T3: From<SysCallReg>,
@@ -346,7 +356,7 @@ where
     T6: From<SysCallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
-        (self)(
+        self(
             ctx,
             ctx.args.get(0).into(),
             ctx.args.get(1).into(),
@@ -355,6 +365,7 @@ where
             ctx.args.get(4).into(),
             ctx.args.get(5).into(),
         )
+        .map(Into::into)
     }
 }
 


### PR DESCRIPTION
Similar to #2664 but for return types.

Syscalls can return various types (`int`, `size_t`, pointers, etc). We probably don't want to return the wrong type, which the plugin may interpret incorrectly. For example if a syscall is supposed to return an `int`, we probably don't want to return a `u64::MAX` from our syscall handler.

Currently our syscall handlers return a `SysCallReg`, which is a 64-bit union of various types, and there is no type checking to make sure our syscall handler is returning a valid type. This PR allows our syscall handlers to specify an explicit return type (ex: `libc::c_int` instead of `SysCallReg`).

Only the "sched.h" syscall handlers have been updated to use this. I didn't bother with the others. We can update them later if we want to, but for now this change allows us to use this for new syscall handlers that we write in the future.

(Related #2658.)

Before:

```rust
pub fn sched_yield(_ctx: &mut SyscallContext) -> SyscallResult {
    Ok(0.into())
}
```

After:

```rust
pub fn sched_yield(_ctx: &mut SyscallContext) -> Result<libc::c_int, SyscallError> {
    Ok(0)
}
```