### PR TITLE
Support `listen()` for tcp wrapper

### DIFF
--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -68,6 +68,20 @@ impl InetSocket {
         }
     }
 
+    pub fn listen(
+        &self,
+        backlog: i32,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
+        cb_queue: &mut CallbackQueue,
+    ) -> Result<(), SyscallError> {
+        match self {
+            Self::LegacyTcp(socket) => {
+                LegacyTcpSocket::listen(socket, backlog, net_ns, rng, cb_queue)
+            }
+        }
+    }
+
     pub fn connect(
         &self,
         addr: &SockaddrStorage,
@@ -253,10 +267,6 @@ impl InetSocketRefMut<'_> {
         pub fn recvfrom<W>(&mut self, bytes: W, cb_queue: &mut CallbackQueue)
             -> Result<(SysCallReg, Option<SockaddrStorage>), SyscallError>
         where W: std::io::Write + std::io::Seek
-    );
-
-    enum_passthrough!(self, (backlog, cb_queue), LegacyTcp;
-        pub fn listen(&mut self, backlog: i32, cb_queue: &mut CallbackQueue) -> Result<(), SyscallError>
     );
 
     pub fn accept(&mut self, cb_queue: &mut CallbackQueue) -> Result<InetSocket, SyscallError> {

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -387,8 +387,10 @@ impl LegacyTcpSocket {
     }
 
     pub fn listen(
-        &mut self,
+        _socket: &Arc<AtomicRefCell<Self>>,
         _backlog: i32,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
         _cb_queue: &mut CallbackQueue,
     ) -> Result<(), SyscallError> {
         todo!();

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -387,13 +387,73 @@ impl LegacyTcpSocket {
     }
 
     pub fn listen(
-        _socket: &Arc<AtomicRefCell<Self>>,
-        _backlog: i32,
-        _net_ns: &NetworkNamespace,
-        _rng: impl rand::Rng,
+        socket: &Arc<AtomicRefCell<Self>>,
+        backlog: i32,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
         _cb_queue: &mut CallbackQueue,
     ) -> Result<(), SyscallError> {
-        todo!();
+        let socket_ref = socket.borrow();
+
+        // only listen on the socket if it is not used for other functions
+        let is_listening_allowed =
+            unsafe { c::tcp_isListeningAllowed(socket_ref.as_legacy_tcp()) } == 1;
+        if !is_listening_allowed {
+            log::debug!("Cannot listen on previously used socket");
+            return Err(Errno::EOPNOTSUPP.into());
+        }
+
+        // if we are already listening, just update the backlog and return 0
+        let is_valid_listener = unsafe { c::tcp_isValidListener(socket_ref.as_legacy_tcp()) } == 1;
+        if is_valid_listener {
+            log::trace!("Socket already set up as a listener; updating backlog");
+            unsafe { c::tcp_updateServerBacklog(socket_ref.as_legacy_tcp(), backlog) };
+            return Ok(());
+        }
+
+        // a listening socket must be bound
+        let is_bound = unsafe { c::legacysocket_isBound(socket_ref.as_legacy_socket()) } == 1;
+        if !is_bound {
+            log::trace!("Implicitly binding listener socket");
+
+            // implicit bind: bind to all interfaces at an ephemeral port
+            let local_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
+
+            // this will allow us to receive packets from any peer address
+            let peer_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
+
+            // associate the socket
+            let local_addr = super::associate_socket(
+                super::InetSocket::LegacyTcp(socket.clone()),
+                local_addr,
+                peer_addr,
+                net_ns,
+                rng,
+            )?;
+
+            unsafe {
+                c::legacysocket_setSocketName(
+                    socket_ref.as_legacy_socket(),
+                    u32::from(*local_addr.ip()).to_be(),
+                    local_addr.port().to_be(),
+                )
+            };
+        }
+
+        // we are allowed to listen but not already listening; start now
+        Worker::with_active_host(|host| {
+            unsafe {
+                c::tcp_enterServerMode(
+                    socket_ref.as_legacy_tcp(),
+                    host,
+                    Worker::active_process_id().unwrap().into(),
+                    backlog,
+                )
+            };
+        })
+        .unwrap();
+
+        Ok(())
     }
 
     pub fn connect(

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -73,6 +73,19 @@ impl Socket {
         }
     }
 
+    pub fn listen(
+        &self,
+        backlog: i32,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
+        cb_queue: &mut CallbackQueue,
+    ) -> Result<(), SyscallError> {
+        match self {
+            Self::Unix(socket) => UnixSocket::listen(socket, backlog, net_ns, rng, cb_queue),
+            Self::Inet(socket) => InetSocket::listen(socket, backlog, net_ns, rng, cb_queue),
+        }
+    }
+
     pub fn connect(
         &self,
         addr: &SockaddrStorage,
@@ -256,10 +269,6 @@ impl SocketRefMut<'_> {
         pub fn recvfrom<W>(&mut self, bytes: W, cb_queue: &mut CallbackQueue)
             -> Result<(SysCallReg, Option<SockaddrStorage>), SyscallError>
         where W: std::io::Write + std::io::Seek
-    );
-
-    enum_passthrough!(self, (backlog, cb_queue), Unix, Inet;
-        pub fn listen(&mut self, backlog: i32, cb_queue: &mut CallbackQueue) -> Result<(), SyscallError>
     );
 
     pub fn accept(&mut self, cb_queue: &mut CallbackQueue) -> Result<Socket, SyscallError> {

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -1,4 +1,5 @@
 use std::collections::{LinkedList, VecDeque};
+use std::ops::DerefMut;
 use std::sync::{Arc, Weak};
 
 use atomic_refcell::AtomicRefCell;
@@ -211,12 +212,17 @@ impl UnixSocket {
     }
 
     pub fn listen(
-        &mut self,
+        socket: &Arc<AtomicRefCell<Self>>,
         backlog: i32,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
         cb_queue: &mut CallbackQueue,
     ) -> Result<(), SyscallError> {
-        self.protocol_state
-            .listen(&mut self.common, backlog, cb_queue)
+        let mut socket_ref = socket.borrow_mut();
+        let socket_ref = socket_ref.deref_mut();
+        socket_ref
+            .protocol_state
+            .listen(&mut socket_ref.common, backlog, cb_queue)
     }
 
     pub fn connect(

--- a/src/main/host/descriptor/tcp.h
+++ b/src/main/host/descriptor/tcp.h
@@ -62,7 +62,7 @@ gint tcp_getConnectionError(TCP* tcp);
 // clang-format on
 
 void tcp_getInfo(TCP* tcp, struct tcp_info *tcpinfo);
-void tcp_enterServerMode(TCP* tcp, const Host* host, const ProcessRefCell* process, gint backlog);
+void tcp_enterServerMode(TCP* tcp, const Host* host, pid_t process, gint backlog);
 void tcp_updateServerBacklog(TCP* tcp, gint backlog);
 /* Address and port must be in network byte order. */
 gint tcp_acceptServerPeer(TCP* tcp, const Host* host, in_addr_t* ip, in_port_t* port,

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -499,11 +499,6 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
-            drop(desc_table);
-            return Self::legacy_syscall(c::syscallhandler_listen, ctx);
-        }
-
         let File::Socket(socket) = file.inner_file() else {
             drop(desc_table);
             return Err(Errno::ENOTSOCK.into());

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -1085,33 +1085,9 @@ SysCallReturn syscallhandler_listen(SysCallHandler* sys,
     }
     utility_debugAssert(tcp_desc);
 
-    /* only listen on the socket if it is not used for other functions */
-    if (!tcp_isListeningAllowed(tcp_desc)) {
-        debug("Cannot listen on previously used socket %i", sockfd);
-        return syscallreturn_makeDoneErrno(EOPNOTSUPP);
-    }
-
-    /* if we are already listening, just update the backlog and return 0. */
-    if (tcp_isValidListener(tcp_desc)) {
-        trace("Socket %i already set up as a listener; updating backlog", sockfd);
-        tcp_updateServerBacklog(tcp_desc, backlog);
-        return syscallreturn_makeDoneU64(0);
-    }
-
-    /* We are allowed to listen but not already listening, start now. */
-    if (!legacysocket_isBound((LegacySocket*)tcp_desc)) {
-        /* Implicit bind: bind to all interfaces at an ephemeral port. */
-        trace("Implicitly binding listener socket %i", sockfd);
-        errcode =
-            _syscallhandler_bindHelper(sys, (LegacySocket*)tcp_desc, htonl(INADDR_ANY), 0, 0, 0);
-        if (errcode < 0) {
-            return syscallreturn_makeDoneErrno(-errcode);
-        }
-    }
-
-    tcp_enterServerMode(
-        tcp_desc, _syscallhandler_getHost(sys), _syscallhandler_getProcess(sys), backlog);
-    return syscallreturn_makeDoneU64(0);
+    /* When we add a TCP socket to the descriptor table we add it as a rust LegacyTcpSocket and
+     * handle it in the rust listen() syscall handler, so we should never get here. */
+    utility_panic("We shouldn't have any C TCP sockets in the descriptor table");
 }
 
 SysCallReturn syscallhandler_recvfrom(SysCallHandler* sys,


### PR DESCRIPTION
The logic generally follows the logic from `src/main/host/syscall/socket.c`.

https://github.com/shadow/shadow/blob/e0cf19596456fbfb162ee67b23e15dbd01d01c30/src/main/host/syscall/socket.c#L1072-L1115