### PR TITLE
VirtualAddressSpaceIndependent derive macro: support enums and unions

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -1472,6 +1472,7 @@ dependencies = [
 name = "vasi-macro"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
  "vasi",

--- a/src/lib/vasi-macro/Cargo.toml
+++ b/src/lib/vasi-macro/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 proc_macro=true
 
 [dependencies]
+proc-macro2 = "1.0.51"
 quote = "1.0.23"
 syn = "1.0.107"
 

--- a/src/lib/vasi-macro/src/lib.rs
+++ b/src/lib/vasi-macro/src/lib.rs
@@ -1,5 +1,6 @@
-use proc_macro::TokenStream;
+use proc_macro2::TokenStream;
 use quote::quote;
+use syn::Field;
 
 /// Implement `vasi::VirtualAddressSpaceIndependent` for the annotated type.
 /// Requires all fields to implement `vasi::VirtualAddressSpaceIndependent`.
@@ -65,13 +66,37 @@ use quote::quote;
 /// }
 /// ```
 ///
+/// A union containing only `VirtualAddressSpaceIndependent` fields qualifies:
+/// ```
+/// use vasi::VirtualAddressSpaceIndependent;
+///
+/// #[derive(VirtualAddressSpaceIndependent)]
+/// union Foo {
+///   x: i32,
+///   y: i32,
+/// }
+/// ```
+///
+/// A union containing a non-vasi member doesn't qualify:
+/// ```compile_fail
+/// use vasi::VirtualAddressSpaceIndependent;
+///
+/// #[derive(VirtualAddressSpaceIndependent)]
+/// struct Foo {
+///   x: i32,
+///   y: *const i32,
+/// }
+/// ```
+///
 /// TODO: Extend to support trait bounds. See e.g.
 /// <https://github.com/dtolnay/syn/blob/master/examples/heapsize/heapsize_derive/src/lib.rs#L16>
 #[proc_macro_derive(
     VirtualAddressSpaceIndependent,
     attributes(unsafe_assume_virtual_address_space_independent)
 )]
-pub fn derive_virtual_address_space_independent(tokens: TokenStream) -> TokenStream {
+pub fn derive_virtual_address_space_independent(
+    tokens: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
     // Construct a representation of Rust code as a syntax tree
     // that we can manipulate
     let ast = syn::parse(tokens).unwrap();
@@ -79,33 +104,42 @@ pub fn derive_virtual_address_space_independent(tokens: TokenStream) -> TokenStr
     impl_derive_virtual_address_space_independent(ast)
 }
 
-fn impl_derive_virtual_address_space_independent(ast: syn::DeriveInput) -> TokenStream {
+fn assertions_for_field(field: &Field) -> TokenStream {
+    if field.attrs.iter().any(|a| {
+        a.path
+            .is_ident("unsafe_assume_virtual_address_space_independent")
+    }) {
+        // Explicitly opted out of assertion.
+        TokenStream::new()
+    } else {
+        let t = &field.ty;
+        quote! {
+            // This is static_assertions::assert_impl_all, re-exported
+            // for use in code generated here.
+            vasi::assert_impl_all!(#t: vasi::VirtualAddressSpaceIndependent);
+        }
+    }
+}
+
+fn impl_derive_virtual_address_space_independent(ast: syn::DeriveInput) -> proc_macro::TokenStream {
     let name = &ast.ident;
-    let mut output = quote! {};
+    let mut assertions = Vec::new();
     match &ast.data {
         syn::Data::Struct(s) => {
             for field in &s.fields {
-                if field.attrs.iter().any(|a| {
-                    a.path
-                        .is_ident("unsafe_assume_virtual_address_space_independent")
-                }) {
-                    // Explicitly opted out of assertion.
-                    continue;
-                }
-                let t = &field.ty;
-                output = quote! {
-                    #output
-                    // This is static_assertions::assert_impl_all, re-exported
-                    // for use in code generated here.
-                    vasi::assert_impl_all!(#t: vasi::VirtualAddressSpaceIndependent);
-                };
+                assertions.push(assertions_for_field(field));
             }
         }
         syn::Data::Enum(_) => unimplemented!("Enums aren't yet implemented"),
-        syn::Data::Union(_) => unimplemented!("Unions aren't yet implemented"),
+        syn::Data::Union(u) => {
+            for field in &u.fields.named {
+                assertions.push(assertions_for_field(field));
+            }
+        }
     };
+    let assertions: TokenStream = assertions.into_iter().collect();
     let gen = quote! {
-        #output
+        #assertions
         /// SAFETY: All fields are vasi::VirtualAddressSpaceIndependent.
         unsafe impl vasi::VirtualAddressSpaceIndependent for #name {}
     };


### PR DESCRIPTION
Extending this to facilitate use with `ShimEvent`.