### PR TITLE
VirtualAddressSpaceIndpendent: use trait bounds in derive macro

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1474,6 +1474,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "static_assertions",
  "syn",
  "vasi",
 ]

--- a/src/lib/shadow-shim-helper-rs/src/option.rs
+++ b/src/lib/shadow-shim-helper-rs/src/option.rs
@@ -1,14 +1,22 @@
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+use vasi::VirtualAddressSpaceIndependent;
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    VirtualAddressSpaceIndependent,
+)]
 #[repr(C)]
 pub enum FfiOption<T> {
     #[default]
     None,
     Some(T),
-}
-
-unsafe impl<T> vasi::VirtualAddressSpaceIndependent for FfiOption<T> where
-    T: vasi::VirtualAddressSpaceIndependent
-{
 }
 
 impl<T> FfiOption<T> {

--- a/src/lib/shadow-shim-helper-rs/src/rootedcell/cell.rs
+++ b/src/lib/shadow-shim-helper-rs/src/rootedcell/cell.rs
@@ -9,17 +9,11 @@ use vasi::VirtualAddressSpaceIndependent;
 /// Unlike [std::cell::Cell], this type is [Send] and [Sync] if `T` is
 /// [Send]. This is safe because the owner is required to prove access to the
 /// associated [Root], which is `![Sync]`, to access.
-#[derive(Debug)]
+#[derive(Debug, VirtualAddressSpaceIndependent)]
 #[repr(C)]
 pub struct RootedCell<T> {
     tag: Tag,
     val: UnsafeCell<T>,
-}
-
-// SAFETY: RootedCell is VirtualAddressSpaceIndependent as long as T is.
-unsafe impl<T> VirtualAddressSpaceIndependent for RootedCell<T> where
-    T: VirtualAddressSpaceIndependent
-{
 }
 
 impl<T> RootedCell<T> {

--- a/src/lib/shadow-shim-helper-rs/src/rootedcell/refcell.rs
+++ b/src/lib/shadow-shim-helper-rs/src/rootedcell/refcell.rs
@@ -9,20 +9,13 @@ use vasi::VirtualAddressSpaceIndependent;
 /// Unlike [std::cell::RefCell], this type is [Send] and [Sync] if `T` is
 /// [Send]. This is safe because the owner is required to prove access to the
 /// associated [Root], which is `![Sync]`, to borrow.
-#[derive(Debug)]
+#[derive(Debug, VirtualAddressSpaceIndependent)]
 #[repr(C)]
 pub struct RootedRefCell<T> {
     tag: Tag,
     val: UnsafeCell<T>,
     reader_count: Cell<u32>,
     writer: Cell<bool>,
-}
-
-// SAFETY: RootedRefCell is VirtualAddressSpaceIndependent as long as T is.
-// e.g. UnsafeCell and Cell are `repr(transparent)`.
-unsafe impl<T> VirtualAddressSpaceIndependent for RootedRefCell<T> where
-    T: VirtualAddressSpaceIndependent
-{
 }
 
 impl<T> RootedRefCell<T> {

--- a/src/lib/vasi-macro/Cargo.toml
+++ b/src/lib/vasi-macro/Cargo.toml
@@ -14,4 +14,5 @@ quote = "1.0.23"
 syn = "1.0.107"
 
 [dev-dependencies]
+static_assertions = "1.1.0"
 vasi = { path = "../vasi" }

--- a/src/lib/vasi-macro/src/lib.rs
+++ b/src/lib/vasi-macro/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::Field;
+use syn::{parse_quote, Attribute, GenericParam, Generics, Type};
 
 /// Implement `vasi::VirtualAddressSpaceIndependent` for the annotated type.
 /// Requires all fields to implement `vasi::VirtualAddressSpaceIndependent`.
@@ -110,8 +110,51 @@ use syn::Field;
 /// }
 /// ```
 ///
-/// TODO: Extend to support trait bounds. See e.g.
-/// <https://github.com/dtolnay/syn/blob/master/examples/heapsize/heapsize_derive/src/lib.rs#L16>
+/// A generic type *conditionally* implements VirtualAddressSpaceIndependent,
+/// if its type parameters do (as the derive macros in the std crate behave).
+/// ```
+/// use vasi::VirtualAddressSpaceIndependent;
+///
+/// #[derive(VirtualAddressSpaceIndependent)]
+/// struct MyWrapper<T> {
+///   val: T,
+/// }
+///
+/// static_assertions::assert_impl_all!(MyWrapper<i32>: vasi::VirtualAddressSpaceIndependent);
+/// static_assertions::assert_not_impl_all!(MyWrapper<* const i32>: vasi::VirtualAddressSpaceIndependent);
+/// ```
+///
+/// Generic type with existing bounds are also supported.
+/// ```
+/// use vasi::VirtualAddressSpaceIndependent;
+///
+/// #[derive(VirtualAddressSpaceIndependent)]
+/// struct MyWrapper<T: Copy> {
+///   val: T,
+/// }
+/// static_assertions::assert_impl_all!(MyWrapper<i32>: vasi::VirtualAddressSpaceIndependent);
+/// static_assertions::assert_not_impl_all!(MyWrapper<* const i32>: vasi::VirtualAddressSpaceIndependent);
+///
+/// #[derive(VirtualAddressSpaceIndependent)]
+/// struct MyWrapper2<T> where T: Copy {
+///   val: T,
+/// }
+/// static_assertions::assert_impl_all!(MyWrapper2<i32>: vasi::VirtualAddressSpaceIndependent);
+/// static_assertions::assert_not_impl_all!(MyWrapper2<* const i32>: vasi::VirtualAddressSpaceIndependent);
+///
+/// ```
+///
+/// As with e.g. Copy and Clone, a field that is dependent on a type parameter
+/// but still isn't VirtualAddressSpaceIndependent will cause the macro not to
+/// compile:
+/// ```compile_fail
+/// use vasi::VirtualAddressSpaceIndependent;
+///
+/// #[derive(VirtualAddressSpaceIndependent)]
+/// struct MyWrapper<T> {
+///   val: *const T,
+/// }
+/// ```
 #[proc_macro_derive(
     VirtualAddressSpaceIndependent,
     attributes(unsafe_assume_virtual_address_space_independent)
@@ -126,50 +169,93 @@ pub fn derive_virtual_address_space_independent(
     impl_derive_virtual_address_space_independent(ast)
 }
 
-fn assertions_for_field(field: &Field) -> TokenStream {
-    if field.attrs.iter().any(|a| {
-        a.path
-            .is_ident("unsafe_assume_virtual_address_space_independent")
-    }) {
-        // Explicitly opted out of assertion.
-        TokenStream::new()
-    } else {
-        let t = &field.ty;
-        quote! {
-            // This is static_assertions::assert_impl_all, re-exported
-            // for use in code generated here.
-            vasi::assert_impl_all!(#t: vasi::VirtualAddressSpaceIndependent);
+// Add a bound `T: VirtualAddressSpaceIndependent` to every type parameter T.
+fn add_trait_bounds(mut generics: Generics) -> Generics {
+    for param in &mut generics.params {
+        if let GenericParam::Type(ref mut type_param) = *param {
+            type_param
+                .bounds
+                .push(parse_quote!(vasi::VirtualAddressSpaceIndependent));
         }
     }
+    generics
+}
+
+fn assume_vasi(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path
+            .is_ident("unsafe_assume_virtual_address_space_independent")
+    })
 }
 
 fn impl_derive_virtual_address_space_independent(ast: syn::DeriveInput) -> proc_macro::TokenStream {
     let name = &ast.ident;
-    let mut assertions = Vec::new();
-    match &ast.data {
-        syn::Data::Struct(s) => {
-            for field in &s.fields {
-                assertions.push(assertions_for_field(field));
-            }
-        }
-        syn::Data::Enum(e) => {
-            for variant in &e.variants {
-                for field in &variant.fields {
-                    assertions.push(assertions_for_field(field));
-                }
-            }
-        }
-        syn::Data::Union(u) => {
-            for field in &u.fields.named {
-                assertions.push(assertions_for_field(field));
-            }
-        }
+    // This will contain calls to a function `check` that accepts VirtualAddressSpaceIndependent types,
+    // which is how we validate that the fields are VirtualAddressSpaceIndependent.
+    // e.g. for an input struct definition
+    // ```
+    // struct MyStruct {
+    //   x: u32,
+    //   y: i32,
+    // }
+    // ```
+    // 
+    // We'll end up generating code like:
+    // ```
+    // impl VirtualAddressSpaceIndependent for MyStruct {
+    //     const IGNORE: () = {
+    //         fn check<T: VirtualAddressSpaceIndependent>() {}
+    //         check::<u32>(); // check type of MyStruct::x
+    //         check::<i32>(); // check type of MyStruct::y
+    //     };
+    // }
+    // ```
+    let types: Vec<&Type> = match &ast.data {
+        syn::Data::Struct(s) => s
+            .fields
+            .iter()
+            .filter(|field| !assume_vasi(&field.attrs))
+            .map(|field| &field.ty)
+            .collect(),
+        syn::Data::Enum(e) => e
+            .variants
+            .iter()
+            .flat_map(|variant| {
+                variant
+                    .fields
+                    .iter()
+                    .filter(|field| !assume_vasi(&field.attrs))
+                    .map(|field| &field.ty)
+            })
+            .collect(),
+        syn::Data::Union(u) => u
+            .fields
+            .named
+            .iter()
+            .filter(|field| !assume_vasi(&field.attrs))
+            .map(|field| &field.ty)
+            .collect(),
     };
-    let assertions: TokenStream = assertions.into_iter().collect();
+
+    // These will fail to compile if any of the types aren't VirtualAddressSpaceIndependent.
+    let calls_to_check: TokenStream = types
+        .into_iter()
+        .map(|ty| quote! {check::<#ty>();})
+        .collect();
+
+    // Add a bound `T: VirtualAddressSpaceIndependent` to every type parameter T.
+    // This allows generic types to be conditionally VirtualAddressSpaceIndependent,
+    // iff their type parameters are.
+    let generics = add_trait_bounds(ast.generics);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
     let gen = quote! {
-        #assertions
-        /// SAFETY: All fields are vasi::VirtualAddressSpaceIndependent.
-        unsafe impl vasi::VirtualAddressSpaceIndependent for #name {}
+        unsafe impl #impl_generics vasi::VirtualAddressSpaceIndependent for #name #ty_generics #where_clause {
+            const IGNORE: () = {
+                const fn check<T: ::vasi::VirtualAddressSpaceIndependent>() {}
+                #calls_to_check
+            };
+        }
     };
     gen.into()
 }

--- a/src/lib/vasi-macro/src/lib.rs
+++ b/src/lib/vasi-macro/src/lib.rs
@@ -199,7 +199,7 @@ fn impl_derive_virtual_address_space_independent(ast: syn::DeriveInput) -> proc_
     //   y: i32,
     // }
     // ```
-    // 
+    //
     // We'll end up generating code like:
     // ```
     // impl VirtualAddressSpaceIndependent for MyStruct {

--- a/src/lib/vasi-sync/src/sync.rs
+++ b/src/lib/vasi-sync/src/sync.rs
@@ -18,6 +18,9 @@ pub use std::{
     sync::Arc,
 };
 
+#[cfg(not(loom))]
+use vasi::VirtualAddressSpaceIndependent;
+
 // Map a *virtual* address to a list of Condvars. This doesn't support mapping into multiple
 // processes, or into different virtual addresses in the same process, etc.
 #[cfg(loom)]
@@ -153,7 +156,7 @@ unsafe impl<T: ?Sized> Send for MutPtr<T> where T: Send {}
 
 // From https://docs.rs/loom/latest/loom/#handling-loom-api-differences
 #[cfg(not(loom))]
-#[derive(Debug)]
+#[derive(Debug, VirtualAddressSpaceIndependent)]
 #[repr(transparent)]
 pub struct UnsafeCell<T>(std::cell::UnsafeCell<T>);
 #[cfg(not(loom))]

--- a/src/lib/vasi/src/lib.rs
+++ b/src/lib/vasi/src/lib.rs
@@ -24,7 +24,10 @@ pub use vasi_macro::VirtualAddressSpaceIndependent;
 /// # Safety
 ///
 /// The type must actually be self-contained, as above.
-pub unsafe trait VirtualAddressSpaceIndependent {}
+pub unsafe trait VirtualAddressSpaceIndependent {
+    /// Used by the derive macro to validate that fields are Vasi.
+    const IGNORE: () = ();
+}
 
 // Types not containing any pointers are trivially VirtualAddressSpaceIndependent.
 unsafe impl VirtualAddressSpaceIndependent for i64 {}

--- a/src/lib/vasi/src/lib.rs
+++ b/src/lib/vasi/src/lib.rs
@@ -79,4 +79,16 @@ unsafe impl<T> VirtualAddressSpaceIndependent for std::cell::UnsafeCell<T> where
 {
 }
 
+// ManuallyDrop is `repr(transparent)` around a `<T>`.
+unsafe impl<T> VirtualAddressSpaceIndependent for std::mem::ManuallyDrop<T> where
+    T: VirtualAddressSpaceIndependent
+{
+}
+
+// MaybeUninit is `repr(transparent)` around a union of `()` and `ManuallyDrop<T>`.
+unsafe impl<T> VirtualAddressSpaceIndependent for std::mem::MaybeUninit<T> where
+    T: VirtualAddressSpaceIndependent
+{
+}
+
 unsafe impl VirtualAddressSpaceIndependent for () {}


### PR DESCRIPTION
Extends the VirtualAddressSpaceIndependent Derive macro to handle generics, and replaces manual implementation of the trait by using the derive macro.

(Previously:)

> For discussion purposes - I'm a bit stumped how to get this to work. In particular I don't see a way to write the `static_assertions` for generics.
> 
> The current incarnation fails in a doc test that tries to use the macro with a generic type.
> 
> The test:
> ```
> /// #[derive(VirtualAddressSpaceIndependent)]
> /// struct MyWrapper<T> {
> ///   val: T,
> /// }
> ```
> 
> The failure:
> ```
>  --> src/lib.rs:120:8
>   |
> 6 | struct MyWrapper<T> {
>   |                  - type parameter from outer function
> 7 |   val: T,
>   |        ^ use of generic parameter from outer function
> ```
> 
> The problem is we end up generating something like this, and `T` isn't allowed in this position:
> 
> ```
> impl MyWrapper<T> where T: VirtualAddressSpaceIndependent {
>   fn _vasi_assertions() {
>     assert_impl_all!(T: vasi::VirtualAddressSpaceIndependent);
>   }
> }
> ```