### PR TITLE
ShimEvent: convert from union to enum

### DIFF
--- a/src/lib/shadow-shim-helper-rs/shim_shmem.c
+++ b/src/lib/shadow-shim-helper-rs/shim_shmem.c
@@ -8,7 +8,7 @@
 #include "lib/shadow-shim-helper-rs/shim_helper.h"
 
 void shim_shmemHandleClone(const ShimEvent* ev) {
-    assert(shimevent_getId(ev) == SHIM_EVENT_ID_CLONE_REQ);
+    assert(shimevent_getId(ev) == SHIM_EVENT_CLONE_REQ);
     const ShimEventShmemBlk* shmem_blk = shimevent_getShmemBlkData(ev);
     ShMemBlock blk = shmemserializer_globalBlockDeserialize(&shmem_blk->serial);
 
@@ -16,7 +16,7 @@ void shim_shmemHandleClone(const ShimEvent* ev) {
 }
 
 void shim_shmemHandleCloneString(const ShimEvent* ev) {
-    assert(shimevent_getId(ev) == SHIM_EVENT_ID_CLONE_STRING_REQ);
+    assert(shimevent_getId(ev) == SHIM_EVENT_CLONE_STRING_REQ);
     const ShimEventShmemBlk* shmem_blk = shimevent_getShmemBlkData(ev);
     ShMemBlock blk = shmemserializer_globalBlockDeserialize(&shmem_blk->serial);
 
@@ -25,7 +25,7 @@ void shim_shmemHandleCloneString(const ShimEvent* ev) {
 }
 
 void shim_shmemHandleWrite(const ShimEvent* ev) {
-    assert(shimevent_getId(ev) == SHIM_EVENT_ID_WRITE_REQ);
+    assert(shimevent_getId(ev) == SHIM_EVENT_WRITE_REQ);
     const ShimEventShmemBlk* shmem_blk = shimevent_getShmemBlkData(ev);
     ShMemBlock blk = shmemserializer_globalBlockDeserialize(&shmem_blk->serial);
 

--- a/src/lib/shadow-shim-helper-rs/shim_shmem.c
+++ b/src/lib/shadow-shim-helper-rs/shim_shmem.c
@@ -8,33 +8,32 @@
 #include "lib/shadow-shim-helper-rs/shim_helper.h"
 
 void shim_shmemHandleClone(const ShimEvent* ev) {
-    assert(ev && ev->event_id == SHIM_EVENT_ID_CLONE_REQ);
+    assert(shimevent_getId(ev) == SHIM_EVENT_ID_CLONE_REQ);
+    const ShimEventShmemBlk* shmem_blk = shimevent_getShmemBlkData(ev);
+    ShMemBlock blk = shmemserializer_globalBlockDeserialize(&shmem_blk->serial);
 
-    ShMemBlock blk = shmemserializer_globalBlockDeserialize(&ev->event_data.shmem_blk.serial);
-
-    memcpy(blk.p, (void*)ev->event_data.shmem_blk.plugin_ptr.val, ev->event_data.shmem_blk.n);
+    memcpy(blk.p, (void*)shmem_blk->plugin_ptr.val, shmem_blk->n);
 }
 
 void shim_shmemHandleCloneString(const ShimEvent* ev) {
-    assert(ev && ev->event_id == SHIM_EVENT_ID_CLONE_STRING_REQ);
+    assert(shimevent_getId(ev) == SHIM_EVENT_ID_CLONE_STRING_REQ);
+    const ShimEventShmemBlk* shmem_blk = shimevent_getShmemBlkData(ev);
+    ShMemBlock blk = shmemserializer_globalBlockDeserialize(&shmem_blk->serial);
 
-    ShMemBlock blk = shmemserializer_globalBlockDeserialize(&ev->event_data.shmem_blk.serial);
-
-    strncpy(blk.p, (void*)ev->event_data.shmem_blk.plugin_ptr.val, ev->event_data.shmem_blk.n);
+    strncpy(blk.p, (void*)shmem_blk->plugin_ptr.val, shmem_blk->n);
     // TODO: Shrink buffer to what's actually needed?
 }
 
 void shim_shmemHandleWrite(const ShimEvent* ev) {
-    assert(ev && ev->event_id == SHIM_EVENT_ID_WRITE_REQ);
+    assert(shimevent_getId(ev) == SHIM_EVENT_ID_WRITE_REQ);
+    const ShimEventShmemBlk* shmem_blk = shimevent_getShmemBlkData(ev);
+    ShMemBlock blk = shmemserializer_globalBlockDeserialize(&shmem_blk->serial);
 
-    ShMemBlock blk = shmemserializer_globalBlockDeserialize(&ev->event_data.shmem_blk.serial);
-
-    memcpy((void*)ev->event_data.shmem_blk.plugin_ptr.val, blk.p, ev->event_data.shmem_blk.n);
+    memcpy((void*)shmem_blk->plugin_ptr.val, blk.p, shmem_blk->n);
 }
 
 void shim_shmemNotifyComplete(struct IPCData* data) {
-    ShimEvent ev = {
-        .event_id = SHIM_EVENT_ID_SHMEM_COMPLETE,
-    };
+    ShimEvent ev;
+    shimevent_initShmemComplete(&ev);
     shimevent_sendEventToShadow(data, &ev);
 }

--- a/src/lib/shadow-shim-helper-rs/shim_shmem.h
+++ b/src/lib/shadow-shim-helper-rs/shim_shmem.h
@@ -3,13 +3,13 @@
 
 #include "lib/shadow-shim-helper-rs/shim_helper.h"
 
-// Handle SHIM_EVENT_ID_CLONE_REQ
+// Handle SHIM_EVENT_CLONE_REQ
 void shim_shmemHandleClone(const ShimEvent* ev);
 
-// Handle SHIM_EVENT_ID_CLONE_STRING_REQ
+// Handle SHIM_EVENT_CLONE_STRING_REQ
 void shim_shmemHandleCloneString(const ShimEvent* ev);
 
-// Handle SHIM_EVENT_ID_WRITE_REQ
+// Handle SHIM_EVENT_WRITE_REQ
 void shim_shmemHandleWrite(const ShimEvent* ev);
 
 // Notify Shadow that a shared memory event has been handled.

--- a/src/lib/shadow-shim-helper-rs/src/ipc.rs
+++ b/src/lib/shadow-shim-helper-rs/src/ipc.rs
@@ -62,10 +62,8 @@ impl Default for IPCData {
 mod export {
     use vasi_sync::scchannel::SelfContainedChannelError;
 
-    use crate::notnull::notnull_mut;
-    use crate::shim_event::{ShimEventData, ShimEventID};
-
     use super::*;
+    use crate::notnull::notnull_mut;
 
     #[no_mangle]
     pub unsafe extern "C" fn ipcData_init(ipc_data: *mut IPCData) {
@@ -130,10 +128,7 @@ mod export {
         let ipc_data = unsafe { ipc_data.as_ref().unwrap() };
         let event = match ipc_data.from_plugin().receive() {
             Ok(e) => e,
-            Err(SelfContainedChannelError::WriterIsClosed) => ShimEvent {
-                event_id: ShimEventID::ProcessDeath,
-                event_data: ShimEventData { none: () },
-            },
+            Err(SelfContainedChannelError::WriterIsClosed) => ShimEvent::ProcessDeath,
         };
         unsafe { ev.write(event) };
     }

--- a/src/lib/shadow-shim-helper-rs/src/shim_event.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_event.rs
@@ -45,20 +45,41 @@ pub struct ShimEventAddThreadReq {
 #[repr(u32)]
 pub enum ShimEvent {
     Null,
+    /// Sent from Shadow to Shim to allow a shim thread to start executing
+    /// after creation.
     Start,
-    // The whole process has died.
-    // We inject this event to trigger cleanup after we've detected that the
-    // native process has died.
+    /// The whole process has died.
+    /// We inject this event to trigger cleanup after we've detected that the
+    /// native process has died.
     ProcessDeath,
+    /// Sent from Shim to Shadow to request handling of a syscall.
     Syscall(ShimEventSyscall),
+    /// Response from Shadow for a completed emulated syscall.
     SyscallComplete(ShimEventSyscallComplete),
+    /// Response from Shadow indicating that the shim should execute
+    /// the last requested syscall natively.
     SyscallDoNative,
+    /// Request from Shadow to copy data from shared memory.
+    /// XXX: Deprecated.
     CloneReq(ShimEventShmemBlk),
+    /// Request from Shadow to copy a string from shared memory.
+    /// XXX: Deprecated.
     CloneStringReq(ShimEventShmemBlk),
+    /// Response from the Shim that the requested shared memory operations has
+    /// completed.
+    /// XXX: Deprecated.
     ShmemComplete,
+    /// Request from Shadow to copy data to shared memory.
+    /// XXX: Deprecated.
     WriteReq(ShimEventShmemBlk),
+    /// Hint from Shadow to the shim that the current thread is about to be blocked.
+    /// i.e. the shim should stop spinning to wait for a response and block instead.
+    /// XXX: Deprecated: we no longer spin in Shadow/Shim IPC.
     Block,
+    /// Request from Shadow to Shim to take the included shared memory block,
+    /// which holds an `IpcData`, and use it to initialize a newly spawned thread.
     AddThreadReq(ShimEventAddThreadReq),
+    /// Response from Shim to Shadow that `AddThreadReq` has completed.
     AddThreadParentRes,
 }
 

--- a/src/lib/shadow-shim-helper-rs/src/shim_event.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_event.rs
@@ -69,7 +69,6 @@ pub union ShimEventData {
     pub shmem_blk: ShimEventShmemBlk,
     pub add_thread_req: ShimEventAddThreadReq,
 }
-
 /// A message between Shadow and the Shim.
 /// TODO: Refactor from a tagged union into an enum.
 #[derive(Copy, Clone, VirtualAddressSpaceIndependent)]
@@ -77,4 +76,152 @@ pub union ShimEventData {
 pub struct ShimEvent {
     pub event_id: ShimEventID,
     pub event_data: ShimEventData,
+}
+
+mod export {
+    use super::*;
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_getId(event: *const ShimEvent) -> ShimEventID {
+        let event = unsafe { event.as_ref().unwrap() };
+        event.event_id
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_getSyscallData(
+        event: *const ShimEvent,
+    ) -> *const ShimEventSyscall {
+        let event = unsafe { event.as_ref().unwrap() };
+        match event.event_id {
+            ShimEventID::Syscall => (),
+            id => panic!("Unexpected event id {id:?}"),
+        };
+        unsafe { &event.event_data.syscall }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_getSyscallCompleteData(
+        event: *const ShimEvent,
+    ) -> *const ShimEventSyscallComplete {
+        let event = unsafe { event.as_ref().unwrap() };
+        match event.event_id {
+            ShimEventID::SyscallComplete => (),
+            id => panic!("Unexpected event id {id:?}"),
+        };
+        unsafe { &event.event_data.syscall_complete }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_getShmemBlkData(
+        event: *const ShimEvent,
+    ) -> *const ShimEventShmemBlk {
+        let event = unsafe { event.as_ref().unwrap() };
+        match event.event_id {
+            ShimEventID::CloneReq | ShimEventID::CloneStringReq | ShimEventID::WriteReq => (),
+            id => panic!("Unexpected event id {id:?}"),
+        };
+        unsafe { &event.event_data.shmem_blk }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_getAddThreadReqData(
+        event: *const ShimEvent,
+    ) -> *const ShimEventAddThreadReq {
+        let event = unsafe { event.as_ref().unwrap() };
+        match event.event_id {
+            ShimEventID::AddThreadReq => (),
+            id => panic!("Unexpected event id {id:?}"),
+        };
+        unsafe { &event.event_data.add_thread_req }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_initSyscall(
+        dst: *mut ShimEvent,
+        syscall_args: *const SysCallArgs,
+    ) {
+        let syscall_args = unsafe { syscall_args.as_ref().unwrap() };
+        let event = ShimEvent {
+            event_id: ShimEventID::Syscall,
+            event_data: ShimEventData {
+                syscall: ShimEventSyscall {
+                    syscall_args: *syscall_args,
+                },
+            },
+        };
+        unsafe { dst.write(event) };
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_initShmemComplete(dst: *mut ShimEvent) {
+        let event = ShimEvent {
+            event_id: ShimEventID::ShmemComplete,
+            event_data: ShimEventData { none: () },
+        };
+        unsafe { dst.write(event) };
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_initSysCallComplete(
+        dst: *mut ShimEvent,
+        retval: SysCallReg,
+        restartable: bool,
+    ) {
+        let event = ShimEvent {
+            event_id: ShimEventID::SyscallComplete,
+            event_data: ShimEventData {
+                syscall_complete: ShimEventSyscallComplete {
+                    retval,
+                    restartable,
+                },
+            },
+        };
+        unsafe { dst.write(event) };
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_initAddThreadParentRes(dst: *mut ShimEvent) {
+        let event = ShimEvent {
+            event_id: ShimEventID::AddThreadParentRes,
+            event_data: ShimEventData { none: () },
+        };
+        unsafe { dst.write(event) };
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_initSyscallDoNative(dst: *mut ShimEvent) {
+        let event = ShimEvent {
+            event_id: ShimEventID::SyscallDoNative,
+            event_data: ShimEventData { none: () },
+        };
+        unsafe { dst.write(event) };
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_initAddThreadReq(
+        dst: *mut ShimEvent,
+        ipc_block: *const ShMemBlockSerialized,
+    ) {
+        let ipc_block = unsafe { ipc_block.as_ref().unwrap() };
+        let event = ShimEvent {
+            event_id: ShimEventID::AddThreadReq,
+            event_data: ShimEventData {
+                shmem_blk: ShimEventShmemBlk {
+                    serial: *ipc_block,
+                    plugin_ptr: PluginPtr::null(),
+                    n: 0,
+                },
+            },
+        };
+        unsafe { dst.write(event) };
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn shimevent_initStart(dst: *mut ShimEvent) {
+        let event = ShimEvent {
+            event_id: ShimEventID::Start,
+            event_data: ShimEventData { none: () },
+        };
+        unsafe { dst.write(event) };
+    }
 }

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -416,7 +416,7 @@ static void _shim_preload_only_child_ipc_wait_for_start_event() {
     shim_newThreadChildInitd();
 
     shimevent_recvEventFromShadow(ipc, &event);
-    assert(shimevent_getId(&event) == SHIM_EVENT_ID_START);
+    assert(shimevent_getId(&event) == SHIM_EVENT_START);
 }
 
 static void _shim_ipc_wait_for_start_event() {
@@ -426,7 +426,7 @@ static void _shim_ipc_wait_for_start_event() {
     ShimEvent event;
     trace("waiting for start event on %p", shim_thisThreadEventIPC);
     shimevent_recvEventFromShadow(shim_thisThreadEventIPC(), &event);
-    assert(shimevent_getId(&event) == SHIM_EVENT_ID_START);
+    assert(shimevent_getId(&event) == SHIM_EVENT_START);
 }
 
 static void _shim_parent_init_seccomp() {

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -84,7 +84,7 @@ static struct {
     shadow_sem_t childInitd;
 } _startThread;
 
-void shim_newThreadStart(ShMemBlockSerialized* block) {
+void shim_newThreadStart(const ShMemBlockSerialized* block) {
     if (shadow_spin_lock(&_startThreadLock)) {
         panic("shadow_spin_lock: %s", strerror(errno));
     };
@@ -416,7 +416,7 @@ static void _shim_preload_only_child_ipc_wait_for_start_event() {
     shim_newThreadChildInitd();
 
     shimevent_recvEventFromShadow(ipc, &event);
-    assert(event.event_id == SHIM_EVENT_ID_START);
+    assert(shimevent_getId(&event) == SHIM_EVENT_ID_START);
 }
 
 static void _shim_ipc_wait_for_start_event() {
@@ -426,7 +426,7 @@ static void _shim_ipc_wait_for_start_event() {
     ShimEvent event;
     trace("waiting for start event on %p", shim_thisThreadEventIPC);
     shimevent_recvEventFromShadow(shim_thisThreadEventIPC(), &event);
-    assert(event.event_id == SHIM_EVENT_ID_START);
+    assert(shimevent_getId(&event) == SHIM_EVENT_ID_START);
 }
 
 static void _shim_parent_init_seccomp() {

--- a/src/lib/shim/shim.h
+++ b/src/lib/shim/shim.h
@@ -27,7 +27,7 @@ struct IPCData* shim_thisThreadEventIPC();
 
 // To be called in parent thread before making the `clone` syscall.
 // It sets up data for the new thread.
-void shim_newThreadStart(ShMemBlockSerialized* block);
+void shim_newThreadStart(const ShMemBlockSerialized* block);
 
 // To be called in parent thread after making the `clone` syscall.
 // It doesn't return until after the child has initialized itself.

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -125,12 +125,12 @@ static SysCallReg _shim_emulated_syscall_event(const ShimEvent* syscall_event) {
         trace("got response of type %d on %p", shimevent_getId(&res), ipc);
 
         switch (shimevent_getId(&res)) {
-            case SHIM_EVENT_ID_BLOCK: {
+            case SHIM_EVENT_BLOCK: {
                 // Ack the message.
                 shimevent_sendEventToShadow(ipc, &res);
                 break;
             }
-            case SHIM_EVENT_ID_SYSCALL_COMPLETE: {
+            case SHIM_EVENT_SYSCALL_COMPLETE: {
                 const ShimEventSyscallComplete* syscall_complete =
                     shimevent_getSyscallCompleteData(&res);
                 // We'll ultimately return the provided result.
@@ -166,7 +166,7 @@ static SysCallReg _shim_emulated_syscall_event(const ShimEvent* syscall_event) {
 
                 return rv;
             }
-            case SHIM_EVENT_ID_SYSCALL_DO_NATIVE: {
+            case SHIM_EVENT_SYSCALL_DO_NATIVE: {
                 // Make the original syscall ourselves and use the result.
                 const ShimEventSyscall* syscall = shimevent_getSyscallData(syscall_event);
                 const SysCallReg* regs = syscall->syscall_args.args;
@@ -212,7 +212,7 @@ static SysCallReg _shim_emulated_syscall_event(const ShimEvent* syscall_event) {
 
                 return rv;
             }
-            case SHIM_EVENT_ID_SYSCALL: {
+            case SHIM_EVENT_SYSCALL: {
                 // Make the requested syscall ourselves and return the result
                 // to Shadow.
                 const ShimEventSyscall* syscall = shimevent_getSyscallData(&res);
@@ -226,19 +226,19 @@ static SysCallReg _shim_emulated_syscall_event(const ShimEvent* syscall_event) {
                 shimevent_sendEventToShadow(ipc, &syscall_complete_event);
                 break;
             }
-            case SHIM_EVENT_ID_CLONE_REQ:
+            case SHIM_EVENT_CLONE_REQ:
                 shim_shmemHandleClone(&res);
                 shim_shmemNotifyComplete(ipc);
                 break;
-            case SHIM_EVENT_ID_CLONE_STRING_REQ:
+            case SHIM_EVENT_CLONE_STRING_REQ:
                 shim_shmemHandleCloneString(&res);
                 shim_shmemNotifyComplete(ipc);
                 break;
-            case SHIM_EVENT_ID_WRITE_REQ:
+            case SHIM_EVENT_WRITE_REQ:
                 shim_shmemHandleWrite(&res);
                 shim_shmemNotifyComplete(ipc);
                 break;
-            case SHIM_EVENT_ID_ADD_THREAD_REQ: {
+            case SHIM_EVENT_ADD_THREAD_REQ: {
                 const ShimEventAddThreadReq* add_thread_req = shimevent_getAddThreadReqData(&res);
                 shim_newThreadStart(&add_thread_req->ipc_block);
                 ShimEvent res;


### PR DESCRIPTION
This will make it easier to work with from Rust code; in particular avoiding `unsafe` union access.