### PR TITLE
Remove reference count from `SysCallHandler`

### DIFF
--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -69,8 +69,6 @@ struct _SysCallHandler {
     bool havePendingResult;
     SysCallReturn pendingResult;
 
-    int referenceCount;
-
     // Since this structure is shared with Rust, we should always include the magic struct
     // member so that the struct is always the same size regardless of compile-time options.
     MAGIC_DECLARE_ALWAYS;

--- a/src/main/host/syscall_handler.h
+++ b/src/main/host/syscall_handler.h
@@ -17,8 +17,7 @@ typedef struct _SysCallHandler SysCallHandler;
 #include "main/host/syscall_types.h"
 
 SysCallHandler* syscallhandler_new(HostId hostId, pid_t processId, pid_t threadId);
-void syscallhandler_ref(SysCallHandler* sys);
-void syscallhandler_unref(SysCallHandler* sys);
+void syscallhandler_free(SysCallHandler* sys);
 SysCallReturn syscallhandler_make_syscall(SysCallHandler* sys,
                                           const SysCallArgs* args);
 

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -430,7 +430,7 @@ impl Drop for Thread {
             unsafe { c::syscallcondition_unref(c) };
         }
         unsafe { c::managedthread_free(self.mthread.ptr()) };
-        unsafe { c::syscallhandler_unref(self.syscallhandler.ptr()) };
+        unsafe { c::syscallhandler_free(self.syscallhandler.ptr()) };
     }
 }
 


### PR DESCRIPTION
I don't think we need this ref count.