### PR TITLE
SelfContainedChannel benchmarks and candidate optimizations

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5dd14596c0e5b954530d0e6f1fd99b89c03e313aa2086e8da4303701a09e1cf"
 
 [[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
 name = "bytecheck"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +162,12 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 name = "bytes"
 version = "1.2.1"
 source = "git+https://github.com/shadow/bytes?rev=c48bd4439e7e043300521925524ecdcce7ff6bcc#c48bd4439e7e043300521925524ecdcce7ff6bcc"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbindgen"
@@ -202,6 +220,33 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clang-sys"
@@ -290,6 +335,42 @@ name = "crc-catalog"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap 3.2.23",
+ "criterion-plot",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
 
 [[package]]
 name = "crossbeam"
@@ -450,6 +531,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +638,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -758,6 +863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +913,34 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1038,6 +1177,15 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schemars"
@@ -1403,6 +1551,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1672,7 @@ dependencies = [
 name = "vasi-sync"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "libc",
  "loom",
  "nix",
@@ -1545,10 +1704,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "which"

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -18,3 +18,7 @@ rand = "0.8.5"
 
 [target.'cfg(loom)'.dependencies]
 loom = "0.5"
+
+[[bench]]
+name = "scchannel"
+harness = false

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -13,6 +13,7 @@ static_assertions = "1.1.0"
 vasi = { path = "../vasi" }
 
 [dev-dependencies]
+criterion = "0.4.0"
 rand = "0.8.5"
 
 [target.'cfg(loom)'.dependencies]

--- a/src/lib/vasi-sync/benches/scchannel.rs
+++ b/src/lib/vasi-sync/benches/scchannel.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use nix::sched::CpuSet;
+use nix::unistd::Pid;
+use vasi_sync::scchannel::SelfContainedChannel;
+
+/// Mock-up of Ipc between Shadow and its plugin.
+/// We specify a large alignment here to get consistent cache interactions or
+/// not between the atomics inside the channels for benchmarking purposes. i.e.
+/// 128 should be large enough to ensure the struct is aligned to the beginning
+/// of a cache line.
+#[repr(align(128))]
+struct Ipc(SelfContainedChannel<()>, SelfContainedChannel<()>);
+
+fn ping_pong(bencher: &mut Bencher, do_pinning: bool) {
+    let initial_cpu_set = nix::sched::sched_getaffinity(Pid::from_raw(0)).unwrap();
+    let pinned_cpu_id = (0..)
+        .into_iter()
+        .find(|i| initial_cpu_set.is_set(*i).unwrap())
+        .unwrap();
+    let pinned_cpu_set = {
+        let mut s = CpuSet::new();
+        s.set(pinned_cpu_id).unwrap();
+        s
+    };
+    if do_pinning {
+        nix::sched::sched_setaffinity(Pid::from_raw(0), &pinned_cpu_set).unwrap();
+    }
+
+    let ipc = Arc::new(Ipc(
+        SelfContainedChannel::new(),
+        SelfContainedChannel::new(),
+    ));
+
+    let receiver_thread = {
+        let ipc = ipc.clone();
+        std::thread::spawn(move || {
+            if do_pinning {
+                nix::sched::sched_setaffinity(Pid::from_raw(0), &pinned_cpu_set).unwrap();
+            }
+            loop {
+                if ipc.0.receive().is_err() {
+                    break;
+                }
+                ipc.1.send(());
+            }
+        })
+    };
+
+    bencher.iter(|| {
+        ipc.0.send(());
+        ipc.1.receive().unwrap();
+    });
+
+    ipc.0.close_writer();
+    receiver_thread.join().unwrap();
+    if do_pinning {
+        nix::sched::sched_setaffinity(Pid::from_raw(0), &initial_cpu_set).unwrap();
+    }
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("ping pong", |b| ping_pong(b, false));
+    c.bench_function("ping pong pinned", |b| ping_pong(b, true));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib/vasi-sync/benches/scchannel.rs
+++ b/src/lib/vasi-sync/benches/scchannel.rs
@@ -40,17 +40,17 @@ fn ping_pong(bencher: &mut Bencher, do_pinning: bool) {
                 nix::sched::sched_setaffinity(Pid::from_raw(0), &pinned_cpu_set).unwrap();
             }
             loop {
-                if ipc.0.receive().is_err() {
+                if unsafe { ipc.0.receive() }.is_err() {
                     break;
                 }
-                ipc.1.send(());
+                unsafe { ipc.1.send(()) };
             }
         })
     };
 
     bencher.iter(|| {
-        ipc.0.send(());
-        ipc.1.receive().unwrap();
+        unsafe { ipc.0.send(()) };
+        unsafe { ipc.1.receive().unwrap() };
     });
 
     ipc.0.close_writer();

--- a/src/lib/vasi-sync/benches/scchannel.rs
+++ b/src/lib/vasi-sync/benches/scchannel.rs
@@ -40,17 +40,17 @@ fn ping_pong(bencher: &mut Bencher, do_pinning: bool) {
                 nix::sched::sched_setaffinity(Pid::from_raw(0), &pinned_cpu_set).unwrap();
             }
             loop {
-                if unsafe { ipc.0.receive() }.is_err() {
+                if ipc.0.receive().is_err() {
                     break;
                 }
-                unsafe { ipc.1.send(()) };
+                ipc.1.send(());
             }
         })
     };
 
     bencher.iter(|| {
-        unsafe { ipc.0.send(()) };
-        unsafe { ipc.1.receive().unwrap() };
+        ipc.0.send(());
+        ipc.1.receive().unwrap();
     });
 
     ipc.0.close_writer();

--- a/src/lib/vasi-sync/src/scchannel.rs
+++ b/src/lib/vasi-sync/src/scchannel.rs
@@ -4,7 +4,7 @@ use std::mem::MaybeUninit;
 
 use vasi::VirtualAddressSpaceIndependent;
 
-use crate::sync::{self, AtomicU32, UnsafeCell};
+use crate::sync::{self, AtomicBool, AtomicU32, UnsafeCell};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, VirtualAddressSpaceIndependent)]
 #[repr(u8)]
@@ -27,22 +27,18 @@ impl From<u8> for ChannelContentsState {
 
 // bit flags in ChannelState
 const WRITER_CLOSED: u32 = 0x1 << 9;
-const HAS_SLEEPER: u32 = 0x1 << 10;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone, VirtualAddressSpaceIndependent)]
 struct ChannelState {
     writer_closed: bool,
-    has_sleeper: bool,
     contents_state: ChannelContentsState,
 }
 
 impl From<u32> for ChannelState {
     fn from(value: u32) -> Self {
-        let has_sleeper = (value & HAS_SLEEPER) != 0;
         let writer_closed = (value & WRITER_CLOSED) != 0;
         let contents_state = ((value & 0xff) as u8).into();
         ChannelState {
-            has_sleeper,
             writer_closed,
             contents_state,
         }
@@ -51,13 +47,12 @@ impl From<u32> for ChannelState {
 
 impl From<ChannelState> for u32 {
     fn from(value: ChannelState) -> Self {
-        let has_sleeper = if value.has_sleeper { HAS_SLEEPER } else { 0 };
         let writer_closed = if value.writer_closed {
             WRITER_CLOSED
         } else {
             0
         };
-        writer_closed | has_sleeper | (value.contents_state as u32)
+        writer_closed | (value.contents_state as u32)
     }
 }
 
@@ -67,7 +62,6 @@ impl AtomicChannelState {
     pub fn new() -> Self {
         Self(AtomicU32::new(
             ChannelState {
-                has_sleeper: false,
                 writer_closed: false,
                 contents_state: ChannelContentsState::Empty,
             }
@@ -97,20 +91,6 @@ impl AtomicChannelState {
     /// Typed interface to `AtomicU32::load`
     fn load(&self, order: sync::atomic::Ordering) -> ChannelState {
         ChannelState::from(self.0.load(order))
-    }
-
-    /// Typed interface to `AtomicU32::compare_exchange`
-    fn compare_exchange(
-        &self,
-        current: ChannelState,
-        new: ChannelState,
-        success: sync::atomic::Ordering,
-        failure: sync::atomic::Ordering,
-    ) -> Result<ChannelState, ChannelState> {
-        self.0
-            .compare_exchange(current.into(), new.into(), success, failure)
-            .map(ChannelState::from)
-            .map_err(ChannelState::from)
     }
 }
 
@@ -151,6 +131,7 @@ impl Error for SelfContainedChannelError {
 pub struct SelfContainedChannel<T> {
     message: UnsafeCell<MaybeUninit<T>>,
     state: AtomicChannelState,
+    has_sleeper: AtomicBool,
 }
 
 impl<T> SelfContainedChannel<T> {
@@ -158,6 +139,7 @@ impl<T> SelfContainedChannel<T> {
         Self {
             message: UnsafeCell::new(MaybeUninit::uninit()),
             state: AtomicChannelState::new(),
+            has_sleeper: AtomicBool::new(false),
         }
     }
 
@@ -168,8 +150,7 @@ impl<T> SelfContainedChannel<T> {
     /// Channel must be empty, and there must not be a parallel call to `send`.
     pub unsafe fn send(&self, message: T) {
         unsafe { self.message.get_mut().deref().as_mut_ptr().write(message) };
-        let prev = self
-            .state
+        self.state
             .fetch_update(
                 sync::atomic::Ordering::Release,
                 sync::atomic::Ordering::Relaxed,
@@ -180,7 +161,8 @@ impl<T> SelfContainedChannel<T> {
                 },
             )
             .unwrap();
-        if prev.has_sleeper {
+        sync::atomic::fence(sync::atomic::Ordering::SeqCst);
+        if self.has_sleeper.load(sync::atomic::Ordering::Relaxed) {
             sync::futex_wake(&self.state.0).unwrap();
         }
     }
@@ -204,39 +186,18 @@ impl<T> SelfContainedChannel<T> {
                 return Err(SelfContainedChannelError::WriterIsClosed);
             }
             assert!(state.contents_state == ChannelContentsState::Empty);
-            assert!(!state.has_sleeper);
-            let mut sleeper_state = state;
-            sleeper_state.has_sleeper = true;
-            match self.state.compare_exchange(
-                state,
-                sleeper_state,
-                sync::atomic::Ordering::Relaxed,
-                sync::atomic::Ordering::Relaxed,
-            ) {
-                Ok(_) => (),
-                Err(s) => {
-                    // Something changed; re-evaluate.
-                    state = s;
-                    continue;
-                }
-            };
-            let expected = sleeper_state.into();
-            match sync::futex_wait(&self.state.0, expected) {
+
+            self.has_sleeper
+                .store(true, sync::atomic::Ordering::Relaxed);
+            sync::atomic::fence(sync::atomic::Ordering::SeqCst);
+            let res = sync::futex_wait(&self.state.0, state.into());
+            self.has_sleeper
+                .store(false, sync::atomic::Ordering::Relaxed);
+
+            match res {
                 Ok(_) | Err(nix::errno::Errno::EINTR) | Err(nix::errno::Errno::EAGAIN) => {
-                    // Something changed; clear the sleeper bit and try again.
-                    let mut updated_state = self
-                        .state
-                        .fetch_update(
-                            sync::atomic::Ordering::Relaxed,
-                            sync::atomic::Ordering::Relaxed,
-                            |mut state| {
-                                state.has_sleeper = false;
-                                Some(state)
-                            },
-                        )
-                        .unwrap();
-                    updated_state.has_sleeper = false;
-                    state = updated_state;
+                    // Something changed; try again.
+                    state = self.state.load(sync::atomic::Ordering::Relaxed);
                     continue;
                 }
                 Err(e) => panic!("Unexpected futex error {:?}", e),
@@ -267,18 +228,18 @@ impl<T> SelfContainedChannel<T> {
     /// channel, making it suitable to be called from a separate watchdog thread
     /// that detects that the writing thread (or process) has died.
     pub fn close_writer(&self) {
-        let prev = self
-            .state
+        self.state
             .fetch_update(
                 sync::atomic::Ordering::Relaxed,
-                sync::atomic::Ordering::Relaxed,
+                sync::atomic::Ordering::Acquire,
                 |mut state| {
                     state.writer_closed = true;
                     Some(state)
                 },
             )
             .unwrap();
-        if prev.has_sleeper {
+        sync::atomic::fence(sync::atomic::Ordering::SeqCst);
+        if self.has_sleeper.load(sync::atomic::Ordering::Relaxed) {
             sync::futex_wake(&self.state.0).unwrap();
         }
     }

--- a/src/lib/vasi-sync/src/scchannel.rs
+++ b/src/lib/vasi-sync/src/scchannel.rs
@@ -25,34 +25,21 @@ impl From<u8> for ChannelContentsState {
     }
 }
 
-// bit flags in ChannelState
-const WRITER_CLOSED: u32 = 0x1 << 9;
-
 #[derive(Debug, Eq, PartialEq, Copy, Clone, VirtualAddressSpaceIndependent)]
 struct ChannelState {
-    writer_closed: bool,
     contents_state: ChannelContentsState,
 }
 
 impl From<u32> for ChannelState {
     fn from(value: u32) -> Self {
-        let writer_closed = (value & WRITER_CLOSED) != 0;
         let contents_state = ((value & 0xff) as u8).into();
-        ChannelState {
-            writer_closed,
-            contents_state,
-        }
+        ChannelState { contents_state }
     }
 }
 
 impl From<ChannelState> for u32 {
     fn from(value: ChannelState) -> Self {
-        let writer_closed = if value.writer_closed {
-            WRITER_CLOSED
-        } else {
-            0
-        };
-        writer_closed | (value.contents_state as u32)
+        value.contents_state as u32
     }
 }
 
@@ -62,35 +49,20 @@ impl AtomicChannelState {
     pub fn new() -> Self {
         Self(AtomicU32::new(
             ChannelState {
-                writer_closed: false,
                 contents_state: ChannelContentsState::Empty,
             }
             .into(),
         ))
     }
 
-    /// Typed interface to `AtomicU32::fetch_update`
-    fn fetch_update<F>(
-        &self,
-        set_order: sync::atomic::Ordering,
-        fetch_order: sync::atomic::Ordering,
-        mut f: F,
-    ) -> Result<ChannelState, ChannelState>
-    where
-        F: FnMut(ChannelState) -> Option<ChannelState>,
-    {
-        self.0
-            .fetch_update(set_order, fetch_order, |x| {
-                let res = f(ChannelState::from(x));
-                res.map(u32::from)
-            })
-            .map(ChannelState::from)
-            .map_err(ChannelState::from)
-    }
-
     /// Typed interface to `AtomicU32::load`
     fn load(&self, order: sync::atomic::Ordering) -> ChannelState {
         ChannelState::from(self.0.load(order))
+    }
+
+    /// Typed interface to `AtomicU32::store`
+    fn store(&self, value: ChannelState, order: sync::atomic::Ordering) {
+        self.0.store(value.into(), order)
     }
 }
 
@@ -132,6 +104,7 @@ pub struct SelfContainedChannel<T> {
     message: UnsafeCell<MaybeUninit<T>>,
     state: AtomicChannelState,
     has_sleeper: AtomicBool,
+    writer_closed: AtomicBool,
 }
 
 impl<T> SelfContainedChannel<T> {
@@ -140,6 +113,7 @@ impl<T> SelfContainedChannel<T> {
             message: UnsafeCell::new(MaybeUninit::uninit()),
             state: AtomicChannelState::new(),
             has_sleeper: AtomicBool::new(false),
+            writer_closed: AtomicBool::new(false),
         }
     }
 
@@ -148,19 +122,12 @@ impl<T> SelfContainedChannel<T> {
     /// # Safety
     ///
     /// Channel must be empty, and there must not be a parallel call to `send`.
+    /// 
+    /// XXX: Must not be closed? (message will leak, but otherwise not unsound)
     pub unsafe fn send(&self, message: T) {
         unsafe { self.message.get_mut().deref().as_mut_ptr().write(message) };
         self.state
-            .fetch_update(
-                sync::atomic::Ordering::Release,
-                sync::atomic::Ordering::Relaxed,
-                |mut state| {
-                    assert_eq!(state.contents_state, ChannelContentsState::Empty);
-                    state.contents_state = ChannelContentsState::Ready;
-                    Some(state)
-                },
-            )
-            .unwrap();
+            .store(ChannelState{ contents_state: ChannelContentsState::Ready }, sync::atomic::Ordering::Relaxed);
         sync::atomic::fence(sync::atomic::Ordering::SeqCst);
         if self.has_sleeper.load(sync::atomic::Ordering::Relaxed) {
             sync::futex_wake(&self.state.0).unwrap();
@@ -182,15 +149,21 @@ impl<T> SelfContainedChannel<T> {
             if state.contents_state == ChannelContentsState::Ready {
                 break;
             }
-            if state.writer_closed {
-                return Err(SelfContainedChannelError::WriterIsClosed);
-            }
             assert!(state.contents_state == ChannelContentsState::Empty);
+
+            sync::atomic::fence(sync::atomic::Ordering::SeqCst);
 
             self.has_sleeper
                 .store(true, sync::atomic::Ordering::Relaxed);
+
+            // Unclear whether this fence is strictly necessary, or whether the futex operation
+            // already effectively has one. Our loom model of futex conservatively doesn't
+            // have such a fence, so a fence is required here to ensure consistent ordering
+            // with the other atomic operations above.
             sync::atomic::fence(sync::atomic::Ordering::SeqCst);
+
             let res = sync::futex_wait(&self.state.0, state.into());
+
             self.has_sleeper
                 .store(false, sync::atomic::Ordering::Relaxed);
 
@@ -206,18 +179,12 @@ impl<T> SelfContainedChannel<T> {
         // We use an Acquire fence here instead of making every load above
         // have Acquire ordering.
         sync::atomic::fence(sync::atomic::Ordering::Acquire);
+        sync::atomic::fence(sync::atomic::Ordering::SeqCst);
+        if self.writer_closed.load(sync::atomic::Ordering::Relaxed) {
+            return Err(SelfContainedChannelError::WriterIsClosed);
+        }
         let val = unsafe { self.message.get_mut().deref().assume_init_read() };
-        self.state
-            .fetch_update(
-                sync::atomic::Ordering::Release,
-                sync::atomic::Ordering::Relaxed,
-                |mut state| {
-                    assert_eq!(state.contents_state, ChannelContentsState::Ready);
-                    state.contents_state = ChannelContentsState::Empty;
-                    Some(state)
-                },
-            )
-            .unwrap();
+        self.state.store(ChannelState { contents_state: ChannelContentsState::Empty }, sync::atomic::Ordering::Release);
         Ok(val)
     }
 
@@ -228,16 +195,11 @@ impl<T> SelfContainedChannel<T> {
     /// channel, making it suitable to be called from a separate watchdog thread
     /// that detects that the writing thread (or process) has died.
     pub fn close_writer(&self) {
+        self.writer_closed
+            .store(true, sync::atomic::Ordering::Relaxed);
+        sync::atomic::fence(sync::atomic::Ordering::SeqCst);
         self.state
-            .fetch_update(
-                sync::atomic::Ordering::Relaxed,
-                sync::atomic::Ordering::Acquire,
-                |mut state| {
-                    state.writer_closed = true;
-                    Some(state)
-                },
-            )
-            .unwrap();
+            .store(ChannelState{ contents_state: ChannelContentsState::Ready }, sync::atomic::Ordering::Relaxed);
         sync::atomic::fence(sync::atomic::Ordering::SeqCst);
         if self.has_sleeper.load(sync::atomic::Ordering::Relaxed) {
             sync::futex_wake(&self.state.0).unwrap();
@@ -250,15 +212,10 @@ unsafe impl<T> Sync for SelfContainedChannel<T> where T: Send {}
 
 impl<T> Drop for SelfContainedChannel<T> {
     fn drop(&mut self) {
-        // Conservatively use Acquire-ordering here to synchronize with the
-        // Release-ordered store in `send`.
-        //
-        // This shouldn't be strictly necessary - for us to have a `&mut` reference, some
-        // external synchronization must have already happened over the whole channel. Indeed
-        // the original Box implementation uses get_mut here, which doesn't have an atomic
-        // operation at all.
-        let state = self.state.load(sync::atomic::Ordering::Acquire);
-        if state.contents_state == ChannelContentsState::Ready {
+        sync::atomic::fence(sync::atomic::Ordering::SeqCst);
+        let writer_closed= self.writer_closed.load(sync::atomic::Ordering::Relaxed);
+        let state = self.state.load(sync::atomic::Ordering::Relaxed);
+        if state.contents_state == ChannelContentsState::Ready && !writer_closed {
             unsafe { self.message.get_mut().deref().assume_init_drop() }
         }
     }

--- a/src/lib/vasi-sync/src/sync.rs
+++ b/src/lib/vasi-sync/src/sync.rs
@@ -8,13 +8,13 @@
 #[cfg(loom)]
 pub use loom::{
     sync::atomic,
-    sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering},
+    sync::atomic::{AtomicI32, AtomicU32, Ordering},
     sync::Arc,
 };
 #[cfg(not(loom))]
 pub use std::{
     sync::atomic,
-    sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering},
+    sync::atomic::{AtomicI32, AtomicU32, Ordering},
     sync::Arc,
 };
 

--- a/src/lib/vasi-sync/src/sync.rs
+++ b/src/lib/vasi-sync/src/sync.rs
@@ -8,13 +8,13 @@
 #[cfg(loom)]
 pub use loom::{
     sync::atomic,
-    sync::atomic::{AtomicI32, AtomicU32, Ordering},
+    sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering},
     sync::Arc,
 };
 #[cfg(not(loom))]
 pub use std::{
     sync::atomic,
-    sync::atomic::{AtomicI32, AtomicU32, Ordering},
+    sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering},
     sync::Arc,
 };
 

--- a/src/lib/vasi-sync/tests/scchannel-tests.rs
+++ b/src/lib/vasi-sync/tests/scchannel-tests.rs
@@ -57,11 +57,6 @@ mod scchannel_tests {
         })
     }
 
-    // This test causes an internal panic in loom. Unclear why.
-    // This scenario shouldn't actually occur in Shadow's usage;
-    // test_writer_close_watchdog_with_write more closely covers that.
-    // XXX: debug or file loom issue.
-    #[cfg(not(loom))]
     #[test]
     fn test_writer_writes_then_closes() {
         sync::model(|| {
@@ -78,10 +73,8 @@ mod scchannel_tests {
                 sync::thread::spawn(move || unsafe { channel.receive() })
             };
             writer.join().unwrap();
-            // We should either get the written value, or an error, depending on
-            // the execution order.
-            let res = reader.join().unwrap();
-            assert!(res == Ok(42) || res == Err(SelfContainedChannelError::WriterIsClosed));
+            // Reader should have gotten the written value.
+            assert_eq!(reader.join().unwrap(), Ok(42));
 
             // Reading from the channel again should return an error since
             // the writer has closed. (And shouldn't deadlock or panic).

--- a/src/lib/vasi-sync/tests/scchannel-tests.rs
+++ b/src/lib/vasi-sync/tests/scchannel-tests.rs
@@ -15,7 +15,7 @@ mod scchannel_tests {
     fn test_single_thread() {
         sync::model(|| {
             let channel = SelfContainedChannel::new();
-            channel.send(42);
+            unsafe { channel.send(42) };
             let val = channel.receive().unwrap();
             assert_eq!(val, 42);
         })
@@ -28,7 +28,7 @@ mod scchannel_tests {
             let writer = {
                 let channel = channel.clone();
                 sync::thread::spawn(move || {
-                    channel.send(42);
+                    unsafe { channel.send(42) };
                 })
             };
             let reader = {
@@ -46,7 +46,7 @@ mod scchannel_tests {
             let channel = SelfContainedChannel::new();
             let writer = {
                 sync::thread::spawn(move || {
-                    channel.send(Box::new(42));
+                    unsafe { channel.send(Box::new(42)) };
                     channel
                 })
             };
@@ -64,7 +64,7 @@ mod scchannel_tests {
             let writer = {
                 let channel = channel.clone();
                 sync::thread::spawn(move || {
-                    channel.send(42);
+                    unsafe { channel.send(42) };
                     channel.close_writer();
                 })
             };
@@ -91,7 +91,7 @@ mod scchannel_tests {
             let channel = sync::Arc::new(SelfContainedChannel::<u32>::new());
             let writer = {
                 let channel = channel.clone();
-                sync::thread::spawn(move || channel.send(42))
+                sync::thread::spawn(move || unsafe { channel.send(42) })
             };
             let reader = {
                 let channel = channel.clone();
@@ -142,11 +142,11 @@ mod scchannel_tests {
                 let recv_channel = beta_to_alpha.clone();
                 sync::thread::spawn(move || {
                     let mut v = Vec::new();
-                    send_channel.send(1);
+                    unsafe { send_channel.send(1) };
                     v.push(recv_channel.receive());
-                    send_channel.send(2);
+                    unsafe { send_channel.send(2) };
                     v.push(recv_channel.receive());
-                    send_channel.send(3);
+                    unsafe { send_channel.send(3) };
                     v.push(recv_channel.receive());
                     v
                 })
@@ -157,11 +157,11 @@ mod scchannel_tests {
                 sync::thread::spawn(move || {
                     let mut v = Vec::new();
                     v.push(recv_channel.receive());
-                    send_channel.send(4);
+                    unsafe { send_channel.send(4) };
                     v.push(recv_channel.receive());
-                    send_channel.send(5);
+                    unsafe { send_channel.send(5) };
                     v.push(recv_channel.receive());
-                    send_channel.send(6);
+                    unsafe { send_channel.send(6) };
                     v
                 })
             };

--- a/src/lib/vasi/src/lib.rs
+++ b/src/lib/vasi/src/lib.rs
@@ -51,6 +51,7 @@ unsafe impl VirtualAddressSpaceIndependent for std::sync::atomic::AtomicU16 {}
 unsafe impl VirtualAddressSpaceIndependent for std::sync::atomic::AtomicI16 {}
 unsafe impl VirtualAddressSpaceIndependent for std::sync::atomic::AtomicU8 {}
 unsafe impl VirtualAddressSpaceIndependent for std::sync::atomic::AtomicI8 {}
+unsafe impl VirtualAddressSpaceIndependent for std::sync::atomic::AtomicBool {}
 
 // An array of T is [VirtualAddressSpaceIndependent] if its elements are.
 unsafe impl<T, const N: usize> VirtualAddressSpaceIndependent for [T; N] where


### PR DESCRIPTION
This adds criterion-based microbenchmarks for SelfContainedChannel. On top of that it adds several candidate optimizations, with the microbenchmark results in the corresponding commit messages.

On my desktop dev machine these are all either neutral or *hurt* performance.

On a larger simulation machine, removing the internal "Reading" and "Writing" states has some benefit, but mostly only when pinning is disabled.

The candidate optimizations and microbenchmark results are reverted, but left in the commit history in case we want to revisit in the future.

# Outdated (to be stripped from merge commit message)

@robgjansen would it be possible for you to run these on the benchmark machine or an equivalent machine? It should only take a few minutes to run.

I think it'd look something like this:

```bash
git remote add sporksmith https://github.com/sporksmith/shadow.git
git fetch sporksmith

# baseline 
git checkout 1cecce3701ab98f049bf6b49e28d51dbd1df2296
cargo bench  --manifest-path=src/Cargo.toml  -p vasi-sync

# after removing Reading and Writing states 
git checkout 2628adb473592324a9db49a66a538884b28167a5
cargo bench  --manifest-path=src/Cargo.toml  -p vasi-sync

# after moving sleeper bit to a separate atomic
git checkout df293781a5f8e06357afc9051997c2718c8d47e0
cargo bench  --manifest-path=src/Cargo.toml  -p vasi-sync

# after moving writer_closed bit to a separate atomic
git checkout 11050ef98876001dc8d6619e104cf197d205b039
cargo bench  --manifest-path=src/Cargo.toml  -p vasi-sync
```