### PR TITLE
Use posix_spawn instead of vfork + exec

### DIFF
--- a/src/main/utility/utility.c
+++ b/src/main/utility/utility.c
@@ -100,19 +100,3 @@ int return_code_for_signal(int signal) {
     // follow the behaviour of bash and add 128 to to the signal.
     return signal + 128;
 }
-
-void die_after_vfork() {
-    // Capture errno in a local, so that it can be examined in a stack trace.
-    int saved_errno = errno;
-
-    // Ensure our saved errno doesn't get optimized away.
-    asm volatile(/*asm=*/"" : /*outputs=*/ : /*inputs=*/"irm"(saved_errno));
-
-    // `abort` and `raise` are higher-level functions that could attempt to
-    // access global memory, which could have surprising results. We resort to a
-    // bare `kill`.
-    kill(getpid(), SIGABRT);
-
-    // Convince the compiler that we really don't return.
-    _exit(1);
-}

--- a/src/main/utility/utility.h
+++ b/src/main/utility/utility.h
@@ -103,9 +103,4 @@ _Noreturn void utility_handleError(const gchar* file, gint line, const gchar* fu
 /* If a process exited by a signal, use this return code. */
 int return_code_for_signal(int signal);
 
-/* Calling anything other than a thin syscall wrapper between `vfork` and `exec`
- can lead to confusing behavior and crashes. Use this function on errors to
- safely abort the process (with a core dump, if enabled). */
-_Noreturn void die_after_vfork();
-
 #endif /* SHD_UTILITY_H_ */


### PR DESCRIPTION
Bare vfork + exec are tricky to use, since it's easy to accidentally corrupt the parent process's state from the child process. It's also unsupported in Rust (https://github.com/rust-lang/libc/pull/1574, https://github.com/rust-lang/libc/issues/1596).

I think we could work around this in Rust by using inline assembly or a C helper function to wrap the fork and exec, but `posix_spawn` basically does that for us already.