### PR TITLE
Fix preadv/preadv2/etc offset calculation and handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ A list of user-facing changes since the latest Shadow release.
   unrelated to running Shadow in Docker following the [existing supported
   documentation](https://shadow.github.io/docs/guide/supported_platforms.html#docker),
   and we continue to support running Shadow in Docker.
+* Fixed the offset calculation in preadv/preadv2/pwritev/pwritev2 to correctly
+  handle negative offsets and large offsets.
+  https://github.com/shadow/shadow/pull/2802
 
 Raw changes since v2.4.0:
 

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -5,6 +5,7 @@
 
 #include "main/host/syscall/uio.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <sys/syscall.h>
 #include <sys/uio.h>
@@ -81,10 +82,9 @@ static SysCallReturn
 _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                             unsigned long iovlen, unsigned long pos_l,
                             unsigned long pos_h, int flags, bool doPreadv) {
-    /* Reconstruct the offset from the high and low bits */
-    pos_h = pos_h & UINT32_MAX;
-    pos_l = pos_l & UINT32_MAX;
-    off_t offset = (off_t)((pos_h << 32) | pos_l);
+    /* On Linux x86-64, an `unsigned long` is 64 bits, so we can ignore `pos_h`. */
+    static_assert(sizeof(unsigned long) == sizeof(off_t), "Unexpected `unsigned long` size");
+    off_t offset = pos_l;
 
     trace("Trying to readv from fd %d, ptr %p, size %zu, pos_l %lu, pos_h %lu, "
           "offset %ld, flags %d",
@@ -205,10 +205,9 @@ static SysCallReturn
 _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
                              unsigned long iovlen, unsigned long pos_l,
                              unsigned long pos_h, int flags, bool doPwritev) {
-    /* Reconstruct the offset from the high and low bits */
-    pos_h = pos_h & UINT32_MAX;
-    pos_l = pos_l & UINT32_MAX;
-    off_t offset = (off_t)((pos_h << 32) | pos_l);
+    /* On Linux x86-64, an `unsigned long` is 64 bits, so we can ignore `pos_h`. */
+    static_assert(sizeof(unsigned long) == sizeof(off_t), "Unexpected `unsigned long` size");
+    off_t offset = pos_l;
 
     trace("Trying to writev to fd %d, ptr %p, size %zu, pos_l %lu, pos_h %lu, "
           "offset %ld, flags %d",

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -78,17 +78,27 @@ static int _syscallhandler_validateVecParams(SysCallHandler* sys, int fd, Plugin
     return 0;
 }
 
-static SysCallReturn
-_syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
-                            unsigned long iovlen, unsigned long pos_l,
-                            unsigned long pos_h, int flags, bool doPreadv) {
+static SysCallReturn _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
+                                                 unsigned long iovlen, unsigned long pos_l,
+                                                 unsigned long pos_h, int flags, bool doPreadv,
+                                                 bool negativeOffsetDisables) {
     /* On Linux x86-64, an `unsigned long` is 64 bits, so we can ignore `pos_h`. */
     static_assert(sizeof(unsigned long) == sizeof(off_t), "Unexpected `unsigned long` size");
     off_t offset = pos_l;
 
+    /* If the offset is -1 for preadv2, disable the offset. */
+    if (offset == -1 && negativeOffsetDisables) {
+        offset = 0;
+        doPreadv = false;
+    }
+
     trace("Trying to readv from fd %d, ptr %p, size %zu, pos_l %lu, pos_h %lu, "
           "offset %ld, flags %d",
           fd, (void*)iovPtr.val, iovlen, pos_l, pos_h, offset, flags);
+
+    if (offset < 0 && doPreadv) {
+        return syscallreturn_makeDoneI64(-EINVAL);
+    }
 
     LegacyFile* desc = NULL;
     struct iovec* iov = NULL;
@@ -201,17 +211,27 @@ _syscallhandler_readvHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
     return syscallreturn_makeDoneI64(result);
 }
 
-static SysCallReturn
-_syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
-                             unsigned long iovlen, unsigned long pos_l,
-                             unsigned long pos_h, int flags, bool doPwritev) {
+static SysCallReturn _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
+                                                  unsigned long iovlen, unsigned long pos_l,
+                                                  unsigned long pos_h, int flags, bool doPwritev,
+                                                  bool negativeOffsetDisables) {
     /* On Linux x86-64, an `unsigned long` is 64 bits, so we can ignore `pos_h`. */
     static_assert(sizeof(unsigned long) == sizeof(off_t), "Unexpected `unsigned long` size");
     off_t offset = pos_l;
 
+    /* If the offset is -1 for pwritev2, disable the offset. */
+    if (offset == -1 && negativeOffsetDisables) {
+        offset = 0;
+        doPwritev = false;
+    }
+
     trace("Trying to writev to fd %d, ptr %p, size %zu, pos_l %lu, pos_h %lu, "
           "offset %ld, flags %d",
           fd, (void*)iovPtr.val, iovlen, pos_l, pos_h, offset, flags);
+
+    if (offset < 0 && doPwritev) {
+        return syscallreturn_makeDoneI64(-EINVAL);
+    }
 
     LegacyFile* desc = NULL;
     struct iovec* iov = NULL;
@@ -330,40 +350,40 @@ _syscallhandler_writevHelper(SysCallHandler* sys, int fd, PluginPtr iovPtr,
 
 SysCallReturn syscallhandler_readv(SysCallHandler* sys,
                                    const SysCallArgs* args) {
-    return _syscallhandler_readvHelper(
-        sys, args->args[0].as_i64, args->args[1].as_ptr, args->args[2].as_u64, 0, 0, 0, false);
+    return _syscallhandler_readvHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
+                                       args->args[2].as_u64, 0, 0, 0, false, false);
 }
 
 SysCallReturn syscallhandler_preadv(SysCallHandler* sys,
                                     const SysCallArgs* args) {
     return _syscallhandler_readvHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                        args->args[2].as_u64, args->args[3].as_u64,
-                                       args->args[4].as_u64, 0, true);
+                                       args->args[4].as_u64, 0, true, false);
 }
 
 SysCallReturn syscallhandler_preadv2(SysCallHandler* sys,
                                      const SysCallArgs* args) {
     return _syscallhandler_readvHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                        args->args[2].as_u64, args->args[3].as_u64,
-                                       args->args[4].as_u64, args->args[5].as_i64, true);
+                                       args->args[4].as_u64, args->args[5].as_i64, true, true);
 }
 
 SysCallReturn syscallhandler_writev(SysCallHandler* sys,
                                     const SysCallArgs* args) {
-    return _syscallhandler_writevHelper(
-        sys, args->args[0].as_i64, args->args[1].as_ptr, args->args[2].as_u64, 0, 0, 0, false);
+    return _syscallhandler_writevHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
+                                        args->args[2].as_u64, 0, 0, 0, false, false);
 }
 
 SysCallReturn syscallhandler_pwritev(SysCallHandler* sys,
                                      const SysCallArgs* args) {
     return _syscallhandler_writevHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                         args->args[2].as_u64, args->args[3].as_u64,
-                                        args->args[4].as_u64, 0, true);
+                                        args->args[4].as_u64, 0, true, false);
 }
 
 SysCallReturn syscallhandler_pwritev2(SysCallHandler* sys,
                                       const SysCallArgs* args) {
     return _syscallhandler_writevHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                         args->args[2].as_u64, args->args[3].as_u64,
-                                        args->args[4].as_u64, args->args[5].as_i64, true);
+                                        args->args[4].as_u64, args->args[5].as_i64, true, true);
 }


### PR DESCRIPTION
Shadow didn't reconstruct the offset correctly and didn't handle negative offsets.