### PR TITLE
Support `sendmsg()` and `recvmsg()` for tcp wrapper

### DIFF
--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -282,6 +282,7 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .raw_line("use crate::host::descriptor::OpenFile;")
         .raw_line("use crate::host::descriptor::socket::inet::InetSocket;")
         .raw_line("use crate::host::host::Host;")
+        .raw_line("use crate::host::memory_manager::MemoryManager;")
         .raw_line("use crate::host::process::ProcessRefCell;")
         .raw_line("use crate::host::syscall::handler::SyscallHandler;")
         .raw_line("use crate::host::syscall_types::SysCallReturnBody;")

--- a/src/main/host/descriptor/tcp.h
+++ b/src/main/host/descriptor/tcp.h
@@ -13,6 +13,7 @@
 #include <sys/un.h>
 
 #include "main/core/support/definitions.h"
+#include "main/host/syscall_types.h"
 #include "main/routing/packet.minimal.h"
 
 #define TCP_MIN_CWND 10
@@ -81,6 +82,11 @@ void tcp_disableReceiveBufferAutotuning(TCP* tcp);
 
 gboolean tcp_isValidListener(TCP* tcp);
 gboolean tcp_isListeningAllowed(TCP* tcp);
+
+gssize tcp_sendUserData(TCP* tcp, const Host* host, PluginVirtualPtr buffer, gsize nBytes,
+                        in_addr_t ip, in_port_t port, const MemoryManager* mem);
+gssize tcp_receiveUserData(TCP* tcp, const Host* host, PluginVirtualPtr buffer, gsize nBytes,
+                           in_addr_t* ip, in_port_t* port, MemoryManager* mem);
 
 gint tcp_shutdown(TCP* tcp, const Host* host, gint how);
 

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -188,10 +188,6 @@ impl SyscallHandler {
             return Err(Errno::ENOTSOCK.into());
         };
 
-        if let Socket::Inet(InetSocket::LegacyTcp(_)) = socket {
-            return Self::legacy_syscall(c::syscallhandler_sendto, ctx).map(Into::into);
-        }
-
         let mut mem = ctx.objs.process.memory_borrow_mut();
 
         let addr = read_sockaddr(&mem, addr_ptr, addr_len)?;
@@ -270,10 +266,6 @@ impl SyscallHandler {
         let File::Socket(ref socket) = file.inner_file() else {
             return Err(Errno::ENOTSOCK.into());
         };
-
-        if let Socket::Inet(InetSocket::LegacyTcp(_)) = socket {
-            return Self::legacy_syscall(c::syscallhandler_recvfrom, ctx).map(Into::into);
-        }
 
         let addr_len_ptr = TypedPluginPtr::new::<libc::socklen_t>(addr_len_ptr, 1);
 

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -9,8 +9,6 @@ use syscall_logger::log_syscall;
 use crate::cshadow as c;
 use crate::host::descriptor::pipe;
 use crate::host::descriptor::shared_buf::SharedBuf;
-use crate::host::descriptor::socket::inet::InetSocket;
-use crate::host::descriptor::socket::Socket;
 use crate::host::descriptor::{
     CompatFile, Descriptor, DescriptorFlags, File, FileMode, FileStatus, OpenFile,
 };
@@ -171,10 +169,6 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
-            return Self::legacy_syscall(c::syscallhandler_read, ctx).map(Into::into);
-        }
-
         let mut result = Self::read_helper(ctx, file.inner_file(), buf_ptr, buf_size, None);
 
         // if the syscall will block, keep the file open until the syscall restarts
@@ -223,10 +217,6 @@ impl SyscallHandler {
                 }
             }
         };
-
-        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
-            return Self::legacy_syscall(c::syscallhandler_pread64, ctx).map(Into::into);
-        }
 
         let mut result = Self::read_helper(ctx, file.inner_file(), buf_ptr, buf_size, Some(offset));
 
@@ -289,10 +279,6 @@ impl SyscallHandler {
             }
         };
 
-        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
-            return Self::legacy_syscall(c::syscallhandler_write, ctx).map(Into::into);
-        }
-
         let mut result = Self::write_helper(ctx, file.inner_file(), buf_ptr, buf_size, None);
 
         // if the syscall will block, keep the file open until the syscall restarts
@@ -342,10 +328,6 @@ impl SyscallHandler {
                 }
             }
         };
-
-        if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(_))) = file.inner_file() {
-            return Self::legacy_syscall(c::syscallhandler_pwrite64, ctx).map(Into::into);
-        }
 
         let mut result =
             Self::write_helper(ctx, file.inner_file(), buf_ptr, buf_size, Some(offset));

--- a/src/main/routing/packet.h
+++ b/src/main/routing/packet.h
@@ -44,6 +44,8 @@ const gchar* protocol_toString(ProtocolType type);
 Packet* packet_new(const Host* host);
 void packet_setPayload(Packet* packet, const Thread* thread, PluginVirtualPtr payload,
                        gsize payloadLength);
+void packet_setPayloadWithMemoryManager(Packet* packet, const Host* host, PluginVirtualPtr payload,
+                                        gsize payloadLength, const MemoryManager* mem);
 Packet* packet_copy(Packet* packet);
 
 // Exposed for unit testing only. Use `packet_new` outside of tests.
@@ -93,6 +95,9 @@ ProtocolType packet_getProtocol(const Packet* packet);
 
 gssize packet_copyPayload(const Packet* packet, const Thread* thread, gsize payloadOffset,
                           PluginVirtualPtr buffer, gsize bufferLength);
+gssize packet_copyPayloadWithMemoryManager(const Packet* packet, gsize payloadOffset,
+                                           PluginVirtualPtr buffer, gsize bufferLength,
+                                           MemoryManager* mem);
 guint packet_copyPayloadShadow(const Packet* packet, gsize payloadOffset, void* buffer,
                                gsize bufferLength);
 GList* packet_copyTCPSelectiveACKs(Packet* packet);

--- a/src/main/routing/payload.h
+++ b/src/main/routing/payload.h
@@ -15,6 +15,8 @@
 typedef struct _Payload Payload;
 
 Payload* payload_new(const Thread* thread, PluginVirtualPtr data, gsize dataLength);
+Payload* payload_newWithMemoryManager(PluginVirtualPtr data, gsize dataLength,
+                                      const MemoryManager* mem);
 
 void payload_ref(Payload* payload);
 void payload_unref(Payload* payload);
@@ -22,6 +24,8 @@ void payload_unref(Payload* payload);
 gsize payload_getLength(Payload* payload);
 gssize payload_getData(Payload* payload, const Thread* thread, gsize offset, PluginVirtualPtr destBuffer,
                        gsize destBufferLength);
+gssize payload_getDataWithMemoryManager(Payload* payload, gsize offset, PluginVirtualPtr destBuffer,
+                                        gsize destBufferLength, MemoryManager* mem);
 
 gsize payload_getDataShadow(Payload* payload, gsize offset, void* destBuffer,
                             gsize destBufferLength);


### PR DESCRIPTION
We don't limit the send/recv buffer size using `SYSCALL_IO_BUFSIZE = 10 MiB` in this new version. I don't think this is needed with the current memory manager.

I duplicated some packet-related C functions to support passing the memory manager through, but this should hopefully be cleaned up once UDP sockets are migrated to rust.

The logic generally follows the logic from `src/main/host/syscall/socket.c`.

https://github.com/shadow/shadow/blob/ec2f888138ef9d466092d027441ad8fedc6ffbc5/src/main/host/syscall/socket.c#L407-L654