### PR TITLE
Unregister threads with ChildPidWatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 A list of user-facing changes since the latest Shadow release.
 
-* item
+* Fixed a memory leak of about 16 bytes per thread due to
+failing to unregister exited threads with a watchdog thread. This is unlikely to
+have been noticeable effect in typical simulations. In particular the per-thread
+data was already getting freed when the whole process exited, so it would only
+affect a process that created and terminated many threads over its lifetime.
 
 Raw changes since v2.5.0:
 

--- a/src/main/host/managed_thread.c
+++ b/src/main/host/managed_thread.c
@@ -302,7 +302,7 @@ void managedthread_run(ManagedThread* mthread, const char* pluginPath, const cha
 
     // In Linux, the PID is equal to the TID of its first thread.
     mthread->nativeTid = mthread->nativePid;
-    childpidwatcher_watch(
+    mthread->notificationHandle = childpidwatcher_watch(
         worker_getChildPidWatcher(), mthread->nativePid, _markPluginExited, mthread->ipc_data);
 
     /* cleanup the dupd env*/
@@ -471,7 +471,7 @@ pid_t managedthread_clone(ManagedThread* child, ManagedThread* parent, unsigned 
     utility_debugAssert(child->ipc_blk.p);
     child->ipc_data = child->ipc_blk.p;
     ipcData_init(child->ipc_data);
-    childpidwatcher_watch(
+    child->notificationHandle = childpidwatcher_watch(
         worker_getChildPidWatcher(), parent->nativePid, _markPluginExited, child->ipc_data);
     ShMemBlockSerialized ipc_blk_serial = shmemallocator_globalBlockSerialize(&child->ipc_blk);
 

--- a/src/main/utility/childpid_watcher.rs
+++ b/src/main/utility/childpid_watcher.rs
@@ -322,12 +322,13 @@ impl ChildPidWatcher {
     /// guaranteed either to have already run, or to never run. i.e. it's safe to
     /// free data that the callback might otherwise access.
     ///
-    /// Panics if `pid` was never registered.
+    /// No-op if `pid` isn't registered.
     pub fn unregister_callback(&self, pid: Pid, handle: WatchHandle) {
         let mut inner = self.inner.lock().unwrap();
-        let pid_data = inner.pids.get_mut(&pid).unwrap();
-        pid_data.callbacks.remove(&handle);
-        inner.maybe_remove_pid(self.epoll, pid);
+        if let Some(pid_data) = inner.pids.get_mut(&pid) {
+            pid_data.callbacks.remove(&handle);
+            inner.maybe_remove_pid(self.epoll, pid);
+        }
     }
 }
 


### PR DESCRIPTION
We were failing to save the ChildPidWatcher notification handles, which
in turn meant we weren't unregistering threads with the ChildPidWatcher
after they exited, thus creating a resource leak. The relevant data was
still getting freed when the whole Process exited, so it would have only
affected Processes that had many threads start and end over their
lifetime.

The callback registered for each thread is only about 16 bytes - a
function pointer and a data pointer.

Additionally this fixes a bug causing a panic when we do unregister a callback for a process that's already been unregistered.