### PR TITLE
ChildPidWatcher more robust unregistration

### DIFF
--- a/src/main/utility/childpid_watcher.rs
+++ b/src/main/utility/childpid_watcher.rs
@@ -405,6 +405,11 @@ mod tests {
             );
         }
 
+        // Should be safe to unregister the pid now.
+        // We don't be able to register any more callbacks, but existing one
+        // should still work.
+        watcher.unregister_pid(child);
+
         // Child should still be alive.
         assert_eq!(
             waitpid(child, Some(WaitPidFlag::WNOHANG)).unwrap(),
@@ -470,6 +475,11 @@ mod tests {
             );
         }
 
+        // Should be safe to unregister the pid now.
+        // We don't be able to register any more callbacks, but existing one
+        // should still work.
+        watcher.unregister_pid(child);
+
         // Wait for our callback to run.
         let mut callback_ran_lock = callback_ran.0.lock().unwrap();
         while !*callback_ran_lock {
@@ -509,6 +519,11 @@ mod tests {
                 }),
             );
         }
+
+        // Should be safe to unregister the pid now.
+        // We don't be able to register any more callbacks, but existing one
+        // should still work.
+        watcher.unregister_pid(child);
 
         for cb_ran in vec![cb1_ran, cb2_ran].drain(..) {
             let mut cb_ran_lock = cb_ran.0.lock().unwrap();
@@ -559,6 +574,11 @@ mod tests {
                 )
             })
             .collect();
+
+        // Should be safe to unregister the pid now.
+        // We don't be able to register any more callbacks, but existing one
+        // should still work.
+        watcher.unregister_pid(child);
 
         watcher.unregister_callback(child, handles[0]);
 

--- a/src/main/utility/childpid_watcher.rs
+++ b/src/main/utility/childpid_watcher.rs
@@ -61,9 +61,15 @@ impl Inner {
     }
 
     fn unwatch_pid(&mut self, epoll: RawFd, pid: Pid) {
-        if let Some(fd) = self.pids.get_mut(&pid).unwrap().fd.take() {
-            epoll_ctl(epoll, EpollOp::EpollCtlDel, fd.as_raw_fd(), None).unwrap();
-        }
+        let Some(piddata) = self.pids.get_mut(&pid) else {
+            // Already unregistered the pid
+            return;
+        };
+        let Some(fd) = piddata.fd.take() else {
+            // Already unwatched the pid
+            return;
+        };
+        epoll_ctl(epoll, EpollOp::EpollCtlDel, fd.as_raw_fd(), None).unwrap();
     }
 
     fn pid_has_exited(&self, pid: Pid) -> bool {


### PR DESCRIPTION
This is an attempt to fix the crash in https://github.com/tmodel-ccs2018/tmodel-ccs2018.github.io.git

I added some testing for unregistration but wasn't able to reproduce the crash.

This *should* fix it, though.