### PR TITLE
Move misc code to rust

### DIFF
--- a/src/lib/shadow-build-common/src/lib.rs
+++ b/src/lib/shadow-build-common/src/lib.rs
@@ -126,6 +126,7 @@ impl ShadowBuildCommon {
             },
             function: cbindgen::FunctionConfig {
                 must_use: Some("__attribute__((warn_unused_result))".into()),
+                no_return: Some("__attribute__((noreturn))".into()),
                 ..cbindgen::FunctionConfig::default()
             },
             export: cbindgen::ExportConfig {

--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -218,7 +218,6 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .blocklist_function("worker_bootHosts")
         .blocklist_function("worker_freeHosts")
         .blocklist_function("syscallhandler_make_syscall")
-        .allowlist_function("return_code_for_signal")
         .allowlist_type("ForeignPtr")
         .allowlist_type("Status")
         .allowlist_type("StatusListener")

--- a/src/main/core/main.c
+++ b/src/main/core/main.c
@@ -18,14 +18,6 @@
 #include "main/bindings/c/bindings.h"
 #include "shd-config.h"
 
-bool main_sidechannelMitigationsEnabled() {
-    int state = prctl(PR_GET_SPECULATION_CTRL, PR_SPEC_STORE_BYPASS, 0, 0, 0);
-    if (state == -1) {
-        panic("prctl: %s", g_strerror(errno));
-    }
-    return (state & PR_SPEC_DISABLE) != 0;
-}
-
 int main_checkGlibVersion() {
     /* check the compiled GLib version */
     if (!GLIB_CHECK_VERSION(2, 32, 0)) {

--- a/src/main/core/main.h
+++ b/src/main/core/main.h
@@ -11,7 +11,6 @@
 
 #include "main/bindings/c/bindings.h"
 
-bool main_sidechannelMitigationsEnabled();
 int main_checkGlibVersion();
 void main_printBuildInfo(const ShadowBuildInfo* shadowBuildInfo);
 void main_logBuildInfo(const ShadowBuildInfo* shadowBuildInfo);

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -275,12 +275,12 @@ fn set_sched_fifo() -> anyhow::Result<()> {
     let mut param: libc::sched_param = unsafe { std::mem::zeroed() };
     param.sched_priority = 1;
 
-    if unsafe { libc::sched_setscheduler(0, libc::SCHED_FIFO, &param as *const _) } != 0 {
-        return Err(anyhow::anyhow!(
-            "Could not set kernel SCHED_FIFO: {}",
-            nix::errno::Errno::from_i32(nix::errno::errno()),
-        ));
-    }
+    let rv = nix::errno::Errno::result(unsafe {
+        libc::sched_setscheduler(0, libc::SCHED_FIFO, &param as *const _)
+    })
+    .context("Could not set kernel SCHED_FIFO")?;
+
+    assert_eq!(rv, 0);
 
     Ok(())
 }

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -264,6 +264,13 @@ static guint _ipPortHash(in_addr_t ip, in_port_t port) {
     return hash_value;
 }
 
+static gint _simulationTimeCompare(const CSimulationTime* value1, const CSimulationTime* value2,
+                                   gpointer userData) {
+    utility_debugAssert(value1 && value2);
+    /* return neg if first before second, pos if second before first, 0 if equal */
+    return (*value1) == (*value2) ? 0 : (*value1) < (*value2) ? -1 : +1;
+}
+
 static void _tcp_flush(TCP* tcp, const Host* host);
 
 static TCP* _tcp_fromLegacyFile(LegacyFile* descriptor) {
@@ -2809,7 +2816,7 @@ TCP* tcp_new(const Host* host, guint receiveBufferSize, guint sendBufferSize) {
     retransmit_tally_init(&tcp->retransmit.tally);
 
     tcp->retransmit.scheduledTimerExpirations =
-            priorityqueue_new((GCompareDataFunc)utility_simulationTimeCompare, NULL, g_free);
+        priorityqueue_new((GCompareDataFunc)_simulationTimeCompare, NULL, g_free);
 
     /* initialize tcp retransmission timeout */
     _tcp_setRetransmitTimeout(tcp, CONFIG_TCP_RTO_INIT);

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -256,6 +256,14 @@ static void _rswlog(const TCP *tcp, const char *format, ...) {
 #endif // RSWLOG
 }
 
+static guint _ipPortHash(in_addr_t ip, in_port_t port) {
+    GString* buffer = g_string_new(NULL);
+    g_string_printf(buffer, "%u:%u", ip, port);
+    guint hash_value = g_str_hash(buffer->str);
+    g_string_free(buffer, TRUE);
+    return hash_value;
+}
+
 static void _tcp_flush(TCP* tcp, const Host* host);
 
 static TCP* _tcp_fromLegacyFile(LegacyFile* descriptor) {
@@ -273,7 +281,7 @@ static TCPChild* _tcpchild_new(TCP* tcp, TCP* parent, int handle, in_addr_t peer
     MAGIC_INIT(child);
 
     /* my parent can find me by my key */
-    child->key = utility_ipPortHash(peerIP, peerPort);
+    child->key = _ipPortHash(peerIP, peerPort);
 
     legacyfile_ref(parent);
     child->parent = parent;
@@ -1737,7 +1745,7 @@ static TCP* _tcp_getSourceTCP(TCP* tcp, in_addr_t ip, in_port_t port) {
         MAGIC_ASSERT(tcp->server);
 
         /* children are multiplexed based on remote ip and port */
-        guint childKey = utility_ipPortHash(ip, port);
+        guint childKey = _ipPortHash(ip, port);
         TCP* tcpChild = g_hash_table_lookup(tcp->server->children, &childKey);
 
         if(tcpChild) {

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -383,6 +383,13 @@ pub fn pathbuf_to_nul_term_cstring(buf: PathBuf) -> CString {
     CString::from_vec_with_nul(bytes).unwrap()
 }
 
+/// Get the return code for a process that exited by the given signal, following the behaviour of
+/// bash.
+pub fn return_code_for_signal(signal: nix::sys::signal::Signal) -> i32 {
+    // bash adds 128 to to the signal
+    (signal as i32).checked_add(128).unwrap()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -433,26 +433,59 @@ mod tests {
 }
 
 mod export {
-    /// Get the backtrace. This function is slow. The string must be freed using `backtrace_free()`.
     #[no_mangle]
-    pub unsafe extern "C" fn backtrace() -> *mut libc::c_char {
-        let s = format!("{:?}", backtrace::Backtrace::new());
+    pub unsafe extern "C" fn utility_handleErrorInner(
+        file_name: *const libc::c_char,
+        line: libc::c_int,
+        fn_name: *const libc::c_char,
+        format: *const libc::c_char,
+        va_list: *mut libc::c_void,
+    ) -> ! {
+        use std::ffi::CStr;
+        let file_name = unsafe { CStr::from_ptr(file_name) };
+        let file_name = file_name.to_bytes().escape_ascii();
 
-        // add a tab at the start of every line
-        let s = s
+        let fn_name = unsafe { CStr::from_ptr(fn_name) };
+        let fn_name = fn_name.to_bytes().escape_ascii();
+
+        log::logger().flush();
+
+        let indent = "    ";
+
+        // add four spaces at the start of every line
+        let backtrace = format!("{:?}", backtrace::Backtrace::new());
+        let backtrace = backtrace
             .trim_end()
             .split('\n')
-            .map(|x| format!("\t{}", x))
+            .map(|x| format!("{indent}{x}"))
             .collect::<Vec<String>>()
             .join("\n");
 
-        let s = std::ffi::CString::new(s).unwrap();
-        s.into_raw()
-    }
+        let pid = nix::unistd::getpid();
+        let ppid = nix::unistd::getppid();
 
-    #[no_mangle]
-    pub unsafe extern "C" fn backtrace_free(backtrace: *mut libc::c_char) {
-        assert!(!backtrace.is_null());
-        unsafe { std::ffi::CString::from_raw(backtrace) };
+        let error_msg = unsafe { vsprintf::vsprintf_raw(format, va_list).unwrap() };
+        let error_msg = error_msg.escape_ascii();
+
+        let error_msg = format!(
+            "**ERROR ENCOUNTERED**\n\
+              {indent}At process: {pid} (parent {ppid})\n\
+              {indent}At file: {file_name}\n\
+              {indent}At line: {line}\n\
+              {indent}At function: {fn_name}\n\
+              {indent}Message: {error_msg}\n\
+            **BEGIN BACKTRACE**\n\
+            {backtrace}\n\
+            **END BACKTRACE**\n\
+            **ABORTING**"
+        );
+
+        if !nix::unistd::isatty(libc::STDOUT_FILENO).unwrap_or(true) {
+            println!("{error_msg}");
+        }
+
+        eprintln!("{error_msg}");
+
+        std::process::abort()
     }
 }

--- a/src/main/utility/utility.c
+++ b/src/main/utility/utility.c
@@ -18,13 +18,6 @@
 #include "main/bindings/c/bindings.h"
 #include "main/utility/utility.h"
 
-gint utility_simulationTimeCompare(const CSimulationTime* value1, const CSimulationTime* value2,
-                                   gpointer userData) {
-    utility_debugAssert(value1 && value2);
-    /* return neg if first before second, pos if second before first, 0 if equal */
-    return (*value1) == (*value2) ? 0 : (*value1) < (*value2) ? -1 : +1;
-}
-
 static GString* _utility_formatError(const gchar* file, gint line, const gchar* function,
                                      const gchar* message, va_list vargs) {
     GString* errorString = g_string_new("**ERROR ENCOUNTERED**\n");

--- a/src/main/utility/utility.c
+++ b/src/main/utility/utility.c
@@ -94,9 +94,3 @@ gchar* utility_strvToNewStr(gchar** strv) {
 
     return g_string_free(strBuffer, FALSE);
 }
-
-int return_code_for_signal(int signal) {
-    // To calculate the return code if the process exited by a signal,
-    // follow the behaviour of bash and add 128 to to the signal.
-    return signal + 128;
-}

--- a/src/main/utility/utility.c
+++ b/src/main/utility/utility.c
@@ -18,40 +18,12 @@
 #include "main/bindings/c/bindings.h"
 #include "main/utility/utility.h"
 
-static GString* _utility_formatError(const gchar* file, gint line, const gchar* function,
-                                     const gchar* message, va_list vargs) {
-    GString* errorString = g_string_new("**ERROR ENCOUNTERED**\n");
-    g_string_append_printf(errorString, "\tAt process: %i (parent %i)\n", (gint) getpid(), (gint) getppid());
-    g_string_append_printf(errorString, "\tAt file: %s\n", file);
-    g_string_append_printf(errorString, "\tAt line: %i\n", line);
-    g_string_append_printf(errorString, "\tAt function: %s\n", function);
-    g_string_append_printf(errorString, "\tMessage: ");
-    g_string_append_vprintf(errorString, message, vargs);
-    g_string_append_printf(errorString, "\n");
-    return errorString;
-}
-
 void utility_handleError(const gchar* file, gint line, const gchar* function, const gchar* message,
                          ...) {
-    logger_flush(logger_getDefault());
-
     va_list vargs;
     va_start(vargs, message);
-    GString* errorString = _utility_formatError(file, line, function, message, vargs);
+    utility_handleErrorInner(file, line, function, message, vargs);
     va_end(vargs);
-
-    char* backtraceString = backtrace();
-
-    if (!isatty(fileno(stdout))) {
-        g_print("%s**BEGIN BACKTRACE**\n%s\n**END BACKTRACE**\n**ABORTING**\n", errorString->str,
-                backtraceString);
-    }
-    g_printerr("%s**BEGIN BACKTRACE**\n%s\n**END BACKTRACE**\n**ABORTING**\n", errorString->str,
-               backtraceString);
-
-    g_string_free(errorString, TRUE);
-    backtrace_free(backtraceString);
-    abort();
 }
 
 gboolean utility_isRandomPath(const gchar* path) {

--- a/src/main/utility/utility.c
+++ b/src/main/utility/utility.c
@@ -18,14 +18,6 @@
 #include "main/bindings/c/bindings.h"
 #include "main/utility/utility.h"
 
-guint utility_ipPortHash(in_addr_t ip, in_port_t port) {
-    GString* buffer = g_string_new(NULL);
-    g_string_printf(buffer, "%u:%u", ip, port);
-    guint hash_value = g_str_hash(buffer->str);
-    g_string_free(buffer, TRUE);
-    return hash_value;
-}
-
 gint utility_simulationTimeCompare(const CSimulationTime* value1, const CSimulationTime* value2,
                                    gpointer userData) {
     utility_debugAssert(value1 && value2);

--- a/src/main/utility/utility.h
+++ b/src/main/utility/utility.h
@@ -89,7 +89,6 @@
 #define MAGIC_CLEAR(object)
 #endif
 
-guint utility_ipPortHash(in_addr_t ip, in_port_t port);
 gint utility_simulationTimeCompare(const CSimulationTime* value1, const CSimulationTime* value2,
                                    gpointer userData);
 gboolean utility_isRandomPath(const gchar* path);

--- a/src/main/utility/utility.h
+++ b/src/main/utility/utility.h
@@ -100,7 +100,4 @@ __attribute__((__format__(__printf__, 4, 5)))
 _Noreturn void utility_handleError(const gchar* file, gint line, const gchar* funtcion,
                                    const gchar* message, ...);
 
-/* If a process exited by a signal, use this return code. */
-int return_code_for_signal(int signal);
-
 #endif /* SHD_UTILITY_H_ */

--- a/src/main/utility/utility.h
+++ b/src/main/utility/utility.h
@@ -89,8 +89,6 @@
 #define MAGIC_CLEAR(object)
 #endif
 
-gint utility_simulationTimeCompare(const CSimulationTime* value1, const CSimulationTime* value2,
-                                   gpointer userData);
 gboolean utility_isRandomPath(const gchar* path);
 
 gchar* utility_strvToNewStr(gchar** strv);


### PR DESCRIPTION
Also moves some utility functions to `tcp.c` since they're only ever called from there.