### PR TITLE
Do not implicitly search current directory for executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ affect a process that created and terminated many threads over its lifetime.
 * Removed deprecated python scripts that only worked on Shadow 1.x config files
 and topologies.
 
+* Shadow no longer implicitly searches its working directory for executables
+to be run under the simulation. If you wish to specify a path relative to
+Shadow's working directory, prefix that path with `./`.
+
 Raw changes since v2.5.0:
 
 * [Merged PRs](https://github.com/shadow/shadow/pulls?q=is%3Apr+merged%3A%3E2023-03-23T18%3A20-0400)

--- a/src/main/core/sim_config.rs
+++ b/src/main/core/sim_config.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Context;
-use log::warn;
 use rand::{Rng, SeedableRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
@@ -339,38 +338,14 @@ fn build_process(proc: &ProcessOptions) -> anyhow::Result<Vec<ProcessInfo>> {
 
     // We currently use `which::which`, which searches the `PATH` similarly to a
     // shell.
-    let new_canonical_path: Result<PathBuf, anyhow::Error> = which::which(&expanded_path)
+    let canonical_path: PathBuf = which::which(&expanded_path)
         .map_err(anyhow::Error::from)
         // `which` returns an absolute path, but it may still contain
         // symbolic links, .., etc.
-        .and_then(|p| p.canonicalize().map_err(anyhow::Error::from));
-    // We previously used only `std::fs::canonicalize`, which doesn't search
-    // `PATH`, and *does* search the current directory.
-    let legacy_canonical_path: Result<PathBuf, anyhow::Error> =
-        expanded_path.canonicalize().map_err(anyhow::Error::from);
+        .and_then(|p| Ok(p.canonicalize()?))
+        .with_context(|| format!("Failed to resolve plugin path '{:?}'", expanded_path))?;
 
-    let canonical_path = if new_canonical_path.is_ok()
-        && legacy_canonical_path.is_ok()
-        && *new_canonical_path.as_ref().unwrap() != *legacy_canonical_path.as_ref().unwrap()
-    {
-        warn!("Ambiguous path: {:?} resolves to either {:?} or {:?}. Using {:?} for backards compatibility, but a future version of shadow will not implicitly search the current working directory. Consider making absolute or prefixing with './'",
-            expanded_path,
-            legacy_canonical_path.as_ref().unwrap(),
-            new_canonical_path.as_ref().unwrap(),
-            legacy_canonical_path.as_ref().unwrap());
-        legacy_canonical_path.as_ref().unwrap()
-    } else if let Ok(p) = new_canonical_path.as_ref() {
-        p
-    } else if let Ok(p) = legacy_canonical_path.as_ref() {
-        warn!("Expanded path {:?} only via legacy fallback search, which implicitly searched current working dir. Consider prefixing with './'", proc.path.to_str().unwrap());
-        p
-    } else {
-        return Err(new_canonical_path
-            .with_context(|| format!("Failed to resolve plugin path '{:?}'", expanded_path))
-            .unwrap_err());
-    };
-
-    verify_plugin_path(canonical_path)
+    verify_plugin_path(&canonical_path)
         .with_context(|| format!("Failed to verify plugin path '{:?}'", canonical_path))?;
     log::info!(
         "Resolved binary path {:?} to {:?}",
@@ -383,7 +358,7 @@ fn build_process(proc: &ProcessOptions) -> anyhow::Result<Vec<ProcessInfo>> {
 
     Ok(vec![
         ProcessInfo {
-            plugin: canonical_path.clone(),
+            plugin: canonical_path,
             start_time,
             stop_time,
             args,

--- a/src/test/bindc/bindc.yaml
+++ b/src/test/bindc/bindc.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: test-bind
+    - path: ./test-bind
       start_time: 1

--- a/src/test/config/read_from_stdin/config-stdin.yaml
+++ b/src/test/config/read_from_stdin/config-stdin.yaml
@@ -7,5 +7,5 @@ hosts:
   testclient:
     network_node_id: 0
     processes:
-    - path: test-config-read-from-stdin
+    - path: ./test-config-read-from-stdin
       start_time: 1

--- a/src/test/cpp/cpp.yaml
+++ b/src/test/cpp/cpp.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: test-cpp
+    - path: ./test-cpp
       start_time: 1

--- a/src/test/determinism/determinism1.test.shadow.config.yaml
+++ b/src/test/determinism/determinism1.test.shadow.config.yaml
@@ -25,5 +25,5 @@ hosts:
     network_node_id: 0
     quantity: 10
     processes:
-    - path: test-determinism
+    - path: ./test-determinism
       start_time: 1

--- a/src/test/epoll/epoll-writeable.yaml
+++ b/src/test/epoll/epoll-writeable.yaml
@@ -7,12 +7,12 @@ hosts:
   server:
     network_node_id: 0
     processes:
-    - path: test-epoll-writeable
+    - path: ./test-epoll-writeable
       args: server_mode
       start_time: 1
   client:
     network_node_id: 0
     processes:
-    - path: test-epoll-writeable
+    - path: ./test-epoll-writeable
       args: client_mode
       start_time: 10

--- a/src/test/epoll/epoll.yaml
+++ b/src/test/epoll/epoll.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: test-epoll
+    - path: ./test-epoll
       start_time: 1

--- a/src/test/file/file.yaml
+++ b/src/test/file/file.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: test-file
+    - path: ./test-file
       start_time: 1

--- a/src/test/futex/futex.yaml
+++ b/src/test/futex/futex.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: test-futex
+    - path: ./test-futex
       start_time: 1

--- a/src/test/golang/simple_http.yaml
+++ b/src/test/golang/simple_http.yaml
@@ -9,7 +9,7 @@ hosts:
   server:
     network_node_id: 0
     processes:
-    - path: test_simple_http
+    - path: ./test_simple_http
       start_time: 3s
   client:
     network_node_id: 0

--- a/src/test/phold/phold.yaml
+++ b/src/test/phold/phold.yaml
@@ -23,7 +23,7 @@ hosts:
     network_node_id: 0
     quantity: 10
     processes:
-    - path: test-phold
+    - path: ./test-phold
       args: loglevel=info basename=peer quantity=10 msgload=1 cpuload=1 size=1
         weightsfilepath=../../../weights.txt runtime=5
       start_time: 1

--- a/src/test/resolver/getaddrinfo.yaml
+++ b/src/test/resolver/getaddrinfo.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: test-getaddrinfo
+    - path: ./test-getaddrinfo
       start_time: 1

--- a/src/test/signal/signal.yaml
+++ b/src/test/signal/signal.yaml
@@ -8,5 +8,5 @@ hosts:
     network_node_id: 0
     quantity: 3
     processes:
-    - path: test-signal
+    - path: ./test-signal
       start_time: 1

--- a/src/test/sockbuf/sockbuf.yaml
+++ b/src/test/sockbuf/sockbuf.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: test-sockbuf
+    - path: ./test-sockbuf
       start_time: 1

--- a/src/test/tcp/tcp-blocking-loopback.yaml
+++ b/src/test/tcp/tcp-blocking-loopback.yaml
@@ -22,9 +22,9 @@ hosts:
   tcptestnode:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: blocking server localhost 1234
       start_time: 1
-    - path: test-tcp
+    - path: ./test-tcp
       args: blocking client localhost 1234
       start_time: 2

--- a/src/test/tcp/tcp-blocking-lossless.yaml
+++ b/src/test/tcp/tcp-blocking-lossless.yaml
@@ -22,12 +22,12 @@ hosts:
   lossless.tcpserver.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: blocking server 0.0.0.0 1234
       start_time: 1
   lossless.tcpclient.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: blocking client lossless.tcpserver.echo 1234
       start_time: 2

--- a/src/test/tcp/tcp-blocking-lossy.yaml
+++ b/src/test/tcp/tcp-blocking-lossy.yaml
@@ -22,12 +22,12 @@ hosts:
   lossy.tcpserver.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: blocking server 0.0.0.0 1234
       start_time: 1
   lossy.tcpclient.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: blocking client lossy.tcpserver.echo 1234
       start_time: 2

--- a/src/test/tcp/tcp-iov-loopback.yaml
+++ b/src/test/tcp/tcp-iov-loopback.yaml
@@ -22,9 +22,9 @@ hosts:
   tcptestnode:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: iov server localhost 1234
       start_time: 1
-    - path: test-tcp
+    - path: ./test-tcp
       args: iov client localhost 1234
       start_time: 2

--- a/src/test/tcp/tcp-iov-lossless.yaml
+++ b/src/test/tcp/tcp-iov-lossless.yaml
@@ -22,12 +22,12 @@ hosts:
   lossless.tcpserver.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: iov server 0.0.0.0 1234
       start_time: 1
   lossless.tcpclient.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: iov client lossless.tcpserver.echo 1234
       start_time: 2

--- a/src/test/tcp/tcp-iov-lossy.yaml
+++ b/src/test/tcp/tcp-iov-lossy.yaml
@@ -22,12 +22,12 @@ hosts:
   lossy.tcpserver.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: iov server 0.0.0.0 1234
       start_time: 1
   lossy.tcpclient.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: iov client lossy.tcpserver.echo 1234
       start_time: 2

--- a/src/test/tcp/tcp-nonblocking-epoll-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-loopback.yaml
@@ -22,9 +22,9 @@ hosts:
   tcptestnode:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-epoll server localhost 1234
       start_time: 1
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-epoll client localhost 1234
       start_time: 2

--- a/src/test/tcp/tcp-nonblocking-epoll-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-lossless.yaml
@@ -22,12 +22,12 @@ hosts:
   lossless.tcpserver.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-epoll server 0.0.0.0 1234
       start_time: 1
   lossless.tcpclient.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-epoll client lossless.tcpserver.echo 1234
       start_time: 2

--- a/src/test/tcp/tcp-nonblocking-epoll-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-epoll-lossy.yaml
@@ -22,12 +22,12 @@ hosts:
   lossy.tcpserver.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-epoll server 0.0.0.0 1234
       start_time: 1
   lossy.tcpclient.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-epoll client lossy.tcpserver.echo 1234
       start_time: 2

--- a/src/test/tcp/tcp-nonblocking-poll-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-loopback.yaml
@@ -22,9 +22,9 @@ hosts:
   tcptestnode:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-poll server localhost 1234
       start_time: 1
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-poll client localhost 1234
       start_time: 2

--- a/src/test/tcp/tcp-nonblocking-poll-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-lossless.yaml
@@ -22,12 +22,12 @@ hosts:
   lossless.tcpserver.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-poll server 0.0.0.0 1234
       start_time: 1
   lossless.tcpclient.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-poll client lossless.tcpserver.echo 1234
       start_time: 2

--- a/src/test/tcp/tcp-nonblocking-poll-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-poll-lossy.yaml
@@ -22,12 +22,12 @@ hosts:
   lossy.tcpserver.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-poll server 0.0.0.0 1234
       start_time: 1
   lossy.tcpclient.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-poll client lossy.tcpserver.echo 1234
       start_time: 2

--- a/src/test/tcp/tcp-nonblocking-select-loopback.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-loopback.yaml
@@ -22,9 +22,9 @@ hosts:
   tcptestnode:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-select server localhost 1234
       start_time: 1
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-select client localhost 1234
       start_time: 2

--- a/src/test/tcp/tcp-nonblocking-select-lossless.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-lossless.yaml
@@ -22,12 +22,12 @@ hosts:
   lossless.tcpserver.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-select server 0.0.0.0 1234
       start_time: 1
   lossless.tcpclient.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-select client lossless.tcpserver.echo 1234
       start_time: 2

--- a/src/test/tcp/tcp-nonblocking-select-lossy.yaml
+++ b/src/test/tcp/tcp-nonblocking-select-lossy.yaml
@@ -22,12 +22,12 @@ hosts:
   lossy.tcpserver.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-select server 0.0.0.0 1234
       start_time: 1
   lossy.tcpclient.echo:
     network_node_id: 0
     processes:
-    - path: test-tcp
+    - path: ./test-tcp
       args: nonblocking-select client lossy.tcpserver.echo 1234
       start_time: 2

--- a/src/test/timerfd/timerfd.yaml
+++ b/src/test/timerfd/timerfd.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: test-timerfd
+    - path: ./test-timerfd
       start_time: 1

--- a/src/test/udp/udp-uniprocess.yaml
+++ b/src/test/udp/udp-uniprocess.yaml
@@ -7,5 +7,5 @@ hosts:
   node1:
     network_node_id: 0
     processes:
-    - path: test-udp-uniprocess
+    - path: ./test-udp-uniprocess
       start_time: 1

--- a/src/test/udp/udp.yaml
+++ b/src/test/udp/udp.yaml
@@ -7,21 +7,21 @@ hosts:
   localnode:
     network_node_id: 0
     processes:
-    - path: test-udp
+    - path: ./test-udp
       args: client localhost:5678
       start_time: 1
-    - path: test-udp
+    - path: ./test-udp
       args: server localhost:5678
       start_time: 1
   testclient:
     network_node_id: 0
     processes:
-    - path: test-udp
+    - path: ./test-udp
       args: client testserver:5678
       start_time: 2
   testserver:
     network_node_id: 0
     processes:
-    - path: test-udp
+    - path: ./test-udp
       args: server 0.0.0.0:5678
       start_time: 2


### PR DESCRIPTION
This is a planned breaking change for the Shadow 3.0 release. See https://github.com/shadow/shadow/discussions/2496 and https://github.com/shadow/shadow/pull/2447#issuecomment-1271551435.

This forces users to explicitly use "./" to specify a binary in the current directory.