### PR TITLE
Fix some incorrect buffer sizes in the memory manager

### DIFF
--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -228,7 +228,7 @@ impl<'a, T: Debug + Pod> ProcessMemoryRefMut<'a, T> {
             CopiedOrMappedMut::Copied(copier, ptr, v) => {
                 trace!(
                     "Flushing {} bytes to {:x}",
-                    ptr.len(),
+                    ptr.len() * std::mem::size_of::<T>(),
                     usize::from(ptr.ptr())
                 );
                 unsafe { copier.copy_to_ptr(*ptr, v)? };
@@ -729,7 +729,11 @@ where
     pub fn free(mut self, ctx: &mut ThreadContext) {
         ctx.process
             .memory_borrow_mut()
-            .do_munmap(ctx, self.ptr.ptr(), self.ptr.len())
+            .do_munmap(
+                ctx,
+                self.ptr.ptr(),
+                self.ptr.len() * std::mem::size_of::<T>(),
+            )
             .unwrap();
         self.freed = true;
     }


### PR DESCRIPTION
One fix is in a log statement, and the other is in `AllocdMem` which we only ever use as an `AllocdMem<u8>`, so neither of these currently cause incorrect behaviour.