### PR TITLE
Split CHANGELOG by semver-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
-A list of user-facing changes since the latest Shadow release.
+A list of changes since the latest Shadow release.
 
-* Fixed a memory leak of about 16 bytes per thread due to
-failing to unregister exited threads with a watchdog thread. This is unlikely to
-have been noticeable effect in typical simulations. In particular the per-thread
-data was already getting freed when the whole process exited, so it would only
-affect a process that created and terminated many threads over its lifetime.
+MAJOR changes (breaking):
 
 * Removed deprecated python scripts that only worked on Shadow 1.x config files
 and topologies.
@@ -12,6 +8,18 @@ and topologies.
 * Shadow no longer implicitly searches its working directory for executables
 to be run under the simulation. If you wish to specify a path relative to
 Shadow's working directory, prefix that path with `./`.
+
+MINOR changes (backwards-compatible):
+
+*
+
+PATCH changes (bugfixes):
+
+* Fixed a memory leak of about 16 bytes per thread due to
+failing to unregister exited threads with a watchdog thread. This is unlikely to
+have been noticeable effect in typical simulations. In particular the per-thread
+data was already getting freed when the whole process exited, so it would only
+affect a process that created and terminated many threads over its lifetime.
 
 Raw changes since v2.5.0:
 


### PR DESCRIPTION
In particular the next release will have a number of breaking changes; it'd probably be useful to have those highlighted and separate from smaller changes. Similarly I think it'd generally be useful to split along `MINOR` and `PATCH` lines.

I think we can still omit changes that should be completely invisible to users (e.g. refactors, conversions to Rust, etc)