### PR TITLE
Simplify memory manager `read_vals`

### DIFF
--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -1073,8 +1073,7 @@ impl LegacyTcpSocket {
                 }
 
                 let optval_ptr = optval_ptr.cast::<OptType>();
-                let optval_ptr = ForeignArrayPtr::new(optval_ptr, 1);
-                let enable = memory_manager.read_vals::<_, 1>(optval_ptr)?[0];
+                let enable = memory_manager.read(optval_ptr)?;
 
                 if enable != 0 {
                     // wants to enable TCP_NODELAY
@@ -1123,8 +1122,8 @@ impl LegacyTcpSocket {
                 }
 
                 let optval_ptr = optval_ptr.cast::<OptType>();
-                let optval_ptr = ForeignArrayPtr::new(optval_ptr, 1);
-                let val: u64 = memory_manager.read_vals::<_, 1>(optval_ptr)?[0]
+                let val: u64 = memory_manager
+                    .read(optval_ptr)?
                     .try_into()
                     .or(Err(Errno::EINVAL))?;
 
@@ -1152,8 +1151,8 @@ impl LegacyTcpSocket {
                 }
 
                 let optval_ptr = optval_ptr.cast::<OptType>();
-                let optval_ptr = ForeignArrayPtr::new(optval_ptr, 1);
-                let val: u64 = memory_manager.read_vals::<_, 1>(optval_ptr)?[0]
+                let val: u64 = memory_manager
+                    .read(optval_ptr)?
                     .try_into()
                     .or(Err(Errno::EINVAL))?;
 

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -1001,8 +1001,7 @@ impl SyscallHandler {
         let mut mem = ctx.objs.process.memory_borrow_mut();
 
         // get the provided optlen
-        let optlen_ptr = ForeignArrayPtr::new(optlen_ptr, 1);
-        let optlen = mem.read_vals::<_, 1>(optlen_ptr)?[0];
+        let optlen = mem.read(optlen_ptr)?;
 
         let mut optlen_new = socket
             .borrow()
@@ -1019,6 +1018,7 @@ impl SyscallHandler {
         }
 
         // write the new optlen back to the plugin
+        let optlen_ptr = ForeignArrayPtr::new(optlen_ptr, 1);
         mem.copy_to_ptr(optlen_ptr, &[optlen_new])?;
 
         Ok(0.into())

--- a/src/main/host/syscall/handler/time.rs
+++ b/src/main/host/syscall/handler/time.rs
@@ -50,7 +50,6 @@ impl SyscallHandler {
         new_value_ptr: ForeignPtr<libc::itimerval>,
         old_value_ptr: ForeignPtr<libc::itimerval>,
     ) -> SyscallResult {
-        let new_value_ptr = ForeignArrayPtr::new(new_value_ptr, 1);
         let old_value_ptr = ForeignArrayPtr::new(old_value_ptr, 1);
 
         if which != libc::ITIMER_REAL {
@@ -66,11 +65,7 @@ impl SyscallHandler {
                 .copy_to_ptr(old_value_ptr, &[itimerval])?;
         }
 
-        let new_value = ctx
-            .objs
-            .process
-            .memory_borrow()
-            .read_vals::<_, 1>(new_value_ptr)?[0];
+        let new_value = ctx.objs.process.memory_borrow().read(new_value_ptr)?;
         let new_value_value =
             SimulationTime::try_from(new_value.it_value).map_err(|_| Errno::EINVAL)?;
         let new_value_interval =

--- a/src/main/utility/pod.rs
+++ b/src/main/utility/pod.rs
@@ -104,6 +104,7 @@ unsafe impl Pod for usize {}
 // impl !Pod for char {}
 
 unsafe impl<T> Pod for std::mem::MaybeUninit<T> where T: Pod {}
+unsafe impl<T, const N: usize> Pod for [T; N] where T: Pod {}
 
 // libc types
 unsafe impl Pod for libc::Dl_info {}


### PR DESCRIPTION
This also renames it to `read` and removes the UB from the `MaybeUninit::uninit().assume_init()` (part of #2555).