### PR TITLE
Add a `write` method to the memory manager

### DIFF
--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -534,8 +534,7 @@ impl LegacyTcpSocket {
                     .unwrap();
 
                 let arg_ptr = arg_ptr.cast::<libc::c_int>();
-                let arg_ptr = ForeignArrayPtr::new(arg_ptr, 1);
-                memory_manager.copy_to_ptr(arg_ptr, &[len])?;
+                memory_manager.write(arg_ptr, &len)?;
 
                 Ok(0.into())
             }
@@ -546,8 +545,7 @@ impl LegacyTcpSocket {
                     .unwrap();
 
                 let arg_ptr = arg_ptr.cast::<libc::c_int>();
-                let arg_ptr = ForeignArrayPtr::new(arg_ptr, 1);
-                memory_manager.copy_to_ptr(arg_ptr, &[len])?;
+                memory_manager.write(arg_ptr, &len)?;
 
                 Ok(0.into())
             }
@@ -557,8 +555,7 @@ impl LegacyTcpSocket {
                     .unwrap();
 
                 let arg_ptr = arg_ptr.cast::<libc::c_int>();
-                let arg_ptr = ForeignArrayPtr::new(arg_ptr, 1);
-                memory_manager.copy_to_ptr(arg_ptr, &[len])?;
+                memory_manager.write(arg_ptr, &len)?;
 
                 Ok(0.into())
             }

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -413,14 +413,28 @@ impl MemoryManager {
     ///
     /// Examples:
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use shadow_shim_helper_rs::syscall_types::ForeignPtr;
+    /// # use shadow_rs::host::memory_manager::MemoryManager;
+    /// # use nix::errno::Errno;
+    /// # fn foo() -> Result<(), Errno> {
+    /// # let memory_manager: MemoryManager = todo!();
     /// let ptr: ForeignPtr<u32> = todo!();
     /// let val: u32 = memory_manager.read(ptr)?;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use shadow_shim_helper_rs::syscall_types::ForeignPtr;
+    /// # use shadow_rs::host::memory_manager::MemoryManager;
+    /// # use nix::errno::Errno;
+    /// # fn foo() -> Result<(), Errno> {
+    /// # let memory_manager: MemoryManager = todo!();
     /// let ptr: ForeignPtr<[u32; 2]> = todo!();
     /// let val: [u32; 2] = memory_manager.read(ptr)?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn read<T: Pod + Debug>(&self, ptr: ForeignPtr<T>) -> Result<T, Errno> {
         let ptr = ptr.cast::<MaybeUninit<T>>();
@@ -433,10 +447,17 @@ impl MemoryManager {
 
     /// Writes a local value `val` into the memory at `ptr`.
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use shadow_shim_helper_rs::syscall_types::ForeignPtr;
+    /// # use shadow_rs::host::memory_manager::MemoryManager;
+    /// # use nix::errno::Errno;
+    /// # fn foo() -> Result<(), Errno> {
+    /// # let mut memory_manager: MemoryManager = todo!();
     /// let ptr: ForeignPtr<u32> = todo!();
     /// let val = 5;
     /// memory_manager.write(ptr, &val)?;
+    /// # Ok(())
+    /// # }
     /// ```
     // take a `&T` rather than a `T` since all `Pod` types are `Copy`, and it's probably more
     // performant to accept a reference than copying the type here if `T` is large

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -431,6 +431,19 @@ impl MemoryManager {
         Ok(unsafe { res.assume_init() })
     }
 
+    /// Writes a local value `val` into the memory at `ptr`.
+    ///
+    /// ```ignore
+    /// let ptr: ForeignPtr<u32> = todo!();
+    /// let val = 5;
+    /// memory_manager.write(ptr, &val)?;
+    /// ```
+    // take a `&T` rather than a `T` since all `Pod` types are `Copy`, and it's probably more
+    // performant to accept a reference than copying the type here if `T` is large
+    pub fn write<T: Pod + Debug>(&mut self, ptr: ForeignPtr<T>, val: &T) -> Result<(), Errno> {
+        self.copy_to_ptr(ForeignArrayPtr::new(ptr, 1), std::slice::from_ref(val))
+    }
+
     /// Similar to `read`, but saves a copy if you already have a `dst` to copy the data into.
     pub fn copy_from_ptr<T: Debug + Pod>(
         &self,

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -941,10 +941,8 @@ impl Process {
                 // Check again
             }
 
-            let typed_clear_child_tid_pvp =
-                ForeignArrayPtr::new(clear_child_tid_pvp.cast::<libc::pid_t>(), 1);
             self.memory_borrow_mut()
-                .copy_to_ptr(typed_clear_child_tid_pvp, &[0])
+                .write(clear_child_tid_pvp.cast::<libc::pid_t>(), &0)
                 .unwrap();
 
             // Wake the corresponding futex.

--- a/src/main/host/syscall/handler/sysinfo.rs
+++ b/src/main/host/syscall/handler/sysinfo.rs
@@ -4,15 +4,12 @@ use syscall_logger::log_syscall;
 
 use crate::core::worker::Worker;
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
-use crate::host::syscall_types::{ForeignArrayPtr, SyscallResult};
+use crate::host::syscall_types::SyscallResult;
 use crate::utility::pod;
 
 impl SyscallHandler {
     #[log_syscall(/* rv */ libc::c_int, /* info */ *const libc::sysinfo)]
     pub fn sysinfo(ctx: &mut SyscallContext, info_ptr: ForeignPtr<libc::sysinfo>) -> SyscallResult {
-        // Pointer to the plugin memory where we write the result.
-        let info_ptr = ForeignArrayPtr::new(info_ptr, 1);
-
         // Seconds are needed for uptime.
         let seconds = Worker::current_time()
             .unwrap()
@@ -45,7 +42,7 @@ impl SyscallHandler {
         ctx.objs
             .process
             .memory_borrow_mut()
-            .copy_to_ptr(info_ptr, &[info])?;
+            .write(info_ptr, &info)?;
         Ok(0.into())
     }
 }

--- a/src/main/host/syscall/io.rs
+++ b/src/main/host/syscall/io.rs
@@ -20,12 +20,12 @@ pub fn write_sockaddr_and_len(
     mem: &mut MemoryManager,
     addr: Option<&SockaddrStorage>,
     plugin_addr: ForeignPtr<u8>,
-    plugin_addr_len: ForeignArrayPtr<libc::socklen_t>,
+    plugin_addr_len: ForeignPtr<libc::socklen_t>,
 ) -> Result<(), SyscallError> {
     let addr = match addr {
         Some(x) => x,
         None => {
-            mem.copy_to_ptr(plugin_addr_len, &[0])?;
+            mem.write(plugin_addr_len, &0)?;
             return Ok(());
         }
     };
@@ -35,7 +35,7 @@ pub fn write_sockaddr_and_len(
 
     // get the provided address buffer length, and overwrite it with the real address length
     let plugin_addr_len = {
-        let mut plugin_addr_len = mem.memory_ref_mut(plugin_addr_len)?;
+        let mut plugin_addr_len = mem.memory_ref_mut(ForeignArrayPtr::new(plugin_addr_len, 1))?;
         let plugin_addr_len_value = plugin_addr_len.get_mut(0).unwrap();
 
         // keep a copy before we change it


### PR DESCRIPTION
This is similar to the existing `read` method, and I think it is a little nicer to use than `copy_to_ptr` in simpler cases.

(Also I'm not sure that the pid address write in `reap_thread()` is correct since I think it's supposed to write a pointer, not a `pid_t`, but for now I'm leaving this the same as it was before.)