### PR TITLE
Change definition of `io::write_partial`

### DIFF
--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -917,12 +917,9 @@ impl LegacyTcpSocket {
                 let mut info = pod::zeroed();
                 unsafe { c::tcp_getInfo(self.as_legacy_tcp(), &mut info) };
 
-                let bytes_written = write_partial::<crate::cshadow::tcp_info>(
-                    memory_manager,
-                    &info,
-                    optval_ptr.cast::<u8>(),
-                    optlen as usize,
-                )?;
+                let optval_ptr = optval_ptr.cast::<crate::cshadow::tcp_info>();
+                let bytes_written =
+                    write_partial(memory_manager, &info, optval_ptr, optlen as usize)?;
 
                 Ok(bytes_written as libc::socklen_t)
             }
@@ -931,12 +928,9 @@ impl LegacyTcpSocket {
                 // TCP_NODELAY is enabled
                 let val = 1;
 
-                let bytes_written = write_partial::<libc::c_int>(
-                    memory_manager,
-                    &val,
-                    optval_ptr.cast::<u8>(),
-                    optlen as usize,
-                )?;
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written =
+                    write_partial(memory_manager, &val, optval_ptr, optlen as usize)?;
 
                 Ok(bytes_written as libc::socklen_t)
             }
@@ -974,12 +968,9 @@ impl LegacyTcpSocket {
                         .try_into()
                         .unwrap();
 
-                let bytes_written = write_partial::<libc::c_int>(
-                    memory_manager,
-                    &sndbuf_size,
-                    optval_ptr.cast::<u8>(),
-                    optlen as usize,
-                )?;
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written =
+                    write_partial(memory_manager, &sndbuf_size, optval_ptr, optlen as usize)?;
 
                 Ok(bytes_written as libc::socklen_t)
             }
@@ -989,12 +980,9 @@ impl LegacyTcpSocket {
                         .try_into()
                         .unwrap();
 
-                let bytes_written = write_partial::<libc::c_int>(
-                    memory_manager,
-                    &rcvbuf_size,
-                    optval_ptr.cast::<u8>(),
-                    optlen as usize,
-                )?;
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written =
+                    write_partial(memory_manager, &rcvbuf_size, optval_ptr, optlen as usize)?;
 
                 Ok(bytes_written as libc::socklen_t)
             }
@@ -1009,12 +997,9 @@ impl LegacyTcpSocket {
                     0
                 };
 
-                let bytes_written = write_partial::<libc::c_int>(
-                    memory_manager,
-                    &error,
-                    optval_ptr.cast::<u8>(),
-                    optlen as usize,
-                )?;
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written =
+                    write_partial(memory_manager, &error, optval_ptr, optlen as usize)?;
 
                 Ok(bytes_written as libc::socklen_t)
             }
@@ -1032,12 +1017,9 @@ impl LegacyTcpSocket {
                     _ => unimplemented!(),
                 };
 
-                let bytes_written = write_partial::<libc::c_int>(
-                    memory_manager,
-                    &sock_type,
-                    optval_ptr.cast::<u8>(),
-                    optlen as usize,
-                )?;
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written =
+                    write_partial(memory_manager, &sock_type, optval_ptr, optlen as usize)?;
 
                 Ok(bytes_written as libc::socklen_t)
             }

--- a/src/main/host/syscall/io.rs
+++ b/src/main/host/syscall/io.rs
@@ -6,7 +6,7 @@ use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use shadow_shim_helper_rs::util::NoTypeInference;
 
 use crate::host::memory_manager::MemoryManager;
-use crate::host::syscall_types::{ForeignArrayPtr, SyscallError};
+use crate::host::syscall_types::ForeignArrayPtr;
 use crate::utility::pod;
 use crate::utility::sockaddr::SockaddrStorage;
 
@@ -21,7 +21,7 @@ pub fn write_sockaddr_and_len(
     addr: Option<&SockaddrStorage>,
     plugin_addr: ForeignPtr<u8>,
     plugin_addr_len: ForeignPtr<libc::socklen_t>,
-) -> Result<(), SyscallError> {
+) -> Result<(), Errno> {
     let addr = match addr {
         Some(x) => x,
         None => {
@@ -69,7 +69,7 @@ pub fn write_sockaddr(
     addr: &SockaddrStorage,
     plugin_addr: ForeignPtr<u8>,
     plugin_addr_len: libc::socklen_t,
-) -> Result<libc::socklen_t, SyscallError> {
+) -> Result<libc::socklen_t, Errno> {
     let from_addr_slice = addr.as_slice();
     let from_len: u32 = from_addr_slice.len().try_into().unwrap();
 
@@ -91,7 +91,7 @@ pub fn read_sockaddr(
     mem: &MemoryManager,
     addr_ptr: ForeignPtr<u8>,
     addr_len: libc::socklen_t,
-) -> Result<Option<SockaddrStorage>, SyscallError> {
+) -> Result<Option<SockaddrStorage>, Errno> {
     if addr_ptr.is_null() {
         return Ok(None);
     }
@@ -109,7 +109,7 @@ pub fn read_sockaddr(
             addr_len,
             std::mem::size_of_val(&addr_buf),
         );
-        return Err(Errno::EINVAL.into());
+        return Err(Errno::EINVAL);
     }
 
     let addr_buf = &mut addr_buf[..addr_len_usize];
@@ -137,7 +137,7 @@ pub fn write_partial<T>(
     val: &T::This,
     val_ptr: ForeignPtr<u8>,
     val_len: usize,
-) -> Result<usize, SyscallError>
+) -> Result<usize, Errno>
 where
     T: NoTypeInference,
     <T as NoTypeInference>::This: pod::Pod,


### PR DESCRIPTION
I think it's clearer this way, and lets us remove the `NoTypeInference` restriction from the function.