### PR TITLE
Move and better-document waiting for thread exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ have been noticeable effect in typical simulations. In particular the per-thread
 data was already getting freed when the whole process exited, so it would only
 affect a process that created and terminated many threads over its lifetime.
 
+* Fixed a potential race condition when exiting managed threads that did not
+have the `clear_child_tid` attribute set. This is unlikely to have affected most
+software running under Shadow, since most thread APIs use this attribute.
+
 Raw changes since v2.5.0:
 
 * [Merged PRs](https://github.com/shadow/shadow/pulls?q=is%3Apr+merged%3A%3E2023-03-23T18%3A20-0400)

--- a/src/lib/vasi-sync/src/scchannel.rs
+++ b/src/lib/vasi-sync/src/scchannel.rs
@@ -319,6 +319,13 @@ impl<T> SelfContainedChannel<T> {
             sync::futex_wake(&self.state.0).unwrap();
         }
     }
+
+    /// Whether the write-end of the channel has been closed (via `close_writer`).
+    pub fn writer_is_closed(&self) -> bool {
+        self.state
+            .load(sync::atomic::Ordering::Relaxed)
+            .writer_closed
+    }
 }
 
 unsafe impl<T> Send for SelfContainedChannel<T> where T: Send {}


### PR DESCRIPTION
  This moves waiting for thread-exit from `Process` to `ManagedThread`, where it more logically belongs. It also adds a check in `ManagedThread`'s `Drop` implementation to validate that we never drop it while the native thread is still running, and adds documentation about why this is important - to prevent memory corruption due to shared memory regions being deallocated and reused.
    
This also fixes a bug - Before we *weren't* waiting for the thread to exit if the `clear_child_tid` attribute wasn't set. I belive this was a race condition, but in practice I think most higher level thread APIs (e.g. libc's `pthread` and Rust's `std::thread`) use this attribute, so wouldn't have wouldn't have been affected.