### PR TITLE
Add `MSG_TRUNC` support for unix sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ prefixed with the hostname. For example a file that was previously named
 
 MINOR changes (backwards-compatible):
 
-*
+* Support the `MSG_TRUNC` flag for unix sockets.
+https://github.com/shadow/shadow/pull/2841
 
 PATCH changes (bugfixes):
 

--- a/src/main/host/syscall/socket.c
+++ b/src/main/host/syscall/socket.c
@@ -521,7 +521,8 @@ SyscallReturn _syscallhandler_sendtoHelper(SysCallHandler* sys, int sockfd,
         return syscallreturn_makeDoneErrno(EINVAL);
     }
 
-    if (flags & ~MSG_DONTWAIT) {
+    // MSG_TRUNC is ignored when sending
+    if (flags & ~(MSG_DONTWAIT | MSG_TRUNC)) {
         warning("Unsupported send flag(s): %d", flags);
     }
 


### PR DESCRIPTION
These are some old changes that might as well be added. Having the tests in place will make it easier to support for inet sockets in the future.