### PR TITLE
Rename `RecvmsgReturn.bytes_read` field to `return_val`

### DIFF
--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -499,7 +499,7 @@ impl LegacyTcpSocket {
             }
 
             Ok(RecvmsgReturn {
-                bytes_read: bytes_read.try_into().unwrap(),
+                return_val: bytes_read.try_into().unwrap(),
                 addr: None,
                 msg_flags: 0,
                 control_len: 0,

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -352,8 +352,9 @@ pub struct RecvmsgArgs<'a> {
 
 /// Return values for [`Socket::recvmsg()`].
 pub struct RecvmsgReturn {
-    /// The number of message bytes read.
-    pub bytes_read: libc::ssize_t,
+    /// The return value for the syscall. Typically is the number of message bytes read, but is
+    /// modifiable by the syscall flag.
+    pub return_val: libc::ssize_t,
     /// The socket address of the received message.
     pub addr: Option<SockaddrStorage>,
     /// Message flags.

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -1498,7 +1498,7 @@ impl Protocol for ConnOrientedConnected {
         self.refresh_file_state(common, cb_queue);
 
         Ok(RecvmsgReturn {
-            bytes_read: rv.try_into().unwrap(),
+            return_val: rv.try_into().unwrap(),
             addr: self.peer_addr.map(Into::into),
             msg_flags: 0,
             control_len: 0,
@@ -1706,7 +1706,7 @@ impl Protocol for ConnLessInitial {
         self.refresh_file_state(common, cb_queue);
 
         Ok(RecvmsgReturn {
-            bytes_read: rv.try_into().unwrap(),
+            return_val: rv.try_into().unwrap(),
             addr: byte_data.from_addr.map(Into::into),
             msg_flags: 0,
             control_len: 0,

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -367,7 +367,7 @@ impl SyscallHandler {
         }
 
         let RecvmsgReturn {
-            bytes_read: bytes_received,
+            return_val,
             addr: from_addr,
             ..
         } = result?;
@@ -377,7 +377,7 @@ impl SyscallHandler {
             io::write_sockaddr_and_len(&mut mem, from_addr.as_ref(), addr_ptr, addr_len_ptr)?;
         }
 
-        Ok(bytes_received)
+        Ok(return_val)
     }
 
     #[log_syscall(/* rv */ libc::ssize_t, /* sockfd */ libc::c_int, /* msg */ *const libc::msghdr,
@@ -462,7 +462,7 @@ impl SyscallHandler {
         // write msg back to the plugin
         io::update_msghdr(&mut mem, msg_ptr, msg)?;
 
-        Ok(result.bytes_read)
+        Ok(result.return_val)
     }
 
     #[log_syscall(/* rv */ libc::c_int, /* sockfd */ libc::c_int, /* addr */ *const libc::sockaddr,

--- a/src/main/host/syscall/handler/uio.rs
+++ b/src/main/host/syscall/handler/uio.rs
@@ -230,14 +230,14 @@ impl SyscallHandler {
             };
 
             // call the socket's recvmsg(), and run any resulting events
-            let RecvmsgReturn { bytes_read, .. } =
+            let RecvmsgReturn { return_val, .. } =
                 crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
                     CallbackQueue::queue_and_run(|cb_queue| {
                         Socket::recvmsg(socket, args, &mut mem, cb_queue)
                     })
                 })?;
 
-            return Ok(bytes_read);
+            return Ok(return_val);
         }
 
         let file_status = file.borrow().get_status();


### PR DESCRIPTION
This field usually is the number of bytes read, but not always (for example see the `MSG_TRUNC` flag).