### PR TITLE
Switch the unbounded thread pool to use a latch instead of parkers

### DIFF
--- a/src/main/core/scheduler/pools/unbounded.rs
+++ b/src/main/core/scheduler/pools/unbounded.rs
@@ -10,9 +10,7 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 
 use crate::utility::synchronization::count_down_latch::{self, build_count_down_latch};
-use crate::utility::synchronization::thread_parking::{
-    ThreadParker, ThreadUnparker, ThreadUnparkerUnassigned,
-};
+use crate::utility::synchronization::simple_latch;
 
 // If making substantial changes to this scheduler, you should verify the compilation error message
 // for each test at the end of this file to make sure that they correctly cause the expected
@@ -30,10 +28,11 @@ impl<T> TaskFn for T where T: Fn(usize) + Send + Sync {}
 pub struct UnboundedThreadPool {
     /// Handles for joining threads when they've exited.
     thread_handles: Vec<std::thread::JoinHandle<()>>,
-    /// Used to unpark threads that are waiting for a new task.
-    thread_unparkers: Vec<ThreadUnparker>,
     /// State shared between all threads.
     shared_state: Arc<SharedState>,
+    /// A latch that is opened when the task is set. Indicates to the threads that they should start
+    /// running the task.
+    task_start_latch: simple_latch::Latch,
     /// The main thread uses this to wait for the threads to finish running the task.
     task_end_waiter: count_down_latch::LatchWaiter,
 }
@@ -53,32 +52,34 @@ impl UnboundedThreadPool {
         });
 
         let (task_end_counter, task_end_waiter) = build_count_down_latch();
+        let mut task_start_latch = simple_latch::Latch::new();
 
         let mut thread_handles = Vec::new();
-        let mut thread_unparkers = Vec::new();
 
         for i in 0..num_threads {
             let shared_state_clone = Arc::clone(&shared_state);
+            let task_start_waiter = task_start_latch.waiter();
             let task_end_counter_clone = task_end_counter.clone();
-
-            let thread_unparker = ThreadUnparkerUnassigned::new();
-            let thread_parker = thread_unparker.parker();
 
             let handle = std::thread::Builder::new()
                 .name(thread_name.to_string())
                 .spawn(move || {
-                    work_loop(i, shared_state_clone, thread_parker, task_end_counter_clone)
+                    work_loop(
+                        i,
+                        shared_state_clone,
+                        task_start_waiter,
+                        task_end_counter_clone,
+                    )
                 })
                 .unwrap();
 
-            thread_unparkers.push(thread_unparker.assign(handle.thread().clone()));
             thread_handles.push(handle);
         }
 
         Self {
             thread_handles,
-            thread_unparkers,
             shared_state,
+            task_start_latch,
             task_end_waiter,
         }
     }
@@ -99,9 +100,7 @@ impl UnboundedThreadPool {
             .load(Ordering::Relaxed);
 
         // start the threads
-        for unparker in &self.thread_unparkers {
-            unparker.unpark();
-        }
+        self.task_start_latch.open();
 
         for handle in self.thread_handles.drain(..) {
             let result = handle.join();
@@ -212,17 +211,15 @@ impl<'a, 'scope> TaskRunner<'a, 'scope> {
 
         *self.scope.pool.shared_state.task.borrow_mut() = Some(f);
 
-        // start the threads
-        for unparker in &self.scope.pool.thread_unparkers {
-            unparker.unpark();
-        }
+        // we've set the task, so start the threads
+        self.scope.pool.task_start_latch.open();
     }
 }
 
 fn work_loop(
     thread_index: usize,
     shared_state: Arc<SharedState>,
-    thread_parker: ThreadParker,
+    mut start_waiter: simple_latch::LatchWaiter,
     mut end_counter: count_down_latch::LatchCounter,
 ) {
     // we don't use `catch_unwind` here for two main reasons:
@@ -259,7 +256,7 @@ fn work_loop(
 
     loop {
         // wait for a new task
-        thread_parker.park();
+        start_waiter.wait();
 
         // scope used to make sure we drop the task before counting down
         {

--- a/src/main/core/scheduler/pools/unbounded.rs
+++ b/src/main/core/scheduler/pools/unbounded.rs
@@ -9,9 +9,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 
-use crate::utility::synchronization::count_down_latch::{
-    build_count_down_latch, LatchCounter, LatchWaiter,
-};
+use crate::utility::synchronization::count_down_latch::{self, build_count_down_latch};
 use crate::utility::synchronization::thread_parking::{
     ThreadParker, ThreadUnparker, ThreadUnparkerUnassigned,
 };
@@ -37,7 +35,7 @@ pub struct UnboundedThreadPool {
     /// State shared between all threads.
     shared_state: Arc<SharedState>,
     /// The main thread uses this to wait for the threads to finish running the task.
-    task_end_waiter: LatchWaiter,
+    task_end_waiter: count_down_latch::LatchWaiter,
 }
 
 pub struct SharedState {
@@ -225,7 +223,7 @@ fn work_loop(
     thread_index: usize,
     shared_state: Arc<SharedState>,
     thread_parker: ThreadParker,
-    mut end_counter: LatchCounter,
+    mut end_counter: count_down_latch::LatchCounter,
 ) {
     // we don't use `catch_unwind` here for two main reasons:
     //

--- a/src/main/utility/synchronization/mod.rs
+++ b/src/main/utility/synchronization/mod.rs
@@ -1,2 +1,3 @@
 pub mod count_down_latch;
+pub mod simple_latch;
 pub mod thread_parking;

--- a/src/main/utility/synchronization/simple_latch.rs
+++ b/src/main/utility/synchronization/simple_latch.rs
@@ -1,0 +1,238 @@
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::Arc;
+
+use nix::errno::Errno;
+
+/// A simple reusable latch. Multiple waiters can wait for the latch to open. After opening the
+/// latch with [`open()`](Self::open), you must not open the latch again until all waiters have
+/// waited with [`wait()`](LatchWaiter::wait) on the latch. In other words, you must not call
+/// `open()` multiple times without making sure that all waiters have successfully returned from
+/// `wait()` each time. This typically requires some other synchronization to make sure that the
+/// waiters have waited. If the latch and its waiters aren't kept in sync, the waiters will usually
+/// panic, but in some cases may behave incorrectly[^note].
+///
+/// [^note]: Since this latch uses a 32-bit wrapping integer to track the positions of the latch and
+/// its waiters, calling `open()` `u32::MAX + 1` times without allowing the waiters to wait will
+/// behave as if you did not call `open()` at all.
+///
+/// The latch uses release-acquire ordering, so any changes made before an `open()` should be
+/// visible in other threads after a `wait()` returns.
+#[derive(Debug)]
+pub struct Latch {
+    /// The generation of the latch.
+    latch_gen: Arc<AtomicI32>,
+}
+
+/// A waiter that waits for the latch to open. A waiter for a latch can be created with
+/// [`waiter()`](Latch::waiter). Cloning a waiter will create a new waiter with the same
+/// state/generation as the existing waiter.
+#[derive(Debug, Clone)]
+pub struct LatchWaiter {
+    /// The generation of this waiter.
+    gen: i32,
+    /// The read-only generation of the latch.
+    latch_gen: Arc<AtomicI32>,
+}
+
+impl Latch {
+    /// Create a new latch.
+    pub fn new() -> Self {
+        Self {
+            latch_gen: Arc::new(AtomicI32::new(0)),
+        }
+    }
+
+    /// Get a new waiter for this latch. The new waiter will have the same generation as the latch,
+    /// meaning that a single [`wait()`](LatchWaiter::wait) will block the waiter until the next
+    /// latch [`open()`](Self::open).
+    pub fn waiter(&mut self) -> LatchWaiter {
+        LatchWaiter {
+            // we're the only one who can mutate the atomic,
+            // so there's no race condition here
+            gen: self.latch_gen.load(Ordering::Relaxed),
+            latch_gen: Arc::clone(&self.latch_gen),
+        }
+    }
+
+    /// Open the latch.
+    pub fn open(&mut self) {
+        // the addition is wrapping
+        let _prev = self.latch_gen.fetch_add(1, Ordering::Release);
+
+        // This is safe since `AtomicI32` "has the same in-memory representation as the underlying
+        // integer type, i32": https://doc.rust-lang.org/std/sync/atomic/struct.AtomicI32.html.
+        //
+        // TODO: Consider using `as_mut_ptr` here once it's stabilized.
+        // https://doc.rust-lang.org/std/sync/atomic/struct.AtomicI32.html#method.as_mut_ptr
+        static_assertions::assert_eq_size!(AtomicI32, i32);
+        static_assertions::assert_eq_align!(AtomicI32, i32);
+
+        let rv = unsafe {
+            libc::syscall(
+                libc::SYS_futex,
+                &self.latch_gen,
+                libc::FUTEX_WAKE,
+                i32::MAX,
+                std::ptr::null() as *const libc::timespec,
+                std::ptr::null_mut() as *mut u32,
+                0u32,
+            )
+        };
+        assert!(rv >= 0);
+    }
+}
+
+impl Default for Latch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LatchWaiter {
+    /// Wait for the latch to open.
+    pub fn wait(&mut self) {
+        loop {
+            let latch_gen = self.latch_gen.load(Ordering::Acquire);
+
+            match latch_gen.wrapping_sub(self.gen) {
+                // the latch has been opened and we can advance to the next generation
+                1 => break,
+                // the latch has not been opened and we're at the same generation
+                0 => {}
+                // the latch has been opened multiple times and we haven't been kept in sync
+                _ => panic!("Latch has been opened multiple times without us waiting"),
+            }
+
+            let rv = Errno::result(unsafe {
+                libc::syscall(
+                    libc::SYS_futex,
+                    &self.latch_gen,
+                    libc::FUTEX_WAIT,
+                    latch_gen,
+                    std::ptr::null() as *const libc::timespec,
+                    std::ptr::null_mut() as *mut u32,
+                    0u32,
+                )
+            });
+            assert!(
+                rv.is_ok() || rv == Err(Errno::EAGAIN) || rv == Err(Errno::EINTR),
+                "FUTEX_WAIT failed with {rv:?}"
+            );
+        }
+
+        self.gen = self.gen.wrapping_add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread::sleep;
+    use std::time::{Duration, Instant};
+
+    use atomic_refcell::AtomicRefCell;
+
+    use super::*;
+
+    #[test]
+    fn test_simple() {
+        let mut latch = Latch::new();
+        let mut waiter = latch.waiter();
+
+        latch.open();
+        waiter.wait();
+        latch.open();
+        waiter.wait();
+        latch.open();
+        waiter.wait();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_multiple_open() {
+        let mut latch = Latch::new();
+        let mut waiter = latch.waiter();
+
+        latch.open();
+        waiter.wait();
+        latch.open();
+        latch.open();
+
+        // this should panic
+        waiter.wait();
+    }
+
+    #[test]
+    fn test_blocking() {
+        let mut latch = Latch::new();
+        let mut waiter = latch.waiter();
+
+        let t = std::thread::spawn(move || {
+            let start = Instant::now();
+            waiter.wait();
+            start.elapsed()
+        });
+
+        let sleep_duration = Duration::from_millis(200);
+        sleep(sleep_duration);
+        latch.open();
+
+        let wait_duration = t.join().unwrap();
+
+        let threshold = Duration::from_millis(20);
+        assert!(wait_duration > sleep_duration - threshold);
+        assert!(wait_duration < sleep_duration + threshold);
+    }
+
+    #[test]
+    fn test_clone() {
+        let mut latch = Latch::new();
+        let mut waiter = latch.waiter();
+
+        latch.open();
+        waiter.wait();
+        latch.open();
+        waiter.wait();
+
+        // new waiter should have the same generation
+        let mut waiter_2 = waiter.clone();
+
+        latch.open();
+        waiter.wait();
+        waiter_2.wait();
+    }
+
+    #[test]
+    fn test_ping_pong() {
+        let mut latch_1 = Latch::new();
+        let mut latch_2 = Latch::new();
+        let mut waiter_1 = latch_1.waiter();
+        let mut waiter_2 = latch_2.waiter();
+
+        let counter = Arc::new(AtomicRefCell::new(0));
+        let counter_clone = Arc::clone(&counter);
+
+        fn latch_loop(
+            latch: &mut Latch,
+            waiter: &mut LatchWaiter,
+            counter: &Arc<AtomicRefCell<usize>>,
+            iterations: usize,
+        ) {
+            for _ in 0..iterations {
+                waiter.wait();
+                *counter.borrow_mut() += 1;
+                latch.open();
+            }
+        }
+
+        let t = std::thread::spawn(move || {
+            latch_loop(&mut latch_2, &mut waiter_1, &counter_clone, 100);
+        });
+
+        latch_1.open();
+        latch_loop(&mut latch_1, &mut waiter_2, &counter, 100);
+
+        t.join().unwrap();
+
+        assert_eq!(*counter.borrow(), 200);
+    }
+}

--- a/src/main/utility/synchronization/thread_parking.rs
+++ b/src/main/utility/synchronization/thread_parking.rs
@@ -153,7 +153,7 @@ impl ThreadParker {
     pub fn park(&self) {
         while self
             .ready_flag
-            .compare_exchange(true, false, Ordering::Release, Ordering::Relaxed)
+            .compare_exchange(true, false, Ordering::Acquire, Ordering::Relaxed)
             .is_err()
         {
             // verify that we're parking from the proper thread (only in debug builds since this is


### PR DESCRIPTION
I'm not sure that the `ThreadUnparker` works correctly when using rust's parking API, so I've updated a comment in it and replaced it in the thread-per-core scheduler (the unbounded thread pool) with a simple futex-based latch instead. The thread-per-host scheduler continues to use the (possibly broken) `ThreadUnparker`.

Another advantage is that it can futex-wake all threads with one syscall, rather than unparking each thread individually.

I ran a benchmark on an earlier version of this PR and there was no performance improvement.