### PR TITLE
Reduce usage of special environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ https://github.com/shadow/shadow/pull/2841
 * Support the `TIMER_ABSTIME` flag for `clock_nanosleep`.
 https://github.com/shadow/shadow/pull/2854
 
+* The experimental config option `use_shim_syscall_handler` has been removed.
+This optimization is now always enabled.
+
 PATCH changes (bugfixes):
 
 * Fixed a memory leak of about 16 bytes per thread due to

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -94,7 +94,6 @@ hosts:
 - [`experimental.use_preload_openssl_crypto`](#experimentaluse_preload_openssl_crypto)
 - [`experimental.use_preload_openssl_rng`](#experimentaluse_preload_openssl_rng)
 - [`experimental.use_sched_fifo`](#experimentaluse_sched_fifo)
-- [`experimental.use_shim_syscall_handler`](#experimentaluse_shim_syscall_handler)
 - [`experimental.use_syscall_counters`](#experimentaluse_syscall_counters)
 - [`host_defaults`](#host_defaults)
 - [`host_defaults.log_level`](#host_defaultslog_level)
@@ -519,13 +518,6 @@ Type: Bool
 Use the `SCHED_FIFO` scheduler. Requires `CAP_SYS_NICE`. See sched(7),
 capabilities(7).
 
-#### `experimental.use_shim_syscall_handler`
-
-Default: true  
-Type: Bool
-
-Use shim-side syscall handler to force hot-path syscalls to be handled via an
-inter-process syscall with Shadow.
 
 #### `experimental.use_syscall_counters`
 

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -293,13 +293,8 @@ static void _shim_parent_init_host_shm() {
 }
 
 static void _shim_parent_init_process_shm() {
-    const char* shm_blk_buf = getenv("SHADOW_SHM_PROCESS_BLK");
-    assert(shm_blk_buf);
-
-    bool err = false;
-    ShMemBlockSerialized shm_blk_serialized = shmemblockserialized_fromString(shm_blk_buf, &err);
-
-    *_shim_process_shared_mem_blk() = shmemserializer_globalBlockDeserialize(&shm_blk_serialized);
+    *_shim_process_shared_mem_blk() =
+        shmemserializer_globalBlockDeserialize(shimshmem_getProcessShmem(shim_threadSharedMem()));
     assert(shim_processSharedMem());
 }
 

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -287,13 +287,8 @@ static void _shim_parent_init_death_signal() {
 }
 
 static void _shim_parent_init_host_shm() {
-    const char* shm_blk_buf = getenv("SHADOW_SHM_HOST_BLK");
-    assert(shm_blk_buf);
-
-    bool err = false;
-    ShMemBlockSerialized shm_blk_serialized = shmemblockserialized_fromString(shm_blk_buf, &err);
-
-    *_shim_host_shared_mem_blk() = shmemserializer_globalBlockDeserialize(&shm_blk_serialized);
+    *_shim_host_shared_mem_blk() = shmemserializer_globalBlockDeserialize(
+        shimshmem_getProcessHostShmem(shim_processSharedMem()));
     assert(shim_hostSharedMem());
 }
 
@@ -457,9 +452,9 @@ static void _shim_parent_init_preload() {
 
     shim_install_hardware_error_handlers();
     patch_vdso((void*)getauxval(AT_SYSINFO_EHDR));
-    _shim_parent_init_host_shm();
-    _shim_parent_init_process_shm();
     _shim_parent_init_thread_shm();
+    _shim_parent_init_process_shm();
+    _shim_parent_init_host_shm();
     _shim_parent_init_logging();
     _shim_parent_set_working_dir();
     _shim_parent_init_ipc();

--- a/src/lib/shim/shim.h
+++ b/src/lib/shim/shim.h
@@ -19,9 +19,6 @@ bool shim_swapAllowNativeSyscalls(bool new);
 // Whether syscall interposition is currently enabled.
 bool shim_interpositionEnabled();
 
-// Whether we are using the shim-side syscall handler.
-bool shim_use_syscall_handler();
-
 // Returns the shmem block used for IPC, which may be uninitialized.
 struct IPCData* shim_thisThreadEventIPC();
 

--- a/src/lib/shim/shim_rdtsc.c
+++ b/src/lib/shim/shim_rdtsc.c
@@ -33,7 +33,7 @@ static uint64_t _shim_rdtsc_nanos(bool allowNative) {
     // *don't* directly call shim_sys_get_simtime_nanos() here.  We need to go
     // through the syscall code to correctly handle the case where
     // `model_unblocked_syscall_latency` is enabled.
-    long rv = shim_emulated_syscall(SYS_clock_gettime, CLOCK_REALTIME, &t);
+    long rv = shim_syscall(SYS_clock_gettime, CLOCK_REALTIME, &t);
     if (rv != 0) {
         panic("emulated SYS_clock_gettime: %s", strerror(-rv));
     }

--- a/src/lib/shim/shim_sys.c
+++ b/src/lib/shim/shim_sys.c
@@ -22,9 +22,9 @@
 static CEmulatedTime _shim_sys_get_time() {
     ShimShmemHost* mem = shim_hostSharedMem();
 
-    // If that's unavailable, fail. This can happen during early init.
+    // If that's unavailable, fail. This shouldn't happen.
     if (mem == NULL) {
-        return 0;
+        panic("mem uninitialized");
     }
 
     return shimshmem_getEmulatedTime(mem);
@@ -66,10 +66,6 @@ bool shim_sys_handle_syscall_locally(long syscall_num, long* rv, va_list args) {
             syscallName = "clock_gettime";
 
             CEmulatedTime emulated_time = _shim_sys_get_time();
-            if (emulated_time == 0) {
-                // Not initialized yet.
-                return false;
-            }
 
             trace("servicing syscall %ld:clock_gettime from the shim", syscall_num);
 
@@ -95,10 +91,6 @@ bool shim_sys_handle_syscall_locally(long syscall_num, long* rv, va_list args) {
             syscallName = "time";
 
             CEmulatedTime emulated_time = _shim_sys_get_time();
-            if (emulated_time == 0) {
-                // Not initialized yet.
-                return false;
-            }
             time_t now = emulated_time / SIMTIME_ONE_SECOND;
 
             trace("servicing syscall %ld:time from the shim", syscall_num);
@@ -118,10 +110,6 @@ bool shim_sys_handle_syscall_locally(long syscall_num, long* rv, va_list args) {
             syscallName = "gettimeofday";
 
             CEmulatedTime emulated_time = _shim_sys_get_time();
-            if (emulated_time == 0) {
-                // Not initialized yet.
-                return false;
-            }
             uint64_t micros = emulated_time / SIMTIME_ONE_MICROSECOND;
 
             trace("servicing syscall %ld:gettimeofday from the shim", syscall_num);

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -273,12 +273,12 @@ long shim_syscallv(long n, va_list args) {
 
     long rv;
 
-    if (shim_interpositionEnabled() && shim_use_syscall_handler() &&
-        shim_sys_handle_syscall_locally(n, &rv, args)) {
+    if (shim_interpositionEnabled() && shim_sys_handle_syscall_locally(n, &rv, args)) {
         // No inter-process syscall needed, we handled it on the shim side! :)
         trace("Handled syscall %ld from the shim; we avoided inter-process overhead.", n);
         // rv was already set
-    } else if ((shim_interpositionEnabled() || syscall_num_is_shadow(n)) && shim_thisThreadEventIPC()) {
+    } else if ((shim_interpositionEnabled() || syscall_num_is_shadow(n)) &&
+               shim_thisThreadEventIPC()) {
         // The syscall is made using the shmem IPC channel.
         trace("Making syscall %ld indirectly; we ask shadow to handle it using the shmem IPC "
               "channel.",

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -588,7 +588,6 @@ impl<'a> Manager<'a> {
                 unblocked_syscall_latency: self.config.unblocked_syscall_latency(),
                 unblocked_vdso_latency: self.config.unblocked_vdso_latency(),
                 use_legacy_working_dir: self.config.use_legacy_working_dir(),
-                use_shim_syscall_handler: self.config.use_shim_syscall_handler(),
                 strace_logging_options: self.config.strace_logging_mode(),
             };
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -154,10 +154,6 @@ impl ConfigOptions {
         self.experimental.use_legacy_working_dir.unwrap()
     }
 
-    pub fn use_shim_syscall_handler(&self) -> bool {
-        self.experimental.use_shim_syscall_handler.unwrap()
-    }
-
     pub fn strace_logging_mode(&self) -> Option<FmtOptions> {
         match self.experimental.strace_logging_mode.as_ref().unwrap() {
             StraceLoggingMode::Standard => Some(FmtOptions::Standard),
@@ -342,12 +338,6 @@ pub struct ExperimentalOptions {
     #[clap(help = EXP_HELP.get("use_memory_manager").unwrap().as_str())]
     pub use_memory_manager: Option<bool>,
 
-    /// Use shim-side syscall handler to force hot-path syscalls to be handled via an inter-process syscall with Shadow
-    #[clap(hide_short_help = true)]
-    #[clap(long, value_name = "bool")]
-    #[clap(help = EXP_HELP.get("use_shim_syscall_handler").unwrap().as_str())]
-    pub use_shim_syscall_handler: Option<bool>,
-
     /// Pin each thread and any processes it executes to the same logical CPU Core to improve cache affinity
     #[clap(hide_short_help = true)]
     #[clap(long, value_name = "bool")]
@@ -487,7 +477,6 @@ impl Default for ExperimentalOptions {
             // Default to the lower end to minimize effect in simualations without busy loops.
             unblocked_vdso_latency: Some(units::Time::new(10, units::TimePrefix::Nano)),
             use_memory_manager: Some(true),
-            use_shim_syscall_handler: Some(true),
             use_cpu_pinning: Some(true),
             runahead: Some(NullableOption::Value(units::Time::new(
                 1,

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -74,7 +74,6 @@ pub struct HostParameters {
     pub unblocked_syscall_latency: SimulationTime,
     pub unblocked_vdso_latency: SimulationTime,
     pub use_legacy_working_dir: bool,
-    pub use_shim_syscall_handler: bool,
     pub strace_logging_options: Option<FmtOptions>,
 }
 
@@ -388,7 +387,6 @@ impl Host {
             argv,
             pause_for_debugging,
             self.params.use_legacy_working_dir,
-            self.params.use_shim_syscall_handler,
             self.params.strace_logging_options,
         );
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -371,19 +371,10 @@ impl Host {
         stop_time: Option<SimulationTime>,
         plugin_name: &CStr,
         plugin_path: &CStr,
-        mut envv: Vec<CString>,
+        envv: Vec<CString>,
         argv: Vec<CString>,
         pause_for_debugging: bool,
     ) {
-        {
-            // SAFETY: We're not touching the data inside the block, only
-            // using its metadata to create a serialized pointer to it.
-            let block = unsafe { &*self.shim_shmem.get() };
-            let mut envvar = String::from("SHADOW_SHM_HOST_BLK=");
-            envvar.push_str(&block.serialize().encode_to_string());
-            envv.push(CString::new(envvar).unwrap());
-        }
-
         let process_id = self.get_new_process_id();
 
         let process = Process::new(
@@ -705,7 +696,7 @@ impl Host {
     /// Do not try to take the lock of [`HostShmem::protected`] directly.
     /// Instead use [`Host::lock_shmem`], [`Host::shim_shmem_lock_borrow`], and
     /// [`Host::shim_shmem_lock_borrow_mut`].
-    pub fn shim_shmem(&self) -> &HostShmem {
+    pub fn shim_shmem(&self) -> &ShMemBlock<'static, HostShmem> {
         unsafe { &*self.shim_shmem.get() }
     }
 

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -251,6 +251,7 @@ impl Process {
 
         let shim_shared_mem = ProcessShmem::new(
             &host.shim_shmem_lock_borrow().unwrap().root,
+            host.shim_shmem().serialize(),
             host.id(),
             strace_logging.as_ref().map(|x| x.file.borrow().as_raw_fd()),
         );

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -264,14 +264,6 @@ impl Process {
             std::fs::canonicalize(host.data_dir_path()).unwrap()
         });
 
-        // TODO: ensure no duplicate env vars.
-        envv.push(
-            CString::new(format!(
-                "SHADOW_SHM_PROCESS_BLK={}",
-                shim_shared_mem_block.serialize().encode_to_string()
-            ))
-            .unwrap(),
-        );
         if !use_shim_syscall_handler {
             envv.push(CString::new("SHADOW_DISABLE_SHIM_SYSCALL=TRUE").unwrap());
         }
@@ -1139,7 +1131,7 @@ impl Process {
     }
 
     /// Shared memory for this process.
-    pub fn shmem(&self) -> &ProcessShmem {
+    pub fn shmem(&self) -> &ShMemBlock<'static, ProcessShmem> {
         &self.shim_shared_mem_block
     }
 }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -204,11 +204,10 @@ impl Process {
         stop_time: Option<SimulationTime>,
         plugin_name: &CStr,
         plugin_path: &CStr,
-        mut envv: Vec<CString>,
+        envv: Vec<CString>,
         argv: Vec<CString>,
         pause_for_debugging: bool,
         use_legacy_working_dir: bool,
-        use_shim_syscall_handler: bool,
         strace_logging_options: Option<FmtOptions>,
     ) -> RootedRc<RootedRefCell<Self>> {
         debug_assert!(stop_time.is_none() || stop_time.unwrap() > start_time);
@@ -263,10 +262,6 @@ impl Process {
         } else {
             std::fs::canonicalize(host.data_dir_path()).unwrap()
         });
-
-        if !use_shim_syscall_handler {
-            envv.push(CString::new("SHADOW_DISABLE_SHIM_SYSCALL=TRUE").unwrap());
-        }
 
         #[cfg(feature = "perf_timers")]
         let cpu_delay_timer = {

--- a/src/main/host/syscall/time.h
+++ b/src/main/host/syscall/time.h
@@ -8,10 +8,7 @@
 
 #include "main/host/syscall/protected.h"
 
-SYSCALL_HANDLER(clock_gettime);
 SYSCALL_HANDLER(clock_nanosleep);
-SYSCALL_HANDLER(gettimeofday);
 SYSCALL_HANDLER(nanosleep);
-SYSCALL_HANDLER(time);
 
 #endif /* SRC_MAIN_HOST_SYSCALL_TIME_H_ */

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -225,6 +225,11 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number, const
 // Single public API function for calling Shadow syscalls
 ///////////////////////////////////////////////////////////
 
+#define SHIM_ONLY(s)                                                                               \
+    case SYS_##s:                                                                                  \
+        panic("syscall " #s " (#%ld) should have been handled in the shim", args->number);         \
+        break
+
 #define HANDLE_C(s)                                                                                \
     case SYS_##s:                                                                                  \
         _syscallhandler_pre_syscall(sys, args->number, #s);                                        \
@@ -296,7 +301,7 @@ SyscallReturn syscallhandler_make_syscall(SysCallHandler* sys, const SysCallArgs
             HANDLE_RUST(accept4);
             HANDLE_RUST(bind);
             HANDLE_RUST(brk);
-            HANDLE_C(clock_gettime);
+            SHIM_ONLY(clock_gettime);
             HANDLE_C(clock_nanosleep);
             HANDLE_C(clone);
             HANDLE_RUST(close);
@@ -359,7 +364,7 @@ SyscallReturn syscallhandler_make_syscall(SysCallHandler* sys, const SysCallArgs
             HANDLE_C(get_robust_list);
             HANDLE_RUST(getsockname);
             HANDLE_RUST(getsockopt);
-            HANDLE_C(gettimeofday);
+            SHIM_ONLY(gettimeofday);
             HANDLE_RUST(ioctl);
             HANDLE_C(kill);
             HANDLE_C(linkat);
@@ -408,7 +413,7 @@ SyscallReturn syscallhandler_make_syscall(SysCallHandler* sys, const SysCallArgs
             HANDLE_RUST(rseq);
             HANDLE_RUST(sched_getaffinity);
             HANDLE_RUST(sched_setaffinity);
-            HANDLE_RUST(sched_yield);
+            SHIM_ONLY(sched_yield);
             HANDLE_C(shadow_get_shm_blk);
             HANDLE_C(shadow_hostname_to_addr_ipv4);
             HANDLE_C(shadow_init_memory_manager);
@@ -446,7 +451,7 @@ SyscallReturn syscallhandler_make_syscall(SysCallHandler* sys, const SysCallArgs
             HANDLE_C(syncfs);
             HANDLE_RUST(sysinfo);
             HANDLE_C(tgkill);
-            HANDLE_C(time);
+            SHIM_ONLY(time);
             HANDLE_C(timerfd_create);
             HANDLE_C(timerfd_gettime);
             HANDLE_C(timerfd_settime);

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -299,6 +299,7 @@ impl Thread {
             tid_address: Cell::new(ForeignPtr::null()),
             shim_shared_memory: Allocator::global().alloc(ThreadShmem::new(
                 &host.shim_shmem_lock_borrow().unwrap(),
+                process.shmem().serialize(),
                 thread_id.into(),
             )),
         };
@@ -340,6 +341,7 @@ impl Thread {
             tid_address: Cell::new(ForeignPtr::null()),
             shim_shared_memory: Allocator::global().alloc(ThreadShmem::new(
                 &ctx.host.shim_shmem_lock_borrow().unwrap(),
+                ctx.process.shmem().serialize(),
                 child_tid.into(),
             )),
         };


### PR DESCRIPTION
Removes the environment variables SHADOW_DISABLE_SHIM_SYSCALL, SHADOW_SHM_PROCESS_BLK, and SHADOW_SHM_HOST_BLK.

As part of removing SHADOW_DISABLE_SHIM_SYSCALL, this also removes the experimental option `use_shim_syscall_handler`, and removes the redundant shadow-side syscall handlers.

Progress on #2848