### PR TITLE
Drop official support for clang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ prefixed with the hostname. For example a file that was previously named
 `shadow.data/hosts/server/server.curl.1000.stdout` is now named
 `shadow.data/hosts/server/curl.1000.stdout`.
 
+* The `clang` C compiler is no longer supported.
+
 MINOR changes (backwards-compatible):
 
 * Support the `MSG_TRUNC` flag for unix sockets.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,10 +25,10 @@ dockerhub. You can override this repo with `-r` or force the script to build a
 new image locally with `-i`.
 
 For example, to perform an incremental build and test on ubuntu 18.04,
-with the clang compiler in debug mode:
+with the gcc compiler in debug mode:
 
 ```{.bash}
-ci/run.sh -c ubuntu:18.04 -C clang -b debug"
+ci/run.sh -c ubuntu:18.04 -C gcc -b debug"
 ```
 
 If the tests fail, shadow's build directory, including test outputs, will be copied
@@ -47,7 +47,7 @@ run an interactive shell in a container built from that image.
 e.g.:
 
 ```{.bash}
-docker run --tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt=seccomp=unconfined -it shadowsim/shadow-ci:ubuntu-22.04-clang-debug /bin/bash
+docker run --tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt=seccomp=unconfined -it shadowsim/shadow-ci:ubuntu-22.04-gcc-debug /bin/bash
 ```
 
 If the failure happened in the middle of building the Docker image, you can do
@@ -55,7 +55,7 @@ the same with the last intermediate layer that was built successfully. e.g.
 given the output:
 
 ```{.bash}
-$ ci/run.sh -i -c ubuntu:22.04 -C clang -b debug
+$ ci/run.sh -i -c ubuntu:22.04 -C gcc -b debug
 <snip>
 Step 13/13 : RUN . ci/container_scripts/build_and_install.sh
  ---> Running in a11c4a554ef8

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -1,7 +1,7 @@
 # Installing Dependencies
 
 ### Required:
-  + gcc, gcc-c++ (or clang, clang++)
+  + gcc, gcc-c++
   + python (version >= 3.6)
   + glib (version >= 2.32.0)
   + cmake (version >= 3.2)
@@ -11,9 +11,6 @@
   + lscpu
   + cargo, rustc (version \~ latest)
   + libclang (version >= 9)
-
-Notice: Clang 13.0.0 is unsupported as it has a miscompilation bug that affects
-        Shadow (see [issue #1741](https://github.com/shadow/shadow/issues/1741)).
 
 ## APT (Debian/Ubuntu):
 
@@ -42,7 +39,7 @@ On older versions of Debian or Ubuntu, the default version of libclang is too
 old, which may cause bindgen to have errors finding system header files,
 particularly when compiling with gcc. In this case you will need to explicitly
 install a newer-than-default version of libclang. e.g. on `debian-10` install
-`libclang-13-dev`, and on `ubuntu-18.04` install `libclang-9-dev`.
+`libclang-13-dev`.
 
 ## YUM (Fedora/CentOS):
 


### PR DESCRIPTION
This is one of the planned breaking changes in
https://github.com/shadow/shadow/discussions/2496

I left in the two CI runs with clang, since I *think* the decision was to still run those for the extra diagnostics. OTOH I'd be happy to remove them; their value will continue to decrease as we get rid of C code.