### PR TITLE
Support the `TIMER_ABSTIME` flag for `clock_nanosleep`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ affect a process that created and terminated many threads over its lifetime.
 have the `clear_child_tid` attribute set. This is unlikely to have affected most
 software running under Shadow, since most thread APIs use this attribute.
 
+* Changed an error value in `clock_nanosleep` and `nanosleep` from `ENOSYS` to
+`ENOTSUP`.
+
 Raw changes since v2.5.0:
 
 * [Merged PRs](https://github.com/shadow/shadow/pulls?q=is%3Apr+merged%3A%3E2023-03-23T18%3A20-0400)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ MINOR changes (backwards-compatible):
 * Support the `MSG_TRUNC` flag for unix sockets.
 https://github.com/shadow/shadow/pull/2841
 
+* Support the `TIMER_ABSTIME` flag for `clock_nanosleep`.
+https://github.com/shadow/shadow/pull/2854
+
 PATCH changes (bugfixes):
 
 * Fixed a memory leak of about 16 bytes per thread due to

--- a/src/main/host/syscall/time.c
+++ b/src/main/host/syscall/time.c
@@ -28,12 +28,12 @@ static SyscallReturn _syscallhandler_nanosleep_helper(SysCallHandler* sys, clock
                                                       UntypedForeignPtr remainder) {
     if (clock_id == CLOCK_PROCESS_CPUTIME_ID || clock_id == CLOCK_THREAD_CPUTIME_ID) {
         warning("Unsupported clock ID %d during nanosleep", clock_id);
-        return syscallreturn_makeDoneErrno(ENOSYS);
+        return syscallreturn_makeDoneErrno(ENOTSUP);
     }
 
     if ((flags & (~TIMER_ABSTIME)) != 0) {
         warning("Unsupported flag %d during nanosleep", flags);
-        return syscallreturn_makeDoneErrno(ENOSYS);
+        return syscallreturn_makeDoneErrno(ENOTSUP);
     }
 
     /* Grab the arg from the syscall register. */


### PR DESCRIPTION
Required for Python 3.11.