### PR TITLE
Add experimental option to spin in the worker threads

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -94,6 +94,7 @@ hosts:
 - [`experimental.use_preload_openssl_rng`](#experimentaluse_preload_openssl_rng)
 - [`experimental.use_sched_fifo`](#experimentaluse_sched_fifo)
 - [`experimental.use_syscall_counters`](#experimentaluse_syscall_counters)
+- [`experimental.use_worker_spinning`](#experimentaluse_worker_spinning)
 - [`host_option_defaults`](#host_option_defaults)
 - [`host_option_defaults.log_level`](#host_option_defaultslog_level)
 - [`host_option_defaults.pcap_capture_size`](#host_option_defaultspcap_capture_size)
@@ -512,6 +513,16 @@ Default: true
 Type: Bool
 
 Count the number of occurrences for individual syscalls.
+
+#### `experimental.use_worker_spinning`
+
+Default: false  
+Type: Bool
+
+Each worker thread will spin in a `sched_yield` loop while waiting for a new task. This is ignored
+if not using the thread-per-core scheduler.
+
+This may improve runtime performance in some environments.
 
 #### `host_option_defaults`
 

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -317,7 +317,11 @@ impl<'a> Manager<'a> {
                     Scheduler::ThreadPerHost(ThreadPerHostSched::new(&cpus, hosts))
                 }
                 configuration::Scheduler::ThreadPerCore => {
-                    Scheduler::ThreadPerCore(ThreadPerCoreSched::new(&cpus, hosts))
+                    Scheduler::ThreadPerCore(ThreadPerCoreSched::new(
+                        &cpus,
+                        hosts,
+                        self.config.experimental.use_worker_spinning.unwrap(),
+                    ))
                 }
             };
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -340,6 +340,13 @@ pub struct ExperimentalOptions {
     #[clap(help = EXP_HELP.get("use_cpu_pinning").unwrap().as_str())]
     pub use_cpu_pinning: Option<bool>,
 
+    /// Each worker thread will spin in a `sched_yield` loop while waiting for a new task. This is
+    /// ignored if not using the thread-per-core scheduler.
+    #[clap(hide_short_help = true)]
+    #[clap(long, value_name = "bool")]
+    #[clap(help = EXP_HELP.get("use_worker_spinning").unwrap().as_str())]
+    pub use_worker_spinning: Option<bool>,
+
     /// If set, overrides the automatically calculated minimum time workers may run ahead when sending events between nodes
     #[clap(hide_short_help = true)]
     #[clap(long, value_name = "seconds")]
@@ -468,6 +475,7 @@ impl Default for ExperimentalOptions {
             unblocked_vdso_latency: Some(units::Time::new(10, units::TimePrefix::Nano)),
             use_memory_manager: Some(true),
             use_cpu_pinning: Some(true),
+            use_worker_spinning: Some(false),
             runahead: Some(NullableOption::Value(units::Time::new(
                 1,
                 units::TimePrefix::Milli,


### PR DESCRIPTION
This adds the experimental option `use_worker_spinning`, which is disabled by default. If enabled, the worker threads will spin indefinitely in a sched_yield loop rather than wait on a futex while waiting for a new task to be ready. This has a large performance benefit on our benchmark runner (#2877). Using this option, we can test on other machines and see if/when we should enable this spinning behaviour by default.

https://github.com/shadow/benchmark-results/tree/master/tgen/2023-04-19-T21-22-45

![1682457053_grim](https://user-images.githubusercontent.com/3708797/234404836-f8369064-4415-4d0b-9164-5c5972d6e26f.png)

https://github.com/shadow/benchmark-results/tree/master/tor/2023-04-25-T16-56-53

![1682457065_grim](https://user-images.githubusercontent.com/3708797/234404846-e1ce6002-4db8-4b92-b23c-58f7a2afdb40.png)