### PR TITLE
Process: remove circular weak reference

### DIFF
--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -16,7 +16,6 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
             "NetworkInterface".into(),
             "Tsc".into(),
         ]);
-        c.add_opaque_types(&["ProcessRefCell"]);
         c.add_opaque_types(&["RootedRefCell_StateEventSource"]);
         c
     };
@@ -255,6 +254,7 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .blocklist_type("Controller")
         .blocklist_type("Counter")
         .blocklist_type("Descriptor")
+        .blocklist_type("Process")
         .blocklist_type("HostId")
         .blocklist_type("TaskRef")
         .allowlist_type("WorkerC")
@@ -283,7 +283,7 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .raw_line("use crate::host::descriptor::socket::inet::InetSocket;")
         .raw_line("use crate::host::host::Host;")
         .raw_line("use crate::host::memory_manager::MemoryManager;")
-        .raw_line("use crate::host::process::ProcessRefCell;")
+        .raw_line("use crate::host::process::Process;")
         .raw_line("use crate::host::syscall::handler::SyscallHandler;")
         .raw_line("use crate::host::syscall_types::SyscallReturn;")
         .raw_line("use crate::host::thread::Thread;")

--- a/src/main/core/support/definitions.h
+++ b/src/main/core/support/definitions.h
@@ -7,7 +7,7 @@
 #define SHD_DEFINITIONS_H_
 
 // TODO put into a shd-types.h file
-typedef struct ProcessRefCell ProcessRefCell;
+typedef struct Process Process;
 typedef struct Host Host;
 
 /**

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -198,12 +198,9 @@ impl Worker {
     }
 
     /// Set the currently-active Process.
-    pub fn set_active_process(process: &Process) {
+    pub fn set_active_process(process: &RootedRc<RootedRefCell<Process>>) {
         Worker::with(|w| {
-            let process = process
-                .weak_rc()
-                .upgrade(w.active_host.borrow().as_ref().unwrap().root())
-                .unwrap();
+            let process = process.clone(w.active_host.borrow().as_ref().unwrap().root());
             let old = w.active_process.borrow_mut().replace(process);
             debug_assert!(old.is_none());
         })

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -663,7 +663,7 @@ mod export {
     use shadow_shim_helper_rs::simulation_time::CSimulationTime;
 
     use super::*;
-    use crate::host::process::ProcessRefCell;
+    use crate::host::process::Process;
 
     #[no_mangle]
     pub extern "C" fn worker_getDNS() -> *mut cshadow::DNS {
@@ -788,14 +788,10 @@ mod export {
     /// Returns a pointer to the current running process. The returned pointer is
     /// invalidated the next time the worker switches processes.
     #[no_mangle]
-    pub extern "C" fn worker_getCurrentProcess() -> *const ProcessRefCell {
+    pub extern "C" fn worker_getCurrentProcess() -> *const Process {
         // We can't use `with_active_process` here since that returns the &Process instead
-        // of the enclosing &ProcessRefCell.
-        Worker::with_active_process_rc(|process| {
-            let process: &ProcessRefCell = process;
-            process as *const _
-        })
-        .unwrap()
+        // of the enclosing &Process.
+        Worker::with_active_process(|process| process as *const _).unwrap()
     }
 
     /// Returns a pointer to the current running thread. The returned pointer is

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -2047,7 +2047,7 @@ static void _tcp_processPacket(LegacySocket* socket, const Host* host, Packet* p
                  * whichever process eventually calls accept() on the parent socket, but this is
                  * difficult to fix and isn't an issue until we support fork().
                  * See: https://github.com/shadow/shadow/issues/1780 */
-                const ProcessRefCell* registerInProcess =
+                const Process* registerInProcess =
                     host_getProcess(host, tcp->server->processForChildren);
                 if (!registerInProcess) {
                     debug("Listening process no longer exists");

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -885,7 +885,7 @@ mod export {
     use super::*;
     use crate::{
         cshadow::{CEmulatedTime, CSimulationTime},
-        host::{process::ProcessRefCell, thread::Thread},
+        host::{process::Process, thread::Thread},
         network::router::Router,
     };
 
@@ -1157,11 +1157,11 @@ mod export {
     pub unsafe extern "C" fn host_getProcess(
         host: *const Host,
         virtual_pid: libc::pid_t,
-    ) -> *const ProcessRefCell {
+    ) -> *const Process {
         let host = unsafe { host.as_ref().unwrap() };
         let virtual_pid = ProcessId::try_from(virtual_pid).unwrap();
         host.process_borrow(virtual_pid)
-            .map(|x| unsafe { x.borrow(host.root()).cprocess(host) })
+            .map(|x| &*x.borrow(host.root()) as *const _)
             .unwrap_or(std::ptr::null_mut())
     }
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -430,8 +430,8 @@ impl Host {
             trace!("{pid:?} doesn't exist");
             return;
         };
+        Worker::set_active_process(&processrc);
         let process = processrc.borrow(self.root());
-        Worker::set_active_process(&process);
         process.resume(self, tid);
         Worker::clear_active_process();
     }
@@ -664,8 +664,8 @@ impl Host {
         let processes = std::mem::take(&mut *self.processes.borrow_mut());
         for (_id, processrc) in processes.into_iter() {
             {
+                Worker::set_active_process(&processrc);
                 let process = processrc.borrow(self.root());
-                Worker::set_active_process(&process);
                 process.stop(self);
                 Worker::clear_active_process();
             }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -469,7 +469,7 @@ impl Process {
         };
         let thread = threadrc.borrow(host.root());
 
-        Worker::set_active_thread(&thread);
+        Worker::set_active_thread(&threadrc);
 
         #[cfg(feature = "perf_timers")]
         self.start_cpu_delay_timer();

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1771,12 +1771,6 @@ mod export {
         Worker::with_active_host(|host| proc.resume(host, tid)).unwrap()
     }
 
-    #[no_mangle]
-    pub unsafe extern "C" fn process_stop(proc: *const Process) {
-        let proc = unsafe { proc.as_ref().unwrap() };
-        Worker::with_active_host(|host| proc.stop(host)).unwrap()
-    }
-
     /// Send the signal described in `siginfo` to `process`. `currentRunningThread`
     /// should be set if there is one (e.g. if this is being called from a syscall
     /// handler), and NULL otherwise (e.g. when called from a timer expiration event).

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -530,6 +530,9 @@ impl Process {
         Worker::clear_active_thread();
     }
 
+    /// Terminate the Process.
+    ///
+    /// Should only be called from [`Host::free_all_applications`].
     pub fn stop(&self, host: &Host) {
         if !self.is_running() {
             debug!("process {} has already stopped", self.name());
@@ -537,8 +540,6 @@ impl Process {
         }
 
         info!("terminating process {}", self.name());
-
-        Worker::set_active_process(self);
 
         #[cfg(feature = "perf_timers")]
         self.start_cpu_delay_timer();
@@ -552,8 +553,6 @@ impl Process {
         }
         #[cfg(not(feature = "perf_timers"))]
         info!("process '{}' stopped", self.name());
-
-        Worker::clear_active_process();
     }
 
     /// Send the signal described in `siginfo` to `process`. `current_thread`

--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -92,7 +92,7 @@ bool _syscallhandler_didListenTimeoutExpire(const SysCallHandler* sys);
 bool _syscallhandler_wasBlocked(const SysCallHandler* sys);
 int _syscallhandler_validateLegacyFile(LegacyFile* descriptor, LegacyFileType expectedType);
 const Host* _syscallhandler_getHost(const SysCallHandler* sys);
-const ProcessRefCell* _syscallhandler_getProcess(const SysCallHandler* sys);
+const Process* _syscallhandler_getProcess(const SysCallHandler* sys);
 const char* _syscallhandler_getProcessName(const SysCallHandler* sys);
 const Thread* _syscallhandler_getThread(const SysCallHandler* sys);
 

--- a/src/main/host/syscall/signal.c
+++ b/src/main/host/syscall/signal.c
@@ -32,8 +32,8 @@ static int _shim_handled_signals[] = {SIGSYS, SIGSEGV};
 // Helpers
 ///////////////////////////////////////////////////////////
 
-static SyscallReturn _syscallhandler_signalProcess(SysCallHandler* sys,
-                                                   const ProcessRefCell* process, int sig) {
+static SyscallReturn _syscallhandler_signalProcess(SysCallHandler* sys, const Process* process,
+                                                   int sig) {
     if (sig < 0 || sig > SHD_SIGRT_MAX) {
         return syscallreturn_makeDoneErrno(EINVAL);
     }
@@ -71,7 +71,7 @@ static SyscallReturn _syscallhandler_signalThread(SysCallHandler* sys, const Thr
         return syscallreturn_makeDoneI64(0);
     }
 
-    const ProcessRefCell* process = thread_getProcess(thread);
+    const Process* process = thread_getProcess(thread);
     struct shd_kernel_sigaction action = shimshmem_getSignalAction(
         host_getShimShmemLock(_syscallhandler_getHost(sys)), process_getSharedMem(process), sig);
     if (action.u.ksa_handler == SIG_IGN ||
@@ -167,7 +167,7 @@ SyscallReturn syscallhandler_kill(SysCallHandler* sys, const SysCallArgs* args) 
         pid = -pid;
     }
 
-    const ProcessRefCell* process = host_getProcess(_syscallhandler_getHost(sys), pid);
+    const Process* process = host_getProcess(_syscallhandler_getHost(sys), pid);
     if (process == NULL) {
         debug("Process %d not found", pid);
         return syscallreturn_makeDoneErrno(ESRCH);
@@ -190,7 +190,7 @@ SyscallReturn syscallhandler_tgkill(SysCallHandler* sys, const SysCallArgs* args
         return syscallreturn_makeDoneErrno(ESRCH);
     }
 
-    const ProcessRefCell* process = thread_getProcess(thread);
+    const Process* process = thread_getProcess(thread);
 
     if (process_getProcessID(process) != tgid) {
         return syscallreturn_makeDoneErrno(ESRCH);

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -346,7 +346,7 @@ static void _syscallcondition_trigger(const Host* host, void* obj, void* arg) {
 #endif
 
         /* Wake up the thread. */
-        process_continue(proc, cond->threadId);
+        host_continue(host, cond->proc, cond->threadId);
     } else {
         // Spurious wakeup. Just return without running the process. The
         // condition's listeners should still be installed, and now that we've

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -209,7 +209,7 @@ static void _syscallcondition_unrefcb(void* cond_ptr) {
 }
 
 #ifdef DEBUG
-static void _syscallcondition_logListeningState(SysCallCondition* cond, const ProcessRefCell* proc,
+static void _syscallcondition_logListeningState(SysCallCondition* cond, const Process* proc,
                                                 const char* listenVerb) {
     GString* string = g_string_new(NULL);
 
@@ -318,7 +318,7 @@ static void _syscallcondition_trigger(const Host* host, void* obj, void* arg) {
     // (which it will be, if we decide to actually run the process below).
     cond->wakeupScheduled = false;
 
-    const ProcessRefCell* proc = host_getProcess(host, cond->proc);
+    const Process* proc = host_getProcess(host, cond->proc);
     if (!proc) {
 #ifdef DEBUG
         _syscallcondition_logListeningState(cond, proc, "ignored (process no longer exists)");
@@ -387,7 +387,7 @@ static void _syscallcondition_notifyStatusChanged(void* obj, void* arg) {
     const Host* host = worker_getCurrentHost();
 
 #ifdef DEBUG
-    const ProcessRefCell* proc = host_getProcess(host, cond->proc);
+    const Process* proc = host_getProcess(host, cond->proc);
     _syscallcondition_logListeningState(cond, proc, "status changed while");
 #endif
 
@@ -399,15 +399,15 @@ static void _syscallcondition_notifyTimeoutExpired(const Host* host, void* obj, 
     MAGIC_ASSERT(cond);
 
 #ifdef DEBUG
-    const ProcessRefCell* proc = host_getProcess(host, cond->proc);
+    const Process* proc = host_getProcess(host, cond->proc);
     _syscallcondition_logListeningState(cond, proc, "timeout expired while");
 #endif
 
     _syscallcondition_scheduleWakeupTask(cond, host);
 }
 
-void syscallcondition_waitNonblock(SysCallCondition* cond, const Host* host,
-                                   const ProcessRefCell* proc, const Thread* thread) {
+void syscallcondition_waitNonblock(SysCallCondition* cond, const Host* host, const Process* proc,
+                                   const Thread* thread) {
     MAGIC_ASSERT(cond);
     utility_debugAssert(host);
     utility_debugAssert(proc);
@@ -501,7 +501,7 @@ bool syscallcondition_wakeupForSignal(SysCallCondition* cond, const Host* host, 
     }
 
 #ifdef DEBUG
-    const ProcessRefCell* proc = host_getProcess(host, cond->proc);
+    const Process* proc = host_getProcess(host, cond->proc);
     _syscallcondition_logListeningState(cond, proc, "signaled while");
 #endif
 

--- a/src/main/host/syscall_condition.h
+++ b/src/main/host/syscall_condition.h
@@ -64,7 +64,7 @@ void syscallcondition_ref(SysCallCondition* cond);
 void syscallcondition_unref(SysCallCondition* cond);
 
 /* Activate the condition by registering the process and thread that will
- * be notified via process_continue() when the condition occurs. After
+ * be notified via host_continue() when the condition occurs. After
  * this call, the condition object will begin listening on the status of
  * the timeout and descriptor given in new(). */
 void syscallcondition_waitNonblock(SysCallCondition* cond, const Host* host, const Process* proc,

--- a/src/main/host/syscall_condition.h
+++ b/src/main/host/syscall_condition.h
@@ -67,8 +67,8 @@ void syscallcondition_unref(SysCallCondition* cond);
  * be notified via process_continue() when the condition occurs. After
  * this call, the condition object will begin listening on the status of
  * the timeout and descriptor given in new(). */
-void syscallcondition_waitNonblock(SysCallCondition* cond, const Host* host,
-                                   const ProcessRefCell* proc, const Thread* thread);
+void syscallcondition_waitNonblock(SysCallCondition* cond, const Host* host, const Process* proc,
+                                   const Thread* thread);
 
 /* Deactivate the condition by deregistering any open listeners and
  * clearing any references to the process an thread given in wait(). */

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -60,14 +60,14 @@ const Host* _syscallhandler_getHost(const SysCallHandler* sys) {
     return host;
 }
 
-const ProcessRefCell* _syscallhandler_getProcess(const SysCallHandler* sys) {
-    const ProcessRefCell* process = worker_getCurrentProcess();
+const Process* _syscallhandler_getProcess(const SysCallHandler* sys) {
+    const Process* process = worker_getCurrentProcess();
     utility_debugAssert(process_getProcessID(process) == sys->processId);
     return process;
 }
 
 const char* _syscallhandler_getProcessName(const SysCallHandler* sys) {
-    const ProcessRefCell* process = worker_getCurrentProcess();
+    const Process* process = worker_getCurrentProcess();
     utility_debugAssert(process_getProcessID(process) == sys->processId);
     return process_getPluginName(process);
 }
@@ -273,7 +273,7 @@ SyscallReturn syscallhandler_make_syscall(SysCallHandler* sys, const SysCallArgs
 
     StraceFmtMode straceLoggingMode = process_straceLoggingMode(_syscallhandler_getProcess(sys));
     const Host* host = _syscallhandler_getHost(sys);
-    const ProcessRefCell* process = _syscallhandler_getProcess(sys);
+    const Process* process = _syscallhandler_getProcess(sys);
     const Thread* thread = _syscallhandler_getThread(sys);
 
     SyscallReturn scr;


### PR DESCRIPTION
This unblocks some further cleanup of managing Process's internal state, and removes some complexity in itself.