### PR TITLE
Remove the '_manager_heartbeat' string

### DIFF
--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -741,8 +741,7 @@ impl<'a> Manager<'a> {
             ru_utime={:.03} minutes, \
             ru_stime={:.03} minutes, \
             ru_nvcsw={}, \
-            ru_nivcsw={}, \
-            _manager_heartbeat", // this is required for tornettools
+            ru_nivcsw={}",
             (now - EmulatedTime::SIMULATION_START).as_nanos(),
             max_memory,
             user_time_minutes,


### PR DESCRIPTION
Tornettools shouldn't search for this string anymore as of shadow/tornettools#96. Part of the 3.0 changes.