### PR TITLE
Change the process 'environment' option to a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ support graceful shutdown.
 their IP address. For example "lo.pcap" and "eth0.pcap" instead of
 "127.0.0.1.pcap" and "11.0.0.1.pcap".
 
+* The process `environment` configuration option now takes a map instead of a
+semicolon-delimited string.
+
 MINOR changes (backwards-compatible):
 
 * Support the `MSG_TRUNC` flag for unix sockets.

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -646,10 +646,21 @@ args: ['--user-agent', 'Mozilla/5.0 (compatible; ...)', 'http://myserver:8080']
 #### `hosts.<hostname>.processes[*].environment`
 
 Default: ""  
-Type: String
+Type: Object
 
-Environment variables passed when executing this process. Multiple variables can
-be specified by using a semicolon separator (ex: `ENV_A=1;ENV_B=2`).
+Environment variables passed when executing this process.
+
+Examples:
+
+```yaml
+environment:
+  ENV_A: "1"
+  ENV_B: foo
+```
+
+```yaml
+environment: { ENV_A: "1", ENV_B: foo }
+```
 
 #### `hosts.<hostname>.processes[*].path`
 

--- a/src/main/core/sim_config.rs
+++ b/src/main/core/sim_config.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::hash::{Hash, Hasher};
 use std::os::unix::fs::MetadataExt;
@@ -13,7 +13,7 @@ use shadow_shim_helper_rs::simulation_time::SimulationTime;
 
 use crate::core::support::configuration::Flatten;
 use crate::core::support::configuration::{
-    parse_string_as_args, ConfigOptions, HostOptions, LogInfoFlag, LogLevel, ProcessArgs,
+    parse_string_as_args, ConfigOptions, EnvName, HostOptions, LogInfoFlag, LogLevel, ProcessArgs,
     ProcessOptions, QDiscMode,
 };
 use crate::core::support::units::{self, Unit};
@@ -190,7 +190,7 @@ pub struct ProcessInfo {
     pub shutdown_time: Option<SimulationTime>,
     pub shutdown_signal: nix::sys::signal::Signal,
     pub args: Vec<OsString>,
-    pub env: String,
+    pub env: BTreeMap<EnvName, String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/test/environment/environment.yaml
+++ b/src/test/environment/environment.yaml
@@ -8,5 +8,11 @@ hosts:
     network_node_id: 0
     processes:
     - path: ../../target/debug/test_env
-      environment: "TESTING_ENV_VAR_1=HELLO WORLD;LD_PRELOAD=/my/custom/ld/preload/path.so;TESTING_ENV_VAR_2=SOMETHING"
+      environment:
+        TESTING_ENV_VAR_1: HELLO WORLD
+        LD_PRELOAD: /my/custom/ld/preload/path.so
+        TESTING_ENV_VAR_2: SOMETHING
+        TESTING_ENV_VAR_3: ""
+        TESTING_ENV_VAR_4: X=Y
+        TESTING_ENV_VAR_5: X;Y
       start_time: 1

--- a/src/test/environment/test_env.rs
+++ b/src/test/environment/test_env.rs
@@ -1,11 +1,23 @@
 fn main() {
-    let var_1 = std::env::var("TESTING_ENV_VAR_1")
+    let var = std::env::var("TESTING_ENV_VAR_1")
         .expect("Environment variable 'TESTING_ENV_VAR_1' not set");
-    assert_eq!(var_1, "HELLO WORLD");
+    assert_eq!(var, "HELLO WORLD");
 
-    let var_2 = std::env::var("TESTING_ENV_VAR_2")
+    let var = std::env::var("TESTING_ENV_VAR_2")
         .expect("Environment variable 'TESTING_ENV_VAR_2' not set");
-    assert_eq!(var_2, "SOMETHING");
+    assert_eq!(var, "SOMETHING");
+
+    let var = std::env::var("TESTING_ENV_VAR_3")
+        .expect("Environment variable 'TESTING_ENV_VAR_3' not set");
+    assert_eq!(var, "");
+
+    let var = std::env::var("TESTING_ENV_VAR_4")
+        .expect("Environment variable 'TESTING_ENV_VAR_4' not set");
+    assert_eq!(var, "X=Y");
+
+    let var = std::env::var("TESTING_ENV_VAR_5")
+        .expect("Environment variable 'TESTING_ENV_VAR_5' not set");
+    assert_eq!(var, "X;Y");
 
     let ld_preload =
         std::env::var("LD_PRELOAD").expect("Environment variable 'LD_PRELOAD' not set");

--- a/src/test/golang/gc.yaml
+++ b/src/test/golang/gc.yaml
@@ -11,4 +11,4 @@ hosts:
     processes:
     - path: ./test_gc
       start_time: 1s
-      environment: GOMAXPROCS=1
+      environment: { GOMAXPROCS: "1" }

--- a/src/test/golang/go_preempt.yaml
+++ b/src/test/golang/go_preempt.yaml
@@ -11,4 +11,4 @@ hosts:
     network_node_id: 0
     processes:
     - path: ./test_go_preempt
-      environment: GOMAXPROCS=1
+      environment: { GOMAXPROCS: "1" }

--- a/src/test/golang/goroutines.yaml
+++ b/src/test/golang/goroutines.yaml
@@ -11,4 +11,4 @@ hosts:
     processes:
     - path: ./test_goroutines
       start_time: 1s
-      environment: GOMAXPROCS=2
+      environment: { GOMAXPROCS: "2" }

--- a/src/test/tgen/fixed_duration/100mbit_100ms.yaml
+++ b/src/test/tgen/fixed_duration/100mbit_100ms.yaml
@@ -25,7 +25,7 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
   client:
@@ -33,6 +33,6 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../XXXCLIENTCONFXXX
       start_time: 1

--- a/src/test/tgen/fixed_duration/10mbit_200ms.yaml
+++ b/src/test/tgen/fixed_duration/10mbit_200ms.yaml
@@ -25,7 +25,7 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
   client:
@@ -33,6 +33,6 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../XXXCLIENTCONFXXX
       start_time: 1

--- a/src/test/tgen/fixed_duration/1gbit_10ms.yaml
+++ b/src/test/tgen/fixed_duration/1gbit_10ms.yaml
@@ -25,7 +25,7 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
   client:
@@ -33,6 +33,6 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../XXXCLIENTCONFXXX
       start_time: 1

--- a/src/test/tgen/fixed_duration/1mbit_300ms.yaml
+++ b/src/test/tgen/fixed_duration/1mbit_300ms.yaml
@@ -25,7 +25,7 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
   client:
@@ -33,6 +33,6 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../XXXCLIENTCONFXXX
       start_time: 1

--- a/src/test/tgen/fixed_size/100mbit_100ms.yaml
+++ b/src/test/tgen/fixed_size/100mbit_100ms.yaml
@@ -25,7 +25,7 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
   client:
@@ -33,6 +33,6 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../XXXCLIENTCONFXXX
       start_time: 1

--- a/src/test/tgen/fixed_size/10mbit_200ms.yaml
+++ b/src/test/tgen/fixed_size/10mbit_200ms.yaml
@@ -25,7 +25,7 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
   client:
@@ -33,6 +33,6 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../XXXCLIENTCONFXXX
       start_time: 1

--- a/src/test/tgen/fixed_size/1gbit_10ms.yaml
+++ b/src/test/tgen/fixed_size/1gbit_10ms.yaml
@@ -25,7 +25,7 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
   client:
@@ -33,6 +33,6 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../XXXCLIENTCONFXXX
       start_time: 1

--- a/src/test/tgen/fixed_size/1mbit_300ms.yaml
+++ b/src/test/tgen/fixed_size/1mbit_300ms.yaml
@@ -25,7 +25,7 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
   client:
@@ -33,6 +33,6 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../XXXCLIENTCONFXXX
       start_time: 1

--- a/src/test/tor/minimal/tor-minimal.yaml
+++ b/src/test/tor/minimal/tor-minimal.yaml
@@ -25,7 +25,7 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../conf/tgen.server.graphml.xml
       start_time: 1
   hiddenserver:
@@ -33,7 +33,7 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../conf/tgen.hiddenserver.graphml.xml
       start_time: 1
     - path: tor
@@ -81,7 +81,7 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../conf/tgen.client.graphml.xml
       start_time: 600
   torclient:
@@ -93,7 +93,7 @@ hosts:
       start_time: 900
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../conf/tgen.torclient.graphml.xml
       start_time: 1500
   torbridgeclient:
@@ -106,7 +106,7 @@ hosts:
       start_time: 900
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../conf/tgen.torclient.graphml.xml
       start_time: 1500
   torhiddenclient:
@@ -118,6 +118,6 @@ hosts:
       start_time: 900
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: OPENBLAS_NUM_THREADS=1
+      environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../conf/tgen.torhiddenclient.graphml.xml
       start_time: 1500


### PR DESCRIPTION
Part of the 3.0 changes.

This also removes the tilde expansion of the user-provided `LD_PRELOAD` arguments.