### PR TITLE
Change pcap filenames to use the interface name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ support graceful shutdown.
 
 * The minimum version of `glib` has been bumped from 2.32 to 2.58.
 
+* Generated pcap files are now named using their interface name instead of
+their IP address. For example "lo.pcap" and "eth0.pcap" instead of
+"127.0.0.1.pcap" and "11.0.0.1.pcap".
+
 MINOR changes (backwards-compatible):
 
 * Support the `MSG_TRUNC` flag for unix sockets.

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -546,7 +546,7 @@ Should Shadow generate pcap files?
 
 Logs all network input and output for this host in PCAP format (for viewing in
 e.g. wireshark). The pcap files will be stored in the host's data directory,
-for example `shadow.data/hosts/myhost/11.0.0.1.pcap`.
+for example `shadow.data/hosts/myhost/eth0.pcap`.
 
 #### `hosts`
 

--- a/src/main/host/network_interface.c
+++ b/src/main/host/network_interface.c
@@ -383,7 +383,7 @@ void networkinterface_removeAllSockets(NetworkInterface* interface) {
     g_hash_table_remove_all(interface->boundSockets);
 }
 
-NetworkInterface* networkinterface_new(Address* address, const gchar* pcapDir,
+NetworkInterface* networkinterface_new(Address* address, const char* name, const gchar* pcapDir,
                                        guint32 pcapCaptureSize, QDiscMode qdisc) {
     NetworkInterface* interface = g_new0(NetworkInterface, 1);
     MAGIC_INIT(interface);
@@ -411,14 +411,14 @@ NetworkInterface* networkinterface_new(Address* address, const gchar* pcapDir,
             g_string_append(filename, "/");
         }
 
-        g_string_append_printf(filename, "%s.pcap", address_toHostIPString(interface->address));
+        g_string_append_printf(filename, "%s.pcap", name);
 
         interface->pcap = pcapwriter_new(filename->str, pcapCaptureSize);
         g_string_free(filename, TRUE);
     }
 
-    debug("bringing up network interface '%s' at '%s' using queuing discipline %s",
-          address_toHostName(interface->address), address_toHostIPString(interface->address),
+    debug("bringing up network interface '%s' for host '%s' at '%s' using queuing discipline %s",
+          name, address_toHostName(interface->address), address_toHostIPString(interface->address),
           interface->qdisc == Q_DISC_MODE_ROUND_ROBIN ? "rr" : "fifo");
 
     worker_count_allocation(NetworkInterface);

--- a/src/main/host/network_interface.h
+++ b/src/main/host/network_interface.h
@@ -19,7 +19,7 @@ typedef struct _NetworkInterface NetworkInterface;
 #include "main/routing/address.h"
 #include "main/routing/packet.minimal.h"
 
-NetworkInterface* networkinterface_new(Address* address, const gchar* pcapDir,
+NetworkInterface* networkinterface_new(Address* address, const char* name, const gchar* pcapDir,
                                        guint32 pcapCaptureSize, QDiscMode qdisc);
 void networkinterface_free(NetworkInterface* interface);
 

--- a/src/test/determinism/determinism1.test.shadow.config.yaml
+++ b/src/test/determinism/determinism1.test.shadow.config.yaml
@@ -23,36 +23,15 @@ network:
 hosts:
   testnode1: &host
     network_node_id: 0
-    # use explicit IP addresses since the comparison script (determinism1_compare.cmake)
-    # depends on these, and otherwise shadow would assign 11.0.0.2 to peer10
-    ip_addr: 11.0.0.1
     processes:
     - path: ./test-determinism
       start_time: 1
-  testnode2:
-    <<: *host
-    ip_addr: 11.0.0.2
-  testnode3:
-    <<: *host
-    ip_addr: 11.0.0.3
-  testnode4:
-    <<: *host
-    ip_addr: 11.0.0.4
-  testnode5:
-    <<: *host
-    ip_addr: 11.0.0.5
-  testnode6:
-    <<: *host
-    ip_addr: 11.0.0.6
-  testnode7:
-    <<: *host
-    ip_addr: 11.0.0.7
-  testnode8:
-    <<: *host
-    ip_addr: 11.0.0.8
-  testnode9:
-    <<: *host
-    ip_addr: 11.0.0.9
-  testnode10:
-    <<: *host
-    ip_addr: 11.0.0.10
+  testnode2: *host
+  testnode3: *host
+  testnode4: *host
+  testnode5: *host
+  testnode6: *host
+  testnode7: *host
+  testnode8: *host
+  testnode9: *host
+  testnode10: *host

--- a/src/test/determinism/determinism1_compare.cmake
+++ b/src/test/determinism/determinism1_compare.cmake
@@ -21,12 +21,12 @@ foreach(LOOPIDX RANGE 1 10)
         ${CMAKE_BINARY_DIR}/determinism1b-shadow.data/hosts/testnode${LOOPIDX}/test-determinism.1000.strace
     )
     exec_diff_check(
-        ${CMAKE_BINARY_DIR}/determinism1a-shadow.data/hosts/testnode${LOOPIDX}/127.0.0.1.pcap
-        ${CMAKE_BINARY_DIR}/determinism1b-shadow.data/hosts/testnode${LOOPIDX}/127.0.0.1.pcap
+        ${CMAKE_BINARY_DIR}/determinism1a-shadow.data/hosts/testnode${LOOPIDX}/lo.pcap
+        ${CMAKE_BINARY_DIR}/determinism1b-shadow.data/hosts/testnode${LOOPIDX}/lo.pcap
     )
     exec_diff_check(
-        ${CMAKE_BINARY_DIR}/determinism1a-shadow.data/hosts/testnode${LOOPIDX}/11.0.0.${LOOPIDX}.pcap
-        ${CMAKE_BINARY_DIR}/determinism1b-shadow.data/hosts/testnode${LOOPIDX}/11.0.0.${LOOPIDX}.pcap
+        ${CMAKE_BINARY_DIR}/determinism1a-shadow.data/hosts/testnode${LOOPIDX}/eth0.pcap
+        ${CMAKE_BINARY_DIR}/determinism1b-shadow.data/hosts/testnode${LOOPIDX}/eth0.pcap
     )
 endforeach(LOOPIDX)
 

--- a/src/test/determinism/determinism2.test.shadow.config.yaml
+++ b/src/test/determinism/determinism2.test.shadow.config.yaml
@@ -23,37 +23,16 @@ network:
 hosts:
   peer1: &host
     network_node_id: 0
-    # use explicit IP addresses since the comparison script (determinism2_compare.cmake)
-    # depends on these, and otherwise shadow would assign 11.0.0.2 to peer10
-    ip_addr: 11.0.0.1
     processes:
     - path: ../phold/test-phold
       args: loglevel=debug basename=peer quantity=10 msgload=1 size=1 cpuload=1 weightsfilepath=../../../weights.txt runtime=5
       start_time: 1
-  peer2:
-    <<: *host
-    ip_addr: 11.0.0.2
-  peer3:
-    <<: *host
-    ip_addr: 11.0.0.3
-  peer4:
-    <<: *host
-    ip_addr: 11.0.0.4
-  peer5:
-    <<: *host
-    ip_addr: 11.0.0.5
-  peer6:
-    <<: *host
-    ip_addr: 11.0.0.6
-  peer7:
-    <<: *host
-    ip_addr: 11.0.0.7
-  peer8:
-    <<: *host
-    ip_addr: 11.0.0.8
-  peer9:
-    <<: *host
-    ip_addr: 11.0.0.9
-  peer10:
-    <<: *host
-    ip_addr: 11.0.0.10
+  peer2: *host
+  peer3: *host
+  peer4: *host
+  peer5: *host
+  peer6: *host
+  peer7: *host
+  peer8: *host
+  peer9: *host
+  peer10: *host

--- a/src/test/determinism/determinism2_compare.cmake
+++ b/src/test/determinism/determinism2_compare.cmake
@@ -29,19 +29,19 @@ foreach(LOOPIDX RANGE 1 10)
         ${CMAKE_BINARY_DIR}/determinism2c-shadow.data/hosts/peer${LOOPIDX}/test-phold.1000.strace
     )
     exec_diff_check(
-        ${CMAKE_BINARY_DIR}/determinism2a-shadow.data/hosts/peer${LOOPIDX}/127.0.0.1.pcap
-        ${CMAKE_BINARY_DIR}/determinism2b-shadow.data/hosts/peer${LOOPIDX}/127.0.0.1.pcap
+        ${CMAKE_BINARY_DIR}/determinism2a-shadow.data/hosts/peer${LOOPIDX}/lo.pcap
+        ${CMAKE_BINARY_DIR}/determinism2b-shadow.data/hosts/peer${LOOPIDX}/lo.pcap
     )
     exec_diff_check(
-        ${CMAKE_BINARY_DIR}/determinism2a-shadow.data/hosts/peer${LOOPIDX}/127.0.0.1.pcap
-        ${CMAKE_BINARY_DIR}/determinism2c-shadow.data/hosts/peer${LOOPIDX}/127.0.0.1.pcap
+        ${CMAKE_BINARY_DIR}/determinism2a-shadow.data/hosts/peer${LOOPIDX}/lo.pcap
+        ${CMAKE_BINARY_DIR}/determinism2c-shadow.data/hosts/peer${LOOPIDX}/lo.pcap
     )
     exec_diff_check(
-        ${CMAKE_BINARY_DIR}/determinism2a-shadow.data/hosts/peer${LOOPIDX}/11.0.0.${LOOPIDX}.pcap
-        ${CMAKE_BINARY_DIR}/determinism2b-shadow.data/hosts/peer${LOOPIDX}/11.0.0.${LOOPIDX}.pcap
+        ${CMAKE_BINARY_DIR}/determinism2a-shadow.data/hosts/peer${LOOPIDX}/eth0.pcap
+        ${CMAKE_BINARY_DIR}/determinism2b-shadow.data/hosts/peer${LOOPIDX}/eth0.pcap
     )
     exec_diff_check(
-        ${CMAKE_BINARY_DIR}/determinism2a-shadow.data/hosts/peer${LOOPIDX}/11.0.0.${LOOPIDX}.pcap
-        ${CMAKE_BINARY_DIR}/determinism2c-shadow.data/hosts/peer${LOOPIDX}/11.0.0.${LOOPIDX}.pcap
+        ${CMAKE_BINARY_DIR}/determinism2a-shadow.data/hosts/peer${LOOPIDX}/eth0.pcap
+        ${CMAKE_BINARY_DIR}/determinism2c-shadow.data/hosts/peer${LOOPIDX}/eth0.pcap
     )
 endforeach(LOOPIDX)


### PR DESCRIPTION
The interface names for 127.0.0.1 and the public IP have been chosen as "lo" and "eth0", which are standard names for these interfaces on Linux. Part of the 3.0 changes.