### PR TITLE
Move signal parsing into serde

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -683,6 +683,8 @@ Type: String OR Integer
 
 The signal that will be sent to the process at
 [`hosts.<hostname>.processes[*].shutdown_time`](#hostshostnameprocessesshutdown_time).
+Signals specified by name should be all-caps and include the SIG prefix; e.g.
+"SIGTERM".
 
 #### `hosts.<hostname>.processes[*].shutdown_time`
 

--- a/src/main/core/sim_config.rs
+++ b/src/main/core/sim_config.rs
@@ -3,7 +3,6 @@ use std::ffi::{OsStr, OsString};
 use std::hash::{Hash, Hasher};
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -294,22 +293,13 @@ fn build_host(
     })
 }
 
-fn parse_signal(s: &str) -> anyhow::Result<nix::sys::signal::Signal> {
-    if let Ok(i) = i32::from_str(s) {
-        nix::sys::signal::Signal::try_from(i).map_err(anyhow::Error::from)
-    } else {
-        nix::sys::signal::Signal::from_str(s).map_err(anyhow::Error::from)
-    }
-}
-
 /// For a process entry in the configuration options, build a `ProcessInfo` object.
 fn build_process(proc: &ProcessOptions, config: &ConfigOptions) -> anyhow::Result<ProcessInfo> {
     let start_time = Duration::from(proc.start_time).try_into().unwrap();
     let shutdown_time = proc
         .shutdown_time
         .map(|x| Duration::from(x).try_into().unwrap());
-    let shutdown_signal = parse_signal(&proc.shutdown_signal)
-        .with_context(|| format!("Parsing shutdown_signal: {}", proc.shutdown_signal))?;
+    let shutdown_signal = *proc.shutdown_signal;
     let sim_stop_time =
         SimulationTime::try_from(Duration::from(config.general.stop_time.unwrap())).unwrap();
 


### PR DESCRIPTION
This takes a bit more code, but keeps with trying to do as much input validation as we can up front. We can also reuse it when adding process end state expectations (e.g. "killed with signal X") for https://github.com/shadow/shadow/discussions/2034