### PR TITLE
Split Process internals by state

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1484,6 +1484,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "std-util"
+version = "0.1.0"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1365,6 +1365,7 @@ dependencies = [
  "shadow_tsc",
  "signal-hook",
  "static_assertions",
+ "std-util",
  "syscall-logger",
  "system-deps",
  "tempfile",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "lib/logger",
     "lib/shmem",
     "lib/shadow-shim-helper-rs",
+    "lib/std-util",
     "lib/syscall-logger",
     "lib/tsc",
     "lib/vasi",

--- a/src/lib/std-util/Cargo.toml
+++ b/src/lib/std-util/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "std-util"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/src/lib/std-util/src/lib.rs
+++ b/src/lib/std-util/src/lib.rs
@@ -1,0 +1,3 @@
+//! Utilities that extend the `std` crate.
+
+pub mod nested_ref;

--- a/src/lib/std-util/src/nested_ref.rs
+++ b/src/lib/std-util/src/nested_ref.rs
@@ -1,0 +1,243 @@
+//! Tools for chaining borrows of [`std::cell::RefCell`].
+//!
+//! Useful for returning an abstract borrow, where multiple inner borrows are required. e.g.:
+//!
+//! ```
+//! use std::cell::RefCell;
+//!
+//! struct MyPrivateType {
+//!   x: RefCell<i32>
+//! }
+//!
+//! pub struct MyPublicType {
+//!   inner: RefCell<MyPrivateType>
+//! }
+//!
+//! impl MyPublicType {
+//!   pub fn borrow_x(&self) -> impl std::ops::Deref<Target=i32> + '_ {
+//!     std_util::nested_ref::NestedRef::map(self.inner.borrow(), |inner| inner.x.borrow())
+//!   }
+//! }
+//! ```
+//!
+//! Currently only supports nested RefCells; i.e. one level of nesting.
+//!
+//! TODO: It might be feasible to genericize the reference types, which would
+//! also add support for arbitrary levels of nesting.
+use std::cell::{Ref, RefMut};
+
+/// A nested [`std::cell::Ref`]. Useful for chaining borrows with [`std::cell::RefCell`].
+pub struct NestedRef<'a, Inner, Outer>
+where
+    Inner: 'static,
+{
+    // unsafely points to the Ref inside `_outer`.
+    // Must be declared first so that it's dropped first.
+    inner: Ref<'a, Inner>,
+    // Boxed so that `Self` is movable without breaking `inner`'s reference.
+    _outer: Box<Ref<'a, Outer>>,
+}
+impl<'a, Inner, Outer> NestedRef<'a, Inner, Outer>
+where
+    Inner: 'static,
+{
+    #[inline]
+    pub fn map(outer: Ref<'a, Outer>, borrow_fn: impl FnOnce(&Outer) -> Ref<Inner>) -> Self {
+        Self::filter_map(outer, |outer| Some(borrow_fn(outer))).unwrap()
+    }
+
+    #[inline]
+    pub fn filter_map(
+        outer: Ref<'a, Outer>,
+        borrow_fn: impl FnOnce(&Outer) -> Option<Ref<Inner>>,
+    ) -> Option<Self> {
+        let boxed_outer = Box::new(outer);
+        let inner: Ref<Inner> = borrow_fn(&boxed_outer)?;
+        // SAFETY: The lifetime of the `inner` returned from `borrow_fn` is the
+        // (anonymous) lifetime of `boxed_outer`. However we only provided the
+        // closure with the reference to the *contents* of the box, `outer`, which
+        // has lifetime 'a. This is safe as long as we ensure that the transmuted
+        // `boxed_outer` outlives the transmuted `inner`.
+        let inner: Ref<'a, Inner> = unsafe { std::mem::transmute(inner) };
+        Some(Self {
+            inner,
+            _outer: boxed_outer,
+        })
+    }
+}
+impl<'a, Inner, Outer> std::ops::Deref for NestedRef<'a, Inner, Outer>
+where
+    Inner: 'static,
+{
+    type Target = Inner;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.deref()
+    }
+}
+
+/// A nested [`std::cell::Ref`]. Useful for chaining a mutable borrow of a
+/// [`std::cell::RefCell`].
+pub struct NestedRefMut<'a, Inner, Outer>
+where
+    Inner: 'static,
+{
+    // unsafely points to the Ref inside `_outer`.
+    // Must be declared first so that it's dropped first.
+    inner: RefMut<'a, Inner>,
+    // Boxed so that `Self` is movable without breaking `inner`'s reference.
+    _outer: Box<Ref<'a, Outer>>,
+}
+impl<'a, Inner, Outer> NestedRefMut<'a, Inner, Outer>
+where
+    Inner: 'static,
+{
+    #[inline]
+    pub fn map(outer: Ref<'a, Outer>, borrow_fn: impl FnOnce(&Outer) -> RefMut<Inner>) -> Self {
+        Self::filter_map(outer, |outer| Some(borrow_fn(outer))).unwrap()
+    }
+
+    #[inline]
+    pub fn filter_map(
+        outer: Ref<'a, Outer>,
+        borrow_fn: impl FnOnce(&Outer) -> Option<RefMut<Inner>>,
+    ) -> Option<Self> {
+        let outer = Box::new(outer);
+        let inner: RefMut<Inner> = borrow_fn(&outer)?;
+        // SAFETY: The lifetime of the `inner` returned from `borrow_fn` is the
+        // (anonymous) lifetime of `boxed_outer`. However we only provided the
+        // closure with the reference to the *contents* of the box, `outer`, which
+        // has lifetime 'a. This is safe as long as we ensure that the transmuted
+        // `boxed_outer` outlives the transmuted `inner`.
+        let inner: RefMut<'a, Inner> = unsafe { std::mem::transmute(inner) };
+        Some(Self {
+            inner,
+            _outer: outer,
+        })
+    }
+}
+impl<'a, Inner, Outer> std::ops::Deref for NestedRefMut<'a, Inner, Outer>
+where
+    Inner: 'static,
+{
+    type Target = Inner;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.deref()
+    }
+}
+impl<'a, Inner, Outer> std::ops::DerefMut for NestedRefMut<'a, Inner, Outer>
+where
+    Inner: 'static,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.deref_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    struct TestOuter {
+        x: RefCell<i32>,
+    }
+
+    #[test]
+    fn nestedref_map() {
+        let outer = RefCell::new(TestOuter {
+            x: RefCell::new(42),
+        });
+        let nested = NestedRef::map(outer.borrow(), |inner| inner.x.borrow());
+        assert_eq!(*nested, 42);
+    }
+
+    #[test]
+    fn nestedref_filter_map_some() {
+        let outer = RefCell::new(TestOuter {
+            x: RefCell::new(42),
+        });
+        let nested = NestedRef::filter_map(outer.borrow(), |inner| Some(inner.x.borrow()));
+        let nested = nested.unwrap();
+        assert_eq!(*nested, 42);
+    }
+
+    #[test]
+    fn nestedref_filter_map_none() {
+        let outer = RefCell::new(TestOuter {
+            x: RefCell::new(42),
+        });
+        let nested = NestedRef::<i32, TestOuter>::filter_map(outer.borrow(), |_inner| None);
+        assert!(nested.is_none());
+    }
+
+    #[test]
+    fn nestedref_is_movable() {
+        let outer = RefCell::new(TestOuter {
+            x: RefCell::new(42),
+        });
+        let nested = NestedRef::map(outer.borrow(), |inner| inner.x.borrow());
+        assert_eq!(*nested, 42);
+        let boxed_nested = Box::new(nested);
+        assert_eq!(**boxed_nested, 42);
+    }
+
+    #[test]
+    fn nestedrefmut_map() {
+        let outer = RefCell::new(TestOuter {
+            x: RefCell::new(42),
+        });
+        {
+            let mut nested = NestedRefMut::map(outer.borrow(), |inner| inner.x.borrow_mut());
+            assert_eq!(*nested, 42);
+            *nested += 1;
+            assert_eq!(*nested, 43);
+            assert!(outer.borrow().x.try_borrow().is_err());
+        }
+        assert_eq!(*outer.borrow().x.borrow(), 43);
+    }
+
+    #[test]
+    fn nestedrefmut_filter_map_some() {
+        let outer = RefCell::new(TestOuter {
+            x: RefCell::new(42),
+        });
+        {
+            let nested =
+                NestedRefMut::filter_map(outer.borrow(), |inner| Some(inner.x.borrow_mut()));
+            let mut nested = nested.unwrap();
+            assert_eq!(*nested, 42);
+            *nested += 1;
+            assert_eq!(*nested, 43);
+            assert!(outer.borrow().x.try_borrow().is_err());
+        }
+        assert_eq!(*outer.borrow().x.borrow(), 43);
+    }
+
+    #[test]
+    fn nestedrefmut_filter_map_none() {
+        let outer = RefCell::new(TestOuter {
+            x: RefCell::new(42),
+        });
+        let nested = NestedRefMut::<i32, TestOuter>::filter_map(outer.borrow(), |_inner| None);
+        assert!(nested.is_none());
+    }
+
+    #[test]
+    fn nestedrefmut_is_movable() {
+        let outer = RefCell::new(TestOuter {
+            x: RefCell::new(42),
+        });
+        {
+            let nested = NestedRefMut::map(outer.borrow(), |inner| inner.x.borrow_mut());
+            assert_eq!(*nested, 42);
+            let mut nested = Box::new(nested);
+            assert_eq!(**nested, 42);
+            **nested += 1;
+            assert_eq!(**nested, 43);
+        }
+        assert_eq!(*outer.borrow().x.borrow(), 43);
+    }
+}

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -46,6 +46,7 @@ shadow_shmem = { path = "../lib/shmem" }
 shadow_tsc = { path = "../lib/tsc" }
 signal-hook = "0.3.15"
 static_assertions = "1.1.0"
+std-util = { path = "../lib/std-util" }
 syscall-logger = { path = "../lib/syscall-logger" }
 tempfile = "3.5"
 vasi-sync = { path = "../lib/vasi-sync" }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -170,11 +170,6 @@ fn itimer_real_expiration(host: &Host, pid: ProcessId) {
 impl Process {
     /// Spawn a new process. The process will be runnable via [`Self::resume`]
     /// once it has been added to the `Host`'s process list.
-    ///
-    /// The returned object shouldn't be moved out of its enclosing RootedRc.
-    /// Doing so breaks an internal weak reference to that RootedRc, which we
-    /// use to access the enclosing RootedRc and RootedRefCell when interacting
-    /// with C APIs.
     pub fn spawn(
         host: &Host,
         process_id: ProcessId,

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -326,6 +326,13 @@ static void _syscallcondition_trigger(const Host* host, void* obj, void* arg) {
         return;
     }
 
+    if (!process_isRunning(proc)) {
+#ifdef DEBUG
+        _syscallcondition_logListeningState(cond, proc, "ignored (process no longer running)");
+#endif
+        return;
+    }
+
     const Thread* thread = process_getThread(proc, cond->threadId);
     if (!thread) {
 #ifdef DEBUG


### PR DESCRIPTION
Processes can be kept around as zombies after they exit, but it usually doesn't make sense to access most of their internal state at this point. Previously there were ad-hoc checks for whether the Process was still running, but by moving the internals into an enum we can't forget to make such checks.

This also helps ensure we clean up everything that ought to be cleaned up when the process exits (goes from the `Runnable` state to the `Zombie` state).