### PR TITLE
Rename the `host_defaults` and `options` config fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and [extension fields](https://docs.docker.com/compose/compose-file/#extension).
 The experimental configuration option that previously enabled this support,
 `use_extended_yaml`, has been removed.
 
-* Removed the `host_defaults.pcap_directory` configuration option and replaced
-it with a new `host_defaults.pcap_enabled` option.
+* Removed the host `pcap_directory` configuration option and replaced
+it with a new `pcap_enabled` option.
 
 * A host's data files (files in `<data-dir>/hosts/<hostname>/`) are no longer
 prefixed with the hostname. For example a file that was previously named
@@ -47,6 +47,9 @@ semicolon-delimited string.
 
 * Removed the `quantity` options for hosts and processes. It's now recommended
 to use YAML anchors and merge keys instead.
+
+* Renamed the `host_defaults` configuration field to `host_option_defaults` and
+renamed the host's `options` field to `host_options`.
 
 MINOR changes (backwards-compatible):
 

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -40,7 +40,7 @@ hosts:
       start_time: 1
   client1: &client_host
     network_node_id: 0
-    options:
+    host_options:
       log_level: debug
     processes:
     - path: /usr/bin/curl
@@ -94,16 +94,16 @@ hosts:
 - [`experimental.use_preload_openssl_rng`](#experimentaluse_preload_openssl_rng)
 - [`experimental.use_sched_fifo`](#experimentaluse_sched_fifo)
 - [`experimental.use_syscall_counters`](#experimentaluse_syscall_counters)
-- [`host_defaults`](#host_defaults)
-- [`host_defaults.log_level`](#host_defaultslog_level)
-- [`host_defaults.pcap_capture_size`](#host_defaultspcap_capture_size)
-- [`host_defaults.pcap_enabled`](#host_defaultspcap_enabled)
+- [`host_option_defaults`](#host_option_defaults)
+- [`host_option_defaults.log_level`](#host_option_defaultslog_level)
+- [`host_option_defaults.pcap_capture_size`](#host_option_defaultspcap_capture_size)
+- [`host_option_defaults.pcap_enabled`](#host_option_defaultspcap_enabled)
 - [`hosts`](#hosts)
 - [`hosts.<hostname>.bandwidth_down`](#hostshostnamebandwidth_down)
 - [`hosts.<hostname>.bandwidth_up`](#hostshostnamebandwidth_up)
 - [`hosts.<hostname>.ip_addr`](#hostshostnameip_addr)
 - [`hosts.<hostname>.network_node_id`](#hostshostnamenetwork_node_id)
-- [`hosts.<hostname>.options`](#hostshostnameoptions)
+- [`hosts.<hostname>.host_options`](#hostshostnamehost_options)
 - [`hosts.<hostname>.processes`](#hostshostnameprocesses)
 - [`hosts.<hostname>.processes[*].args`](#hostshostnameprocessesargs)
 - [`hosts.<hostname>.processes[*].environment`](#hostshostnameprocessesenvironment)
@@ -513,20 +513,20 @@ Type: Bool
 
 Count the number of occurrences for individual syscalls.
 
-#### `host_defaults`
+#### `host_option_defaults`
 
 Default options for all hosts. These options can also be overridden for each
-host individually in the host's [`hosts.<hostname>.options`](#hostshostnameoptions)
+host individually in the host's [`hosts.<hostname>.host_options`](#hostshostnamehost_options)
 section.
 
-#### `host_defaults.log_level`
+#### `host_option_defaults.log_level`
 
 Default: null  
 Type: "error" OR "warning" OR "info" OR "debug" OR "trace" OR null
 
 Log level at which to print host log messages.
 
-#### `host_defaults.pcap_capture_size`
+#### `host_option_defaults.pcap_capture_size`
 
 Default: "65535 B"  
 Type: String OR Integer
@@ -536,7 +536,7 @@ enabled.
 
 The default of 65535 bytes is the maximum length of an IP packet.
 
-#### `host_defaults.pcap_enabled`
+#### `host_option_defaults.pcap_enabled`
 
 Default: false  
 Type: Bool
@@ -601,9 +601,9 @@ Type: Integer
 
 Network graph node ID to assign the host to.
 
-#### `hosts.<hostname>.options`
+#### `hosts.<hostname>.host_options`
 
-See [`host_defaults`](#host_defaults) for supported fields.
+See [`host_option_defaults`](#host_option_defaults) for supported fields.
 
 Example:
 
@@ -611,7 +611,7 @@ Example:
 hosts:
   client:
     ...
-    options:
+    host_options:
       log_level: debug
 ```
 

--- a/src/main/core/sim_config.rs
+++ b/src/main/core/sim_config.rs
@@ -252,16 +252,20 @@ fn build_host(
             .map(|x| x.convert(units::SiPrefixUpper::Base).unwrap().value()),
 
         ip_addr: host.ip_addr.map(|x| x.into()),
-        log_level: host.options.log_level.flatten(),
-        pcap_config: host.options.pcap_enabled.unwrap().then_some(PcapConfig {
-            capture_size: host
-                .options
-                .pcap_capture_size
-                .unwrap()
-                .convert(units::SiPrefixUpper::Base)
-                .unwrap()
-                .value(),
-        }),
+        log_level: host.host_options.log_level.flatten(),
+        pcap_config: host
+            .host_options
+            .pcap_enabled
+            .unwrap()
+            .then_some(PcapConfig {
+                capture_size: host
+                    .host_options
+                    .pcap_capture_size
+                    .unwrap()
+                    .convert(units::SiPrefixUpper::Base)
+                    .unwrap()
+                    .value(),
+            }),
 
         // some options come from the config options and not the host options
         heartbeat_log_level: config.experimental.host_heartbeat_log_level,

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -63,7 +63,7 @@ pub struct CliOptions {
     pub network: NetworkOptions,
 
     #[clap(flatten)]
-    pub host_defaults: HostDefaultOptions,
+    pub host_default_options: HostDefaultOptions,
 
     #[clap(flatten)]
     pub experimental: ExperimentalOptions,
@@ -78,7 +78,7 @@ pub struct ConfigFileOptions {
     pub network: NetworkOptions,
 
     #[serde(default)]
-    pub host_defaults: HostDefaultOptions,
+    pub host_default_options: HostDefaultOptions,
 
     #[serde(default)]
     pub experimental: ExperimentalOptions,
@@ -107,17 +107,17 @@ impl ConfigOptions {
         // override config options with command line options
         config_file.general = options.general.with_defaults(config_file.general);
         config_file.network = options.network.with_defaults(config_file.network);
-        config_file.host_defaults = options
-            .host_defaults
-            .with_defaults(config_file.host_defaults);
+        config_file.host_default_options = options
+            .host_default_options
+            .with_defaults(config_file.host_default_options);
         config_file.experimental = options.experimental.with_defaults(config_file.experimental);
 
         // copy the host defaults to all of the hosts
         for host in config_file.hosts.values_mut() {
-            host.options = host
-                .options
+            host.host_options = host
+                .host_options
                 .clone()
-                .with_defaults(config_file.host_defaults.clone());
+                .with_defaults(config_file.host_default_options.clone());
         }
 
         Self {
@@ -594,7 +594,7 @@ pub struct HostOptions {
     pub bandwidth_up: Option<units::BitsPerSec<units::SiPrefixUpper>>,
 
     #[serde(default = "HostDefaultOptions::new_empty")]
-    pub options: HostDefaultOptions,
+    pub host_options: HostDefaultOptions,
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema)]

--- a/src/test/determinism/determinism1.test.shadow.config.yaml
+++ b/src/test/determinism/determinism1.test.shadow.config.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 5
-host_defaults:
+host_default_options:
   pcap_enabled: true
 network:
   graph:

--- a/src/test/determinism/determinism2.test.shadow.config.yaml
+++ b/src/test/determinism/determinism2.test.shadow.config.yaml
@@ -1,6 +1,6 @@
 general:
   stop_time: 10
-host_defaults:
+host_default_options:
   pcap_enabled: true
 network:
   graph:


### PR DESCRIPTION
https://github.com/shadow/shadow/issues/2065#issuecomment-1507299498

> top-level field "host_defaults" -> "host_option_defaults"
> host field "options" -> "host_options"

Closes #2065.