### PR TITLE
Fix search string in the parse script

### DIFF
--- a/src/tools/parse-shadow.py
+++ b/src/tools/parse-shadow.py
@@ -146,7 +146,7 @@ def process_shadow_lines(passed_args):
     max_mem, max_seconds = 0, 0
     d = {'ticks':{}, 'nodes':{}}
 
-    if re.search("manager_heartbeat", line) is not None:
+    if re.search("[Pp]rocess resource usage at simtime", line) is not None:
         parts = line.strip().split()
         if len(parts) < 14: return None
 


### PR DESCRIPTION
This broke in https://github.com/shadow/shadow/pull/2874.

This bug prevents the benchmark runner from generating tgen runtime performance graphs.