### PR TITLE
Add config option expected_end_state    

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ to use YAML anchors and merge keys instead.
 * Renamed the `host_defaults` configuration field to `host_option_defaults` and
 renamed the host's `options` field to `host_options`.
 
+* Shadow now interprets a process still running at the end of the simulation as
+an error by default. This can be overridden by the new per-process option
+`expected_final_state`. https://github.com/shadow/shadow/pull/2886
+
 MINOR changes (backwards-compatible):
 
 * Support the `MSG_TRUNC` flag for unix sockets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,12 @@ returning `-1` instead of `NULL` on errors.
 
 * A call to `epoll_ctl` with an unknown operation will return `EINVAL`.
 
+* Simulated Processes are now reaped and deallocated after the exit, reducing
+run-time memory usage when processes exit over the course of the simulation.
+This was unlikely to have affected most users, since Shadow currently doesn't
+support `fork`, so any simulation has a fixed number of processes, all of which
+are explicitly specified in shadow's config.
+
 Raw changes since v2.5.0:
 
 * [Merged PRs](https://github.com/shadow/shadow/pulls?q=is%3Apr+merged%3A%3E2023-03-23T18%3A20-0400)

--- a/docs/compatibility_notes.md
+++ b/docs/compatibility_notes.md
@@ -150,7 +150,7 @@ hosts:
       start_time: 0s
       # Tell shadow to expect this process to still be running at the end of the
       # simulation.
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:
@@ -223,7 +223,7 @@ hosts:
     - path: opentracker
       # Tell shadow to expect this process to still be running at the end of the
       # simulation.
-      expected_final_state: !running
+      expected_final_state: running
   uploader:
     network_node_id: 0
     processes:
@@ -238,7 +238,7 @@ hosts:
     - path: ctorrent
       args: example.torrent
       start_time: 12s
-      expected_final_state: !running
+      expected_final_state: running
   downloader1: &downloader_host
     network_node_id: 0
     processes:
@@ -246,7 +246,7 @@ hosts:
     - path: ctorrent
       args: ../uploader/example.torrent
       start_time: 30s
-      expected_final_state: !running
+      expected_final_state: running
   downloader2: *downloader_host
   downloader3: *downloader_host
   downloader4: *downloader_host

--- a/docs/compatibility_notes.md
+++ b/docs/compatibility_notes.md
@@ -148,6 +148,9 @@ hosts:
     - path: iperf3
       args: -s --bind 0.0.0.0
       start_time: 0s
+      # Tell shadow to expect this process to still be running at the end of the
+      # simulation.
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:
@@ -218,24 +221,32 @@ hosts:
     network_node_id: 0
     processes:
     - path: opentracker
+      # Tell shadow to expect this process to still be running at the end of the
+      # simulation.
+      expected_final_state: !running
   uploader:
     network_node_id: 0
     processes:
     - path: cp
       args: ../../../foo .
       start_time: 10s
+    # Create the torrent file
     - path: ctorrent
       args: -t foo -s example.torrent -u http://tracker:6969/announce
       start_time: 11s
+    # Serve the torrent
     - path: ctorrent
       args: example.torrent
       start_time: 12s
+      expected_final_state: !running
   downloader1: &downloader_host
     network_node_id: 0
     processes:
+    # Download and share the torrent
     - path: ctorrent
       args: ../uploader/example.torrent
       start_time: 30s
+      expected_final_state: !running
   downloader2: *downloader_host
   downloader3: *downloader_host
   downloader4: *downloader_host

--- a/docs/getting_started_basic.md
+++ b/docs/getting_started_basic.md
@@ -38,6 +38,9 @@ hosts:
     - path: /usr/bin/python3
       args: -m http.server 80
       start_time: 3s
+      # Tell shadow to expect this process to still be running at the end of the
+      # simulation.
+      expected_final_state: !running
   # three hosts with hostnames 'client1', 'client2', and 'client3' using a yaml
   # anchor to avoid duplicating the options for each host
   client1: &client_host

--- a/docs/getting_started_basic.md
+++ b/docs/getting_started_basic.md
@@ -40,7 +40,7 @@ hosts:
       start_time: 3s
       # Tell shadow to expect this process to still be running at the end of the
       # simulation.
-      expected_final_state: !running
+      expected_final_state: running
   # three hosts with hostnames 'client1', 'client2', and 'client3' using a yaml
   # anchor to avoid duplicating the options for each host
   client1: &client_host

--- a/docs/getting_started_tgen.md
+++ b/docs/getting_started_tgen.md
@@ -71,6 +71,9 @@ hosts:
       # See notes below explaining Shadow's directory structure.
       args: ../../../tgen.server.graphml.xml
       start_time: 1s
+      # Tell shadow to expect this process to still be running at the end of the
+      # simulation.
+      expected_final_state: !running
   client1: &client_host
     network_node_id: 0
     processes:

--- a/docs/getting_started_tgen.md
+++ b/docs/getting_started_tgen.md
@@ -73,7 +73,7 @@ hosts:
       start_time: 1s
       # Tell shadow to expect this process to still be running at the end of the
       # simulation.
-      expected_final_state: !running
+      expected_final_state: running
   client1: &client_host
     network_node_id: 0
     processes:

--- a/docs/shadow_config_overview.md
+++ b/docs/shadow_config_overview.md
@@ -75,6 +75,14 @@ Acceptable unit *prefixes* are:
 
 Examples: `20 B`, `100 MB`, `100 megabyte`, `10 kibibytes`, `30 MiB`, `1024 Mbytes`
 
+## Unix Signals
+
+Several options allow the user to specify a Unix Signal. These can be specified
+either as a string signal name (e.g. `SIGKILL`), or an integer signal number (e.g. `9`).
+String signal names must be capitalized and include the `SIG` prefix.
+
+Realtime signals (signal numbers 32+) are not supported.
+
 ## YAML Extensions
 
 Shadow supports the extended YAML conventions for [merge

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -201,7 +201,7 @@ Initialize randomness using seed N.
 *Required*  
 Type: String OR Integer
 
-The simulated time at which simulated processes are sent a SIGKILL signal.
+The simulated time at which the simulation ends.
 
 #### `general.template_directory`
 

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -38,7 +38,7 @@ hosts:
     - path: /usr/sbin/nginx
       args: -c ../../../nginx.conf -p .
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
   client1: &client_host
     network_node_id: 0
     host_options:
@@ -676,30 +676,30 @@ environment: { ENV_A: "1", ENV_B: foo }
 
 #### `hosts.<hostname>.processes[*].expected_final_state`
 
-Default: !exited 0  
-Type: !exited \<Integer\> OR !signaled [Unix Signal](./shadow_config_overview.md#unix-signals) OR !running
+Default: \{exited: 0\}  
+Type: \{"exited": \<Integer\>\} OR \{"signaled": [Unix Signal](./shadow_config_overview.md#unix-signals)\} OR "running"
 
 The expected state of the process at the end of the simulation. If the process
 exits before the end of the simulation with an unexpected state, or is still running
-at the end of the simulation when this was not `!running`, shadow will log an error
+at the end of the simulation when this was not `running`, shadow will log an error
 and return a non-zero status for the simulation.
 
-Use `!exited` to indicate that a process should have exited normally; e.g. by returning
+Use `exited` to indicate that a process should have exited normally; e.g. by returning
 from `main` or calling `exit`.
 
-Use `!signaled` to indicate that a process should have been killed by a signal.
+Use `signaled` to indicate that a process should have been killed by a signal.
 
-Use `!running` for a process expected to still be running at the end of the simulation,
+Use `running` for a process expected to still be running at the end of the simulation,
 such as a server process that you didn't arrange to shutdown before the end of the simulation.
 (All processes will be killed by Shadow when the simulation ends).
 
 Examples:
 
-- `!exited 0`
-- `!exited 1`
-- `!signaled SIGINT`
-- `!signaled 9`
-- `!running`
+- `{exited: 0}`
+- `{exited: 1}`
+- `{signaled: SIGINT}`
+- `{signaled: 9}`
+- `running`
 
 #### `hosts.<hostname>.processes[*].path`
 
@@ -733,7 +733,7 @@ If the process is expected to be killed directly by the signal instead of
 catching it and exiting cleanly, you can set
 [`expected_final_state`](#hostshostnameprocessesexpected_final_state) to prevent
 Shadow from interpreting this as an error. e.g. `SIGKILL` cannot be caught, so
-will always result in an end state of `!signaled SIGKILL` if the process didn't
+will always result in an end state of `{signaled: SIGKILL}` if the process didn't
 already exit before the signal was sent.
 
 ```yaml
@@ -742,7 +742,7 @@ args: "1000"
 start_time: 1s
 shutdown_time: 2s
 shutdown_signal: SIGKILL
-expected_final_state: !signaled SIGKILL
+expected_final_state: {signaled: SIGKILL}
 ```
 
 #### `hosts.<hostname>.processes[*].shutdown_time`

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -677,7 +677,7 @@ environment: { ENV_A: "1", ENV_B: foo }
 #### `hosts.<hostname>.processes[*].expected_final_state`
 
 Default: !exited 0  
-Type: !exited \<Integer\> OR !signaled \<Signal String or Integer\> OR !running
+Type: !exited \<Integer\> OR !signaled [Unix Signal](./shadow_config_overview.md#unix-signals) OR !running
 
 The expected state of the process at the end of the simulation. If the process
 exits before the end of the simulation with an unexpected state, or is still running
@@ -719,7 +719,7 @@ absolute path as appropriate.
 #### `hosts.<hostname>.processes[*].shutdown_signal`
 
 Default: "SIGTERM"  
-Type: String OR Integer
+Type: [Unix Signal](./shadow_config_overview.md#unix-signals)
 
 The signal that will be sent to the process at
 [`hosts.<hostname>.processes[*].shutdown_time`](#hostshostnameprocessesshutdown_time).

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -38,6 +38,7 @@ hosts:
     - path: /usr/sbin/nginx
       args: -c ../../../nginx.conf -p .
       start_time: 1
+      expected_final_state: !running
   client1: &client_host
     network_node_id: 0
     host_options:
@@ -108,6 +109,7 @@ hosts:
 - [`hosts.<hostname>.processes`](#hostshostnameprocesses)
 - [`hosts.<hostname>.processes[*].args`](#hostshostnameprocessesargs)
 - [`hosts.<hostname>.processes[*].environment`](#hostshostnameprocessesenvironment)
+- [`hosts.<hostname>.processes[*].expected_final_state`](#hostshostnameprocessesexpected_final_state)
 - [`hosts.<hostname>.processes[*].path`](#hostshostnameprocessespath)
 - [`hosts.<hostname>.processes[*].shutdown_signal`](#hostshostnameprocessesshutdown_signal)
 - [`hosts.<hostname>.processes[*].shutdown_time`](#hostshostnameprocessesshutdown_time)
@@ -672,6 +674,33 @@ environment:
 environment: { ENV_A: "1", ENV_B: foo }
 ```
 
+#### `hosts.<hostname>.processes[*].expected_final_state`
+
+Default: !exited 0  
+Type: !exited \<Integer\> OR !signaled \<Signal String or Integer\> OR !running
+
+The expected state of the process at the end of the simulation. If the process
+exits before the end of the simulation with an unexpected state, or is still running
+at the end of the simulation when this was not `!running`, shadow will log an error
+and return a non-zero status for the simulation.
+
+Use `!exited` to indicate that a process should have exited normally; e.g. by returning
+from `main` or calling `exit`.
+
+Use `!signaled` to indicate that a process should have been killed by a signal.
+
+Use `!running` for a process expected to still be running at the end of the simulation,
+such as a server process that you didn't arrange to shutdown before the end of the simulation.
+(All processes will be killed by Shadow when the simulation ends).
+
+Examples:
+
+- `!exited 0`
+- `!exited 1`
+- `!signaled SIGINT`
+- `!signaled 9`
+- `!running`
+
 #### `hosts.<hostname>.processes[*].path`
 
 *Required*  
@@ -696,6 +725,25 @@ The signal that will be sent to the process at
 [`hosts.<hostname>.processes[*].shutdown_time`](#hostshostnameprocessesshutdown_time).
 Signals specified by name should be all-caps and include the SIG prefix; e.g.
 "SIGTERM".
+
+Many long-running processes support exiting cleanly when sent `SIGTERM` or
+`SIGINT`.
+
+If the process is expected to be killed directly by the signal instead of
+catching it and exiting cleanly, you can set
+[`expected_final_state`](#hostshostnameprocessesexpected_final_state) to prevent
+Shadow from interpreting this as an error. e.g. `SIGKILL` cannot be caught, so
+will always result in an end state of `!signaled SIGKILL` if the process didn't
+already exit before the signal was sent.
+
+```yaml
+path: sleep
+args: "1000"
+start_time: 1s
+shutdown_time: 2s
+shutdown_signal: SIGKILL
+expected_final_state: !signaled SIGKILL
+```
 
 #### `hosts.<hostname>.processes[*].shutdown_time`
 

--- a/examples/curl/shadow.yaml
+++ b/examples/curl/shadow.yaml
@@ -13,7 +13,7 @@ hosts:
     - path: python3
       args: -m http.server 80
       start_time: 0s
-      expected_final_state: !running
+      expected_final_state: running
   client1: &client_host
     network_node_id: 0
     processes:

--- a/examples/curl/shadow.yaml
+++ b/examples/curl/shadow.yaml
@@ -13,6 +13,7 @@ hosts:
     - path: python3
       args: -m http.server 80
       start_time: 0s
+      expected_final_state: !running
   client1: &client_host
     network_node_id: 0
     processes:

--- a/examples/etcd/shadow.yaml
+++ b/examples/etcd/shadow.yaml
@@ -33,7 +33,7 @@ hosts:
         --advertise-client-urls http://server1:2379
         --listen-peer-urls http://0.0.0.0:2380
         --initial-advertise-peer-urls http://server1:2380
-      expected_final_state: !running
+      expected_final_state: running
     - path: etcdctl
       args: set my-key my-value
       start_time: 10s
@@ -53,7 +53,7 @@ hosts:
         --advertise-client-urls http://server2:2379
         --listen-peer-urls http://0.0.0.0:2380
         --initial-advertise-peer-urls http://server2:2380
-      expected_final_state: !running
+      expected_final_state: running
     - path: etcdctl
       args: get my-key
       start_time: 12s
@@ -71,7 +71,7 @@ hosts:
         --advertise-client-urls http://server3:2379
         --listen-peer-urls http://0.0.0.0:2380
         --initial-advertise-peer-urls http://server3:2380
-      expected_final_state: !running
+      expected_final_state: running
     - path: etcdctl
       args: get my-key
       start_time: 12s

--- a/examples/etcd/shadow.yaml
+++ b/examples/etcd/shadow.yaml
@@ -33,6 +33,7 @@ hosts:
         --advertise-client-urls http://server1:2379
         --listen-peer-urls http://0.0.0.0:2380
         --initial-advertise-peer-urls http://server1:2380
+      expected_final_state: !running
     - path: etcdctl
       args: set my-key my-value
       start_time: 10s
@@ -52,6 +53,7 @@ hosts:
         --advertise-client-urls http://server2:2379
         --listen-peer-urls http://0.0.0.0:2380
         --initial-advertise-peer-urls http://server2:2380
+      expected_final_state: !running
     - path: etcdctl
       args: get my-key
       start_time: 12s
@@ -69,6 +71,7 @@ hosts:
         --advertise-client-urls http://server3:2379
         --listen-peer-urls http://0.0.0.0:2380
         --initial-advertise-peer-urls http://server3:2380
+      expected_final_state: !running
     - path: etcdctl
       args: get my-key
       start_time: 12s

--- a/examples/http-server/shadow.yaml
+++ b/examples/http-server/shadow.yaml
@@ -13,7 +13,7 @@ hosts:
     - path: node
       args: /usr/local/bin/http-server -p 80 -d
       start_time: 3s
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:

--- a/examples/http-server/shadow.yaml
+++ b/examples/http-server/shadow.yaml
@@ -13,6 +13,7 @@ hosts:
     - path: node
       args: /usr/local/bin/http-server -p 80 -d
       start_time: 3s
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:

--- a/examples/iperf-2/shadow.yaml
+++ b/examples/iperf-2/shadow.yaml
@@ -12,6 +12,7 @@ hosts:
     - path: iperf
       args: -s
       start_time: 0s
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:

--- a/examples/iperf-2/shadow.yaml
+++ b/examples/iperf-2/shadow.yaml
@@ -12,7 +12,7 @@ hosts:
     - path: iperf
       args: -s
       start_time: 0s
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:

--- a/examples/nginx/shadow.yaml
+++ b/examples/nginx/shadow.yaml
@@ -12,6 +12,7 @@ hosts:
     - path: nginx
       args: -c ../../../nginx.conf -p .
       start_time: 0s
+      expected_final_state: !running
   client1: &client_host
     network_node_id: 0
     processes:

--- a/examples/nginx/shadow.yaml
+++ b/examples/nginx/shadow.yaml
@@ -12,7 +12,7 @@ hosts:
     - path: nginx
       args: -c ../../../nginx.conf -p .
       start_time: 0s
-      expected_final_state: !running
+      expected_final_state: running
   client1: &client_host
     network_node_id: 0
     processes:

--- a/examples/wget2/shadow.yaml
+++ b/examples/wget2/shadow.yaml
@@ -12,6 +12,7 @@ hosts:
     - path: python3
       args: -m http.server 80
       start_time: 0s
+      expected_final_state: !running
   client1: &client_host
     network_node_id: 0
     processes:

--- a/examples/wget2/shadow.yaml
+++ b/examples/wget2/shadow.yaml
@@ -12,7 +12,7 @@ hosts:
     - path: python3
       args: -m http.server 80
       start_time: 0s
-      expected_final_state: !running
+      expected_final_state: running
   client1: &client_host
     network_node_id: 0
     processes:

--- a/src/main/core/controller.rs
+++ b/src/main/core/controller.rs
@@ -67,7 +67,7 @@ impl<'a> Controller<'a> {
 
         if num_plugin_errors > 0 {
             return Err(anyhow::anyhow!(
-                "{num_plugin_errors} managed processes exited with a non-zero error code"
+                "{num_plugin_errors} managed processes in unexpected final state"
             ));
         }
 

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -629,6 +629,7 @@ impl<'a> Manager<'a> {
                 envv,
                 argv,
                 pause_for_debugging,
+                proc.expected_final_state,
             );
 
             host.stop_execution_timer();

--- a/src/main/core/sim_config.rs
+++ b/src/main/core/sim_config.rs
@@ -21,6 +21,8 @@ use crate::core::support::units::{self, Unit};
 use crate::network::graph::{load_network_graph, IpAssignment, NetworkGraph, RoutingInfo};
 use crate::utility::tilde_expansion;
 
+use super::support::configuration::ProcessFinalState;
+
 /// The simulation configuration after processing the configuration options and network graph.
 pub struct SimConfig {
     // deterministic source of randomness for the simulation
@@ -192,6 +194,7 @@ pub struct ProcessInfo {
     pub shutdown_signal: nix::sys::signal::Signal,
     pub args: Vec<OsString>,
     pub env: BTreeMap<EnvName, String>,
+    pub expected_final_state: ProcessFinalState,
 }
 
 #[derive(Debug, Clone)]
@@ -370,6 +373,7 @@ fn build_process(proc: &ProcessOptions, config: &ConfigOptions) -> anyhow::Resul
         shutdown_signal,
         args,
         env: proc.environment.clone(),
+        expected_final_state: proc.expected_final_state,
     })
 }
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -554,17 +554,25 @@ impl Default for HostDefaultOptions {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum ProcessFinalState {
-    Exited(i32),
-    Signaled(Signal),
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Copy, Clone, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum RunningVal {
     Running,
+}
+
+/// The enum variants here have an extra level of indirection to get the
+/// serde serialization that we want.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum ProcessFinalState {
+    Exited { exited: i32 },
+    Signaled { signaled: Signal },
+    Running(RunningVal),
 }
 
 impl Default for ProcessFinalState {
     fn default() -> Self {
-        Self::Exited(0)
+        Self::Exited { exited: 0 }
     }
 }
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -27,7 +27,7 @@ use shadow_tsc::Tsc;
 use vasi_sync::scmutex::SelfContainedMutexGuard;
 
 use crate::core::sim_config::PcapConfig;
-use crate::core::support::configuration::QDiscMode;
+use crate::core::support::configuration::{ProcessFinalState, QDiscMode};
 use crate::core::work::event::{Event, EventData};
 use crate::core::work::event_queue::EventQueue;
 use crate::core::work::task::TaskRef;
@@ -376,6 +376,7 @@ impl Host {
         envv: Vec<CString>,
         argv: Vec<CString>,
         pause_for_debugging: bool,
+        expected_final_state: ProcessFinalState,
     ) {
         debug_assert!(shutdown_time.is_none() || shutdown_time.unwrap() > start_time);
 
@@ -403,6 +404,7 @@ impl Host {
                 argv,
                 pause_for_debugging,
                 host.params.strace_logging_options,
+                expected_final_state,
             );
             let thread_id = process.borrow(host.root()).thread_group_leader_id();
             host.processes.borrow_mut().insert(process_id, process);

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -36,7 +36,7 @@ use super::syscall::formatter::StraceFmtMode;
 use super::syscall_types::ForeignArrayPtr;
 use super::thread::{Thread, ThreadId};
 use super::timer::Timer;
-use crate::core::support::configuration::ProcessFinalState;
+use crate::core::support::configuration::{ProcessFinalState, RunningVal};
 use crate::core::work::task::TaskRef;
 use crate::core::worker::Worker;
 use crate::cshadow;
@@ -1245,9 +1245,9 @@ impl Process {
             );
             if let Some(expected_final_state) = runnable.expected_final_state {
                 let actual_final_state = match exit_status {
-                    ExitStatus::Normal(i) => ProcessFinalState::Exited(i),
-                    ExitStatus::Signaled(s) => ProcessFinalState::Signaled(s.into()),
-                    ExitStatus::StoppedByShadow => ProcessFinalState::Running,
+                    ExitStatus::Normal(i) => ProcessFinalState::Exited { exited: i },
+                    ExitStatus::Signaled(s) => ProcessFinalState::Signaled { signaled: s.into() },
+                    ExitStatus::StoppedByShadow => ProcessFinalState::Running(RunningVal::Running),
                 };
                 if expected_final_state == actual_final_state {
                     (s, log::Level::Info)

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1283,6 +1283,17 @@ impl Process {
     }
 }
 
+impl Drop for Process {
+    fn drop(&mut self) {
+        // Should only be dropped in the zombie state.
+        debug_assert!(self.zombie().is_some());
+        // Shouldn't be dropped while a parent exists.
+        // Assuming for now that once we implement parent processes, we'll clear
+        // the parent id after the child has been reaped or the parent exits.
+        debug_assert!(self.ppid().is_none());
+    }
+}
+
 /// Tracks a memory reference made by a legacy C memory-read API.
 struct UnsafeBorrow {
     // Must come before `manager`, so that it's dropped first, since it's

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1255,6 +1255,12 @@ impl Process {
     pub fn shmem(&self) -> impl Deref<Target = ShMemBlock<'static, ProcessShmem>> + '_ {
         Ref::map(self.runnable().unwrap(), |r| &r.shim_shared_mem_block)
     }
+
+    /// The parent of this process.
+    pub fn ppid(&self) -> Option<ProcessId> {
+        // We don't yet support child processes, so there is never a ppid.
+        None
+    }
 }
 
 /// Tracks a memory reference made by a legacy C memory-read API.

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -36,6 +36,7 @@ use super::syscall::formatter::StraceFmtMode;
 use super::syscall_types::ForeignArrayPtr;
 use super::thread::{Thread, ThreadId};
 use super::timer::Timer;
+use crate::core::support::configuration::ProcessFinalState;
 use crate::core::work::task::TaskRef;
 use crate::core::worker::Worker;
 use crate::cshadow;
@@ -92,22 +93,15 @@ impl From<ProcessId> for libc::pid_t {
 pub enum ExitStatus {
     Normal(i32),
     Signaled(nix::sys::signal::Signal),
-    // We don't expect to ever get this state, but having it gives us an out in
-    // case of an unexpected problem retrieving it.  Having this state seems a
-    // little clearer than wrapper the ExitStatus in an Option, since we want to
-    // indicate that the process exited with unknown state vs the process hasn't
-    // exited.
-    Unknown,
-}
-
-impl From<ExitStatus> for i32 {
-    fn from(value: ExitStatus) -> Self {
-        match value {
-            ExitStatus::Normal(n) => n,
-            ExitStatus::Signaled(s) => utility::return_code_for_signal(s),
-            ExitStatus::Unknown => -1,
-        }
-    }
+    /// The process was killed by Shadow rather than exiting "naturally" as part
+    /// of the simulation. Currently this only happens when the process is still
+    /// running when the simulation stop_time is reached.
+    ///
+    /// A signal delivered via `shutdown_signal` does not result in this status;
+    /// e.g. if the process is killed directly by the signal the ExitStatus will
+    /// be `Signaled`; if the process handles the signal and exits by calling
+    /// `exit`, the status will be `Normal`.
+    StoppedByShadow,
 }
 
 #[derive(Debug)]
@@ -189,6 +183,14 @@ impl Common {
 /// A process that is currently runnable.
 pub struct RunnableProcess {
     common: Common,
+
+    // Expected end state, if any. We'll report an error if this is present and
+    // doesn't match the actual exit status.
+    //
+    // This will be None e.g. for processes created via `fork` instead of
+    // spawned directly from Shadow's config file. In those cases it's the
+    // parent's responsibility to reap and interpret the exit status.
+    expected_final_state: Option<ProcessFinalState>,
 
     // Shared memory allocation for shared state with shim.
     shim_shared_mem_block: ShMemBlock<'static, ProcessShmem>,
@@ -628,6 +630,7 @@ impl Process {
         argv: Vec<CString>,
         pause_for_debugging: bool,
         strace_logging_options: Option<FmtOptions>,
+        expected_final_state: ProcessFinalState,
     ) -> RootedRc<RootedRefCell<Process>> {
         let desc_table = RefCell::new(DescriptorTable::new());
         let itimer_real = RefCell::new(Timer::new(move |host| {
@@ -723,6 +726,7 @@ impl Process {
                 Self {
                     state: RefCell::new(Some(ProcessState::Runnable(RunnableProcess {
                         common,
+                        expected_final_state: Some(expected_final_state),
                         shim_shared_mem_block,
                         memory_manager: Box::new(RefCell::new(memory_manager)),
                         desc_table,
@@ -1202,53 +1206,61 @@ impl Process {
         }
 
         use nix::sys::wait::WaitStatus;
-        let exit_status = match nix::sys::wait::waitpid(runnable.native_pid, None) {
-            Ok(WaitStatus::Exited(_pid, code)) => ExitStatus::Normal(code),
-            Ok(WaitStatus::Signaled(_pid, signal, _core_dump)) => ExitStatus::Signaled(signal),
-            Ok(status) => {
-                warn!("Unexpected status: {status:?}");
-                ExitStatus::Unknown
+        let exit_status = match (
+            killed_by_shadow,
+            nix::sys::wait::waitpid(runnable.native_pid, None),
+        ) {
+            (true, Ok(WaitStatus::Signaled(_pid, Signal::SIGKILL, _core_dump))) => {
+                ExitStatus::StoppedByShadow
             }
-            Err(e) => {
-                warn!("waitpid: {e:?}");
-                ExitStatus::Unknown
+            (true, waitstatus) => {
+                warn!("Unexpected waitstatus after killed by shadow: {waitstatus:?}");
+                ExitStatus::StoppedByShadow
+            }
+            (false, Ok(WaitStatus::Exited(_pid, code))) => ExitStatus::Normal(code),
+            (false, Ok(WaitStatus::Signaled(_pid, signal, _core_dump))) => {
+                ExitStatus::Signaled(signal)
+            }
+            (false, Ok(status)) => {
+                panic!("Unexpected status: {status:?}");
+            }
+            (false, Err(e)) => {
+                panic!("waitpid: {e:?}");
             }
         };
         let exitcode_path = runnable.common.output_file_name("exitcode");
-        let exitcode_contents = if killed_by_shadow {
-            // Process never died during the simulation; shadow chose to kill it;
-            // typically because the simulation end time was reached.
-            // Write out an empty exitcode file.
-            String::new()
-        } else {
-            format!("{}", i32::from(exit_status))
+        let exitcode_contents = match exit_status {
+            ExitStatus::StoppedByShadow => String::new(),
+            ExitStatus::Normal(n) => format!("{n}"),
+            ExitStatus::Signaled(s) => format!("{}", utility::return_code_for_signal(s)),
         };
         if let Err(e) = std::fs::write(exitcode_path, exitcode_contents) {
             warn!("Couldn't write exitcode file: {e:?}");
         }
 
-        let main_result_string = {
-            let mut s = format!("process '{name}'", name = runnable.common.name());
-            if killed_by_shadow {
-                write!(s, " killed by Shadow").unwrap();
-            } else {
-                write!(s, " exited with status {exit_status:?}").unwrap();
-                if exit_status == ExitStatus::Normal(libc::EXIT_SUCCESS) {
-                    write!(s, " (success)").unwrap();
+        let (main_result_string, log_level) = {
+            let mut s = format!(
+                "process '{name}' exited with status {exit_status:?}",
+                name = runnable.common.name()
+            );
+            if let Some(expected_final_state) = runnable.expected_final_state {
+                let actual_final_state = match exit_status {
+                    ExitStatus::Normal(i) => ProcessFinalState::Exited(i),
+                    ExitStatus::Signaled(s) => ProcessFinalState::Signaled(s.into()),
+                    ExitStatus::StoppedByShadow => ProcessFinalState::Running,
+                };
+                if expected_final_state == actual_final_state {
+                    (s, log::Level::Info)
                 } else {
-                    write!(s, " (error)").unwrap();
+                    Worker::increment_plugin_error_count();
+                    write!(s, "; expected end state was {expected_final_state} but was {actual_final_state}").unwrap();
+                    (s, log::Level::Error)
                 }
+            } else {
+                (s, log::Level::Info)
             }
-            s
         };
-
-        // if there was no error or was intentionally killed
-        if exit_status == ExitStatus::Normal(libc::EXIT_SUCCESS) || killed_by_shadow {
-            info!("{}", main_result_string);
-        } else {
-            warn!("{}", main_result_string);
-            Worker::increment_plugin_error_count();
-        }
+        log::log!(log_level, "{}", main_result_string);
 
         *opt_state = Some(ProcessState::Zombie(ZombieProcess {
             common: runnable.into_common(),

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -60,7 +60,7 @@ endmacro()
 ## example: add_shadow_tests(BASENAME bind LOGLEVEL debug ARGS --pin-cpus)
 ## will create a test named bind-shadow
 macro(add_shadow_tests)
-   cmake_parse_arguments(SHADOW_TEST "" "BASENAME;LOGLEVEL;SHADOW_CONFIG;CHECK_RETVAL;POST_CMD;EXPECT_ERROR" "ARGS;CONFIGURATIONS;PROPERTIES" ${ARGN})
+   cmake_parse_arguments(SHADOW_TEST "" "BASENAME;LOGLEVEL;SHADOW_CONFIG;POST_CMD;EXPECT_ERROR" "ARGS;CONFIGURATIONS;PROPERTIES" ${ARGN})
    if(DEFINED SHADOW_TEST_UNPARSED_ARGUMENTS)
       message(FATAL_ERROR "Unrecognized arguments: ${SHADOW_TEST_UNPARSED_ARGUMENTS}")
    endif()
@@ -75,10 +75,6 @@ macro(add_shadow_tests)
 
    if(NOT DEFINED SHADOW_TEST_SHADOW_CONFIG)
        set(SHADOW_TEST_SHADOW_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/${SHADOW_TEST_BASENAME}.yaml")
-   endif()
-
-   if(NOT DEFINED SHADOW_TEST_CHECK_RETVAL)
-      set(SHADOW_TEST_CHECK_RETVAL TRUE)
    endif()
 
    if(NOT DEFINED SHADOW_TEST_EXPECT_ERROR)
@@ -112,28 +108,6 @@ macro(add_shadow_tests)
       set(POST_CMD "true")
    endif()
 
-   if(SHADOW_TEST_CHECK_RETVAL)
-      # Validate that all processes exited with code 0.  Processes that don't
-      # exit have an empty exitcode file, which will cause this check to
-      # fail.
-      # We *don't* fail in the case that nothing matched the glob, which is
-      # why we need to explicitly check whether the file exists.
-      set(CHECK_RETVAL_CMD "
-            for f in ${SHADOW_TEST_NAME}.data/hosts/*/*.exitcode
-            do
-            # Check if glob actually matched
-            if [ ! -f $f ]\; then continue\; fi
-            # Check if the file contains 0
-            if [ \"`cat $f`\" != 0 ]
-            then
-               echo FAIL: $f isn\\'t 0
-               exit 1
-            fi
-         done")
-   else()
-      set(CHECK_RETVAL_CMD "true")
-   endif()
-
    set(SHADOW_TEST_COMMAND sh -c "\
       rm -rf ${SHADOW_TEST_NAME}.data \
       && ${INVERT_ERROR_CODE} ${CMAKE_BINARY_DIR}/src/main/shadow \
@@ -141,7 +115,6 @@ macro(add_shadow_tests)
       --log-level=${SHADOW_TEST_LOGLEVEL} \
       ${SHADOW_TEST_ARGS} \
       ${SHADOW_TEST_SHADOW_CONFIG} \
-      && (${CHECK_RETVAL_CMD}) \
       && (${POST_CMD}) \
       "
    )

--- a/src/test/config/CMakeLists.txt
+++ b/src/test/config/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(expected_final_process_state)
 add_subdirectory(parsing)
 add_subdirectory(read_from_stdin)
 add_subdirectory(shutdown)

--- a/src/test/config/expected_final_process_state/CMakeLists.txt
+++ b/src/test/config/expected_final_process_state/CMakeLists.txt
@@ -1,0 +1,32 @@
+# We can test many successful expectations in one go
+add_shadow_tests(BASENAME expected_final_process_state_success)
+
+# Failed "expect signal"
+add_shadow_tests(
+    BASENAME expected_final_process_state_expect_signal_get_wrong_signal
+    PROPERTIES PASS_REGULAR_EXPRESSION "1 managed processes in unexpected final state")
+add_shadow_tests(
+    BASENAME expected_final_process_state_expect_signal_get_exit
+    PROPERTIES PASS_REGULAR_EXPRESSION "1 managed processes in unexpected final state")
+add_shadow_tests(
+    BASENAME expected_final_process_state_expect_signal_get_running
+    PROPERTIES PASS_REGULAR_EXPRESSION "1 managed processes in unexpected final state")
+
+# Failed "expect exit"
+add_shadow_tests(
+    BASENAME expected_final_process_state_expect_exit_get_wrong_exit
+    PROPERTIES PASS_REGULAR_EXPRESSION "1 managed processes in unexpected final state")
+add_shadow_tests(
+    BASENAME expected_final_process_state_expect_exit_get_signal
+    PROPERTIES PASS_REGULAR_EXPRESSION "1 managed processes in unexpected final state")
+add_shadow_tests(
+    BASENAME expected_final_process_state_expect_exit_get_running
+    PROPERTIES PASS_REGULAR_EXPRESSION "1 managed processes in unexpected final state")
+
+# Failed "expect running"
+add_shadow_tests(
+    BASENAME expected_final_process_state_expect_running_get_exit
+    PROPERTIES PASS_REGULAR_EXPRESSION "1 managed processes in unexpected final state")
+add_shadow_tests(
+    BASENAME expected_final_process_state_expect_running_get_signal
+    PROPERTIES PASS_REGULAR_EXPRESSION "1 managed processes in unexpected final state")

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_running.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_running.yaml
@@ -1,0 +1,14 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  mytesthost:
+    network_node_id: 0
+    processes:
+    - path: sleep
+      args: '100'
+      start_time: 1
+      # Intentionally incorrect; testing that Shadow correctly fails.
+      expected_final_state: !exited 0

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_running.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_running.yaml
@@ -11,4 +11,4 @@ hosts:
       args: '100'
       start_time: 1
       # Intentionally incorrect; testing that Shadow correctly fails.
-      expected_final_state: !exited 0
+      expected_final_state: {exited: 0}

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_signal.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_signal.yaml
@@ -1,0 +1,16 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  mytesthost:
+    network_node_id: 0
+    processes:
+    - path: sleep
+      args: '10'
+      start_time: 1
+      shutdown_time: 2
+      shutdown_signal: SIGINT
+      # Intentionally incorrect; testing that Shadow correctly fails.
+      expected_final_state: !exited 0

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_signal.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_signal.yaml
@@ -13,4 +13,4 @@ hosts:
       shutdown_time: 2
       shutdown_signal: SIGINT
       # Intentionally incorrect; testing that Shadow correctly fails.
-      expected_final_state: !exited 0
+      expected_final_state: {exited: 0}

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_wrong_exit.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_wrong_exit.yaml
@@ -10,4 +10,4 @@ hosts:
     - path: "true"
       start_time: 1
       # Intentionally incorrect; testing that Shadow correctly fails.
-      expected_final_state: !exited 1
+      expected_final_state: {exited: 1}

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_wrong_exit.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_exit_get_wrong_exit.yaml
@@ -1,0 +1,13 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  mytesthost:
+    network_node_id: 0
+    processes:
+    - path: "true"
+      start_time: 1
+      # Intentionally incorrect; testing that Shadow correctly fails.
+      expected_final_state: !exited 1

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_running_get_exit.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_running_get_exit.yaml
@@ -10,4 +10,4 @@ hosts:
     - path: "true"
       start_time: 1
       # Intentionally incorrect; testing that Shadow correctly fails.
-      expected_final_state: !running
+      expected_final_state: running

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_running_get_exit.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_running_get_exit.yaml
@@ -1,0 +1,13 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  mytesthost:
+    network_node_id: 0
+    processes:
+    - path: "true"
+      start_time: 1
+      # Intentionally incorrect; testing that Shadow correctly fails.
+      expected_final_state: !running

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_running_get_signal.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_running_get_signal.yaml
@@ -13,4 +13,4 @@ hosts:
       shutdown_time: 2
       shutdown_signal: SIGINT
       # Intentionally incorrect; testing that Shadow correctly fails.
-      expected_final_state: !running
+      expected_final_state: running

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_running_get_signal.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_running_get_signal.yaml
@@ -1,0 +1,16 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  mytesthost:
+    network_node_id: 0
+    processes:
+    - path: sleep
+      args: '10'
+      start_time: 1
+      shutdown_time: 2
+      shutdown_signal: SIGINT
+      # Intentionally incorrect; testing that Shadow correctly fails.
+      expected_final_state: !running

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_exit.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_exit.yaml
@@ -1,0 +1,13 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  mytesthost:
+    network_node_id: 0
+    processes:
+    - path: "true"
+      start_time: 1
+      # Intentionally incorrect; testing that Shadow correctly fails.
+      expected_final_state: !signaled SIGTERM

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_exit.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_exit.yaml
@@ -10,4 +10,4 @@ hosts:
     - path: "true"
       start_time: 1
       # Intentionally incorrect; testing that Shadow correctly fails.
-      expected_final_state: !signaled SIGTERM
+      expected_final_state: {signaled: SIGTERM}

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_running.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_running.yaml
@@ -11,4 +11,4 @@ hosts:
       args: '100'
       start_time: 1
       # Intentionally incorrect; testing that Shadow correctly fails.
-      expected_final_state: !signaled SIGTERM
+      expected_final_state: {signaled: SIGTERM}

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_running.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_running.yaml
@@ -1,0 +1,14 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  mytesthost:
+    network_node_id: 0
+    processes:
+    - path: sleep
+      args: '100'
+      start_time: 1
+      # Intentionally incorrect; testing that Shadow correctly fails.
+      expected_final_state: !signaled SIGTERM

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_wrong_signal.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_wrong_signal.yaml
@@ -13,4 +13,4 @@ hosts:
       shutdown_time: 2
       shutdown_signal: SIGINT
       # Intentionally incorrect; testing that Shadow correctly fails.
-      expected_final_state: !signaled SIGTERM
+      expected_final_state: {signaled: SIGTERM}

--- a/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_wrong_signal.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_expect_signal_get_wrong_signal.yaml
@@ -1,0 +1,16 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  mytesthost:
+    network_node_id: 0
+    processes:
+    - path: sleep
+      args: '10'
+      start_time: 1
+      shutdown_time: 2
+      shutdown_signal: SIGINT
+      # Intentionally incorrect; testing that Shadow correctly fails.
+      expected_final_state: !signaled SIGTERM

--- a/src/test/config/expected_final_process_state/expected_final_process_state_success.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_success.yaml
@@ -12,14 +12,14 @@ hosts:
       start_time: 1
       shutdown_time: 2
       shutdown_signal: SIGINT
-      expected_final_state: !signaled SIGINT
+      expected_final_state: {signaled: SIGINT}
     - path: sleep
       args: '100'
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
     - path: "true"
       start_time: 1
-      expected_final_state: !exited 0
+      expected_final_state: {exited: 0}
     - path: "false"
       start_time: 1
-      expected_final_state: !exited 1
+      expected_final_state: {exited: 1}

--- a/src/test/config/expected_final_process_state/expected_final_process_state_success.yaml
+++ b/src/test/config/expected_final_process_state/expected_final_process_state_success.yaml
@@ -1,0 +1,25 @@
+general:
+  stop_time: 5
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  mytesthost:
+    network_node_id: 0
+    processes:
+    - path: sleep
+      args: '10'
+      start_time: 1
+      shutdown_time: 2
+      shutdown_signal: SIGINT
+      expected_final_state: !signaled SIGINT
+    - path: sleep
+      args: '100'
+      start_time: 1
+      expected_final_state: !running
+    - path: "true"
+      start_time: 1
+      expected_final_state: !exited 0
+    - path: "false"
+      start_time: 1
+      expected_final_state: !exited 1

--- a/src/test/config/shutdown/CMakeLists.txt
+++ b/src/test/config/shutdown/CMakeLists.txt
@@ -1,23 +1,3 @@
-add_shadow_tests(
-    BASENAME shutdown_signal_sigint
-    # `sleep` should die with signal SIGINT (2), giving exitcode 128+2=130
-    POST_CMD "test `cat hosts/*/sleep.*.exitcode` -eq 130"
-    # Shadow should return failure
-    EXPECT_ERROR TRUE
-    CHECK_RETVAL FALSE)
-
-add_shadow_tests(
-    BASENAME shutdown_signal_sigterm
-    # `sleep` should die with signal SIGTERM (15), giving exitcode 128+15=143
-    POST_CMD "test `cat hosts/*/sleep.*.exitcode` -eq 143"
-    # Shadow should return failure
-    EXPECT_ERROR TRUE
-    CHECK_RETVAL FALSE)
-
-add_shadow_tests(
-    BASENAME shutdown_signal_sigkill
-    # `sleep` should die with signal SIGKILL (9), giving exitcode 128+9=137
-    POST_CMD "test `cat hosts/*/sleep.*.exitcode` -eq 137"
-    # Shadow should return failure
-    EXPECT_ERROR TRUE
-    CHECK_RETVAL FALSE)
+add_shadow_tests(BASENAME shutdown_signal_sigint)
+add_shadow_tests(BASENAME shutdown_signal_sigterm)
+add_shadow_tests(BASENAME shutdown_signal_sigkill)

--- a/src/test/config/shutdown/shutdown_signal_sigint.yaml
+++ b/src/test/config/shutdown/shutdown_signal_sigint.yaml
@@ -12,3 +12,4 @@ hosts:
       start_time: 1
       shutdown_time: 2
       shutdown_signal: SIGINT
+      expected_final_state: !signaled SIGINT

--- a/src/test/config/shutdown/shutdown_signal_sigint.yaml
+++ b/src/test/config/shutdown/shutdown_signal_sigint.yaml
@@ -12,4 +12,4 @@ hosts:
       start_time: 1
       shutdown_time: 2
       shutdown_signal: SIGINT
-      expected_final_state: !signaled SIGINT
+      expected_final_state: {signaled: SIGINT}

--- a/src/test/config/shutdown/shutdown_signal_sigkill.yaml
+++ b/src/test/config/shutdown/shutdown_signal_sigkill.yaml
@@ -12,4 +12,4 @@ hosts:
       start_time: 1
       shutdown_time: 2
       shutdown_signal: SIGKILL
-      expected_final_state: !signaled SIGKILL
+      expected_final_state: {signaled: SIGKILL}

--- a/src/test/config/shutdown/shutdown_signal_sigkill.yaml
+++ b/src/test/config/shutdown/shutdown_signal_sigkill.yaml
@@ -12,3 +12,4 @@ hosts:
       start_time: 1
       shutdown_time: 2
       shutdown_signal: SIGKILL
+      expected_final_state: !signaled SIGKILL

--- a/src/test/config/shutdown/shutdown_signal_sigterm.yaml
+++ b/src/test/config/shutdown/shutdown_signal_sigterm.yaml
@@ -12,4 +12,4 @@ hosts:
       start_time: 1
       shutdown_time: 2
       shutdown_signal: SIGTERM
-      expected_final_state: !signaled SIGTERM
+      expected_final_state: {signaled: SIGTERM}

--- a/src/test/config/shutdown/shutdown_signal_sigterm.yaml
+++ b/src/test/config/shutdown/shutdown_signal_sigterm.yaml
@@ -12,3 +12,4 @@ hosts:
       start_time: 1
       shutdown_time: 2
       shutdown_signal: SIGTERM
+      expected_final_state: !signaled SIGTERM

--- a/src/test/exit/CMakeLists.txt
+++ b/src/test/exit/CMakeLists.txt
@@ -2,9 +2,7 @@ add_linux_tests(BASENAME exit COMMAND sh -c "../../target/debug/test_exit")
 add_shadow_tests(BASENAME exit)
 
 add_executable(test_exit_sigsegv test_exit_sigsegv.c)
-# Expect the managed process to exit with with 139 (128 + SIGSEGV).
-add_shadow_tests(BASENAME exit_sigsegv EXPECT_ERROR true CHECK_RETVAL false POST_CMD "test `cat hosts/*/*.exitcode` -eq 139")
+add_shadow_tests(BASENAME exit_sigsegv)
 
 add_executable(test_exit_abort test_exit_abort.c)
-# Expect the managed process to exit with with 134 (128 + SIGABRT)
-add_shadow_tests(BASENAME exit_abort EXPECT_ERROR true CHECK_RETVAL false POST_CMD "test `cat hosts/*/*.exitcode` -eq 134")
+add_shadow_tests(BASENAME exit_abort)

--- a/src/test/exit/exit_abort.yaml
+++ b/src/test/exit/exit_abort.yaml
@@ -8,3 +8,4 @@ hosts:
     network_node_id: 0
     processes:
     - path: ./test_exit_abort
+      expected_final_state: !signaled SIGABRT

--- a/src/test/exit/exit_abort.yaml
+++ b/src/test/exit/exit_abort.yaml
@@ -8,4 +8,4 @@ hosts:
     network_node_id: 0
     processes:
     - path: ./test_exit_abort
-      expected_final_state: !signaled SIGABRT
+      expected_final_state: {signaled: SIGABRT}

--- a/src/test/exit/exit_sigsegv.yaml
+++ b/src/test/exit/exit_sigsegv.yaml
@@ -9,4 +9,4 @@ hosts:
     processes:
     - path: ./test_exit_sigsegv
       start_time: 1
-      expected_final_state: !signaled SIGSEGV
+      expected_final_state: {signaled: SIGSEGV}

--- a/src/test/exit/exit_sigsegv.yaml
+++ b/src/test/exit/exit_sigsegv.yaml
@@ -9,3 +9,4 @@ hosts:
     processes:
     - path: ./test_exit_sigsegv
       start_time: 1
+      expected_final_state: !signaled SIGSEGV

--- a/src/test/golang/CMakeLists.txt
+++ b/src/test/golang/CMakeLists.txt
@@ -36,7 +36,6 @@ endmacro()
 add_golang_test_exe(BASENAME test_simple_http)
 add_shadow_tests(
     BASENAME simple_http
-    CHECK_RETVAL false
     CONFIGURATIONS extra
     PROPERTIES
       LABELS golang)

--- a/src/test/golang/simple_http.yaml
+++ b/src/test/golang/simple_http.yaml
@@ -11,7 +11,7 @@ hosts:
     processes:
     - path: ./test_simple_http
       start_time: 3s
-      expected_final_state: !running
+      expected_final_state: running
 
   client1: &host
     network_node_id: 0

--- a/src/test/golang/simple_http.yaml
+++ b/src/test/golang/simple_http.yaml
@@ -11,6 +11,8 @@ hosts:
     processes:
     - path: ./test_simple_http
       start_time: 3s
+      expected_final_state: !running
+
   client1: &host
     network_node_id: 0
     processes:

--- a/src/test/regression/2210/CMakeLists.txt
+++ b/src/test/regression/2210/CMakeLists.txt
@@ -1,8 +1,2 @@
 # regression test for https://github.com/shadow/shadow/issues/2210
-add_shadow_tests(
-  BASENAME regression-2210
-  # python should die with signal 9, giving exitcode 128+9=137
-  POST_CMD "test `cat hosts/*/*.1000.exitcode` -eq 137"
-  # shadow should return failure
-  EXPECT_ERROR TRUE
-  CHECK_RETVAL FALSE)
+add_shadow_tests(BASENAME regression-2210)

--- a/src/test/regression/2210/regression-2210.yaml
+++ b/src/test/regression/2210/regression-2210.yaml
@@ -10,6 +10,7 @@ hosts:
     - path: python3
       args: '-c "import threading, time; threading.Thread(target=lambda: time.sleep(10)).start(); time.sleep(10)"'
       start_time: 3
+      expected_final_state: !signaled SIGKILL
     - path: kill
       args: "-KILL 1000"
       start_time: 5

--- a/src/test/regression/2210/regression-2210.yaml
+++ b/src/test/regression/2210/regression-2210.yaml
@@ -10,7 +10,7 @@ hosts:
     - path: python3
       args: '-c "import threading, time; threading.Thread(target=lambda: time.sleep(10)).start(); time.sleep(10)"'
       start_time: 3
-      expected_final_state: !signaled SIGKILL
+      expected_final_state: {signaled: SIGKILL}
     - path: kill
       args: "-KILL 1000"
       start_time: 5

--- a/src/test/regression/CMakeLists.txt
+++ b/src/test/regression/CMakeLists.txt
@@ -4,26 +4,18 @@ add_shadow_tests(BASENAME exit_after_signal_sched)
 # Regression test for https://github.com/shadow/shadow/issues/1868.
 # Shadow should explicitly fail when a process start time is after
 # the simulation end time.
-add_shadow_tests(BASENAME small_stop_time EXPECT_ERROR TRUE CHECK_RETVAL FALSE)
+add_shadow_tests(BASENAME small_stop_time EXPECT_ERROR TRUE)
 
 # Regression test for https://github.com/shadow/shadow/issues/2152
 add_shadow_tests(
     BASENAME packet_after_simulation_end
-    # Processes still running at the end.
-    CHECK_RETVAL FALSE
     PROPERTIES
       # Requires curl and python
       CONFIGURATIONS extra
     )
 
 # Regression test for https://github.com/shadow/shadow/issues/2151
-add_shadow_tests(
-  BASENAME sigkill_self
-  # Command should die with signal 9, giving exitcode 128+9=137
-  POST_CMD "test `cat hosts/*/*.exitcode` -eq 137"
-  # Shadow should return failure
-  EXPECT_ERROR TRUE
-  CHECK_RETVAL FALSE)
+add_shadow_tests(BASENAME sigkill_self)
 
 add_executable(test_flush_after_exit test_flush_after_exit.c)
 add_linux_tests(BASENAME flush_after_exit COMMAND bash -c "test `./test_flush_after_exit` == 'Hello'")

--- a/src/test/regression/packet_after_simulation_end.yaml
+++ b/src/test/regression/packet_after_simulation_end.yaml
@@ -31,7 +31,7 @@ hosts:
     - path: /usr/bin/python3
       args: -m http.server 80
       start_time: 1s
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:
@@ -41,4 +41,4 @@ hosts:
       # Network graph has 2s latency, so we expect this process to still be
       # alive at the end.  (and packets still in flight, which is what we're
       # testing)
-      expected_final_state: !running
+      expected_final_state: running

--- a/src/test/regression/packet_after_simulation_end.yaml
+++ b/src/test/regression/packet_after_simulation_end.yaml
@@ -31,9 +31,14 @@ hosts:
     - path: /usr/bin/python3
       args: -m http.server 80
       start_time: 1s
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:
     - path: /usr/bin/curl
       args: -s server
       start_time: 2s
+      # Network graph has 2s latency, so we expect this process to still be
+      # alive at the end.  (and packets still in flight, which is what we're
+      # testing)
+      expected_final_state: !running

--- a/src/test/regression/sigkill_self.yaml
+++ b/src/test/regression/sigkill_self.yaml
@@ -11,4 +11,4 @@ hosts:
     - path: "kill"
       args: -KILL 1000
       start_time: 1s
-      expected_final_state: !signaled SIGKILL
+      expected_final_state: {signaled: SIGKILL}

--- a/src/test/regression/sigkill_self.yaml
+++ b/src/test/regression/sigkill_self.yaml
@@ -11,3 +11,4 @@ hosts:
     - path: "kill"
       args: -KILL 1000
       start_time: 1s
+      expected_final_state: !signaled SIGKILL

--- a/src/test/signal/CMakeLists.txt
+++ b/src/test/signal/CMakeLists.txt
@@ -11,10 +11,4 @@ add_linux_tests(BASENAME signals-extra COMMAND sh -c "../../target/debug/test_si
 add_shadow_tests(BASENAME signals-extra)
 
 ## Basic cross-process signal tests.
-add_shadow_tests(
-    BASENAME signals-multiprocess
-    # `sleep` should die with signal SIGINT (2), giving exitcode 128+2=130
-    POST_CMD "test `cat hosts/*/sleep.*.exitcode` -eq 130"
-    # Shadow should return failure
-    EXPECT_ERROR TRUE
-    CHECK_RETVAL FALSE)
+add_shadow_tests(BASENAME signals-multiprocess)

--- a/src/test/signal/signals-multiprocess.yaml
+++ b/src/test/signal/signals-multiprocess.yaml
@@ -12,7 +12,7 @@ hosts:
     - path: sleep
       args: '10'
       start_time: 1
-      expected_final_state: !signaled SIGINT
+      expected_final_state: {signaled: SIGINT}
     - path: kill 
       args: -SIGINT '1000'
       start_time: 2

--- a/src/test/signal/signals-multiprocess.yaml
+++ b/src/test/signal/signals-multiprocess.yaml
@@ -12,6 +12,7 @@ hosts:
     - path: sleep
       args: '10'
       start_time: 1
+      expected_final_state: !signaled SIGINT
     - path: kill 
       args: -SIGINT '1000'
       start_time: 2

--- a/src/test/socket/bind/CMakeLists.txt
+++ b/src/test/socket/bind/CMakeLists.txt
@@ -8,4 +8,4 @@ add_shadow_tests(
       TIMEOUT 30
     )
 
-add_shadow_tests(BASENAME bind_in_new_process CHECK_RETVAL false)
+add_shadow_tests(BASENAME bind_in_new_process)

--- a/src/test/tgen/fixed_duration/100mbit_100ms.yaml
+++ b/src/test/tgen/fixed_duration/100mbit_100ms.yaml
@@ -28,7 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_duration/100mbit_100ms.yaml
+++ b/src/test/tgen/fixed_duration/100mbit_100ms.yaml
@@ -28,6 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_duration/10mbit_200ms.yaml
+++ b/src/test/tgen/fixed_duration/10mbit_200ms.yaml
@@ -28,7 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_duration/10mbit_200ms.yaml
+++ b/src/test/tgen/fixed_duration/10mbit_200ms.yaml
@@ -28,6 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_duration/1gbit_10ms.yaml
+++ b/src/test/tgen/fixed_duration/1gbit_10ms.yaml
@@ -28,7 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_duration/1gbit_10ms.yaml
+++ b/src/test/tgen/fixed_duration/1gbit_10ms.yaml
@@ -28,6 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_duration/1mbit_300ms.yaml
+++ b/src/test/tgen/fixed_duration/1mbit_300ms.yaml
@@ -28,7 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_duration/1mbit_300ms.yaml
+++ b/src/test/tgen/fixed_duration/1mbit_300ms.yaml
@@ -28,6 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_duration/CMakeLists.txt
+++ b/src/test/tgen/fixed_duration/CMakeLists.txt
@@ -39,8 +39,6 @@ foreach(client 1stream 10streams 100streams 1000streams)
     add_shadow_tests(BASENAME tgen-duration-${network}-${client}
                     SHADOW_CONFIG ${CMAKE_CURRENT_BINARY_DIR}/${network}-${client}.yaml
                     LOGLEVEL info
-                    # tgen server runs forever, which is not a failure
-                    CHECK_RETVAL false
                     POST_CMD "${CMAKE_CURRENT_SOURCE_DIR}/verify.sh ${network} ${client}"
                     PROPERTIES
                       TIMEOUT ${TIMEOUTVAL}

--- a/src/test/tgen/fixed_size/100mbit_100ms.yaml
+++ b/src/test/tgen/fixed_size/100mbit_100ms.yaml
@@ -28,7 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_size/100mbit_100ms.yaml
+++ b/src/test/tgen/fixed_size/100mbit_100ms.yaml
@@ -28,6 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_size/10mbit_200ms.yaml
+++ b/src/test/tgen/fixed_size/10mbit_200ms.yaml
@@ -28,7 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_size/10mbit_200ms.yaml
+++ b/src/test/tgen/fixed_size/10mbit_200ms.yaml
@@ -28,6 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_size/1gbit_10ms.yaml
+++ b/src/test/tgen/fixed_size/1gbit_10ms.yaml
@@ -28,7 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_size/1gbit_10ms.yaml
+++ b/src/test/tgen/fixed_size/1gbit_10ms.yaml
@@ -28,6 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_size/1mbit_300ms.yaml
+++ b/src/test/tgen/fixed_size/1mbit_300ms.yaml
@@ -28,7 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_size/1mbit_300ms.yaml
+++ b/src/test/tgen/fixed_size/1mbit_300ms.yaml
@@ -28,6 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../server.graphml
       start_time: 1
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:

--- a/src/test/tgen/fixed_size/CMakeLists.txt
+++ b/src/test/tgen/fixed_size/CMakeLists.txt
@@ -30,8 +30,6 @@ foreach(client 1stream_1b_1000x 1stream_1kib_100x 1stream_1mib_10x 10streams_1mi
     add_shadow_tests(BASENAME tgen-size-${network}-${client}
                     SHADOW_CONFIG ${CMAKE_CURRENT_BINARY_DIR}/${network}-${client}.yaml
                     LOGLEVEL info
-                    # tgen server runs forever, which is not a failure
-                    CHECK_RETVAL false
                     POST_CMD "${CMAKE_CURRENT_SOURCE_DIR}/verify.sh ${network} ${client}"
                     PROPERTIES
                       TIMEOUT 60

--- a/src/test/threads/CMakeLists.txt
+++ b/src/test/threads/CMakeLists.txt
@@ -2,7 +2,7 @@ add_linux_tests(BASENAME pthreads COMMAND sh -c "../../target/debug/test_pthread
 add_shadow_tests(BASENAME pthreads)
 
 add_linux_tests(BASENAME threads-noexit COMMAND sh -c "../../target/debug/test_threads_noexit")
-add_shadow_tests(BASENAME threads-noexit CHECK_RETVAL FALSE)
+add_shadow_tests(BASENAME threads-noexit)
 
 add_linux_tests(BASENAME threads-group-leader-exits COMMAND sh -c "../../target/debug/test_threads_group_leader_exits")
 add_shadow_tests(BASENAME threads-group-leader-exits)

--- a/src/test/threads/threads-noexit.yaml
+++ b/src/test/threads/threads-noexit.yaml
@@ -10,4 +10,4 @@ hosts:
     processes:
     - path: ../../target/debug/test_threads_noexit
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running

--- a/src/test/threads/threads-noexit.yaml
+++ b/src/test/threads/threads-noexit.yaml
@@ -10,3 +10,4 @@ hosts:
     processes:
     - path: ../../target/debug/test_threads_noexit
       start_time: 1
+      expected_final_state: !running

--- a/src/test/tor/minimal/CMakeLists.txt
+++ b/src/test/tor/minimal/CMakeLists.txt
@@ -12,9 +12,6 @@ add_custom_target(tor-minimal-shadow-data-template ALL
 
 add_shadow_tests(BASENAME tor-minimal
                  LOGLEVEL info
-                 # don't check tor's return value since it will be killed by shadow at the end of
-                 # the sim
-                 CHECK_RETVAL false
                  ARGS
                    --use-cpu-pinning true
                    --parallelism 2

--- a/src/test/tor/minimal/tor-minimal.yaml
+++ b/src/test/tor/minimal/tor-minimal.yaml
@@ -28,7 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../conf/tgen.server.graphml.xml
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
   hiddenserver:
     network_node_id: 0
     processes:
@@ -37,12 +37,12 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../conf/tgen.hiddenserver.graphml.xml
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
     - path: tor
       args: --Address hiddenserver --Nickname hiddenserver
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
-      expected_final_state: !running
+      expected_final_state: running
   4uthority:
     network_node_id: 0
     ip_addr: 100.0.0.1
@@ -51,7 +51,7 @@ hosts:
       args: --Address 4uthority --Nickname 4uthority
             --defaults-torrc torrc-defaults -f torrc
       start_time: 1
-      expected_final_state: !running
+      expected_final_state: running
   exit1:
     network_node_id: 0
     processes:
@@ -59,7 +59,7 @@ hosts:
       args: --Address exit1 --Nickname exit1
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
-      expected_final_state: !running
+      expected_final_state: running
   exit2:
     network_node_id: 0
     processes:
@@ -67,7 +67,7 @@ hosts:
       args: --Address exit2 --Nickname exit2
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
-      expected_final_state: !running
+      expected_final_state: running
   relay1:
     network_node_id: 0
     processes:
@@ -75,7 +75,7 @@ hosts:
       args: --Address relay1 --Nickname relay1
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
-      expected_final_state: !running
+      expected_final_state: running
   relay2:
     network_node_id: 0
     processes:
@@ -83,7 +83,7 @@ hosts:
       args: --Address relay2 --Nickname relay2
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
-      expected_final_state: !running
+      expected_final_state: running
   client:
     network_node_id: 0
     processes:
@@ -99,7 +99,7 @@ hosts:
       args: --Address torclient --Nickname torclient
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
-      expected_final_state: !running
+      expected_final_state: running
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
       environment: { OPENBLAS_NUM_THREADS: "1" }
@@ -113,7 +113,7 @@ hosts:
             --UseBridges 1 --Bridge 100.0.0.1:9111
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
-      expected_final_state: !running
+      expected_final_state: running
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
       environment: { OPENBLAS_NUM_THREADS: "1" }
@@ -126,7 +126,7 @@ hosts:
       args: --Address torhiddenclient --Nickname torhiddenclient
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
-      expected_final_state: !running
+      expected_final_state: running
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
       environment: { OPENBLAS_NUM_THREADS: "1" }

--- a/src/test/tor/minimal/tor-minimal.yaml
+++ b/src/test/tor/minimal/tor-minimal.yaml
@@ -28,6 +28,7 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../conf/tgen.server.graphml.xml
       start_time: 1
+      expected_final_state: !running
   hiddenserver:
     network_node_id: 0
     processes:
@@ -36,10 +37,12 @@ hosts:
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../conf/tgen.hiddenserver.graphml.xml
       start_time: 1
+      expected_final_state: !running
     - path: tor
       args: --Address hiddenserver --Nickname hiddenserver
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
+      expected_final_state: !running
   4uthority:
     network_node_id: 0
     ip_addr: 100.0.0.1
@@ -48,6 +51,7 @@ hosts:
       args: --Address 4uthority --Nickname 4uthority
             --defaults-torrc torrc-defaults -f torrc
       start_time: 1
+      expected_final_state: !running
   exit1:
     network_node_id: 0
     processes:
@@ -55,6 +59,7 @@ hosts:
       args: --Address exit1 --Nickname exit1
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
+      expected_final_state: !running
   exit2:
     network_node_id: 0
     processes:
@@ -62,6 +67,7 @@ hosts:
       args: --Address exit2 --Nickname exit2
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
+      expected_final_state: !running
   relay1:
     network_node_id: 0
     processes:
@@ -69,6 +75,7 @@ hosts:
       args: --Address relay1 --Nickname relay1
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
+      expected_final_state: !running
   relay2:
     network_node_id: 0
     processes:
@@ -76,6 +83,7 @@ hosts:
       args: --Address relay2 --Nickname relay2
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
+      expected_final_state: !running
   client:
     network_node_id: 0
     processes:
@@ -91,6 +99,7 @@ hosts:
       args: --Address torclient --Nickname torclient
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
+      expected_final_state: !running
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
       environment: { OPENBLAS_NUM_THREADS: "1" }
@@ -104,6 +113,7 @@ hosts:
             --UseBridges 1 --Bridge 100.0.0.1:9111
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
+      expected_final_state: !running
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
       environment: { OPENBLAS_NUM_THREADS: "1" }
@@ -116,6 +126,7 @@ hosts:
       args: --Address torhiddenclient --Nickname torhiddenclient
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
+      expected_final_state: !running
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
       environment: { OPENBLAS_NUM_THREADS: "1" }


### PR DESCRIPTION
* Allows the user to specify the expected state of a process at the end of a simulation.
* Changes the default behavior to treat a process still running at the end of the simulation as an error.
    
See https://github.com/shadow/shadow/discussions/2034 