### PR TITLE
Don't auto-generate getcwd libc wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ software running under Shadow, since most thread APIs use this attribute.
 error instead of escaping the Shadow simulation.
 https://github.com/shadow/shadow/issues/2718
 
+* Stopped overriding libc's `getcwd` with an incorrect wrapper that was
+returning `-1` instead of `NULL` on errors.
+
 Raw changes since v2.5.0:
 
 * [Merged PRs](https://github.com/shadow/shadow/pulls?q=is%3Apr+merged%3A%3E2023-03-23T18%3A20-0400)

--- a/src/lib/libc_preload/gen_syscall_wrappers_c.py
+++ b/src/lib/libc_preload/gen_syscall_wrappers_c.py
@@ -33,6 +33,9 @@ skip.add('exit')
 skip.add('open')
 skip.add('openat')
 
+# Returns NULL instead of -1 on error
+skip.add('getcwd')
+
 # syscall wrappers that return errors directly instead of through errno.
 direct_errors = set()
 direct_errors.add('clock_nanosleep')

--- a/src/lib/libc_preload/syscall_wrappers.c
+++ b/src/lib/libc_preload/syscall_wrappers.c
@@ -248,9 +248,7 @@ INTERPOSE(get_robust_list);
 #ifdef SYS_getcpu // kernel entry: num=309 func=sys_getcpu
 INTERPOSE(getcpu);
 #endif
-#ifdef SYS_getcwd // kernel entry: num=79 func=sys_getcwd
-INTERPOSE(getcwd);
-#endif
+// Skipping SYS_getcwd
 #ifdef SYS_getdents // kernel entry: num=78 func=sys_getdents
 INTERPOSE(getdents);
 #endif


### PR DESCRIPTION
Unlike most libc syscall wrappers, getcwd is supposed to return NULL instead of -1 on errors. The incorrect wrapper was causing a segfault when trying to run bash under shadow.