### PR TITLE
Clean up setup script options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ the simulation's `stop_time`.
 * Sub-second configuration values are now allowed for all time-related options,
 including `start_time`, `stop_time`, etc.
 
+* Removed the `--profile`, `--include`, and `--library` setup script options.
+
 PATCH changes (bugfixes):
 
 * Fixed a memory leak of about 16 bytes per thread due to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,6 @@ endif()
 message(STATUS "Building Shadow ${SHADOW_VERSION_STRING_CONF}")
 
 ## setup shadow options
-option(SHADOW_PROFILE "build with profile settings (default: OFF)" OFF)
 option(SHADOW_TEST "build tests (default: OFF)" OFF)
 option(SHADOW_WERROR "turn compiler warnings into errors. (default: OFF)" OFF)
 option(SHADOW_COVERAGE "enable code-coverage instrumentation. (default: OFF)" OFF)
@@ -147,7 +146,6 @@ option(SHADOW_USE_PERF_TIMERS "compile in timers for tracking the run time of va
 MESSAGE(STATUS)
 MESSAGE(STATUS "-------------------------------------------------------------------------------")
 MESSAGE(STATUS "Current settings: (change with '$ cmake -D<OPTION>=<ON|OFF>')")
-MESSAGE(STATUS "SHADOW_PROFILE=${SHADOW_PROFILE}")
 MESSAGE(STATUS "SHADOW_TEST=${SHADOW_TEST}")
 MESSAGE(STATUS "SHADOW_WERROR=${SHADOW_WERROR}")
 MESSAGE(STATUS "SHADOW_COVERAGE=${SHADOW_COVERAGE}")
@@ -200,13 +198,6 @@ endif()
 if($ENV{VERBOSE})
     add_definitions(-DVERBOSE)
 endif()
-
-if(SHADOW_PROFILE STREQUAL ON)
-    message(STATUS "Building Shadow core with profiling support using '-pg'")
-    add_cflags(-pg)
-    add_definitions(-DDEBUG)
-    ## see src/main/CMakeLists.txt, where we add the -pg flags
-endif(SHADOW_PROFILE STREQUAL ON)
 
 #if(POLICY  CMP0026)
 #    cmake_policy(SET  CMP0026  OLD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,13 +37,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message(FATAL_ERROR "Shadow requires an out-of-source build. Please create a separate build directory and run 'cmake path/to/shadow [options]' there.")
 endif(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 
-## additional user-defined include directories
-foreach(include ${CMAKE_EXTRA_INCLUDES})
-    include_directories(${include})
-    set(CMAKE_MODULE_PATH "${include}" ${CMAKE_MODULE_PATH})
-endforeach(include)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/" ${CMAKE_MODULE_PATH})
-
 message(STATUS "CMAKE_MODULE_PATH = ${CMAKE_MODULE_PATH}")
 
 ## Mismatched C and C++ compilers can result in confusing errors at link time.
@@ -58,10 +52,6 @@ if((CMAKE_C_COMPILER MATCHES "[/^]clang") AND (CMAKE_C_COMPILER_VERSION VERSION_
 	message(FATAL_ERROR "Clang 13.0.0 is not supported (see https://github.com/shadow/shadow/issues/1741)")
 endif()
 
-## additional user-defined library directories
-foreach(library ${CMAKE_EXTRA_LIBRARIES})
-    link_directories(${library})
-endforeach(library)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 ## use the installed shim path only when shadow is installed

--- a/cmake/FindDL.cmake
+++ b/cmake/FindDL.cmake
@@ -10,14 +10,14 @@
 ## Check for the header files
 
 find_path (DL_INCLUDES dlfcn.h
-  PATHS /usr/local/include /usr/include ${CMAKE_EXTRA_INCLUDES}
+  PATHS /usr/local/include /usr/include
   )
 
 ## -----------------------------------------------------------------------------
 ## Check for the library
 
 find_library (DL_LIBRARIES dl
-  PATHS /usr/local/lib /usr/lib /lib ${CMAKE_EXTRA_LIBRARIES}
+  PATHS /usr/local/lib /usr/lib /lib
   )
 
 ## -----------------------------------------------------------------------------

--- a/cmake/FindM.cmake
+++ b/cmake/FindM.cmake
@@ -10,14 +10,14 @@
 ## Check for the header files
 
 find_path (M_INCLUDES math.h
-  PATHS /usr/local/include /usr/include ${CMAKE_EXTRA_INCLUDES}
+  PATHS /usr/local/include /usr/include
   )
 
 ## -----------------------------------------------------------------------------
 ## Check for the library
 
 find_library (M_LIBRARIES m
-  PATHS /usr/local/lib /usr/lib /lib ${CMAKE_EXTRA_LIBRARIES}
+  PATHS /usr/local/lib /usr/lib /lib
   )
 
 ## -----------------------------------------------------------------------------

--- a/cmake/FindRPTH.cmake
+++ b/cmake/FindRPTH.cmake
@@ -10,25 +10,15 @@
 ## Check for the header files
 
 find_path (RPTH_INCLUDES rpth.h
-  PATHS ${CMAKE_EXTRA_INCLUDES} NO_DEFAULT_PATH
+  PATHS /usr/local/include /usr/include /include /sw/include /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu/
   )
-if(NOT RPTH_INCLUDES)
-    find_path (RPTH_INCLUDES rpth.h
-      PATHS /usr/local/include /usr/include /include /sw/include /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu/ ${CMAKE_EXTRA_INCLUDES}
-      )
-endif(NOT RPTH_INCLUDES)
 
 ## -----------------------------------------------------------------------------
 ## Check for the library
 
 find_library (RPTH_LIBRARIES NAMES rpth
-  PATHS ${CMAKE_EXTRA_LIBRARIES} NO_DEFAULT_PATH
+  PATHS /usr/local/lib /usr/lib /lib /sw/lib
   )
-if(NOT RPTH_LIBRARIES)
-    find_library (RPTH_LIBRARIES NAMES rpth
-      PATHS /usr/local/lib /usr/lib /lib /sw/lib ${CMAKE_EXTRA_LIBRARIES}
-      )
-endif(NOT RPTH_LIBRARIES)
 
 ## -----------------------------------------------------------------------------
 ## Actions taken when all components have been found

--- a/cmake/FindRT.cmake
+++ b/cmake/FindRT.cmake
@@ -10,14 +10,14 @@
 ## Check for the header files
 
 find_path (RT_INCLUDES time.h
-  PATHS /usr/local/include /usr/include ${CMAKE_EXTRA_INCLUDES}
+  PATHS /usr/local/include /usr/include
   )
 
 ## -----------------------------------------------------------------------------
 ## Check for the library
 
 find_library (RT_LIBRARIES rt
-  PATHS /usr/local/lib /usr/lib /lib ${CMAKE_EXTRA_LIBRARIES}
+  PATHS /usr/local/lib /usr/lib /lib
   )
 
 ## -----------------------------------------------------------------------------

--- a/setup
+++ b/setup
@@ -75,7 +75,7 @@ def main():
         action="store_true", dest="do_debug",
         default=False)
 
-    parser_build.add_argument('-C', '--coverage',
+    parser_build.add_argument('--coverage',
         help="Enable profiling data for code coverage reporting.",
         action="store_true", dest="do_coverage",
         default=False)

--- a/setup
+++ b/setup
@@ -45,18 +45,6 @@ def main():
         action="store", dest="prefix",
         default=INSTALL_PREFIX)
 
-    parser_build.add_argument('-i', '--include',
-        help="Deprecated. Use --search instead",
-        metavar="PATH",
-        action="append", dest="extra_includes",
-        default=[])
-
-    parser_build.add_argument('-l', '--library',
-        help="Deprecated. Use --search instead",
-        metavar="PATH",
-        action="append", dest="extra_libraries",
-        default=[])
-
     parser_build.add_argument('-s', '--search',
         # Ultimately sets CMAKE_PREFIX_PATH
         # https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html#variable:CMAKE_PREFIX_PATH
@@ -226,20 +214,10 @@ def build(args, remaining):
     # we will run from build directory
     calledDirectory = os.getcwd()
 
-    if len(args.extra_includes) > 0:
-        logging.warning("--include is deprecated. Use --search instead.")
-
-    if len(args.extra_libraries) > 0:
-        logging.warning("--library is deprecated. Use --search instead.")
-
-    # add extra library and include directories as absolution paths
-    make_paths_absolute(args.extra_includes)
-    make_paths_absolute(args.extra_libraries)
+    # add extra search directories as absolution paths
     make_paths_absolute(args.search_prefix)
 
     # make sure we can access them from cmake
-    cmake_cmd += " -DCMAKE_EXTRA_INCLUDES=" + ';'.join(args.extra_includes)
-    cmake_cmd += " -DCMAKE_EXTRA_LIBRARIES=" + ';'.join(args.extra_libraries)
     cmake_cmd += " -DCMAKE_PREFIX_PATH=" + ';'.join(args.search_prefix)
 
     # look for the clang/clang++ compilers

--- a/setup
+++ b/setup
@@ -96,11 +96,6 @@ def main():
         action="store", dest="njobs",
         default=multiprocessing.cpu_count())
 
-    parser_build.add_argument('-o', '--profile',
-        help="Build in gprof profiling information when running Shadow.",
-        action="store_true", dest="do_profile",
-        default=False)
-
     parser_build.add_argument('-t', '--test',
         help="Build tests.",
         action="store_true", dest="do_test",
@@ -219,7 +214,6 @@ def build(args, remaining):
     cmake_cmd += " -DCMAKE_BUILD_TYPE=" + ("Debug" if args.do_debug else "Release")
     if args.do_verbose: os.putenv("VERBOSE", "1")
     if args.do_test: cmake_cmd += " -DSHADOW_TEST=ON"
-    if args.do_profile: cmake_cmd += " -DSHADOW_PROFILE=ON"
     if args.do_werror: cmake_cmd += " -DSHADOW_WERROR=ON"
     if args.do_use_perf_timers: cmake_cmd += " -DSHADOW_USE_PERF_TIMERS=ON"
 


### PR DESCRIPTION
Part of the 3.0 changes.

- remove the `--profile` option
  - closes #2405
- remove the `-C` short form for `--coverage`
  - the coverage option is rarely used and I don't think it needs a short form
- remove deprecated `--include` and `--library` options
  - i don't know if these are still useful, but they're marked as deprecated so now would be the time to remove them