### PR TITLE
Log system memory info during the heartbeat

### DIFF
--- a/src/main/core/mod.rs
+++ b/src/main/core/mod.rs
@@ -2,6 +2,7 @@ pub mod controller;
 pub mod logger;
 pub mod main;
 pub mod manager;
+pub mod resource_usage;
 pub mod scheduler;
 pub mod sim_config;
 pub mod sim_stats;

--- a/src/main/core/resource_usage.rs
+++ b/src/main/core/resource_usage.rs
@@ -1,0 +1,77 @@
+use std::fs::File;
+use std::io::{Read, Seek};
+
+use serde::Serialize;
+
+/// Memory usage information parsed from '/proc/meminfo'. All units are converted to bytes.
+#[derive(Copy, Clone, Debug, Default, Serialize)]
+pub struct MemInfo {
+    mem_total: Option<u64>,
+    mem_free: Option<u64>,
+    swap_total: Option<u64>,
+    swap_free: Option<u64>,
+    buffers: Option<u64>,
+    cached: Option<u64>,
+    s_reclaimable: Option<u64>,
+    shmem: Option<u64>,
+}
+
+/// Collects some of the fields from '/proc/meminfo'. This function will seek to the start of the
+/// file before reading.
+pub fn meminfo(file: &mut File) -> std::io::Result<MemInfo> {
+    let mut buffer = String::new();
+    file.rewind()?;
+    file.read_to_string(&mut buffer)?;
+
+    let lines = buffer.lines().filter_map(|line| {
+        let Some((name, val)) = line.split_once(':') else {
+            // don't know how to parse this line
+            return None;
+        };
+
+        let name = name.trim();
+        let val = val.trim();
+
+        let (val, unit) = val
+            .rsplit_once(' ')
+            .map(|(x, y)| (x, Some(y)))
+            .unwrap_or((val, None));
+
+        Some((name, val, unit))
+    });
+
+    let mut mem = MemInfo::default();
+
+    for (name, val, unit) in lines {
+        let Some(val) = val.parse().ok() else {
+            // expected an integer
+            continue;
+        };
+
+        match name {
+            "MemTotal" => mem.mem_total = as_base_unit(val, unit),
+            "MemFree" => mem.mem_free = as_base_unit(val, unit),
+            "SwapTotal" => mem.swap_total = as_base_unit(val, unit),
+            "SwapFree" => mem.swap_free = as_base_unit(val, unit),
+            "Buffers" => mem.buffers = as_base_unit(val, unit),
+            "Cached" => mem.cached = as_base_unit(val, unit),
+            "SReclaimable" => mem.s_reclaimable = as_base_unit(val, unit),
+            "Shmem" => mem.shmem = as_base_unit(val, unit),
+            _ => {}
+        }
+    }
+
+    Ok(mem)
+}
+
+/// Returns `None` if either the `unit` wasn't known, or the base unit is too large.
+fn as_base_unit(val: u64, unit: Option<&str>) -> Option<u64> {
+    let mul = match unit {
+        None => 1,
+        Some("B") => 1,
+        Some("kB") => 1024,
+        Some(_) => return None,
+    };
+
+    val.checked_mul(mul)
+}


### PR DESCRIPTION
In the future, we should be able to use this data to compute memory usage in tornettools instead of running `/usr/bin/free` in a loop. While I think it would be best to not write json directly in the log file, I think this is fine until we have better structured logging. Even though it's json, we'll still consider it unsupported along with everything else in the log file.

Ex:

```
00:00:01.057619 [546333:shadow] n/a [INFO] [n/a] [manager.rs:765] [shadow_rs::core::manager] System memory usage in bytes at simtime 6120000000 ns reported by /proc/meminfo: {"mem_total":67169312768,"mem_free":48688345088,"swap_total":68719472640,"swap_free":55525654528,"buffers":0,"cached":7910858752,"s_reclaimable":0,"shmem":5169258496}
```

Double-checked that the performance didn't change:

https://github.com/shadow/benchmark-results/tree/master/tor/2023-04-27-T20-50-03

![run_time](https://user-images.githubusercontent.com/3708797/235177660-422b43e3-e0f4-45bb-8518-f660beaf7f6e.png)