### PR TITLE
Update to rust 1.69.0 and use `CStr::from_bytes_until_nul`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,4 +7,4 @@
 # that the newly specified version is baked in and doesn't have to be installed
 # (and rust deps rebuilt) during every incremental build.
 [toolchain]
-channel = "1.68.0"
+channel = "1.69.0"

--- a/src/main/utility/sockaddr.rs
+++ b/src/main/utility/sockaddr.rs
@@ -295,9 +295,7 @@ where
 
         // For pathname socket addresses, the path is a C-style nul-terminated string which may be
         // shorter than the address length (`self.len`). Bytes after the nul are ignored.
-        let first_nul = path.iter().position(|&x| x == 0)?;
-
-        return Some(CStr::from_bytes_with_nul(&path[..(first_nul + 1)]).unwrap());
+        CStr::from_bytes_until_nul(path).ok()
     }
 
     /// If the socket address represents an abstract address, returns the bytes representing the


### PR DESCRIPTION
`CStr::from_bytes_until_nul` makes the code nicer, and probably performs better since it uses `memchr::memchr` rather than our `position(|c| *c == 0)`.