### PR TITLE
Make `ForeignPtr` `Send` and `Sync`

### DIFF
--- a/src/lib/shadow-shim-helper-rs/src/syscall_types.rs
+++ b/src/lib/shadow-shim-helper-rs/src/syscall_types.rs
@@ -37,6 +37,7 @@ impl<T> ForeignPtr<T> {
         }
     }
 
+    #[inline]
     pub fn null() -> Self {
         // this will be an invalid pointer so we don't really care what type rust will infer for
         // this `ForeignPtr`
@@ -67,15 +68,18 @@ impl<T> ForeignPtr<T> {
     /// // cast to a u8 pointer
     /// let ptr: ForeignPtr<u8> = ptr.cast();
     /// ```
+    #[inline]
     pub fn cast<U: NoTypeInference>(&self) -> ForeignPtr<U::This> {
         ForeignPtr::new_with_type_inference(self.val)
     }
 
+    #[inline]
     pub fn is_null(&self) -> bool {
         self.val == 0
     }
 
     /// Create a `ForeignPtr` from a raw pointer to plugin memory.
+    #[inline]
     pub fn from_raw_ptr(ptr: *mut T) -> Self {
         let val = ptr as usize;
         // the type of this `ForeignPtr` will be inferred from the pointer type
@@ -83,12 +87,14 @@ impl<T> ForeignPtr<T> {
     }
 
     /// Add an offset to a pointer. `count` is in units of `T`.
+    #[inline]
     pub fn add(&self, count: usize) -> Self {
         let val = self.val;
         Self::new_with_type_inference(val + count * std::mem::size_of::<T>())
     }
 
     /// Subtract an offset from a pointer. `count` is in units of `T`.
+    #[inline]
     pub fn sub(&self, count: usize) -> Self {
         let val = self.val;
         Self::new_with_type_inference(val - count * std::mem::size_of::<T>())
@@ -96,13 +102,16 @@ impl<T> ForeignPtr<T> {
 }
 
 impl<T> From<ForeignPtr<T>> for usize {
+    #[inline]
     fn from(v: ForeignPtr<T>) -> Self {
         v.val
     }
 }
 
+/// Convert an integer to an untyped `ForeignPtr`.
 impl From<usize> for ForeignPtr<()> {
-    fn from(v: usize) -> ForeignPtr<()> {
+    #[inline]
+    fn from(v: usize) -> Self {
         ForeignPtr {
             val: v,
             _phantom: Default::default(),
@@ -110,8 +119,10 @@ impl From<usize> for ForeignPtr<()> {
     }
 }
 
+/// Convert an integer to an untyped `ForeignPtr`.
 impl From<u64> for ForeignPtr<()> {
-    fn from(v: u64) -> ForeignPtr<()> {
+    #[inline]
+    fn from(v: u64) -> Self {
         ForeignPtr {
             val: v.try_into().unwrap(),
             _phantom: Default::default(),
@@ -120,6 +131,7 @@ impl From<u64> for ForeignPtr<()> {
 }
 
 impl<T> From<ForeignPtr<T>> for u64 {
+    #[inline]
     fn from(v: ForeignPtr<T>) -> Self {
         v.val.try_into().unwrap()
     }
@@ -128,6 +140,7 @@ impl<T> From<ForeignPtr<T>> for u64 {
 impl<T> Copy for ForeignPtr<T> {}
 
 impl<T> Clone for ForeignPtr<T> {
+    #[inline]
     fn clone(&self) -> Self {
         *self
     }
@@ -157,18 +170,21 @@ pub struct ManagedPhysicalMemoryAddr {
 }
 
 impl From<ManagedPhysicalMemoryAddr> for usize {
+    #[inline]
     fn from(v: ManagedPhysicalMemoryAddr) -> usize {
         v.val
     }
 }
 
 impl From<usize> for ManagedPhysicalMemoryAddr {
+    #[inline]
     fn from(v: usize) -> ManagedPhysicalMemoryAddr {
         ManagedPhysicalMemoryAddr { val: v }
     }
 }
 
 impl From<u64> for ManagedPhysicalMemoryAddr {
+    #[inline]
     fn from(v: u64) -> ManagedPhysicalMemoryAddr {
         ManagedPhysicalMemoryAddr {
             val: v.try_into().unwrap(),
@@ -177,6 +193,7 @@ impl From<u64> for ManagedPhysicalMemoryAddr {
 }
 
 impl From<ManagedPhysicalMemoryAddr> for u64 {
+    #[inline]
     fn from(v: ManagedPhysicalMemoryAddr) -> u64 {
         v.val.try_into().unwrap()
     }
@@ -193,9 +210,11 @@ pub struct SysCallArgs {
 }
 
 impl SysCallArgs {
+    #[inline]
     pub fn get(&self, i: usize) -> SysCallReg {
         self.args[i]
     }
+    #[inline]
     pub fn number(&self) -> i64 {
         self.number
     }
@@ -217,78 +236,91 @@ static_assertions::assert_eq_align!(SysCallReg, u64);
 static_assertions::assert_eq_size!(SysCallReg, u64);
 
 impl PartialEq for SysCallReg {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         unsafe { self.as_u64 == other.as_u64 }
     }
 }
 
 impl From<u64> for SysCallReg {
+    #[inline]
     fn from(v: u64) -> Self {
         Self { as_u64: v }
     }
 }
 
 impl From<SysCallReg> for u64 {
+    #[inline]
     fn from(v: SysCallReg) -> u64 {
         unsafe { v.as_u64 }
     }
 }
 
 impl From<u32> for SysCallReg {
+    #[inline]
     fn from(v: u32) -> Self {
         Self { as_u64: v as u64 }
     }
 }
 
 impl From<SysCallReg> for u32 {
+    #[inline]
     fn from(v: SysCallReg) -> u32 {
         (unsafe { v.as_u64 }) as u32
     }
 }
 
 impl From<usize> for SysCallReg {
+    #[inline]
     fn from(v: usize) -> Self {
         Self { as_u64: v as u64 }
     }
 }
 
 impl From<SysCallReg> for usize {
+    #[inline]
     fn from(v: SysCallReg) -> usize {
         unsafe { v.as_u64 as usize }
     }
 }
 
 impl From<isize> for SysCallReg {
+    #[inline]
     fn from(v: isize) -> Self {
         Self { as_i64: v as i64 }
     }
 }
 
 impl From<SysCallReg> for isize {
+    #[inline]
     fn from(v: SysCallReg) -> isize {
         unsafe { v.as_i64 as isize }
     }
 }
 
 impl From<i64> for SysCallReg {
+    #[inline]
     fn from(v: i64) -> Self {
         Self { as_i64: v }
     }
 }
 
 impl From<SysCallReg> for i64 {
+    #[inline]
     fn from(v: SysCallReg) -> i64 {
         unsafe { v.as_i64 }
     }
 }
 
 impl From<i32> for SysCallReg {
+    #[inline]
     fn from(v: i32) -> Self {
         Self { as_i64: v as i64 }
     }
 }
 
 impl From<SysCallReg> for i32 {
+    #[inline]
     fn from(v: SysCallReg) -> i32 {
         (unsafe { v.as_i64 }) as i32
     }
@@ -297,6 +329,7 @@ impl From<SysCallReg> for i32 {
 impl TryFrom<SysCallReg> for u8 {
     type Error = <u8 as TryFrom<u64>>::Error;
 
+    #[inline]
     fn try_from(v: SysCallReg) -> Result<u8, Self::Error> {
         (unsafe { v.as_u64 }).try_into()
     }
@@ -305,6 +338,7 @@ impl TryFrom<SysCallReg> for u8 {
 impl TryFrom<SysCallReg> for u16 {
     type Error = <u16 as TryFrom<u64>>::Error;
 
+    #[inline]
     fn try_from(v: SysCallReg) -> Result<u16, Self::Error> {
         (unsafe { v.as_u64 }).try_into()
     }
@@ -313,6 +347,7 @@ impl TryFrom<SysCallReg> for u16 {
 impl TryFrom<SysCallReg> for i8 {
     type Error = <i8 as TryFrom<i64>>::Error;
 
+    #[inline]
     fn try_from(v: SysCallReg) -> Result<i8, Self::Error> {
         (unsafe { v.as_i64 }).try_into()
     }
@@ -321,12 +356,14 @@ impl TryFrom<SysCallReg> for i8 {
 impl TryFrom<SysCallReg> for i16 {
     type Error = <i16 as TryFrom<i64>>::Error;
 
+    #[inline]
     fn try_from(v: SysCallReg) -> Result<i16, Self::Error> {
         (unsafe { v.as_i64 }).try_into()
     }
 }
 
 impl<T> From<ForeignPtr<T>> for SysCallReg {
+    #[inline]
     fn from(v: ForeignPtr<T>) -> Self {
         Self {
             as_ptr: v.cast::<()>(),
@@ -335,6 +372,7 @@ impl<T> From<ForeignPtr<T>> for SysCallReg {
 }
 
 impl<T> From<SysCallReg> for ForeignPtr<T> {
+    #[inline]
     fn from(v: SysCallReg) -> Self {
         // This allows rust to infer the type for the cast. This isn't ideal since we generally want
         // to require that the user be explicit about casts (for example we use the
@@ -347,6 +385,7 @@ impl<T> From<SysCallReg> for ForeignPtr<T> {
 
 // Useful for syscalls whose strongly-typed wrappers return some Result<(), ErrType>
 impl From<()> for SysCallReg {
+    #[inline]
     fn from(_: ()) -> SysCallReg {
         SysCallReg { as_i64: 0 }
     }

--- a/src/lib/shadow-shim-helper-rs/src/syscall_types.rs
+++ b/src/lib/shadow-shim-helper-rs/src/syscall_types.rs
@@ -1,6 +1,6 @@
 use vasi::VirtualAddressSpaceIndependent;
 
-use crate::util::NoTypeInference;
+use crate::util::{NoTypeInference, SyncSendPointer};
 
 /// Used to indicate an untyped `ForeignPtr` in C code. We use the unit type as the generic rather
 /// than `libc::c_void` since the unit type is zero-sized and `libc::c_void` has a size of 1 byte,
@@ -23,7 +23,10 @@ pub type UntypedForeignPtr = ForeignPtr<()>;
 #[repr(C)]
 pub struct ForeignPtr<T> {
     val: usize,
-    _phantom: std::marker::PhantomData<T>,
+    // `ForeignPtr` behaves as if it holds a pointer to a `T`, and we want this `ForeignPtr` to be
+    // `Send` + `Sync`
+    #[unsafe_assume_virtual_address_space_independent]
+    _phantom: std::marker::PhantomData<SyncSendPointer<T>>,
 }
 
 impl<T> ForeignPtr<T> {

--- a/src/lib/shadow-shim-helper-rs/src/util/mod.rs
+++ b/src/lib/shadow-shim-helper-rs/src/util/mod.rs
@@ -18,3 +18,66 @@ pub trait NoTypeInference {
 impl<T> NoTypeInference for T {
     type This = T;
 }
+
+/// A type that allows us to make a pointer Send + Sync since there is no way
+/// to add these traits to the pointer itself.
+#[derive(Debug)]
+pub struct SyncSendPointer<T>(*mut T);
+
+// We can't automatically `derive` Copy and Clone without unnecessarily
+// requiring T to be Copy and Clone.
+// https://github.com/rust-lang/rust/issues/26925
+impl<T> Copy for SyncSendPointer<T> {}
+impl<T> Clone for SyncSendPointer<T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+unsafe impl<T> Send for SyncSendPointer<T> {}
+unsafe impl<T> Sync for SyncSendPointer<T> {}
+
+impl<T> SyncSendPointer<T> {
+    /// # Safety
+    ///
+    /// The object pointed to by `ptr` must actually be `Sync` and `Send` or
+    /// else not subsequently used in contexts where it matters.
+    pub unsafe fn new(ptr: *mut T) -> Self {
+        Self(ptr)
+    }
+
+    pub fn ptr(&self) -> *mut T {
+        self.0
+    }
+}
+
+/// A type that allows us to make a pointer Send since there is no way
+/// to add this traits to the pointer itself.
+#[derive(Debug)]
+pub struct SendPointer<T>(*mut T);
+
+// We can't automatically `derive` Copy and Clone without unnecessarily
+// requiring T to be Copy and Clone.
+// https://github.com/rust-lang/rust/issues/26925
+impl<T> Copy for SendPointer<T> {}
+impl<T> Clone for SendPointer<T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+unsafe impl<T> Send for SendPointer<T> {}
+
+impl<T> SendPointer<T> {
+    /// # Safety
+    ///
+    /// The object pointed to by `ptr` must actually be `Send` or else not
+    /// subsequently used in contexts where it matters.
+    pub unsafe fn new(ptr: *mut T) -> Self {
+        Self(ptr)
+    }
+
+    pub fn ptr(&self) -> *mut T {
+        self.0
+    }
+}

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -13,6 +13,7 @@ use rand::seq::SliceRandom;
 use rand_xoshiro::Xoshiro256PlusPlus;
 use shadow_shim_helper_rs::emulated_time::EmulatedTime;
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
+use shadow_shim_helper_rs::util::SyncSendPointer;
 use shadow_shim_helper_rs::HostId;
 
 use crate::core::controller::{Controller, ShadowStatusBarState, SimController};
@@ -27,9 +28,9 @@ use crate::core::worker;
 use crate::cshadow as c;
 use crate::host::host::{Host, HostParameters};
 use crate::network::graph::{IpAssignment, RoutingInfo};
+use crate::utility;
 use crate::utility::childpid_watcher::ChildPidWatcher;
 use crate::utility::status_bar::Status;
-use crate::utility::{self, SyncSendPointer};
 
 pub struct Manager<'a> {
     manager_config: Option<ManagerConfig>,

--- a/src/main/core/work/task.rs
+++ b/src/main/core/work/task.rs
@@ -60,13 +60,11 @@ impl PartialEq for TaskRef {
 impl Eq for TaskRef {}
 
 pub mod export {
+    use shadow_shim_helper_rs::util::SyncSendPointer;
     use shadow_shim_helper_rs::{notnull::notnull_mut, HostId};
 
     use super::*;
-    use crate::{
-        host::host::Host,
-        utility::{HostTreePointer, SyncSendPointer},
-    };
+    use crate::{host::host::Host, utility::HostTreePointer};
 
     pub type TaskCallbackFunc = extern "C" fn(*const Host, *mut libc::c_void, *mut libc::c_void);
     pub type TaskObjectFreeFunc = Option<extern "C" fn(*mut libc::c_void)>;

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -10,6 +10,7 @@ use shadow_shim_helper_rs::emulated_time::EmulatedTime;
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
+use shadow_shim_helper_rs::util::SyncSendPointer;
 use shadow_shim_helper_rs::HostId;
 
 use super::work::event_queue::EventQueue;
@@ -27,7 +28,6 @@ use crate::network::packet::Packet;
 use crate::utility::childpid_watcher::ChildPidWatcher;
 use crate::utility::counter::Counter;
 use crate::utility::status_bar;
-use crate::utility::SyncSendPointer;
 
 static USE_OBJECT_COUNTERS: AtomicBool = AtomicBool::new(false);
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -21,6 +21,7 @@ use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::rootedcell::Root;
 use shadow_shim_helper_rs::shim_shmem::{HostShmem, HostShmemProtected};
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
+use shadow_shim_helper_rs::util::SyncSendPointer;
 use shadow_shim_helper_rs::HostId;
 use shadow_shmem::allocator::ShMemBlock;
 use shadow_tsc::Tsc;
@@ -43,7 +44,7 @@ use crate::network::router::Router;
 use crate::network::PacketDevice;
 #[cfg(feature = "perf_timers")]
 use crate::utility::perf_timer::PerfTimer;
-use crate::utility::{self, pod, SyncSendPointer};
+use crate::utility::{self, pod};
 
 pub struct HostParameters {
     pub id: HostId,

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -8,6 +8,7 @@ use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::shim_shmem::{HostShmemProtected, ProcessShmem, ThreadShmem};
 use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SysCallReg};
+use shadow_shim_helper_rs::util::SendPointer;
 use shadow_shim_helper_rs::HostId;
 use shadow_shmem::allocator::{Allocator, ShMemBlock};
 
@@ -17,7 +18,7 @@ use super::managed_thread::{self, ManagedThread};
 use super::process::{Process, ProcessId};
 use crate::cshadow as c;
 use crate::host::syscall_condition::{SysCallConditionRef, SysCallConditionRefMut};
-use crate::utility::{syscall, IsSend, SendPointer};
+use crate::utility::{syscall, IsSend};
 
 /// The thread's state after having been allowed to execute some code.
 #[derive(Debug)]

--- a/src/main/network/net_namespace.rs
+++ b/src/main/network/net_namespace.rs
@@ -6,13 +6,13 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use shadow_shim_helper_rs::util::SyncSendPointer;
 use shadow_shim_helper_rs::HostId;
 
 use crate::core::support::configuration::QDiscMode;
 use crate::cshadow;
 use crate::host::descriptor::socket::abstract_unix_ns::AbstractUnixNamespace;
 use crate::host::network_interface::{NetworkInterface, PcapOptions};
-use crate::utility::SyncSendPointer;
 
 // The start of our random port range in host order, used if application doesn't
 // specify the port it wants to bind to, and for client connections.

--- a/src/main/network/packet.rs
+++ b/src/main/network/packet.rs
@@ -1,9 +1,10 @@
 use std::io::Write;
 use std::net::Ipv4Addr;
 
+use shadow_shim_helper_rs::util::SyncSendPointer;
+
 use crate::cshadow as c;
 use crate::utility::pcap_writer::PacketDisplay;
-use crate::utility::SyncSendPointer;
 
 pub enum PacketStatus {
     RouterEnqueued = c::_PacketDeliveryStatusFlags_PDS_ROUTER_ENQUEUED as isize,

--- a/src/main/utility/childpid_watcher.rs
+++ b/src/main/utility/childpid_watcher.rs
@@ -627,9 +627,9 @@ mod tests {
 
 mod export {
     use shadow_shim_helper_rs::notnull::*;
+    use shadow_shim_helper_rs::util::SyncSendPointer;
 
     use super::*;
-    use crate::utility::SyncSendPointer;
 
     #[no_mangle]
     pub unsafe extern "C" fn childpidwatcher_new() -> *mut ChildPidWatcher {

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -34,69 +34,6 @@ use shadow_shim_helper_rs::HostId;
 use crate::core::worker::Worker;
 use crate::host::host::Host;
 
-/// A type that allows us to make a pointer Send + Sync since there is no way
-/// to add these traits to the pointer itself.
-#[derive(Debug)]
-pub struct SyncSendPointer<T>(*mut T);
-
-// We can't automatically `derive` Copy and Clone without unnecessarily
-// requiring T to be Copy and Clone.
-// https://github.com/rust-lang/rust/issues/26925
-impl<T> Copy for SyncSendPointer<T> {}
-impl<T> Clone for SyncSendPointer<T> {
-    fn clone(&self) -> Self {
-        Self(self.0)
-    }
-}
-
-unsafe impl<T> Send for SyncSendPointer<T> {}
-unsafe impl<T> Sync for SyncSendPointer<T> {}
-
-impl<T> SyncSendPointer<T> {
-    /// # Safety
-    ///
-    /// The object pointed to by `ptr` must actually be `Sync` and `Send` or
-    /// else not subsequently used in contexts where it matters.
-    pub unsafe fn new(ptr: *mut T) -> Self {
-        Self(ptr)
-    }
-
-    pub fn ptr(&self) -> *mut T {
-        self.0
-    }
-}
-
-/// A type that allows us to make a pointer Send since there is no way
-/// to add this traits to the pointer itself.
-#[derive(Debug)]
-pub struct SendPointer<T>(*mut T);
-
-// We can't automatically `derive` Copy and Clone without unnecessarily
-// requiring T to be Copy and Clone.
-// https://github.com/rust-lang/rust/issues/26925
-impl<T> Copy for SendPointer<T> {}
-impl<T> Clone for SendPointer<T> {
-    fn clone(&self) -> Self {
-        Self(self.0)
-    }
-}
-
-unsafe impl<T> Send for SendPointer<T> {}
-
-impl<T> SendPointer<T> {
-    /// # Safety
-    ///
-    /// The object pointed to by `ptr` must actually be `Send` or else not
-    /// subsequently used in contexts where it matters.
-    pub unsafe fn new(ptr: *mut T) -> Self {
-        Self(ptr)
-    }
-
-    pub fn ptr(&self) -> *mut T {
-        self.0
-    }
-}
-
 /// A pointer to an object that is safe to dereference from any thread,
 /// *if* the Host lock for the specified host is held.
 #[derive(Debug)]


### PR DESCRIPTION
This also:

- ~makes `PhantomData<T>` `VirtualAddressSpaceIndependent` for all `T`~
- adds inlining to methods of `ForeignPtr`, `SysCallReg`, and `SysCallArgs` since these methods are very small functions around integer operations, otherwise they wouldn't be inlined across crate boundaries