### PR TITLE
Don't install a rustup toolchain in the docs

### DIFF
--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -65,12 +65,10 @@ then
   rustup override set nightly-2023-03-13
 fi
 
-# This forces installation of the toolchain. When used with Docker,
-# this causes the rust installation get "baked in" to the Docker image layer
-# that runs this script, which is typically what we want.
-#
-# The version specified in the current version of rust-toolchain.toml will still
-# ultimately be respected, installing that toolchain on demand if necessary.
+# This forces installation of the toolchain required in Shadow's
+# "rust-toolchain.toml" (if this script is run from the shadow directory). When
+# used with Docker, this causes the rust installation to get "baked in" to the
+# Docker image layer that runs this script, which is typically what we want.
 cargo --version
 
 # Install a version of the golang std library that supports dynamic linking

--- a/docs/compatibility_notes.md
+++ b/docs/compatibility_notes.md
@@ -197,12 +197,18 @@ Example for etcd version 3.3.x.
 1. The etcd binary [must not be statically
 linked](limitations.md#statically-linked-executables). You can build a
 dynamically linked version by replacing `CGO_ENABLED=0` with `CGO_ENABLED=1` in
-etcd's `build.sh` script. The etcd packages included in the Debian and Ubuntu
-APT repositories are dynamically linked, so they can be used directly.
+etcd's `scripts/build.sh` and `scripts/build_lib.sh` scripts. The etcd packages
+included in the Debian and Ubuntu APT repositories are dynamically linked, so
+they can be used directly.
 
 2. Each etcd peer must be started at a different time since etcd uses the
 current time as an RNG seed. See [issue
 #2858](https://github.com/shadow/shadow/issues/2858) for details.
+
+3. If using etcd version greater than 3.5.4, you must build etcd from source
+and comment out the [keepalive period
+assignment](https://github.com/etcd-io/etcd/blob/4485db379e80cc9955c3fdd6a776fc630c32cc36/client/pkg/transport/keepalive_listener.go#L68-L70)
+as Shadow does not support this.
 
 ## CTorrent and opentracker
 

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -9,7 +9,7 @@
   + pkg-config
   + xz-utils
   + lscpu
-  + cargo, rustc (version \~ latest)
+  + rustup (version \~ latest)
   + libclang (version >= 9)
 
 ## APT (Debian/Ubuntu):
@@ -32,7 +32,7 @@ sudo apt-get install -y \
     g++
 
 # rustup: https://rustup.rs
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none
 ```
 
 On older versions of Debian or Ubuntu, the default version of libclang is too
@@ -67,5 +67,5 @@ sudo dnf install -y \
     gcc-c++
 
 # rustup: https://rustup.rs
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none
 ```


### PR DESCRIPTION
We don't use it, so no point in installing it.

Also updates the etcd compatibility notes.