### PR TITLE
Drop per-process exitcode files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ renamed the host's `options` field to `host_options`.
 an error by default. This can be overridden by the new per-process option
 `expected_final_state`. https://github.com/shadow/shadow/pull/2886
 
+* The per-process `.exitcode` file has been removed due to its confusing semantics,
+and the new `expected_final_state` attribute replacing its primary use-case.
+https://github.com/shadow/shadow/pull/2906
+
 MINOR changes (backwards-compatible):
 
 * Support the `MSG_TRUNC` flag for unix sockets.

--- a/docs/getting_started_basic.md
+++ b/docs/getting_started_basic.md
@@ -84,7 +84,6 @@ For example:
 
 ```bash
 $ ls -l shadow.data/hosts/client1/
--rw-rw-r-- 1 user user   1 Jun  2 16:54 curl.1000.exitcode
 -rw-rw-r-- 1 user user   0 Jun  2 16:54 curl.1000.shimlog
 -rw-r--r-- 1 user user   0 Jun  2 16:54 curl.1000.stderr
 -rw-r--r-- 1 user user 542 Jun  2 16:54 curl.1000.stdout

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -118,9 +118,6 @@ struct Common {
     // unique id of the program that this process should run
     name: CString,
 
-    // The basename (directory + file stem) for files that should be stored in the data directory.
-    file_basename: PathBuf,
-
     // the name of the executable as provided in shadow's config, for logging purposes
     plugin_name: CString,
 
@@ -169,10 +166,6 @@ impl Common {
         assert_eq!(low_part >> VADDR_BITS, 0);
 
         ManagedPhysicalMemoryAddr::from(high_part | low_part)
-    }
-
-    fn output_file_name(&self, extension: &str) -> PathBuf {
-        Process::static_output_file_name(&self.file_basename, extension)
     }
 
     fn name(&self) -> &str {
@@ -716,7 +709,6 @@ impl Process {
             host_id: host.id(),
             working_dir,
             name,
-            file_basename,
             plugin_name,
         };
         RootedRc::new(

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1228,15 +1228,6 @@ impl Process {
                 panic!("waitpid: {e:?}");
             }
         };
-        let exitcode_path = runnable.common.output_file_name("exitcode");
-        let exitcode_contents = match exit_status {
-            ExitStatus::StoppedByShadow => String::new(),
-            ExitStatus::Normal(n) => format!("{n}"),
-            ExitStatus::Signaled(s) => format!("{}", utility::return_code_for_signal(s)),
-        };
-        if let Err(e) = std::fs::write(exitcode_path, exitcode_contents) {
-            warn!("Couldn't write exitcode file: {e:?}");
-        }
 
         let (main_result_string, log_level) = {
             let mut s = format!(


### PR DESCRIPTION
The semantics of these were a bit awkward (e.g. 128+signum for death-by-signal; empty for still-running), and the per-process `expected_final_state` attribute replaces their primary use-case.

If we decide to bring these back, we should consider a richer format; maybe just the serialized actual process final state. e.g. "running", "{exited: 0}", "{signaled: SIGINT}", ...