### PR TITLE
Enable the experimental worker spinning by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,10 @@ including `start_time`, `stop_time`, etc.
 
 * Added partial support for the `epoll_pwait2` syscall.
 
+* Enabled CPU spinning in Shadow's scheduler. This significantly improves
+Shadow's runtime performance, but may have higher CPU and power/battery usage.
+https://github.com/shadow/shadow/issues/2877
+
 PATCH changes (bugfixes):
 
 * Fixed a memory leak of about 16 bytes per thread due to

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -518,7 +518,7 @@ Count the number of occurrences for individual syscalls.
 
 #### `experimental.use_worker_spinning`
 
-Default: false  
+Default: true  
 Type: Bool
 
 Each worker thread will spin in a `sched_yield` loop while waiting for a new task. This is ignored

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -475,7 +475,7 @@ impl Default for ExperimentalOptions {
             unblocked_vdso_latency: Some(units::Time::new(10, units::TimePrefix::Nano)),
             use_memory_manager: Some(true),
             use_cpu_pinning: Some(true),
-            use_worker_spinning: Some(false),
+            use_worker_spinning: Some(true),
             runahead: Some(NullableOption::Value(units::Time::new(
                 1,
                 units::TimePrefix::Milli,


### PR DESCRIPTION
This enables it in all cases unless opted out of. The performance impact is documented in #2877. We may change this before the 3.0 release.