### PR TITLE
Fix merging of `host_options` and `host_option_defaults`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ exits. https://github.com/shadow/shadow/pull/2913
 on Debian 10 will need to install a newer kernel, e.g. via backports.
 See [supported platforms](supported_platforms.md).
 
+* Fixed a bug causing `host_options` to undo any changes made to
+`host_option_defaults`.
+
 MAJOR changes (breaking):
 
 * Removed deprecated python scripts that only worked on Shadow 1.x config files


### PR DESCRIPTION
This seems to fix it.

With:

```yaml
host_option_defaults:
  pcap_enabled: true
hosts:
  hostname:
    host_options:
      log_level: trace
```

We now get:

```
host_options: HostDefaultOptions {
    log_level: Some(
        Value(
            Trace,
        ),
    ),
    pcap_enabled: Some(
        true,
    ),
    pcap_capture_size: Some(
        Bytes {
            value: 65535,
            prefix: Base,
        },
    ),
},
```