### PR TITLE
Log level policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ This also reduces noise in shadow's log about an unimplemented syscall being att
   Shadow's affinity/cgroup). The default value for `parallelism` has also been
   changed from 1 to 0.
 
+* Added a concrete policy about log levels to our [style
+guide](https://shadow.github.io/docs/guide/coding_style.html). While this is
+aimed primarily at shadow developers, it may also be useful for users to
+understand what these log levels mean. To conform to this new policy, we've
+also reduced the severity of logging that we returned `ENOSYS` for a missing syscall
+from `Error` to `Warning`. https://github.com/shadow/shadow/pull/2923
+
 MAJOR changes (breaking):
 
 * Removed deprecated python scripts that only worked on Shadow 1.x config files

--- a/docs/coding_style.md
+++ b/docs/coding_style.md
@@ -1,5 +1,29 @@
 # Coding style
 
+## Logging
+
+In Rust code, we use the [log](https://docs.rs/log/latest/log/) framework for
+logging. In C code we use a wrapper library that *also* uses Rust's
+[log](https://docs.rs/log/latest/log/) framework internally.
+
+For general guidance on what levels to log at, see [log::Level](https://docs.rs/log/latest/log/enum.Level.html#variants).
+
+Some shadow-specific log level policies:
+
+* We reserve the `Error` level for situations in which the `shadow`
+process as a whole will exit with a non-zero code. Conversely, when `shadow` exits
+with a non-zero code, the user should be able to get some idea of what caused it by
+looking at the `Error`-level log entries.
+
+* `Warning` should be used for messages that ought to be checked by the user
+before trusting the results of a simulation. For example, we use these in
+syscall handlers when an unimplemented syscall or option is used, and shadow is
+forced to return something like `ENOTSUP`, `EINVAL` or `ENOSYS`. In such cases
+the simulation is able to continue, and *might* still be representative of what
+would happen on a real Linux system; e.g. libc will often fall back to an older
+syscall, resulting in minimal impact on the simulated behavior of the managed
+process.
+
 ## Clang-format
 
 Our C code formatting style is defined in our

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -253,7 +253,8 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number, const
         break
 #define UNSUPPORTED(s)                                                                             \
     case SYS_##s:                                                                                  \
-        error("Returning error ENOSYS for explicitly unsupported syscall %ld " #s, args->number);  \
+        warning(                                                                                   \
+            "Returning error ENOSYS for explicitly unsupported syscall %ld " #s, args->number);    \
         scr = syscallreturn_makeDoneErrno(ENOSYS);                                                 \
         if (straceLoggingMode != STRACE_FMT_MODE_OFF) {                                            \
             scr = log_syscall(                                                                     \
@@ -555,9 +556,6 @@ SyscallReturn syscallhandler_make_syscall(SysCallHandler* sys, const SysCallArgs
                         "host %s",
                         args->number, sys->threadId, process_getPluginName(process),
                         host_getName(host));
-                error("Returning error %i (ENOSYS) for unsupported syscall %li, which may result in "
-                      "unusual behavior",
-                      ENOSYS, args->number);
                 scr = syscallreturn_makeDoneI64(-ENOSYS);
 
                 if (straceLoggingMode != STRACE_FMT_MODE_OFF) {


### PR DESCRIPTION
This PR adds some guidance about log levels to our style guide, and changes the logging for unimplemented syscalls to conform to this proposed policy.