### PR TITLE
Implement clone3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ See [supported platforms](supported_platforms.md).
 * Fixed a bug causing `host_options` to undo any changes made to
 `host_option_defaults`.
 
+* Implemented the `clone3` syscall. Thread libraries we're aware of that use
+`clone3` were gracefully falling back to `clone`, but eventually they may not do so.
+This also reduces noise in shadow's log about an unimplemented syscall being attempted.
+
 MAJOR changes (breaking):
 
 * Removed deprecated python scripts that only worked on Shadow 1.x config files

--- a/src/lib/shim/shim.h
+++ b/src/lib/shim/shim.h
@@ -3,6 +3,7 @@
 
 #include <stdatomic.h>
 #include <sys/types.h>
+#include <sys/ucontext.h>
 
 #include "lib/shadow-shim-helper-rs/shim_helper.h"
 #include "lib/shmem/shmem_allocator.h"
@@ -24,7 +25,7 @@ struct IPCData* shim_thisThreadEventIPC();
 
 // To be called in parent thread before making the `clone` syscall.
 // It sets up data for the new thread.
-void shim_newThreadStart(const ShMemBlockSerialized* block);
+void shim_newThreadStart(const ShMemBlockSerialized* block, const ucontext_t* clone_ctx);
 
 // To be called in parent thread after making the `clone` syscall.
 // It doesn't return until after the child has initialized itself.

--- a/src/lib/shim/shim.h
+++ b/src/lib/shim/shim.h
@@ -25,7 +25,7 @@ struct IPCData* shim_thisThreadEventIPC();
 
 // To be called in parent thread before making the `clone` syscall.
 // It sets up data for the new thread.
-void shim_newThreadStart(const ShMemBlockSerialized* block, const ucontext_t* clone_ctx);
+void shim_newThreadStart(const ShMemBlockSerialized* block);
 
 // To be called in parent thread after making the `clone` syscall.
 // It doesn't return until after the child has initialized itself.

--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -237,8 +237,8 @@ static bool _shim_api_hostname_to_addr_ipv4(const char* node, uint32_t* addr) {
     // can intercept it, but we want to send to Shadow through shmem in preload mode. Let
     // shim_syscall figure it out.
     trace("Performing custom shadow syscall SYS_shadow_hostname_to_addr_ipv4 for name %s", node);
-    int rv =
-        shim_syscall(SYS_shadow_hostname_to_addr_ipv4, node, strlen(node), addr, sizeof(*addr));
+    int rv = shim_syscall(
+        NULL, SYS_shadow_hostname_to_addr_ipv4, node, strlen(node), addr, sizeof(*addr));
 
     if (rv == 0) {
 #ifdef DEBUG

--- a/src/lib/shim/shim_api_syscall.c
+++ b/src/lib/shim/shim_api_syscall.c
@@ -21,7 +21,7 @@ static long _shim_api_retval_to_errno(long retval) {
 }
 
 long shim_api_syscallv(long n, va_list args) {
-    long rv = shim_syscallv(n, args);
+    long rv = shim_syscallv(NULL, n, args);
     return _shim_api_retval_to_errno(rv);
 }
 

--- a/src/lib/shim/shim_rdtsc.c
+++ b/src/lib/shim/shim_rdtsc.c
@@ -33,7 +33,7 @@ static uint64_t _shim_rdtsc_nanos(bool allowNative) {
     // *don't* directly call shim_sys_get_simtime_nanos() here.  We need to go
     // through the syscall code to correctly handle the case where
     // `model_unblocked_syscall_latency` is enabled.
-    long rv = shim_syscall(SYS_clock_gettime, CLOCK_REALTIME, &t);
+    long rv = shim_syscall(NULL, SYS_clock_gettime, CLOCK_REALTIME, &t);
     if (rv != 0) {
         panic("emulated SYS_clock_gettime: %s", strerror(-rv));
     }

--- a/src/lib/shim/shim_seccomp.c
+++ b/src/lib/shim/shim_seccomp.c
@@ -21,16 +21,6 @@
 #include "lib/shim/shim_syscall.h"
 #include "lib/shim/shim_tls.h"
 
-// Used during initialization of a new thread. Stores the context
-// of the original call site of the clone syscall, so that the child
-// can restore it (with modifications such as the syscall return value).
-// TODO: consider dynamically allocating this via mmap instead since it's
-// relatively large, and only needed during initialization of a new thread.
-static ShimTlsVar _shim_parent_thread_ctx_var = {0};
-ucontext_t* shim_parent_thread_ctx() {
-    return shimtlsvar_ptr(&_shim_parent_thread_ctx_var, sizeof(ucontext_t));
-}
-
 // Handler function that receives syscalls that are stopped by the seccomp filter.
 static void _shim_seccomp_handle_sigsys(int sig, siginfo_t* info, void* voidUcontext) {
     ucontext_t* ctx = (ucontext_t*)(voidUcontext);

--- a/src/lib/shim/shim_seccomp.c
+++ b/src/lib/shim/shim_seccomp.c
@@ -127,7 +127,7 @@ void shim_seccomp_init() {
         /* Always allow sched_yield. Sometimes used in IPC with Shadow; emulating
          * would add unnecessary overhead, and potentially cause recursion.
          * `shadow_spin_lock` relies on this exception
-         * 
+         *
          * TODO: Remove this exception, as it could interfere with escaping busy-loops
          * in managed code.
          */
@@ -148,6 +148,13 @@ void shim_seccomp_init() {
         BPF_JUMP(BPF_JMP + BPF_JGT + BPF_K, ((long)shim_native_syscallv) + 2000,
                  /*true-skip=*/2, /*false-skip=*/0),
         BPF_JUMP(BPF_JMP + BPF_JGE + BPF_K, (long)shim_native_syscallv, /*true-skip=*/0,
+                 /*false-skip=*/1),
+        BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW),
+
+        /* Allow syscalls from `shim_clone` as above. */
+        BPF_JUMP(BPF_JMP + BPF_JGT + BPF_K, ((long)shim_clone) + 2000,
+                 /*true-skip=*/2, /*false-skip=*/0),
+        BPF_JUMP(BPF_JMP + BPF_JGE + BPF_K, (long)shim_clone, /*true-skip=*/0,
                  /*false-skip=*/1),
         BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW),
 

--- a/src/lib/shim/shim_seccomp.h
+++ b/src/lib/shim/shim_seccomp.h
@@ -6,11 +6,13 @@
 #ifndef SRC_LIB_SHIM_SHIM_SECCOMP_H_
 #define SRC_LIB_SHIM_SHIM_SECCOMP_H_
 
+#include <sys/ucontext.h>
+
 // Initialize the seccomp filter and syscall signal handler function.
 void shim_seccomp_init();
 
 // Gets and resets the instruction pointer to which the child should resume
 // execution after a clone syscall.
-void* shim_seccomp_take_clone_rip();
+ucontext_t* shim_seccomp_take_clone_ctx();
 
 #endif // SRC_LIB_SHIM_SHIM_SECCOMP_H_

--- a/src/lib/shim/shim_seccomp.h
+++ b/src/lib/shim/shim_seccomp.h
@@ -13,6 +13,6 @@ void shim_seccomp_init();
 
 // Gets and resets the instruction pointer to which the child should resume
 // execution after a clone syscall.
-ucontext_t* shim_seccomp_take_clone_ctx();
+ucontext_t* shim_parent_thread_ctx();
 
 #endif // SRC_LIB_SHIM_SHIM_SECCOMP_H_

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -19,6 +19,60 @@
 // Never inline, so that the seccomp filter can reliably whitelist a syscall from
 // this function.
 // TODO: Drop if/when we whitelist using /proc/self/maps
+long __attribute__((noinline)) shim_clone(void* clone_rip, int32_t flags, void* child_stack,
+                                          pid_t* ptid, pid_t* ctid, uint64_t newtls) {
+    if (!clone_rip) {
+        panic("clone with RIP");
+    }
+    long rv = 0;
+    // Make the clone syscall, and then in the child thread initialize the shim's state,
+    // and then *jump* to the instruction after the original clone syscall instruction.
+    //
+    // Forcing the thread initialization to happen here instead of doing it
+    // lazily ensures that we don't try to install the sigaltstack from
+    // inside the seccomp signal handler. Doing so "works" without error,
+    // but is reverted when the signal handler returns.
+    //
+    // Note that from the child thread's point of view, many of the general purpose
+    // registers will have different values than they had in the parent thread just-before.
+    // I can't find any documentation on whether the child thread is allowed to make
+    // any assumptions about the state of such registers, but glibc's implementation
+    // of the clone library function doesn't. If we had to, we could save and restore
+    // the other registers in the same way as we are the RIP register.
+    register pid_t* r10 __asm__("r10") = ctid;
+    register long r8 __asm__("r8") = newtls;
+    // Store clone_rip in a callee-save register, so that we can call shim_ensure_init
+    // without clobbering it.
+    register long r12 __asm__("r12") = (long)clone_rip;
+    // Store address of shim_ensure_init in a callee-save register.
+    // TODO: We ought to be able to put the literal "shim_ensure_init" in
+    // the inline assembly and have the assembler resolve the address for
+    // us, but on ubuntu 18.04's gcc this ends up generating a relocation it
+    // can't resolve at the link step.
+    register long r13 __asm__("r13") = (long)&shim_ensure_init;
+    __asm__ __volatile__("syscall\n"
+                         // If in the parent, done with asm.
+                         "cmp $0, %%rax\n"
+                         "jne shim_native_syscallv_out\n"
+                         // Initialize state for this thread
+                         "callq *%%r13\n"
+                         // Restore return value of clone
+                         "movq $0, %%rax\n"
+                         // Jump to original clone call site.
+                         "jmp *%%r12\n"
+                         "shim_native_syscallv_out:\n"
+                         : "=a"(rv)
+                         : "a"(SYS_clone), "D"(flags), "S"(child_stack), "d"(ptid), "r"(r10),
+                           "r"(r8), "r"(r12), "r"(r13)
+                         : "rcx", "r11", "memory");
+    // Wait for child to initialize itself.
+    shim_newThreadFinish();
+    return rv;
+}
+
+// Never inline, so that the seccomp filter can reliably whitelist a syscall from
+// this function.
+// TODO: Drop if/when we whitelist using /proc/self/maps
 long __attribute__((noinline)) shim_native_syscallv(long n, va_list args) {
     long arg1 = va_arg(args, long);
     long arg2 = va_arg(args, long);
@@ -28,72 +82,29 @@ long __attribute__((noinline)) shim_native_syscallv(long n, va_list args) {
     long arg6 = va_arg(args, long);
     long rv;
 
-    // When interposing a clone syscall, we can't return in the new child thread.
-    // Instead we *jump* to just after the original syscall instruction, using
-    // the RIP saved in our SIGSYS signal handler.
-    //
-    // TODO: it'd be cleaner for this to be a separate, dedicated, function.
-    // However right now the actual clone syscall instruction *must* be executed
-    // from this function to pass the seccomp filter.
-    void* clone_rip = NULL;
-    if (n == SYS_clone && (clone_rip = shim_seccomp_take_clone_rip()) != NULL) {
-        // Make the clone syscall, and then in the child thread initialize the shim's state,
-        // and then *jump* to the instruction after the original clone syscall instruction.
-        //
-        // Forcing the thread initialization to happen here instead of doing it
-        // lazily ensures that we don't try to install the sigaltstack from
-        // inside the seccomp signal handler. Doing so "works" without error,
-        // but is reverted when the signal handler returns.
-        //
-        // Note that from the child thread's point of view, many of the general purpose
-        // registers will have different values than they had in the parent thread just-before.
-        // I can't find any documentation on whether the child thread is allowed to make
-        // any assumptions about the state of such registers, but glibc's implementation
-        // of the clone library function doesn't. If we had to, we could save and restore
-        // the other registers in the same way as we are the RIP register.
+    if (n == SYS_clone) {
+        void* clone_rip = shim_seccomp_take_clone_rip();
+        int32_t flags = (int32_t)arg1;
+        void* child_stack = (void*)arg2;
+        pid_t* ptid = (pid_t*)arg3;
+        pid_t* ctid = (pid_t*)arg4;
+        uint64_t newtls = arg5;
+        rv = shim_clone(clone_rip, flags, child_stack, ptid, ctid, newtls);
+    } else {
+        // r8, r9, and r10 aren't supported as register-constraints in
+        // extended asm templates. We have to use [local register
+        // variables](https://gcc.gnu.org/onlinedocs/gcc/Local-Register-Variables.html)
+        // instead. Calling any functions in between the register assignment and the
+        // asm template could clobber these registers, which is why we don't do the
+        // assignment directly above.
         register long r10 __asm__("r10") = arg4;
         register long r8 __asm__("r8") = arg5;
-        // Store clone_rip in a callee-save register, so that we can call shim_ensure_init
-        // without clobbering it.
-        register long r12 __asm__("r12") = (long)clone_rip;
-        // Store address of shim_ensure_init in a callee-save register.
-        // TODO: We ought to be able to put the literal "shim_ensure_init" in
-        // the inline assembly and have the assembler resolve the address for
-        // us, but on ubuntu 18.04's gcc this ends up generating a relocation it
-        // can't resolve at the link step.
-        register long r13 __asm__("r13") = (long)&shim_ensure_init;
-        __asm__ __volatile__("syscall\n"
-                             // If in the parent, done with asm.
-                             "cmp $0, %%rax\n"
-                             "jne shim_native_syscallv_out\n"
-                             // Initialize state for this thread
-                             "callq *%%r13\n"
-                             // Restore return value of clone
-                             "movq $0, %%rax\n"
-                             // Jump to original clone call site.
-                             "jmp *%%r12\n"
-                             "shim_native_syscallv_out:\n"
+        register long r9 __asm__("r9") = arg6;
+        __asm__ __volatile__("syscall"
                              : "=a"(rv)
-                             : "a"(n), "D"(arg1), "S"(arg2), "d"(arg3), "r"(r10), "r"(r8), "r"(r12), "r"(r13)
+                             : "a"(n), "D"(arg1), "S"(arg2), "d"(arg3), "r"(r10), "r"(r8), "r"(r9)
                              : "rcx", "r11", "memory");
-        // Wait for child to initialize itself.
-        shim_newThreadFinish();
-        return rv;
     }
-
-    // r8, r9, and r10 aren't supported as register-constraints in
-    // extended asm templates. We have to use [local register
-    // variables](https://gcc.gnu.org/onlinedocs/gcc/Local-Register-Variables.html)
-    // instead. Calling any functions in between the register assignment and the
-    // asm template could clobber these registers, which is why we don't do the
-    // assignment directly above.
-    register long r10 __asm__("r10") = arg4;
-    register long r8 __asm__("r8") = arg5;
-    register long r9 __asm__("r9") = arg6;
-    __asm__ __volatile__("syscall"
-                         : "=a"(rv)
-                         : "a"(n), "D"(arg1), "S"(arg2), "d"(arg3), "r"(r10), "r"(r8), "r"(r9)
-                         : "rcx", "r11", "memory");
     return rv;
 }
 

--- a/src/lib/shim/shim_syscall.h
+++ b/src/lib/shim/shim_syscall.h
@@ -16,11 +16,11 @@ long shim_syscallv(const ucontext_t* ctx, long n, va_list args);
 
 // Force the native execution of a syscall instruction (using asm so it can't be
 // intercepted).
-long shim_native_syscall(long n, ...);
+long shim_native_syscall(const ucontext_t* ctx, long n, ...);
 
 // Same as `shim_native_syscall()`, but accepts a variable argument list.
 // We disable inlining so seccomp can allow syscalls made from this function.
-long __attribute__((noinline)) shim_native_syscallv(long n, va_list args);
+long __attribute__((noinline)) shim_native_syscallv(const ucontext_t* ctx, long n, va_list args);
 
 // Force the emulation of the syscall through Shadow.
 long shim_emulated_syscall(const ucontext_t* ctx, long n, ...);
@@ -28,7 +28,7 @@ long shim_emulated_syscall(const ucontext_t* ctx, long n, ...);
 // Same as `shim_emulated_syscall()`, but accepts a variable argument list.
 long shim_emulated_syscallv(const ucontext_t* ctx, long n, va_list args);
 
-long __attribute__((noinline)) shim_clone(void* clone_rip, int32_t flags, void* child_stack,
+long __attribute__((noinline)) shim_clone(const ucontext_t* ctx, int32_t flags, void* child_stack,
                                           pid_t* ptid, pid_t* ctid, uint64_t newtls);
 
 #endif

--- a/src/lib/shim/shim_syscall.h
+++ b/src/lib/shim/shim_syscall.h
@@ -3,15 +3,16 @@
 
 #include <stdarg.h>
 #include <stdbool.h>
+#include <sys/ucontext.h>
 
 #include "lib/shadow-shim-helper-rs/shim_helper.h"
 
 // Ask the shim to handle a syscall. Internally decides whether to execute a
 // native syscall or to emulate the syscall through Shadow.
-long shim_syscall(long n, ...);
+long shim_syscall(const ucontext_t* ctx, long n, ...);
 
 // Same as `shim_syscall()`, but accepts a variable argument list.
-long shim_syscallv(long n, va_list args);
+long shim_syscallv(const ucontext_t* ctx, long n, va_list args);
 
 // Force the native execution of a syscall instruction (using asm so it can't be
 // intercepted).
@@ -22,10 +23,10 @@ long shim_native_syscall(long n, ...);
 long __attribute__((noinline)) shim_native_syscallv(long n, va_list args);
 
 // Force the emulation of the syscall through Shadow.
-long shim_emulated_syscall(long n, ...);
+long shim_emulated_syscall(const ucontext_t* ctx, long n, ...);
 
 // Same as `shim_emulated_syscall()`, but accepts a variable argument list.
-long shim_emulated_syscallv(long n, va_list args);
+long shim_emulated_syscallv(const ucontext_t* ctx, long n, va_list args);
 
 long __attribute__((noinline)) shim_clone(void* clone_rip, int32_t flags, void* child_stack,
                                           pid_t* ptid, pid_t* ctid, uint64_t newtls);

--- a/src/lib/shim/shim_syscall.h
+++ b/src/lib/shim/shim_syscall.h
@@ -27,4 +27,7 @@ long shim_emulated_syscall(long n, ...);
 // Same as `shim_emulated_syscall()`, but accepts a variable argument list.
 long shim_emulated_syscallv(long n, va_list args);
 
+long __attribute__((noinline)) shim_clone(void* clone_rip, int32_t flags, void* child_stack,
+                                          pid_t* ptid, pid_t* ctid, uint64_t newtls);
+
 #endif

--- a/src/lib/shim/shim_tls.c
+++ b/src/lib/shim/shim_tls.c
@@ -11,7 +11,7 @@
 
 // This needs to be big enough to store all thread-local variables for a single
 // thread. We fail at runtime if this limit is exceeded.
-#define BYTES_PER_THREAD 1024
+#define BYTES_PER_THREAD 4096
 
 // Stores the TLS for a single thread.
 typedef struct ShimThreadLocalStorage {

--- a/src/lib/shim/shim_tls.c
+++ b/src/lib/shim/shim_tls.c
@@ -11,7 +11,7 @@
 
 // This needs to be big enough to store all thread-local variables for a single
 // thread. We fail at runtime if this limit is exceeded.
-#define BYTES_PER_THREAD 4096
+#define BYTES_PER_THREAD 1024
 
 // Stores the TLS for a single thread.
 typedef struct ShimThreadLocalStorage {

--- a/src/main/host/syscall/handler/clone.rs
+++ b/src/main/host/syscall/handler/clone.rs
@@ -7,6 +7,8 @@ use crate::host::syscall_types::SyscallError;
 
 use super::{SyscallContext, SyscallHandler};
 
+// We don't use nix::sched::CloneFlags here, because nix omits flags
+// that it doesn't support. e.g. https://docs.rs/nix/0.26.2/src/nix/sched.rs.html#57
 bitflags::bitflags! {
     // While `clone` is documented as taking an i32 parameter for flags,
     // in `clone3` its a u64. Promote to u64 throughout.

--- a/src/main/host/syscall/handler/clone.rs
+++ b/src/main/host/syscall/handler/clone.rs
@@ -1,4 +1,4 @@
-use log::warn;
+use log::{debug, trace, warn};
 use nix::errno::Errno;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use syscall_logger::log_syscall;
@@ -48,16 +48,7 @@ bitflags::bitflags! {
 }
 
 impl SyscallHandler {
-    // Note that the syscall args are different than the libc wrapper.
-    // See "C library/kernel differences" in clone(2).
-    #[log_syscall(
-        /* rv */libc::pid_t,
-        /* flags */i32,
-        /* child_stack */*const libc::c_void,
-        /* ptid */*const libc::pid_t,
-        /* ctid */*const libc::pid_t,
-        /* newtls */*const libc::c_void)]
-    pub fn clone(
+    fn clone_internal(
         ctx: &mut SyscallContext,
         flags_and_exit_signal: i32,
         child_stack: ForeignPtr<()>,
@@ -128,6 +119,80 @@ impl SyscallHandler {
         }
 
         Ok(libc::pid_t::from(child_tid))
+    }
+    // Note that the syscall args are different than the libc wrapper.
+    // See "C library/kernel differences" in clone(2).
+    #[log_syscall(
+        /* rv */libc::pid_t,
+        /* flags */i32,
+        /* child_stack */*const libc::c_void,
+        /* ptid */*const libc::pid_t,
+        /* ctid */*const libc::pid_t,
+        /* newtls */*const libc::c_void)]
+    pub fn clone(
+        ctx: &mut SyscallContext,
+        flags_and_exit_signal: i32,
+        child_stack: ForeignPtr<()>,
+        ptid: ForeignPtr<libc::pid_t>,
+        ctid: ForeignPtr<libc::pid_t>,
+        newtls: u64,
+    ) -> Result<libc::pid_t, SyscallError> {
+        Self::clone_internal(ctx, flags_and_exit_signal, child_stack, ptid, ctid, newtls)
+    }
+
+    #[log_syscall(
+        /* rv */libc::pid_t,
+        /* args*/*const libc::c_void,
+        /* args_size*/usize)]
+    pub fn clone3(
+        ctx: &mut SyscallContext,
+        args: ForeignPtr<libc::clone_args>,
+        args_size: usize,
+    ) -> Result<libc::pid_t, SyscallError> {
+        if args_size != std::mem::size_of::<libc::clone_args>() {
+            // TODO: allow smaller size, and be careful to only read
+            // as much as the caller specified, and zero-fill the rest.
+            return Err(Errno::EINVAL.into());
+        }
+        let args = ctx.objs.process.memory_borrow().read(args)?;
+        trace!("clone3 args: {args:?}");
+        let Ok(flags) = i32::try_from(args.flags) else {
+            debug!("Couldn't safely truncate flags to 32 bits: {} ({:?})",
+                   args.flags, CloneFlags::from_bits(args.flags));
+            return Err(Errno::EINVAL.into());
+        };
+        if flags & 0xff != 0 {
+            // We can't multiplex through `clone` in this case, since these bits
+            // conflict with the exit signal. Currently this won't happen in practice
+            // because there are no legal flags that use these bits. It's possible
+            // that clone3-flags could be added here, but more likely they'll use
+            // the higher bits first. (clone3 uses 64 bits vs clone's 32).
+            debug!(
+                "clone3 got a flag it can't pass through to clone: {} ({:?})",
+                flags & 0xff,
+                CloneFlags::from_bits(args.flags & 0xff)
+            );
+            return Err(Errno::EINVAL.into());
+        }
+        let Ok(exit_signal) = i32::try_from(args.exit_signal) else {
+            // Couldn't truncate to the 32 bits allowed by `clone`, but
+            // there also aren't any valid signal numbers that need that many bits.
+            debug!("Bad signal number: {}", args.exit_signal);
+            return Err(Errno::EINVAL.into());
+        };
+        if exit_signal & !0xff != 0 {
+            // Couldn't fit into the 8 bits allowed for the signal number by `clone`,
+            // but there also aren't any valid signal numbers that need that many bits.
+            return Err(Errno::EINVAL.into());
+        }
+        Self::clone_internal(
+            ctx,
+            flags | exit_signal,
+            ForeignPtr::<()>::from(args.stack + args.stack_size),
+            ForeignPtr::<libc::pid_t>::from_raw_ptr(args.parent_tid as *mut libc::pid_t),
+            ForeignPtr::<libc::pid_t>::from_raw_ptr(args.child_tid as *mut libc::pid_t),
+            args.tls,
+        )
     }
 
     #[log_syscall(/* rv */libc::pid_t)]

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -43,6 +43,7 @@ impl SyscallHandler {
             libc::SYS_bind => SyscallHandlerFn::call(Self::bind, &mut ctx),
             libc::SYS_brk => SyscallHandlerFn::call(Self::brk, &mut ctx),
             libc::SYS_clone => SyscallHandlerFn::call(Self::clone, &mut ctx),
+            libc::SYS_clone3 => SyscallHandlerFn::call(Self::clone3, &mut ctx),
             libc::SYS_close => SyscallHandlerFn::call(Self::close, &mut ctx),
             libc::SYS_connect => SyscallHandlerFn::call(Self::connect, &mut ctx),
             libc::SYS_dup => SyscallHandlerFn::call(Self::dup, &mut ctx),

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -306,6 +306,9 @@ SyscallReturn syscallhandler_make_syscall(SysCallHandler* sys, const SysCallArgs
             SHIM_ONLY(clock_gettime);
             HANDLE_C(clock_nanosleep);
             HANDLE_RUST(clone);
+#ifdef SYS_clone3
+            HANDLE_RUST(clone3);
+#endif
             HANDLE_RUST(close);
             HANDLE_RUST(connect);
             HANDLE_C(creat);

--- a/src/main/utility/pod.rs
+++ b/src/main/utility/pod.rs
@@ -274,6 +274,7 @@ unsafe impl Pod for libc::utimbuf {}
 unsafe impl Pod for libc::utmpx {}
 unsafe impl Pod for libc::utsname {}
 unsafe impl Pod for libc::winsize {}
+unsafe impl Pod for libc::clone_args {}
 
 // shadow re-exports this definition from /usr/include/linux/tcp.h
 unsafe impl Pod for crate::cshadow::tcp_info {}


### PR DESCRIPTION
Implements clone3, currently using clone internally.

This also requires restoring general purpose registers from the original context of the syscall, since glibc's clone3 implementation assumes they still have the original values from the parent in the newly created child thread.