### PR TITLE
Support a `parallelism` of 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ See [supported platforms](supported_platforms.md).
 `clone3` were gracefully falling back to `clone`, but eventually they may not do so.
 This also reduces noise in shadow's log about an unimplemented syscall being attempted.
 
+* Added support for a `parallelism` value of 0, which allows Shadow to choose a
+  reasonable parallelism (we currently use the number of phyiscal cores in
+  Shadow's affinity/cgroup). The default value for `parallelism` has also been
+  changed from 1 to 0.
+
 MAJOR changes (breaking):
 
 * Removed deprecated python scripts that only worked on Shadow 1.x config files

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -167,11 +167,15 @@ helpful for programs with "busy loops" that otherwise deadlock under Shadow.
 
 #### `general.parallelism`
 
-Default: 1  
+Default: 0  
 Type: Integer
 
-How many parallel threads to use to run the simulation. Optimal performance is
-usually obtained with `nproc`, or sometimes `nproc`/2 with hyperthreading.
+How many parallel threads to use to run the simulation. Optimal performance is usually obtained with
+the number of *physical* CPU cores (`nproc` without hyperthreading or `nproc`/2 with
+hyperthreading).
+
+A value of 0 will allow Shadow to choose the number of threads, typically the number of physical CPU
+cores available in the current CPU affinity mask and cgroup.
 
 Virtual hosts depend on network packets that can potentially arrive from other
 virtual hosts, so each worker can only advance according to the propagation

--- a/src/main/core/cpu.rs
+++ b/src/main/core/cpu.rs
@@ -1,0 +1,146 @@
+pub struct RangeListIter<'a> {
+    current_range: Option<std::ops::RangeInclusive<u32>>,
+    remaining: &'a str,
+}
+
+impl Iterator for RangeListIter<'_> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // if we have an active range to process
+            if let Some(current_range) = &mut self.current_range {
+                // get the next num in the range
+                let Some(rv) = current_range.next() else {
+                    // we've returned all numbers in the range, so clear the range and start over
+                    self.current_range = None;
+                    continue;
+                };
+
+                // return the next num in the range
+                break Some(rv);
+            // we don't have an active range, but there are more ranges to process
+            } else if !self.remaining.is_empty() {
+                let (next_range, remaining) = match self.remaining.split_once(',') {
+                    // there was at least one comma
+                    Some(x) => x,
+                    // there are no more commas
+                    None => (self.remaining, ""),
+                };
+
+                self.remaining = remaining;
+
+                if next_range.is_empty() {
+                    continue;
+                }
+
+                let mut split = next_range.split('-');
+                let start = split.next().unwrap();
+                let end = split.next();
+                assert!(split.next().is_none());
+
+                let start = start.parse().unwrap();
+                let end = end.map(|x| x.parse().unwrap()).unwrap_or(start);
+
+                self.current_range = Some(std::ops::RangeInclusive::new(start, end));
+
+                continue;
+            // no active range and no more ranges remaining
+            } else {
+                // the iterator is complete
+                break None;
+            }
+        }
+    }
+}
+
+/// Take an input of a list of ranges like '1-3,5,7-10' and return an iterator of integers like
+/// \[1,2,3,5,7,8,9,10\]. The returned iterator will panic if the input is not nicely formatted (no
+/// whitespace, etc) or contains invalid characters.
+///
+/// The iterator will return items in the order of the list, meaning that they are not guaranteed to
+/// be returned in increasing order and there may be duplicates. For example "1,2,3,3,2" would
+/// return items \[1, 2, 3, 3, 2\].
+pub fn parse_range_list(range_list: &str) -> RangeListIter {
+    RangeListIter {
+        current_range: None,
+        remaining: range_list,
+    }
+}
+
+/// Get the nodes from `/sys/devices/system/node/possible`.
+pub fn nodes() -> Vec<u32> {
+    let name = "/sys/devices/system/node/possible";
+    parse_range_list(std::fs::read_to_string(name).unwrap().trim()).collect()
+}
+
+/// Get the CPUs in a node from `/sys/devices/system/node/node{node}/cpulist`.
+pub fn cpus(node: u32) -> Vec<u32> {
+    let name = format!("/sys/devices/system/node/node{node}/cpulist");
+    parse_range_list(std::fs::read_to_string(name).unwrap().trim()).collect()
+}
+
+/// Get the core ID from `/sys/devices/system/cpu/cpu{cpu}/topology/core_id`.
+pub fn core(cpu: u32) -> u32 {
+    let name = format!("/sys/devices/system/cpu/cpu{cpu}/topology/core_id");
+    std::fs::read_to_string(name)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap()
+}
+
+/// Get the online CPUs from `/sys/devices/system/cpu/online`.
+pub fn online() -> Vec<u32> {
+    let name = "/sys/devices/system/cpu/online";
+    parse_range_list(std::fs::read_to_string(name).unwrap().trim()).collect()
+}
+
+/// Count the number of physical cores available. Uses `sched_getaffinity` so should take into
+/// account CPU affinity and cgroups.
+pub fn count_physical_cores() -> u32 {
+    let affinity = nix::sched::sched_getaffinity(nix::unistd::Pid::from_raw(0)).unwrap();
+
+    let mut physical_cores = std::collections::HashSet::new();
+
+    for cpu in online() {
+        if affinity.is_set(cpu.try_into().unwrap()).unwrap() {
+            physical_cores.insert(core(cpu));
+        }
+    }
+
+    assert!(!physical_cores.is_empty());
+    physical_cores.len().try_into().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check(list: &str, array: &[u32]) {
+        let list: Vec<_> = parse_range_list(list).collect();
+        assert_eq!(list, array);
+    }
+
+    #[test]
+    fn test_range_list() {
+        check("", &[]);
+        check("1", &[1]);
+        check("1,2", &[1, 2]);
+        check("1-2", &[1, 2]);
+        check("1-1", &[1]);
+        check("1,2,3", &[1, 2, 3]);
+        check("1-3", &[1, 2, 3]);
+        check("1,2-3,4", &[1, 2, 3, 4]);
+        check("1,2-4,5", &[1, 2, 3, 4, 5]);
+        check(
+            "0-5,7-9,13,15-19",
+            &[0, 1, 2, 3, 4, 5, 7, 8, 9, 13, 15, 16, 17, 18, 19],
+        );
+        check("1,,5", &[1, 5]);
+        check("1,1,5", &[1, 1, 5]);
+        check("1-1,5", &[1, 5]);
+        check("1-1,0,5", &[1, 0, 5]);
+        check("1-0", &[]);
+    }
+}

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -281,6 +281,10 @@ impl<'a> Manager<'a> {
                 }))
             });
 
+        // shadow is parallelized at the host level, so we don't need more parallelism than the
+        // number of hosts
+        let parallelism = std::cmp::min(parallelism, hosts.len());
+
         // should have either all `Some` values, or all `None` values
         let cpus: Vec<Option<u32>> = cpu_iter.take(parallelism).collect();
         if cpus[0].is_some() {

--- a/src/main/core/mod.rs
+++ b/src/main/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod controller;
+pub mod cpu;
 pub mod logger;
 pub mod main;
 pub mod manager;

--- a/src/main/core/scheduler/thread_per_core.rs
+++ b/src/main/core/scheduler/thread_per_core.rs
@@ -19,7 +19,8 @@ pub struct ThreadPerCoreSched<HostType: Host> {
 
 impl<HostType: Host> ThreadPerCoreSched<HostType> {
     /// A new host scheduler with threads that are pinned to the provided OS processors. Each thread
-    /// is assigned many hosts, and threads may steal hosts from other threads.
+    /// is assigned many hosts, and threads may steal hosts from other threads. The number of
+    /// threads created will be the length of `cpu_ids`.
     pub fn new<T>(cpu_ids: &[Option<u32>], hosts: T, yield_spin: bool) -> Self
     where
         T: IntoIterator<Item = HostType>,

--- a/src/main/core/scheduler/thread_per_host.rs
+++ b/src/main/core/scheduler/thread_per_host.rs
@@ -17,7 +17,8 @@ pub struct ThreadPerHostSched {
 
 impl ThreadPerHostSched {
     /// A new host scheduler with logical processors that are pinned to the provided OS processors.
-    /// Each logical processor is assigned many threads, and each thread is given a single host.
+    /// Each logical processor is assigned many threads, and each thread is given a single host. The
+    /// number of threads created will be the length of `hosts`.
     pub fn new<T>(cpu_ids: &[Option<u32>], hosts: T) -> Self
     where
         T: IntoIterator<Item = Box<Host>>,

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, HashSet};
 use std::ffi::{CStr, CString, OsStr, OsString};
-use std::num::NonZeroU32;
 use std::os::unix::ffi::OsStrExt;
 use std::str::FromStr;
 
@@ -188,13 +187,12 @@ pub struct GeneralOptions {
     #[serde(default = "default_some_1")]
     pub seed: Option<u32>,
 
-    /// How many parallel threads to use to run the simulation. Optimal
-    /// performance is usually obtained with `nproc`, or sometimes `nproc`/2
-    /// with hyperthreading.
+    /// How many parallel threads to use to run the simulation. A value of 0 will allow Shadow to
+    /// choose the number of threads.
     #[clap(long, short = 'p', value_name = "cores")]
     #[clap(help = GENERAL_HELP.get("parallelism").unwrap().as_str())]
-    #[serde(default = "default_some_nz_1")]
-    pub parallelism: Option<NonZeroU32>,
+    #[serde(default = "default_some_0")]
+    pub parallelism: Option<u32>,
 
     /// The simulated time that ends Shadow's high network bandwidth/reliability bootstrap period
     #[clap(long, value_name = "seconds")]
@@ -1286,14 +1284,14 @@ fn default_some_false() -> Option<bool> {
     Some(false)
 }
 
-/// Helper function for serde default `Some(1)` values.
-fn default_some_1() -> Option<u32> {
-    Some(1)
+/// Helper function for serde default `Some(0)` values.
+fn default_some_0() -> Option<u32> {
+    Some(0)
 }
 
 /// Helper function for serde default `Some(1)` values.
-fn default_some_nz_1() -> Option<NonZeroU32> {
-    Some(std::num::NonZeroU32::new(1).unwrap())
+fn default_some_1() -> Option<u32> {
+    Some(1)
 }
 
 /// Helper function for serde default `Some(NullableOption::Value(1 sec))` values.

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -98,6 +98,11 @@ macro(add_shadow_tests)
       list(APPEND SHADOW_TEST_ARGS "--strace-logging-mode" "standard")
    endif()
 
+   # If parallelism is not explicitly set, we use a single thread
+   if(NOT "${SHADOW_TEST_ARGS}" MATCHES ".*--parallelism.*")
+      list(APPEND SHADOW_TEST_ARGS "--parallelism" "1")
+   endif()
+
    string(REPLACE ";" " " SHADOW_TEST_ARGS "${SHADOW_TEST_ARGS}")
 
    set(SHADOW_TEST_NAME ${SHADOW_TEST_BASENAME}-shadow)


### PR DESCRIPTION
If `parallelism` is 0 (the new default), shadow will choose the parallelism level equal to the number of physical CPU cores available.