### PR TITLE
Allow-list seccomp native syscalls by code section

### DIFF
--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -25,7 +25,8 @@
 // Never inline, so that the seccomp filter can reliably whitelist a syscall from
 // this function.
 // TODO: Drop if/when we whitelist using /proc/self/maps
-long __attribute__((noinline)) shim_clone(const ucontext_t* ctx, int32_t flags, void* child_stack,
+__attribute__((noinline, section("shadow_allow_syscalls")))
+long shim_clone(const ucontext_t* ctx, int32_t flags, void* child_stack,
                                           pid_t* ptid, pid_t* ctid, uint64_t newtls) {
     if (!child_stack) {
         panic("clone without a new stack not implemented");
@@ -115,7 +116,8 @@ long __attribute__((noinline)) shim_clone(const ucontext_t* ctx, int32_t flags, 
 // Never inline, so that the seccomp filter can reliably whitelist a syscall from
 // this function.
 // TODO: Drop if/when we whitelist using /proc/self/maps
-long __attribute__((noinline)) shim_native_syscallv(const ucontext_t* ctx, long n, va_list args) {
+__attribute__((noinline, section("shadow_allow_syscalls")))
+long shim_native_syscallv(const ucontext_t* ctx, long n, va_list args) {
     long arg1 = va_arg(args, long);
     long arg2 = va_arg(args, long);
     long arg3 = va_arg(args, long);

--- a/src/lib/shim/shim_syscall.h
+++ b/src/lib/shim/shim_syscall.h
@@ -18,17 +18,10 @@ long shim_syscallv(const ucontext_t* ctx, long n, va_list args);
 // intercepted).
 long shim_native_syscall(const ucontext_t* ctx, long n, ...);
 
-// Same as `shim_native_syscall()`, but accepts a variable argument list.
-// We disable inlining so seccomp can allow syscalls made from this function.
-long __attribute__((noinline)) shim_native_syscallv(const ucontext_t* ctx, long n, va_list args);
-
 // Force the emulation of the syscall through Shadow.
 long shim_emulated_syscall(const ucontext_t* ctx, long n, ...);
 
 // Same as `shim_emulated_syscall()`, but accepts a variable argument list.
 long shim_emulated_syscallv(const ucontext_t* ctx, long n, va_list args);
-
-long __attribute__((noinline)) shim_clone(const ucontext_t* ctx, int32_t flags, void* child_stack,
-                                          pid_t* ptid, pid_t* ctid, uint64_t newtls);
 
 #endif


### PR DESCRIPTION
There's no easy way to get an authoritative "end" address of an    
arbitrary individual function, so we were just guessing a loose upper    
bound, and hoping that managed code that tried to make direct syscalls    
didn't unluckily end up in the allow-listed address range.    
    
We *can* reliably get the end address of a linker section, and place    
functions we want to allow-list into that section.    
    
Since we're not using a linker script, we're depending on the linker    
to create the `__start_*` and `__end_*` symbols. This is a little    
fragile, but should be obvious if it breaks, and resolvable by    
adding/modifying a linker script to explicitly add such symbols    
ourselves. 