### PR TITLE
Begin linux-api: a no_std + no-runtime-libc crate for interacting directly with linux kernel apis

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -745,6 +745,11 @@ name = "linux-api"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+ "cbindgen",
+ "libc",
+ "log",
+ "nix",
+ "shadow-build-common",
  "vasi",
 ]
 
@@ -1406,6 +1411,7 @@ dependencies = [
  "crossbeam",
  "gml-parser",
  "libc",
+ "linux-api",
  "log",
  "logger",
  "lzma-rs",
@@ -1446,6 +1452,7 @@ dependencies = [
  "cbindgen",
  "cc",
  "libc",
+ "linux-api",
  "log",
  "logger",
  "nix",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "bindgen",
  "bitflags 2.2.1",
  "cbindgen",
+ "libc",
  "log",
  "nix",
  "shadow-build-common",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -741,6 +741,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-api"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "vasi",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -745,11 +745,12 @@ name = "linux-api"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+ "bitflags 2.2.1",
  "cbindgen",
- "libc",
  "log",
  "nix",
  "shadow-build-common",
+ "static_assertions",
  "vasi",
 ]
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "main",
     "test",
+    "lib/linux-api",
     "lib/shadow-build-common",
     "lib/gml-parser",
     "lib/logger",

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -6,12 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# FIXME: remove this dependency. While the libc crate supports no_std, it
-# does depend on the C standard library.
-libc = { version = "0.2.144", default-features = false }
+bitflags = "2.2.1"
 log = { version = "0.4.17", default-features = false }
 # FIXME: remove this dependendency. nix doesn't have a no_std configuration.
 nix = "0.26.2"
+static_assertions = "1.1.0"
 vasi = { path = "../vasi" }
 
 [build-dependencies]

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2021"
 
 [dependencies]
 bitflags = "2.2.1"
+# We try to minimize our usage of the libc crate, but currently need it to work
+# around different versions of the kernel headers resulting in different bindgen
+# field names. In particular siginfo_t gets different generated names for its
+# internal (~anonymous) union fields.
+libc = { version = "0.2.144", default-features = false }
 log = { version = "0.4.17", default-features = false }
 # FIXME: remove this dependendency. nix doesn't have a no_std configuration.
 nix = "0.26.2"

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "linux-api"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+vasi = { path = "../vasi" }
+
+[build-dependencies]
+bindgen = { version = "0.65.1" }

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -6,7 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# FIXME: remove this dependency. While the libc crate supports no_std, it
+# does depend on the C standard library.
+libc = { version = "0.2.144", default-features = false }
+log = { version = "0.4.17", default-features = false }
+# FIXME: remove this dependendency. nix doesn't have a no_std configuration.
+nix = "0.26.2"
 vasi = { path = "../vasi" }
 
 [build-dependencies]
+shadow-build-common = { path = "../shadow-build-common" }
 bindgen = { version = "0.65.1" }
+cbindgen = { version = "0.24.3" }

--- a/src/lib/linux-api/build.rs
+++ b/src/lib/linux-api/build.rs
@@ -29,6 +29,8 @@ fn run_bindgen() {
         .allowlist_var("SIGRTMIN")
         .allowlist_var("SIGRTMAX")
         .allowlist_var("SS_AUTODISARM")
+        // sigaction flags
+        .allowlist_var("SA_.*")
         // signal numbers
         .allowlist_var("SIG.*")
         .generate()
@@ -41,6 +43,7 @@ fn run_bindgen() {
         // Use ::core instead of ::std, since this crate is no_std.
         .use_core()
         .header_contents("kernel_defs.h", header_contents)
+        .allowlist_type("siginfo_t")
         .allowlist_type("sigset_t")
         .allowlist_type("sigaction")
         .generate()
@@ -55,8 +58,9 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
 
     let config = cbindgen::Config {
         include_guard: Some("linux_kernel_types_h".into()),
+        after_includes: Some("typedef int32_t LinuxSigActionFlags;\n".into()),
         export: cbindgen::ExportConfig {
-            include: vec!["linux_sigaction".into()],
+            include: vec!["linux_sigaction".into(), "linux_siginfo_t".into()],
             ..base_config.export.clone()
         },
         ..base_config

--- a/src/lib/linux-api/build.rs
+++ b/src/lib/linux-api/build.rs
@@ -1,5 +1,7 @@
 use std::{env, path::PathBuf};
 
+use shadow_build_common::ShadowBuildCommon;
+
 fn run_bindgen() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
@@ -47,6 +49,34 @@ fn run_bindgen() {
         .expect("Couldn't write bindings!");
 }
 
+fn run_cbindgen(build_common: &ShadowBuildCommon) {
+    let base_config = build_common.cbindgen_base_config();
+    let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let config = cbindgen::Config {
+        include_guard: Some("linux_kernel_types_h".into()),
+        export: cbindgen::ExportConfig {
+            include: vec!["shd_kernel_sigaction".into()],
+            ..base_config.export.clone()
+        },
+        ..base_config
+    };
+
+    cbindgen::Builder::new()
+        .with_crate(crate_dir)
+        .with_config(config)
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file("../../../build/src/lib/linux-api/linux-api.h");
+}
+
 fn main() {
+    let build_common =
+        shadow_build_common::ShadowBuildCommon::new(std::path::Path::new("../../.."), None);
+    run_cbindgen(&build_common);
+
+    // We *don't* use ShadowBuildCommon here, since we don't want the defaults used
+    // in other places. Since we're generating bindings for kernel definitions, we need
+    // to be careful to avoid conflicts with libc definitions.
     run_bindgen();
 }

--- a/src/lib/linux-api/build.rs
+++ b/src/lib/linux-api/build.rs
@@ -56,7 +56,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
     let config = cbindgen::Config {
         include_guard: Some("linux_kernel_types_h".into()),
         export: cbindgen::ExportConfig {
-            include: vec!["shd_kernel_sigaction".into()],
+            include: vec!["linux_sigaction".into()],
             ..base_config.export.clone()
         },
         ..base_config

--- a/src/lib/linux-api/build.rs
+++ b/src/lib/linux-api/build.rs
@@ -1,0 +1,52 @@
+use std::{env, path::PathBuf};
+
+fn run_bindgen() {
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    // Careful here to include *kernel* headers, and *not* glibc headers,
+    // which may have different definitions. A notable example is
+    // `<linux/signal.h>`  vs `<signal.h>`.
+    let header_contents = "
+            #include <stdint.h>
+            #include <stddef.h>
+            #include <linux/signal.h>
+            #include <sys/syscall.h>
+        ";
+
+    // Constants only (allowlist_var).
+    // Originally I kept this separate to support re-exporting this module publicly
+    // without having to enumerate the constants, but that turns out not to work well.
+    // TODO: consider merging with other bindings below.
+    bindgen::Builder::default()
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Use ::core instead of ::std, since this crate is no_std.
+        .use_core()
+        .header_contents("kernel_defs.h", header_contents)
+        // syscall numbers
+        .allowlist_var("SYS_.*")
+        .allowlist_var("SIGRTMIN")
+        .allowlist_var("SIGRTMAX")
+        .allowlist_var("SS_AUTODISARM")
+        // signal numbers
+        .allowlist_var("SIG.*")
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file(out_path.join("constants.rs"))
+        .expect("Couldn't write bindings!");
+
+    bindgen::Builder::default()
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Use ::core instead of ::std, since this crate is no_std.
+        .use_core()
+        .header_contents("kernel_defs.h", header_contents)
+        .allowlist_type("sigset_t")
+        .allowlist_type("sigaction")
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file(out_path.join("types.rs"))
+        .expect("Couldn't write bindings!");
+}
+
+fn main() {
+    run_bindgen();
+}

--- a/src/lib/linux-api/src/lib.rs
+++ b/src/lib/linux-api/src/lib.rs
@@ -28,6 +28,8 @@ mod bindings {
     include!(concat!(env!("OUT_DIR"), "/types.rs"));
 }
 
+pub mod signal;
+
 use bindings::sigaction;
 unsafe impl vasi::VirtualAddressSpaceIndependent for sigaction {}
 

--- a/src/lib/linux-api/src/lib.rs
+++ b/src/lib/linux-api/src/lib.rs
@@ -29,19 +29,3 @@ mod bindings {
 }
 
 pub mod signal;
-
-use bindings::sigaction;
-unsafe impl vasi::VirtualAddressSpaceIndependent for sigaction {}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn sigset_size() {
-        // The kernel definition should (currently) be 8 bytes.
-        // At some point this may get increased, but it shouldn't be the glibc
-        // size of ~100 bytes.
-        assert_eq!(std::mem::size_of::<bindings::sigset_t>(), 8);
-    }
-}

--- a/src/lib/linux-api/src/lib.rs
+++ b/src/lib/linux-api/src/lib.rs
@@ -1,0 +1,45 @@
+//! This crate constants and types for interacting with the Linux kernel.
+//! It is no_std and doesn't depend on libc.
+
+#![cfg_attr(not(test), no_std)]
+
+mod constants_bindings {
+    #![allow(unused)]
+    #![allow(non_upper_case_globals)]
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    // https://github.com/rust-lang/rust/issues/66220
+    #![allow(improper_ctypes)]
+    #![allow(unsafe_op_in_unsafe_fn)]
+    #![allow(clippy::all)]
+    include!(concat!(env!("OUT_DIR"), "/constants.rs"));
+}
+pub use constants_bindings::*;
+
+mod bindings {
+    #![allow(unused)]
+    #![allow(non_upper_case_globals)]
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    // https://github.com/rust-lang/rust/issues/66220
+    #![allow(improper_ctypes)]
+    #![allow(unsafe_op_in_unsafe_fn)]
+    #![allow(clippy::all)]
+    include!(concat!(env!("OUT_DIR"), "/types.rs"));
+}
+
+use bindings::sigaction;
+unsafe impl vasi::VirtualAddressSpaceIndependent for sigaction {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn sigset_size() {
+        // The kernel definition should (currently) be 8 bytes.
+        // At some point this may get increased, but it shouldn't be the glibc
+        // size of ~100 bytes.
+        assert_eq!(std::mem::size_of::<bindings::sigset_t>(), 8);
+    }
+}

--- a/src/lib/linux-api/src/lib.rs
+++ b/src/lib/linux-api/src/lib.rs
@@ -1,5 +1,5 @@
 //! This crate constants and types for interacting with the Linux kernel.
-//! It is no_std and doesn't depend on libc.
+//! It is no_std and shouldn't have a runtime dependency on libc.
 
 #![cfg_attr(not(test), no_std)]
 

--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -76,7 +76,7 @@ fn test_from_signal() {
     assert_ne!(sigset, shd_kernel_sigset_t::EMPTY);
 }
 
-impl std::ops::BitOr for shd_kernel_sigset_t {
+impl core::ops::BitOr for shd_kernel_sigset_t {
     type Output = Self;
 
     fn bitor(self, rhs: Self) -> Self::Output {
@@ -95,7 +95,7 @@ fn test_bitor() {
     assert!(!sigset.has(Signal::SIGALRM));
 }
 
-impl std::ops::BitOrAssign for shd_kernel_sigset_t {
+impl core::ops::BitOrAssign for shd_kernel_sigset_t {
     fn bitor_assign(&mut self, rhs: Self) {
         self.val |= rhs.val
     }
@@ -110,7 +110,7 @@ fn test_bitorassign() {
     assert!(!sigset.has(Signal::SIGALRM));
 }
 
-impl std::ops::BitAnd for shd_kernel_sigset_t {
+impl core::ops::BitAnd for shd_kernel_sigset_t {
     type Output = Self;
 
     fn bitand(self, rhs: Self) -> Self::Output {
@@ -132,7 +132,7 @@ fn test_bitand() {
     assert!(!and.has(Signal::SIGALRM));
 }
 
-impl std::ops::BitAndAssign for shd_kernel_sigset_t {
+impl core::ops::BitAndAssign for shd_kernel_sigset_t {
     fn bitand_assign(&mut self, rhs: Self) {
         self.val &= rhs.val
     }
@@ -148,7 +148,7 @@ fn test_bitand_assign() {
     assert!(!set.has(Signal::SIGALRM));
 }
 
-impl std::ops::Not for shd_kernel_sigset_t {
+impl core::ops::Not for shd_kernel_sigset_t {
     type Output = Self;
 
     fn not(self) -> Self::Output {

--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -5,16 +5,17 @@ use crate::{bindings, constants_bindings};
 
 pub const LINUX_STANDARD_SIGNAL_MAX_NO: i32 = 31;
 
-/// Lowest and highest valid realtime signal, according to signal(7).  We don't
-/// use libc's SIGRTMIN and SIGRTMAX directly since those may omit some signal
-/// numbers that libc reserves for its internal use. We still need to handle
-/// those signal numbers in Shadow.
-pub const LINUX_SIGRT_MIN: i32 = 32;
+/// Lowest realtime signal number.
+pub const LINUX_SIGRT_MIN: i32 = constants_bindings::SIGRTMIN as i32;
+/// Highest realtime signal number.
+//
+// According to signal(7). bindgen fails to bind this one.
 pub const LINUX_SIGRT_MAX: i32 = 64;
 
-// Definition is sometimes missing in the userspace headers. We could include
-// the kernel signal header, but it has definitions that conflict with the
-// userspace headers.
+/// Definition is sometimes missing in the userspace headers.
+//
+// bindgen fails to bind this one.
+// Copied from linux's include/uapi/linux/signal.h.
 pub const LINUX_SS_AUTODISARM: i32 = 1 << 31;
 
 // Bindgen doesn't succesfully bind these constants; maybe because
@@ -144,6 +145,8 @@ impl linux_siginfo_t {
 pub struct linux_sigset_t {
     val: u64,
 }
+static_assertions::assert_eq_align!(linux_sigset_t, bindings::sigset_t);
+static_assertions::assert_eq_size!(linux_sigset_t, bindings::sigset_t);
 
 impl linux_sigset_t {
     pub const EMPTY: Self = Self { val: 0 };

--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -43,97 +43,60 @@ bitflags::bitflags! {
 // We can't derive this since the bitflags field uses an internal type.
 unsafe impl VirtualAddressSpaceIndependent for LinuxSigActionFlags {}
 
-#[derive(Copy, Clone, VirtualAddressSpaceIndependent)]
+// We use libc::siginfo_t internally, because bindings::siginfo_t gets
+// different field names when generated on different platforms.
+#[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
 #[repr(C)]
-pub struct linux_siginfo_t {
-    // We don't wrap bindings::siginfo_t directly,
-    // since this would introduce a dependency on the original system
-    // header file in the cbindgen'd version of this type, and requiring our C code
-    // to include the kernel headers results in naming conflicts.
-
-    // cbindgen doesn't understand repr(C, align(x)).
-    // alignment validated by static assertion below.
-    _align: u64,
-    // We also can't use core::mem::size_of::<bindings::siginfo_t> to specify
-    // the size here, because that also confuses cbindgen.
-    // Size validated by static assertion below.
-    _padding: [u8; 120],
-}
+pub struct linux_siginfo_t(libc::siginfo_t);
 static_assertions::assert_eq_align!(linux_siginfo_t, bindings::siginfo_t);
 static_assertions::assert_eq_size!(linux_siginfo_t, bindings::siginfo_t);
 
+unsafe impl VirtualAddressSpaceIndependent for linux_siginfo_t {}
+
 impl linux_siginfo_t {
-    fn as_bound_type(&self) -> &bindings::siginfo_t {
-        static_assertions::assert_eq_align!(linux_siginfo_t, bindings::siginfo_t);
-        static_assertions::assert_eq_size!(linux_siginfo_t, bindings::siginfo_t);
+    /// # Safety
+    ///
+    /// Pointer fields must not be dereferenced from outside of their
+    /// native virtual address space.
+    pub unsafe fn as_siginfo(&self) -> &libc::siginfo_t {
+        static_assertions::assert_eq_align!(linux_siginfo_t, libc::siginfo_t);
+        static_assertions::assert_eq_size!(linux_siginfo_t, libc::siginfo_t);
         unsafe { core::mem::transmute(self) }
     }
 
-    fn as_bound_type_mut(&mut self) -> &mut bindings::siginfo_t {
-        static_assertions::assert_eq_align!(linux_siginfo_t, bindings::siginfo_t);
-        static_assertions::assert_eq_size!(linux_siginfo_t, bindings::siginfo_t);
+    /// # Safety
+    ///
+    /// Pointer fields must not be dereferenced from outside of their
+    /// native virtual address space.
+    pub unsafe fn as_siginfo_mut(&mut self) -> &mut libc::siginfo_t {
+        static_assertions::assert_eq_align!(linux_siginfo_t, libc::siginfo_t);
+        static_assertions::assert_eq_size!(linux_siginfo_t, libc::siginfo_t);
         unsafe { core::mem::transmute(self) }
     }
 
     pub fn signo(&self) -> &i32 {
-        unsafe {
-            &self
-                .as_bound_type()
-                .__bindgen_anon_1
-                .__bindgen_anon_1
-                .si_signo
-        }
+        unsafe { &self.as_siginfo().si_signo }
     }
 
     pub fn signo_mut(&mut self) -> &mut i32 {
-        unsafe {
-            &mut self
-                .as_bound_type_mut()
-                .__bindgen_anon_1
-                .__bindgen_anon_1
-                .si_signo
-        }
+        unsafe { &mut self.as_siginfo_mut().si_signo }
     }
 
     pub fn errno(&self) -> &i32 {
-        unsafe {
-            &self
-                .as_bound_type()
-                .__bindgen_anon_1
-                .__bindgen_anon_1
-                .si_errno
-        }
+        unsafe { &self.as_siginfo().si_errno }
     }
 
     pub fn errno_mut(&mut self) -> &mut i32 {
-        unsafe {
-            &mut self
-                .as_bound_type_mut()
-                .__bindgen_anon_1
-                .__bindgen_anon_1
-                .si_errno
-        }
+        unsafe { &mut self.as_siginfo_mut().si_errno }
     }
 
     pub fn code(&self) -> &i32 {
-        unsafe {
-            &self
-                .as_bound_type()
-                .__bindgen_anon_1
-                .__bindgen_anon_1
-                .si_code
-        }
+        unsafe { &self.as_siginfo().si_code }
     }
 
     pub fn code_mut(&mut self) -> &mut i32 {
-        unsafe {
-            &mut self
-                .as_bound_type_mut()
-                .__bindgen_anon_1
-                .__bindgen_anon_1
-                .si_code
-        }
+        unsafe { &mut self.as_siginfo_mut().si_code }
     }
 }
 

--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -1,5 +1,7 @@
-use nix::sys::signal::{self, Signal};
+use nix::sys::signal::Signal;
 use vasi::VirtualAddressSpaceIndependent;
+
+use crate::{bindings, constants_bindings};
 
 pub const LINUX_STANDARD_SIGNAL_MAX_NO: i32 = 31;
 
@@ -10,10 +12,129 @@ pub const LINUX_STANDARD_SIGNAL_MAX_NO: i32 = 31;
 pub const LINUX_SIGRT_MIN: i32 = 32;
 pub const LINUX_SIGRT_MAX: i32 = 64;
 
-/// Definition is sometimes missing in the userspace headers. We could include
-/// the kernel signal header, but it has definitions that conflict with the
-/// userspace headers.
+// Definition is sometimes missing in the userspace headers. We could include
+// the kernel signal header, but it has definitions that conflict with the
+// userspace headers.
 pub const LINUX_SS_AUTODISARM: i32 = 1 << 31;
+
+// Bindgen doesn't succesfully bind these constants; maybe because
+// the macros defining them cast them to pointers.
+//
+// Copied from linux's include/uapi/asm-generic/signal-defs.h.
+pub const LINUX_SIG_DFL: usize = 0;
+pub const LINUX_SIG_IGN: usize = 1;
+pub const LINUX_SIG_ERR: usize = (-1_isize) as usize;
+
+bitflags::bitflags! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Debug, Default)]
+    pub struct LinuxSigActionFlags: core::ffi::c_int {
+        const NOCLDSTOP = constants_bindings::SA_NOCLDSTOP as i32;
+        const NOCLDWAIT = constants_bindings::SA_NOCLDWAIT as i32;
+        const NODEFER = constants_bindings::SA_NODEFER as i32;
+        const ONSTACK = constants_bindings::SA_ONSTACK as i32;
+        const RESETHAND = constants_bindings::SA_RESETHAND as i32;
+        const RESTART = constants_bindings::SA_RESTART as i32;
+        const RESTORER = constants_bindings::SA_RESTORER as i32;
+        const SIGINFO = constants_bindings::SA_SIGINFO as i32;
+    }
+}
+// We can't derive this since the bitflags field uses an internal type.
+unsafe impl VirtualAddressSpaceIndependent for LinuxSigActionFlags {}
+
+#[derive(Copy, Clone, VirtualAddressSpaceIndependent)]
+#[allow(non_camel_case_types)]
+#[repr(C)]
+pub struct linux_siginfo_t {
+    // We don't wrap bindings::siginfo_t directly,
+    // since this would introduce a dependency on the original system
+    // header file in the cbindgen'd version of this type, and requiring our C code
+    // to include the kernel headers results in naming conflicts.
+
+    // cbindgen doesn't understand repr(C, align(x)).
+    // alignment validated by static assertion below.
+    _align: u64,
+    // We also can't use core::mem::size_of::<bindings::siginfo_t> to specify
+    // the size here, because that also confuses cbindgen.
+    // Size validated by static assertion below.
+    _padding: [u8; 120],
+}
+static_assertions::assert_eq_align!(linux_siginfo_t, bindings::siginfo_t);
+static_assertions::assert_eq_size!(linux_siginfo_t, bindings::siginfo_t);
+
+impl linux_siginfo_t {
+    fn as_bound_type(&self) -> &bindings::siginfo_t {
+        static_assertions::assert_eq_align!(linux_siginfo_t, bindings::siginfo_t);
+        static_assertions::assert_eq_size!(linux_siginfo_t, bindings::siginfo_t);
+        unsafe { core::mem::transmute(self) }
+    }
+
+    fn as_bound_type_mut(&mut self) -> &mut bindings::siginfo_t {
+        static_assertions::assert_eq_align!(linux_siginfo_t, bindings::siginfo_t);
+        static_assertions::assert_eq_size!(linux_siginfo_t, bindings::siginfo_t);
+        unsafe { core::mem::transmute(self) }
+    }
+
+    pub fn signo(&self) -> &i32 {
+        unsafe {
+            &self
+                .as_bound_type()
+                .__bindgen_anon_1
+                .__bindgen_anon_1
+                .si_signo
+        }
+    }
+
+    pub fn signo_mut(&mut self) -> &mut i32 {
+        unsafe {
+            &mut self
+                .as_bound_type_mut()
+                .__bindgen_anon_1
+                .__bindgen_anon_1
+                .si_signo
+        }
+    }
+
+    pub fn errno(&self) -> &i32 {
+        unsafe {
+            &self
+                .as_bound_type()
+                .__bindgen_anon_1
+                .__bindgen_anon_1
+                .si_errno
+        }
+    }
+
+    pub fn errno_mut(&mut self) -> &mut i32 {
+        unsafe {
+            &mut self
+                .as_bound_type_mut()
+                .__bindgen_anon_1
+                .__bindgen_anon_1
+                .si_errno
+        }
+    }
+
+    pub fn code(&self) -> &i32 {
+        unsafe {
+            &self
+                .as_bound_type()
+                .__bindgen_anon_1
+                .__bindgen_anon_1
+                .si_code
+        }
+    }
+
+    pub fn code_mut(&mut self) -> &mut i32 {
+        unsafe {
+            &mut self
+                .as_bound_type_mut()
+                .__bindgen_anon_1
+                .__bindgen_anon_1
+                .si_code
+        }
+    }
+}
 
 /// Compatible with the Linux kernel's definition of sigset_t on x86_64.
 ///
@@ -169,7 +290,7 @@ pub union LinuxSigactionUnion {
     // Rust guarantees that the outer Option doesn't change the size:
     // https://doc.rust-lang.org/std/option/index.html#representation
     ksa_handler: Option<extern "C" fn(i32)>,
-    ksa_sigaction: Option<extern "C" fn(i32, *mut libc::siginfo_t, *mut libc::c_void)>,
+    ksa_sigaction: Option<extern "C" fn(i32, *mut linux_siginfo_t, *mut core::ffi::c_void)>,
 }
 
 /// Compatible with kernel's definition of `struct sigaction`. Different from
@@ -186,7 +307,7 @@ pub struct linux_sigaction {
     // shim, where it is valid to do so.
     #[unsafe_assume_virtual_address_space_independent]
     u: LinuxSigactionUnion,
-    ksa_flags: i32,
+    ksa_flags: LinuxSigActionFlags,
     // Rust guarantees that the outer Option doesn't change the size:
     // https://doc.rust-lang.org/std/option/index.html#representation
     //
@@ -197,18 +318,23 @@ pub struct linux_sigaction {
 }
 
 impl linux_sigaction {
-    pub fn handler(&self) -> signal::SigHandler {
+    pub fn handler(&self) -> nix::sys::signal::SigHandler {
         let handler_int: usize = unsafe { self.u.ksa_handler }
             .map(|f| f as usize)
             .unwrap_or(0);
-        if handler_int == libc::SIG_IGN {
-            signal::SigHandler::SigIgn
-        } else if handler_int == libc::SIG_DFL {
-            signal::SigHandler::SigDfl
-        } else if self.ksa_flags & libc::SA_SIGINFO != 0 {
-            signal::SigHandler::SigAction(unsafe { self.u.ksa_sigaction.unwrap() })
+        if handler_int == LINUX_SIG_IGN {
+            nix::sys::signal::SigHandler::SigIgn
+        } else if handler_int == LINUX_SIG_DFL {
+            nix::sys::signal::SigHandler::SigDfl
+        } else if self.ksa_flags.contains(LinuxSigActionFlags::SIGINFO) {
+            // We need to cast the function pointer to what nix expects.
+            // To avoid naming and depending on libc we use a transmute.
+            // FIXME: get rid of transmute (and nix deps altogether).
+            nix::sys::signal::SigHandler::SigAction(unsafe {
+                core::mem::transmute(self.u.ksa_sigaction.unwrap())
+            })
         } else {
-            signal::SigHandler::Handler(unsafe { self.u.ksa_handler.unwrap() })
+            nix::sys::signal::SigHandler::Handler(unsafe { self.u.ksa_handler.unwrap() })
         }
     }
 }

--- a/src/lib/shadow-shim-helper-rs/Cargo.toml
+++ b/src/lib/shadow-shim-helper-rs/Cargo.toml
@@ -20,6 +20,7 @@ shadow_shmem = { path = "../shmem" }
 static_assertions = "1.1.0"
 vasi = { path = "../vasi" }
 vasi-sync = { path = "../vasi-sync" }
+linux-api = { path = "../linux-api" }
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }

--- a/src/lib/shadow-shim-helper-rs/build.rs
+++ b/src/lib/shadow-shim-helper-rs/build.rs
@@ -9,7 +9,10 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
     let mut config = cbindgen::Config {
         sys_includes: vec!["signal.h".into()],
         include_guard: Some("shim_helpers_h".into()),
-        includes: vec!["lib/shmem/shmem_allocator.h".into()],
+        includes: vec![
+            "lib/linux-api/linux-api.h".into(),
+            "lib/shmem/shmem_allocator.h".into(),
+        ],
         // We typedef `UntypedForeignPtr` to `ForeignPtr<()>` in rust, but cbindgen won't generate
         // bindings for `ForeignPtr<()>` so we need to write our own. This must have the same size,
         // alignment, non-zst fields, and field order as `ForeignPtr<()>`.

--- a/src/lib/shadow-shim-helper-rs/src/lib.rs
+++ b/src/lib/shadow-shim-helper-rs/src/lib.rs
@@ -12,7 +12,6 @@ pub mod option;
 pub mod rootedcell;
 pub mod shim_event;
 pub mod shim_shmem;
-pub mod signals;
 pub mod simulation_time;
 pub mod syscall_types;
 pub mod util;

--- a/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
@@ -1,4 +1,7 @@
 use libc::{siginfo_t, stack_t};
+use linux_api::signal::{
+    shd_kernel_sigaction, shd_kernel_sigset_t, SHD_SIGRT_MAX, SHD_STANDARD_SIGNAL_MAX_NO,
+};
 use nix::sys::signal::Signal;
 use shadow_shmem::allocator::ShMemBlockSerialized;
 use vasi::VirtualAddressSpaceIndependent;
@@ -9,9 +12,6 @@ use crate::HostId;
 use crate::{
     emulated_time::{AtomicEmulatedTime, EmulatedTime},
     rootedcell::{refcell::RootedRefCell, Root},
-    signals::{
-        shd_kernel_sigaction, shd_kernel_sigset_t, SHD_SIGRT_MAX, SHD_STANDARD_SIGNAL_MAX_NO,
-    },
     simulation_time::SimulationTime,
 };
 

--- a/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
@@ -1,6 +1,6 @@
 use libc::{siginfo_t, stack_t};
 use linux_api::signal::{
-    shd_kernel_sigaction, shd_kernel_sigset_t, SHD_SIGRT_MAX, SHD_STANDARD_SIGNAL_MAX_NO,
+    linux_sigaction, linux_sigset_t, LINUX_SIGRT_MAX, LINUX_STANDARD_SIGNAL_MAX_NO,
 };
 use nix::sys::signal::Signal;
 use shadow_shmem::allocator::ShMemBlockSerialized;
@@ -166,10 +166,10 @@ impl ProcessShmem {
                 host_root,
                 ProcessShmemProtected {
                     host_id,
-                    pending_signals: shd_kernel_sigset_t::EMPTY,
+                    pending_signals: linux_sigset_t::EMPTY,
                     pending_standard_siginfos: [SiginfoWrapper::new();
-                        SHD_STANDARD_SIGNAL_MAX_NO as usize],
-                    signal_actions: [shd_kernel_sigaction::default(); SHD_SIGRT_MAX as usize],
+                        LINUX_STANDARD_SIGNAL_MAX_NO as usize],
+                    signal_actions: [linux_sigaction::default(); LINUX_SIGRT_MAX as usize],
                 },
             ),
         }
@@ -182,16 +182,16 @@ pub struct ProcessShmemProtected {
     pub host_id: HostId,
 
     // Process-directed pending signals.
-    pub pending_signals: shd_kernel_sigset_t,
+    pub pending_signals: linux_sigset_t,
 
     // siginfo for each of the standard signals.
-    pending_standard_siginfos: [SiginfoWrapper; SHD_STANDARD_SIGNAL_MAX_NO as usize],
+    pending_standard_siginfos: [SiginfoWrapper; LINUX_STANDARD_SIGNAL_MAX_NO as usize],
 
     // actions for both standard and realtime signals.
     // We currently support configuring handlers for realtime signals, but not
     // actually delivering them. This is to handle the case where handlers are
     // defensively installed, but not used in practice.
-    signal_actions: [shd_kernel_sigaction; SHD_SIGRT_MAX as usize],
+    signal_actions: [linux_sigaction; LINUX_SIGRT_MAX as usize],
 }
 
 impl ProcessShmemProtected {
@@ -213,7 +213,7 @@ impl ProcessShmemProtected {
     /// Function pointers in `shd_kernel_sigaction::u` are valid only
     /// from corresponding managed process, and may be libc::SIG_DFL or
     /// libc::SIG_IGN.
-    pub unsafe fn signal_action(&self, signal: Signal) -> &shd_kernel_sigaction {
+    pub unsafe fn signal_action(&self, signal: Signal) -> &linux_sigaction {
         &self.signal_actions[signal as usize - 1]
     }
 
@@ -222,7 +222,7 @@ impl ProcessShmemProtected {
     /// Function pointers in `shd_kernel_sigaction::u` are valid only
     /// from corresponding managed process, and may be libc::SIG_DFL or
     /// libc::SIG_IGN.
-    pub unsafe fn signal_action_mut(&mut self, signal: Signal) -> &mut shd_kernel_sigaction {
+    pub unsafe fn signal_action_mut(&mut self, signal: Signal) -> &mut linux_sigaction {
         &mut self.signal_actions[signal as usize - 1]
     }
 
@@ -268,10 +268,10 @@ impl ThreadShmem {
                 &host.root,
                 ThreadShmemProtected {
                     host_id: host.host_id,
-                    pending_signals: shd_kernel_sigset_t::EMPTY,
+                    pending_signals: linux_sigset_t::EMPTY,
                     pending_standard_siginfos: [SiginfoWrapper::new();
-                        SHD_STANDARD_SIGNAL_MAX_NO as usize],
-                    blocked_signals: shd_kernel_sigset_t::EMPTY,
+                        LINUX_STANDARD_SIGNAL_MAX_NO as usize],
+                    blocked_signals: linux_sigset_t::EMPTY,
                     sigaltstack: StackWrapper(stack_t {
                         ss_sp: std::ptr::null_mut(),
                         ss_flags: libc::SS_DISABLE,
@@ -289,15 +289,15 @@ pub struct ThreadShmemProtected {
     pub host_id: HostId,
 
     // Thread-directed pending signals.
-    pub pending_signals: shd_kernel_sigset_t,
+    pub pending_signals: linux_sigset_t,
 
     // siginfo for each of the 32 standard signals.
-    pending_standard_siginfos: [SiginfoWrapper; SHD_STANDARD_SIGNAL_MAX_NO as usize],
+    pending_standard_siginfos: [SiginfoWrapper; LINUX_STANDARD_SIGNAL_MAX_NO as usize],
 
     // Signal mask, e.g. as set by `sigprocmask`.
     // We don't use sigset_t since glibc uses a much larger bitfield than
     // actually supported by the kernel.
-    pub blocked_signals: shd_kernel_sigset_t,
+    pub blocked_signals: linux_sigset_t,
 
     // Configured alternate signal stack for this thread.
     sigaltstack: StackWrapper,
@@ -605,7 +605,7 @@ pub mod export {
     pub unsafe extern "C" fn shimshmem_getProcessPendingSignals(
         lock: *const ShimShmemHostLock,
         process: *const ShimShmemProcess,
-    ) -> shd_kernel_sigset_t {
+    ) -> linux_sigset_t {
         let process_mem = unsafe { process.as_ref().unwrap() };
         let lock = unsafe { lock.as_ref().unwrap() };
         let protected = process_mem.protected.borrow(&lock.root);
@@ -621,7 +621,7 @@ pub mod export {
     pub unsafe extern "C" fn shimshmem_setProcessPendingSignals(
         lock: *const ShimShmemHostLock,
         process: *const ShimShmemProcess,
-        s: shd_kernel_sigset_t,
+        s: linux_sigset_t,
     ) {
         let process_mem = unsafe { process.as_ref().unwrap() };
         let lock = unsafe { lock.as_ref().unwrap() };
@@ -681,7 +681,7 @@ pub mod export {
         lock: *const ShimShmemHostLock,
         process: *const ShimShmemProcess,
         sig: i32,
-    ) -> shd_kernel_sigaction {
+    ) -> linux_sigaction {
         let process_mem = unsafe { process.as_ref().unwrap() };
         let lock = unsafe { lock.as_ref().unwrap() };
         let protected = process_mem.protected.borrow(&lock.root);
@@ -696,7 +696,7 @@ pub mod export {
         lock: *const ShimShmemHostLock,
         process: *const ShimShmemProcess,
         sig: i32,
-        action: *const shd_kernel_sigaction,
+        action: *const linux_sigaction,
     ) {
         let process_mem = unsafe { process.as_ref().unwrap() };
         let lock = unsafe { lock.as_ref().unwrap() };
@@ -725,7 +725,7 @@ pub mod export {
     pub unsafe extern "C" fn shimshmem_getThreadPendingSignals(
         lock: *const ShimShmemHostLock,
         thread: *const ShimShmemThread,
-    ) -> shd_kernel_sigset_t {
+    ) -> linux_sigset_t {
         let thread_mem = unsafe { thread.as_ref().unwrap() };
         let lock = unsafe { lock.as_ref().unwrap() };
         let protected = thread_mem.protected.borrow(&lock.root);
@@ -741,7 +741,7 @@ pub mod export {
     pub unsafe extern "C" fn shimshmem_setThreadPendingSignals(
         lock: *const ShimShmemHostLock,
         thread: *const ShimShmemThread,
-        s: shd_kernel_sigset_t,
+        s: linux_sigset_t,
     ) {
         let thread_mem = unsafe { thread.as_ref().unwrap() };
         let lock = unsafe { lock.as_ref().unwrap() };
@@ -800,7 +800,7 @@ pub mod export {
     pub unsafe extern "C" fn shimshmem_getBlockedSignals(
         lock: *const ShimShmemHostLock,
         thread: *const ShimShmemThread,
-    ) -> shd_kernel_sigset_t {
+    ) -> linux_sigset_t {
         let thread_mem = unsafe { thread.as_ref().unwrap() };
         let lock = unsafe { lock.as_ref().unwrap() };
         let protected = thread_mem.protected.borrow(&lock.root);
@@ -816,7 +816,7 @@ pub mod export {
     pub unsafe extern "C" fn shimshmem_setBlockedSignals(
         lock: *const ShimShmemHostLock,
         thread: *const ShimShmemThread,
-        s: shd_kernel_sigset_t,
+        s: linux_sigset_t,
     ) {
         let thread_mem = unsafe { thread.as_ref().unwrap() };
         let lock = unsafe { lock.as_ref().unwrap() };

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -181,7 +181,7 @@ static void _shim_init_signal_stack() {
         // is running on the same thread would clobber the first handler's stack.
         // Instead we want the second handler to push a new frame on the alt
         // stack that's already installed.
-        .ss_flags = SS_AUTODISARM,
+        .ss_flags = LINUX_SS_AUTODISARM,
     };
 
     if (sigaltstack(&stack_descriptor, NULL) != 0) {

--- a/src/lib/shim/shim_signals.c
+++ b/src/lib/shim/shim_signals.c
@@ -8,7 +8,7 @@
 #include <ucontext.h>
 
 static void _call_signal_handler(const struct linux_sigaction* action, int signo,
-                                 siginfo_t* siginfo, ucontext_t* ucontext) {
+                                 linux_siginfo_t* siginfo, ucontext_t* ucontext) {
     shim_swapAllowNativeSyscalls(false);
     if (action->ksa_flags & SA_SIGINFO) {
         action->u.ksa_sigaction(signo, siginfo, ucontext);
@@ -34,7 +34,7 @@ static _Noreturn void _die_with_fatal_signal(int signo) {
 // signal actions had the SA_RESTART flag set.
 bool shim_process_signals(ShimShmemHostLock* host_lock, ucontext_t* ucontext) {
     int signo;
-    siginfo_t siginfo;
+    linux_siginfo_t siginfo;
     bool restartable = true;
     while ((signo = shimshmem_takePendingUnblockedSignal(
                 host_lock, shim_processSharedMem(), shim_threadSharedMem(), &siginfo)) != 0) {

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "4.2.7", features = ["derive", "wrap_help"] }
 crossbeam = "0.8.2"
 gml-parser = { path = "../lib/gml-parser" }
 libc = "0.2"
+linux-api = { path = "../lib/linux-api" }
 # don't log debug or trace levels in release mode
 log = { version = "0.4", features = ["release_max_level_debug"] }
 logger = { path = "../lib/logger" }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::Ordering;
 #[cfg(feature = "perf_timers")]
 use std::time::Duration;
 
+use linux_api::signal::{defaultaction, ShdKernelDefaultAction};
 use log::{debug, info, trace, warn};
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
@@ -23,7 +24,6 @@ use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::rootedcell::Root;
 use shadow_shim_helper_rs::shim_shmem::ProcessShmem;
-use shadow_shim_helper_rs::signals::{defaultaction, ShdKernelDefaultAction};
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
 use shadow_shim_helper_rs::syscall_types::{ForeignPtr, ManagedPhysicalMemoryAddr};
 use shadow_shim_helper_rs::HostId;

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::Ordering;
 #[cfg(feature = "perf_timers")]
 use std::time::Duration;
 
-use linux_api::signal::{defaultaction, ShdKernelDefaultAction};
+use linux_api::signal::{defaultaction, LinuxDefaultAction};
 use log::{debug, info, trace, warn};
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
@@ -463,7 +463,7 @@ impl RunnableProcess {
             let handler = action.handler();
             if handler == nixsignal::SigHandler::SigIgn
                 || (handler == nixsignal::SigHandler::SigDfl
-                    && defaultaction(signal) == ShdKernelDefaultAction::IGN)
+                    && defaultaction(signal) == LinuxDefaultAction::IGN)
             {
                 return;
             }

--- a/src/main/host/syscall_condition.c
+++ b/src/main/host/syscall_condition.c
@@ -500,9 +500,8 @@ bool syscallcondition_wakeupForSignal(SysCallCondition* cond, const Host* host, 
 
     ShimShmemHostLock* hostLock = host_getShimShmemLock(host);
     const Thread* thread = host_getThread(host, cond->threadId);
-    shd_kernel_sigset_t blockedSignals =
-        shimshmem_getBlockedSignals(hostLock, thread_sharedMem(thread));
-    if (shd_sigismember(&blockedSignals, signo)) {
+    linux_sigset_t blockedSignals = shimshmem_getBlockedSignals(hostLock, thread_sharedMem(thread));
+    if (linux_sigismember(&blockedSignals, signo)) {
         // Signal is blocked. Don't schedule.
         return false;
     }


### PR DESCRIPTION
To begin, this migrates our existing `signals` module into this new module. We already can't use the libc bindings for most of these types and constants, because libc is free to (and does) use its own incompatible definitions with the same names.

This starts to migrate the code away from depending on libc and nix, making some progress on #2919 

It also adds bindings to the kernel definitions. It's tricky to wrap and re-export these directly in some cases, but it lets us at least internally validate that our definitions are consistent with the bindgen'd definitions.