### PR TITLE
Fix two warnings on nightly

### DIFF
--- a/src/lib/syscall-logger/src/lib.rs
+++ b/src/lib/syscall-logger/src/lib.rs
@@ -60,7 +60,7 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
     let context_arg_name;
 
     {
-        let input_fn = match &mut input {
+        let input_fn: &mut _ = match &mut input {
             syn::Item::Fn(input_fn) => input_fn,
             _ => panic!("Expected Item::Fn"),
         };

--- a/src/lib/syscall-logger/src/lib.rs
+++ b/src/lib/syscall-logger/src/lib.rs
@@ -60,7 +60,7 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
     let context_arg_name;
 
     {
-        let mut input_fn = match &mut input {
+        let input_fn = match &mut input {
             syn::Item::Fn(input_fn) => input_fn,
             _ => panic!("Expected Item::Fn"),
         };

--- a/src/main/host/syscall/io.rs
+++ b/src/main/host/syscall/io.rs
@@ -389,7 +389,7 @@ pub fn update_msghdr(
 ) -> Result<(), Errno> {
     let msg_ptr = ForeignArrayPtr::new(msg_ptr, 1);
     let mut mem_ref = mem.memory_ref_mut(msg_ptr)?;
-    let mut plugin_msg = &mut mem_ref.deref_mut()[0];
+    let plugin_msg = &mut mem_ref.deref_mut()[0];
 
     // write only the msg fields that may have changed
     plugin_msg.msg_namelen = msg.name_len;


### PR DESCRIPTION
```
warning: variable does not need to be mutable
  --> lib/syscall-logger/src/lib.rs:63:13
   |
63 |         let mut input_fn = match &mut input {
   |             ----^^^^^^^^
   |             |
   |             help: remove this `mut`
   |
   = note: `#[warn(unused_mut)]` on by default
```

```
warning: variable does not need to be mutable
   --> main/host/syscall/io.rs:392:9
    |
392 |     let mut plugin_msg = &mut mem_ref.deref_mut()[0];
    |         ----^^^^^^^^^^
    |         |
    |         help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default
```