### PR TITLE
Reduce the number of log messages at 'info' level

### DIFF
--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -907,7 +907,7 @@ fn get_required_preload_path(libname: &str) -> anyhow::Result<PathBuf> {
 
     let libpath = libpath.ok_or_else(|| anyhow::anyhow!(format!("Could not library in rpath")))?;
 
-    log::info!(
+    log::debug!(
         "Found required preload library {} at path {}",
         libname,
         libpath.display(),

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use atomic_refcell::AtomicRefCell;
-use log::{debug, info, trace};
+use log::{debug, trace};
 use logger::LogLevel;
 use nix::sys::signal::Signal;
 use once_cell::unsync::OnceCell;
@@ -322,7 +322,7 @@ impl Host {
 
         res.stop_execution_timer();
 
-        info!(
+        debug!(
             concat!(
                 "Setup host id '{:?}'",
                 " name '{name}'",
@@ -663,7 +663,7 @@ impl Host {
 
         self.stop_execution_timer();
         #[cfg(feature = "perf_timers")]
-        info!(
+        debug!(
             "host '{}' has been shut down, total execution time was {:?}",
             self.name(),
             self.execution_timer.borrow().elapsed()

--- a/src/main/host/managed_thread.rs
+++ b/src/main/host/managed_thread.rs
@@ -3,7 +3,7 @@ use std::ffi::{CStr, CString};
 use std::os::fd::RawFd;
 use std::sync::{atomic, Arc};
 
-use log::{debug, error, info, log_enabled, trace, Level};
+use log::{debug, error, log_enabled, trace, Level};
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;
@@ -136,7 +136,7 @@ impl ManagedThread {
             ))
             .unwrap(),
         );
-        info!("forking new mthread with environment '{envv:?}', arguments '{argv:?}', and working directory '{working_dir:?}'");
+        debug!("forking new mthread with environment '{envv:?}', arguments '{argv:?}', and working directory '{working_dir:?}'");
 
         let shimlog_fd = nix::fcntl::open(
             log_path,

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::Ordering;
 #[cfg(feature = "perf_timers")]
 use std::time::Duration;
 
-use log::{debug, info, trace, warn};
+use log::{debug, trace, warn};
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
 use nix::sys::signal as nixsignal;
@@ -813,7 +813,7 @@ impl Process {
         let native_pid = {
             let main_thread = main_thread.borrow(host.root());
 
-            info!("starting process '{}'", plugin_name);
+            debug!("starting process '{}'", plugin_name);
 
             Process::set_shared_time(host);
 
@@ -835,7 +835,7 @@ impl Process {
             main_thread.native_pid()
         };
 
-        info!("process '{}' started", plugin_name);
+        debug!("process '{}' started", plugin_name);
 
         if pause_for_debugging {
             // will block until logger output has been flushed
@@ -910,7 +910,7 @@ impl Process {
         #[cfg(feature = "perf_timers")]
         {
             let delay = self.stop_cpu_delay_timer(host);
-            info!("process '{}' ran for {:?}", &*self.name(), delay);
+            debug!("process '{}' ran for {:?}", &*self.name(), delay);
         }
         #[cfg(not(feature = "perf_timers"))]
         debug!("process '{}' done continuing", &*self.name());
@@ -960,7 +960,7 @@ impl Process {
                 debug!("process {} has already stopped", &*self.name());
                 return;
             };
-            info!("terminating process {}", &*self.name());
+            debug!("terminating process {}", &*self.name());
 
             #[cfg(feature = "perf_timers")]
             runnable.start_cpu_delay_timer();
@@ -972,10 +972,10 @@ impl Process {
             #[cfg(feature = "perf_timers")]
             {
                 let delay = runnable.stop_cpu_delay_timer(host);
-                info!("process '{}' stopped in {:?}", &*self.name(), delay);
+                debug!("process '{}' stopped in {:?}", &*self.name(), delay);
             }
             #[cfg(not(feature = "perf_timers"))]
-            info!("process '{}' stopped", &*self.name());
+            debug!("process '{}' stopped", &*self.name());
         }
 
         // Mutates `self.state`, so we need to have dropped `runnable`.
@@ -1156,7 +1156,7 @@ impl Process {
 
     /// Transitions `self` from a `RunnableProcess` to a `ZombieProcess`.
     fn handle_process_exit(&self, host: &Host, killed_by_shadow: bool) {
-        info!(
+        debug!(
             "process '{}' has completed or is otherwise no longer running",
             &*self.name()
         );
@@ -1184,7 +1184,7 @@ impl Process {
         };
 
         #[cfg(feature = "perf_timers")]
-        info!(
+        debug!(
             "total runtime for process '{}' was {:?}",
             runnable.common.name(),
             runnable.total_run_time.get()
@@ -1237,14 +1237,14 @@ impl Process {
                     ExitStatus::StoppedByShadow => ProcessFinalState::Running(RunningVal::Running),
                 };
                 if expected_final_state == actual_final_state {
-                    (s, log::Level::Info)
+                    (s, log::Level::Debug)
                 } else {
                     Worker::increment_plugin_error_count();
                     write!(s, "; expected end state was {expected_final_state} but was {actual_final_state}").unwrap();
                     (s, log::Level::Error)
                 }
             } else {
-                (s, log::Level::Info)
+                (s, log::Level::Debug)
             }
         };
         log::log!(log_level, "{}", main_result_string);

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -112,16 +112,16 @@ void syscallhandler_free(SysCallHandler* sys) {
     MAGIC_ASSERT(sys);
 
 #ifdef USE_PERF_TIMERS
-    info("handled %li syscalls in %f seconds", sys->numSyscalls, sys->perfSecondsTotal);
+    debug("handled %li syscalls in %f seconds", sys->numSyscalls, sys->perfSecondsTotal);
 #else
-    info("handled %li syscalls", sys->numSyscalls);
+    debug("handled %li syscalls", sys->numSyscalls);
 #endif
 
     if (_countSyscalls && sys->syscall_counter) {
         // Log the plugin thread specific counts
         char* str = counter_alloc_string(sys->syscall_counter);
-        info("Thread %d (%s) syscall counts: %s", sys->threadId,
-             _syscallhandler_getProcessName(sys), str);
+        debug("Thread %d (%s) syscall counts: %s", sys->threadId,
+              _syscallhandler_getProcessName(sys), str);
         counter_free_string(sys->syscall_counter, str);
 
         // Add up the counts at the worker level


### PR DESCRIPTION
Shadow outputs a lot of messages at 'info' level that aren't very useful unless you're debugging something. This PR reduces the number of 'info' log messages to unclutter the log at the default log level.