### PR TITLE
We no longer need executable /dev/shm

### DIFF
--- a/.github/workflows/extra_tests.yml
+++ b/.github/workflows/extra_tests.yml
@@ -201,7 +201,7 @@ jobs:
       # 65536k. github's default docker seccomp policy seems to disallow
       # process_vm_readv and process_vm_writev; disable it altogether. See
       # https://docs.docker.com/engine/security/seccomp/
-      options: '--tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt seccomp=unconfined'
+      options: '--shm-size=1024g --security-opt seccomp=unconfined'
 
     strategy:
       matrix:
@@ -339,7 +339,7 @@ jobs:
       # 65536k. github's default docker seccomp policy seems to disallow
       # process_vm_readv and process_vm_writev; disable it altogether. See
       # https://docs.docker.com/engine/security/seccomp/
-      options: '--tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt seccomp=unconfined'
+      options: '--shm-size=1024g --security-opt seccomp=unconfined'
 
     steps:
       - run: apt-get update
@@ -421,7 +421,7 @@ jobs:
       # 65536k. github's default docker seccomp policy seems to disallow
       # process_vm_readv and process_vm_writev; disable it altogether. See
       # https://docs.docker.com/engine/security/seccomp/
-      options: '--tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt seccomp=unconfined'
+      options: '--shm-size=1024g --security-opt seccomp=unconfined'
 
     steps:
       - run: apt-get update

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -56,7 +56,7 @@ jobs:
       # 65536k. github's default docker seccomp policy seems to disallow
       # process_vm_readv and process_vm_writev; disable it altogether. See
       # https://docs.docker.com/engine/security/seccomp/
-      options: '--tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt seccomp=unconfined'
+      options: '--shm-size=1024g --security-opt seccomp=unconfined'
     env:
       CC: ${{ matrix.cc }}
       CONTAINER: ${{ matrix.container }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ MINOR changes (backwards-compatible):
 
 PATCH changes (bugfixes):
 
-*
+* Updated documentation and tests to reflect that shadow no longer requires
+`/dev/shm` to be executable. (This requirement was actually removed in v3.0.0)
 
 Full changelog since v3.0.0:
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -125,9 +125,8 @@ EOF
 
     # Start the container and copy the most recent code.
     DOCKER_CREATE_FLAGS=()
-    # Shadow needs some space allocated to /dev/shm, and it should be mounted as
-    # executable.
-    DOCKER_CREATE_FLAGS+=("--tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g")
+    # Shadow needs some extra space allocated to /dev/shm
+    DOCKER_CREATE_FLAGS+=("--shm-size=1024g")
     # Docker's default seccomp policy disables the `personality` syscall, which
     # shadow uses to disable ASLR. This causes shadow's determinism tests to fail.
     # https://github.com/moby/moby/issues/43011

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -47,7 +47,7 @@ run an interactive shell in a container built from that image.
 e.g.:
 
 ```{.bash}
-docker run --tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt=seccomp=unconfined -it shadowsim/shadow-ci:ubuntu-22.04-gcc-debug /bin/bash
+docker run --shm-size=1024g --security-opt=seccomp=unconfined -it shadowsim/shadow-ci:ubuntu-22.04-gcc-debug /bin/bash
 ```
 
 If the failure happened in the middle of building the Docker image, you can do
@@ -67,5 +67,5 @@ You can start a container from the image where Docker tried (and failed) to run
 `ci/the build_and_install.sh` script was executed with:
 
 ```{.bash}
-docker run --tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt=seccomp=unconfined -it a11c4a554ef8 /bin/bash
+docker run --shm-size=1024g --security-opt=seccomp=unconfined -it a11c4a554ef8 /bin/bash
 ```

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -34,14 +34,13 @@ By these criteria, Shadow's oldest supported kernel version is currently 5.4
 ## Docker
 
 If you are installing Shadow within a Docker container, you must increase the
-size of the container's `/dev/shm` mount, add the "exec" mount option, and
-disable the seccomp security profile. You can do this by passing additional
-flags to `docker run`.
+size of the container's `/dev/shm` mount and disable the seccomp security
+profile. You can do this by passing additional flags to `docker run`.
 
 Example:
 
 ```bash
-docker run -it --tmpfs /dev/shm:rw,nosuid,nodev,exec,size=1024g --security-opt seccomp=unconfined ubuntu:22.04
+docker run -it --shm-size=1024g --security-opt seccomp=unconfined ubuntu:22.04
 ```
 
 If you are having difficulty installing Shadow on any supported platforms, you


### PR DESCRIPTION
Now that the MemoryMapper uses `memfd_create` instead of creating files in `/dev/shm` (a422da50ea7e6ee8438486b534c251ae9c1e9a0c), `/dev/shm` no longer needs to be executable.