### PR TITLE
Add test for cli help output

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -153,6 +153,7 @@ endmacro()
 ## === end test helper macros ===
 
 add_subdirectory(bindc)
+add_subdirectory(cli)
 add_subdirectory(clone)
 add_subdirectory(compressed-graph)
 add_subdirectory(config)

--- a/src/test/cli/CMakeLists.txt
+++ b/src/test/cli/CMakeLists.txt
@@ -1,0 +1,15 @@
+# to update the expected help text, run:
+# ./build/src/main/shadow --help > src/test/cli/help-long-expected
+# ./build/src/main/shadow -h > src/test/cli/help-short-expected
+
+add_test(NAME cli-long COMMAND sh -c "${CMAKE_BINARY_DIR}/src/main/shadow --help > help-long-current")
+add_test(
+    NAME cli-long-compare
+    COMMAND ${CMAKE_COMMAND} -E compare_files help-long-current ${CMAKE_CURRENT_SOURCE_DIR}/help-long-expected)
+set_tests_properties(cli-long-compare PROPERTIES DEPENDS cli-long)
+
+add_test(NAME cli-short COMMAND sh -c "${CMAKE_BINARY_DIR}/src/main/shadow -h > help-short-current")
+add_test(
+    NAME cli-short-compare
+    COMMAND ${CMAKE_COMMAND} -E compare_files help-short-current ${CMAKE_CURRENT_SOURCE_DIR}/help-short-expected)
+set_tests_properties(cli-short-compare PROPERTIES DEPENDS cli-short)

--- a/src/test/cli/help-long-expected
+++ b/src/test/cli/help-long-expected
@@ -1,0 +1,177 @@
+Run real applications over simulated networks.
+
+For documentation, visit https://shadow.github.io/docs/guide
+
+Usage: shadow [OPTIONS] [CONFIG]
+
+Arguments:
+  [CONFIG]
+          Path to the Shadow configuration file. Use '-' to read from stdin
+
+Options:
+      --debug-hosts <hostnames>
+          Pause after starting any processes on the comma-delimited list of hostnames
+
+  -g, --gdb
+          Pause to allow gdb to attach
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+      --shm-cleanup
+          Exit after running shared memory cleanup routine
+
+      --show-build-info
+          Exit after printing build information
+
+      --show-config
+          Exit after printing the final configuration
+
+  -V, --version
+          Print version
+
+General (Override configuration file options):
+      --bootstrap-end-time <seconds>
+          The simulated time that ends Shadow's high network bandwidth/reliability bootstrap period
+          [default: "0 sec"]
+
+  -d, --data-directory <path>
+          Path to store simulation output [default: "shadow.data"]
+
+  -e, --template-directory <path>
+          Path to recursively copy during startup and use as the data-directory [default: null]
+
+      --heartbeat-interval <seconds>
+          Interval at which to print heartbeat messages [default: "1 sec"]
+
+  -l, --log-level <level>
+          Log level of output written on stdout. If Shadow was built in release mode, then log
+          messages at level 'trace' will always be dropped [default: "info"]
+
+      --model-unblocked-syscall-latency <bool>
+          Model syscalls and VDSO functions that don't block as having some latency. This should
+          have minimal effect on typical simulations, but can be helpful for programs with "busy
+          loops" that otherwise deadlock under Shadow. [default: false]
+
+  -p, --parallelism <cores>
+          How many parallel threads to use to run the simulation. A value of 0 will allow Shadow to
+          choose the number of threads. [default: 0]
+
+      --progress <bool>
+          Show the simulation progress on stderr [default: false]
+
+      --seed <N>
+          Initialize randomness using seed N [default: 1]
+
+      --stop-time <seconds>
+          The simulated time at which simulated processes are sent a SIGKILL signal
+
+Network (Override network options):
+      --use-shortest-path <bool>
+          When routing packets, follow the shortest path rather than following a direct edge between
+          nodes. If false, the network graph is required to be complete. [default: true]
+
+Host Defaults (Default options for hosts):
+      --host-log-level <level>
+          Log level at which to print node messages [default: null]
+
+      --pcap-capture-size <bytes>
+          How much data to capture per packet (header and payload) if pcap logging is enabled
+          [default: "65535 B"]
+
+      --pcap-enabled <bool>
+          Should shadow generate pcap files? [default: false]
+
+Experimental (Unstable and may change or be removed at any time, regardless of Shadow version):
+      --host-heartbeat-interval <seconds>
+          Amount of time between heartbeat messages for this host [default: "1 sec"]
+
+      --host-heartbeat-log-info <options>
+          List of information to show in the host's heartbeat message [default: ["node"]]
+
+      --host-heartbeat-log-level <level>
+          Log level at which to print host statistics [default: "info"]
+
+      --interface-qdisc <mode>
+          The queueing discipline to use at the network interface [default: "fifo"]
+
+      --max-unapplied-cpu-latency <seconds>
+          Max amount of execution-time latency allowed to accumulate before the clock is moved
+          forward. Moving the clock forward is a potentially expensive operation, so larger values
+          reduce simulation overhead, at the cost of coarser time jumps. Note also that
+          accumulated-but-unapplied latency is discarded when a thread is blocked on a syscall.
+          [default: "1 μs"]
+
+      --runahead <seconds>
+          If set, overrides the automatically calculated minimum time workers may run ahead when
+          sending events between nodes [default: "1 ms"]
+
+      --scheduler <name>
+          The host scheduler implementation, which decides how to assign hosts to threads and
+          threads to CPU cores [default: "thread-per-core"]
+
+      --socket-recv-autotune <bool>
+          Enable receive window autotuning [default: true]
+
+      --socket-recv-buffer <bytes>
+          Initial size of the socket's receive buffer [default: "174760 B"]
+
+      --socket-send-autotune <bool>
+          Enable send window autotuning [default: true]
+
+      --socket-send-buffer <bytes>
+          Initial size of the socket's send buffer [default: "131072 B"]
+
+      --strace-logging-mode <mode>
+          Log the syscalls for each process to individual "strace" files [default: "off"]
+
+      --unblocked-syscall-latency <seconds>
+          Simulated latency of an unblocked syscall. For efficiency Shadow only actually adds this
+          latency if and when `max_unapplied_cpu_latency` is reached. [default: "1 μs"]
+
+      --unblocked-vdso-latency <seconds>
+          Simulated latency of a vdso "syscall". For efficiency Shadow only actually adds this
+          latency if and when `max_unapplied_cpu_latency` is reached. [default: "10 ns"]
+
+      --use-cpu-pinning <bool>
+          Pin each thread and any processes it executes to the same logical CPU Core to improve
+          cache affinity [default: true]
+
+      --use-dynamic-runahead <bool>
+          Update the minimum runahead dynamically throughout the simulation. [default: false]
+
+      --use-memory-manager <bool>
+          Use the MemoryManager. It can be useful to disable for debugging, but will hurt
+          performance in most cases [default: true]
+
+      --use-object-counters <bool>
+          Count object allocations and deallocations. If disabled, we will not be able to detect
+          object memory leaks [default: true]
+
+      --use-preload-libc <bool>
+          Preload our libc library for all managed processes for fast syscall interposition when
+          possible. [default: true]
+
+      --use-preload-openssl-crypto <bool>
+          Preload our OpenSSL crypto library for all managed processes to skip some crypto
+          operations (may speed up simulation if your CPU lacks AES-NI support, but can cause bugs
+          so do not use unless you know what you're doing). [default: false]
+
+      --use-preload-openssl-rng <bool>
+          Preload our OpenSSL RNG library for all managed processes to mitigate non-deterministic
+          use of OpenSSL. [default: true]
+
+      --use-sched-fifo <bool>
+          Use the SCHED_FIFO scheduler. Requires CAP_SYS_NICE. See sched(7), capabilities(7)
+          [default: false]
+
+      --use-syscall-counters <bool>
+          Count the number of occurrences for individual syscalls [default: true]
+
+      --use-worker-spinning <bool>
+          Each worker thread will spin in a `sched_yield` loop while waiting for a new task. This is
+          ignored if not using the thread-per-core scheduler. [default: true]
+
+If units are not specified, all values are assumed to be given in their base unit (seconds, bytes,
+bits, etc). Units can optionally be specified (for example: '1024 B', '1024 bytes', '1 KiB', '1
+kibibyte', etc) and are case-sensitive.

--- a/src/test/cli/help-short-expected
+++ b/src/test/cli/help-short-expected
@@ -1,0 +1,60 @@
+Run real applications over simulated networks.
+
+For documentation, visit https://shadow.github.io/docs/guide
+
+Usage: shadow [OPTIONS] [CONFIG]
+
+Arguments:
+  [CONFIG]  Path to the Shadow configuration file. Use '-' to read from stdin
+
+Options:
+      --debug-hosts <hostnames>  Pause after starting any processes on the comma-delimited list of
+                                 hostnames
+  -g, --gdb                      Pause to allow gdb to attach
+  -h, --help                     Print help (see more with '--help')
+      --shm-cleanup              Exit after running shared memory cleanup routine
+      --show-build-info          Exit after printing build information
+      --show-config              Exit after printing the final configuration
+  -V, --version                  Print version
+
+General (Override configuration file options):
+      --bootstrap-end-time <seconds>
+          The simulated time that ends Shadow's high network bandwidth/reliability bootstrap period
+          [default: "0 sec"]
+  -d, --data-directory <path>
+          Path to store simulation output [default: "shadow.data"]
+  -e, --template-directory <path>
+          Path to recursively copy during startup and use as the data-directory [default: null]
+      --heartbeat-interval <seconds>
+          Interval at which to print heartbeat messages [default: "1 sec"]
+  -l, --log-level <level>
+          Log level of output written on stdout. If Shadow was built in release mode, then log
+          messages at level 'trace' will always be dropped [default: "info"]
+      --model-unblocked-syscall-latency <bool>
+          Model syscalls and VDSO functions that don't block as having some latency. This should
+          have minimal effect on typical simulations, but can be helpful for programs with "busy
+          loops" that otherwise deadlock under Shadow. [default: false]
+  -p, --parallelism <cores>
+          How many parallel threads to use to run the simulation. A value of 0 will allow Shadow to
+          choose the number of threads. [default: 0]
+      --progress <bool>
+          Show the simulation progress on stderr [default: false]
+      --seed <N>
+          Initialize randomness using seed N [default: 1]
+      --stop-time <seconds>
+          The simulated time at which simulated processes are sent a SIGKILL signal
+
+Network (Override network options):
+      --use-shortest-path <bool>  When routing packets, follow the shortest path rather than
+                                  following a direct edge between nodes. If false, the network graph
+                                  is required to be complete. [default: true]
+
+Host Defaults (Default options for hosts):
+      --host-log-level <level>     Log level at which to print node messages [default: null]
+      --pcap-capture-size <bytes>  How much data to capture per packet (header and payload) if pcap
+                                   logging is enabled [default: "65535 B"]
+      --pcap-enabled <bool>        Should shadow generate pcap files? [default: false]
+
+If units are not specified, all values are assumed to be given in their base unit (seconds, bytes,
+bits, etc). Units can optionally be specified (for example: '1024 B', '1024 bytes', '1 KiB', '1
+kibibyte', etc) and are case-sensitive.


### PR DESCRIPTION
Clap often changes the formatting of the help text. This adds a test that compares the help output to a golden output. If we update our config options or upgrade clap, we will need to regenerate the golden output. This should hopefully help prevent unexpected changes in the help text when we upgrade clap.