### PR TITLE
Add the `LegacyTcp` wrapper to the interface qdisc 

### DIFF
--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -16,7 +16,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
             "NetworkInterface".into(),
             "Tsc".into(),
         ]);
-        c.add_opaque_types(&["RootedRefCell_StateEventSource"]);
+        c.add_opaque_types(&["RootedRefCell_StateEventSource", "InetSocketWeak"]);
         c
     };
 
@@ -278,7 +278,7 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .raw_line("use crate::core::support::configuration::QDiscMode;")
         .raw_line("use crate::host::descriptor::File;")
         .raw_line("use crate::host::descriptor::OpenFile;")
-        .raw_line("use crate::host::descriptor::socket::inet::InetSocket;")
+        .raw_line("use crate::host::descriptor::socket::inet::{InetSocket, InetSocketWeak};")
         .raw_line("use crate::host::host::Host;")
         .raw_line("use crate::host::memory_manager::MemoryManager;")
         .raw_line("use crate::host::process::Process;")

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -64,7 +64,13 @@ impl LegacyTcpSocket {
             _counter: ObjectCounter::new("LegacyTcpSocket"),
         };
 
-        Arc::new(AtomicRefCell::new(socket))
+        let rv = Arc::new(AtomicRefCell::new(socket));
+
+        let inet_socket = InetSocket::LegacyTcp(rv.clone());
+        let inet_socket = Box::into_raw(Box::new(inet_socket.downgrade()));
+        unsafe { c::tcp_setRustSocket(legacy_tcp, inet_socket) };
+
+        rv
     }
 
     /// Get a canonical handle for this socket. We use the address of the `TCP` object so that the

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -453,7 +453,13 @@ mod export {
     #[no_mangle]
     pub extern "C" fn inetsocket_drop(socket: *const InetSocket) {
         assert!(!socket.is_null());
-        unsafe { Box::from_raw(socket as *mut InetSocket) };
+        unsafe { Box::from_raw(socket.cast_mut()) };
+    }
+
+    /// Helper for GLib functions that take a `TaskObjectFreeFunc`. See [`inetsocket_drop`].
+    #[no_mangle]
+    pub extern "C" fn inetsocket_dropVoid(socket: *mut libc::c_void) {
+        inetsocket_drop(socket.cast_const().cast())
     }
 
     /// Increment the ref count of the `InetSocket` object. The returned pointer will not be the
@@ -528,6 +534,24 @@ mod export {
         let mut packet = PacketRc::from_raw(packet);
         socket.borrow().update_packet_header(&mut packet);
         packet.into_inner();
+    }
+
+    /// Get a legacy C [`TCP`](c::TCP) pointer for the socket. Will panic if `socket` is not a
+    /// legacy TCP socket or if `socket` is already mutably borrowed. Will never return `NULL`.
+    #[no_mangle]
+    pub extern "C" fn inetsocket_asLegacyTcp(socket: *const InetSocket) -> *mut c::TCP {
+        let socket = unsafe { socket.as_ref() }.unwrap();
+
+        #[allow(irrefutable_let_patterns)]
+        let InetSocket::LegacyTcp(socket) = socket else {
+            panic!("Socket was not a legacy TCP socket: {socket:?}");
+        };
+
+        let ptr = socket.borrow().as_legacy_tcp();
+        // this should never be true
+        assert!(!ptr.is_null());
+
+        ptr
     }
 
     /// Decrement the ref count of the `InetSocketWeak` object. The pointer must not be used after

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -118,6 +118,10 @@ static void _tcp_logCongestionInfo(TCP* tcp);
 struct _TCP {
     LegacySocket super;
 
+    // this adds a circular reference between the rust `LegacyTcpSocket` and this `TCP`, but we
+    // can't avoid it because `_flush` calls back into the host
+    InetSocketWeak* rustSocket;
+
     enum TCPState state;
     enum TCPState stateLast;
     enum TCPFlags flags;
@@ -742,9 +746,12 @@ static void _tcp_setState(TCP* tcp, const Host* host, enum TCPState state) {
         }
         case TCPS_TIMEWAIT: {
             /* schedule a close timer self-event to finish out the closing process */
-            legacyfile_ref(tcp);
-            TaskRef* closeTask = taskref_new_bound(
-                host_getID(host), _tcp_runCloseTimerExpiredTask, tcp, NULL, legacyfile_unref, NULL);
+            utility_alwaysAssert(tcp->rustSocket != NULL);
+            const InetSocket* inetSocket = inetsocketweak_upgrade(tcp->rustSocket);
+            utility_alwaysAssert(inetSocket != NULL);
+            TaskRef* closeTask =
+                taskref_new_bound(host_getID(host), _tcp_runCloseTimerExpiredTask,
+                                  (void*)inetSocket, NULL, inetsocket_dropVoid, NULL);
             CSimulationTime delay = CONFIG_TCPCLOSETIMER_DELAY;
 
             /* if a child of a server initiated the close, close more quickly */
@@ -761,9 +768,13 @@ static void _tcp_setState(TCP* tcp, const Host* host, enum TCPState state) {
     }
 }
 
-static void _tcp_runCloseTimerExpiredTask(const Host* host, gpointer voidTcp, gpointer userData) {
-    TCP* tcp = voidTcp;
+static void _tcp_runCloseTimerExpiredTask(const Host* host, gpointer voidInetSocket,
+                                          gpointer userData) {
+    const InetSocket* inetSocket = voidInetSocket;
+    utility_alwaysAssert(inetSocket != NULL);
+    TCP* tcp = inetsocket_asLegacyTcp(inetSocket);
     MAGIC_ASSERT(tcp);
+
     _tcp_setState(tcp, host, TCPS_CLOSED);
 }
 
@@ -1059,10 +1070,12 @@ static void _tcp_scheduleRetransmitTimer(TCP* tcp, const Host* host, CSimulation
     gboolean success = priorityqueue_push(tcp->retransmit.scheduledTimerExpirations, expireTimePtr);
 
     if(success) {
-        legacyfile_ref(tcp);
+        utility_alwaysAssert(tcp->rustSocket != NULL);
+        const InetSocket* inetSocket = inetsocketweak_upgrade(tcp->rustSocket);
+        utility_alwaysAssert(inetSocket != NULL);
         TaskRef* retexpTask =
-            taskref_new_bound(host_getID(host), _tcp_runRetransmitTimerExpiredTask, tcp, NULL,
-                              legacyfile_unref, NULL);
+            taskref_new_bound(host_getID(host), _tcp_runRetransmitTimerExpiredTask,
+                              (void*)inetSocket, NULL, inetsocket_dropVoid, NULL);
         host_scheduleTaskWithDelay(host, retexpTask, delay);
         taskref_drop(retexpTask);
 
@@ -1327,8 +1340,13 @@ static void _tcp_flush(TCP* tcp, const Host* host) {
         /* packet will get stored in retrans queue in tcp_networkInterfaceIsAboutToSendPacket */
 
         /* socket will queue it ASAP */
-        CompatSocket compatSocket = compatsocket_fromLegacySocket(&(tcp->super));
-        compatSocket = compatsocket_refAs(&compatSocket);
+
+        utility_alwaysAssert(tcp->rustSocket != NULL);
+        const InetSocket* inetSocket = inetsocketweak_upgrade(tcp->rustSocket);
+        utility_alwaysAssert(inetSocket != NULL);
+
+        CompatSocket compatSocket = compatsocket_fromInetSocket(inetSocket);
+
         gboolean success =
             legacysocket_addToOutputBuffer(&(tcp->super), compatSocket, host, packet);
 
@@ -1423,9 +1441,11 @@ static void _tcp_flush(TCP* tcp, const Host* host) {
     }
 }
 
-static void _tcp_runRetransmitTimerExpiredTask(const Host* host, gpointer voidTcp,
+static void _tcp_runRetransmitTimerExpiredTask(const Host* host, gpointer voidInetSocket,
                                                gpointer unused) {
-    TCP* tcp = voidTcp;
+    const InetSocket* inetSocket = voidInetSocket;
+    utility_alwaysAssert(inetSocket != NULL);
+    TCP* tcp = inetsocket_asLegacyTcp(inetSocket);
     MAGIC_ASSERT(tcp);
 
     /* a timer expired, update our timer tracking state */
@@ -1965,9 +1985,12 @@ static void _tcp_logCongestionInfo(TCP* tcp) {
           &tcp->super.super);
 }
 
-static void _tcp_sendACKTaskCallback(const Host* host, gpointer voidTcp, gpointer userData) {
-    TCP* tcp = voidTcp;
+static void _tcp_sendACKTaskCallback(const Host* host, gpointer voidInetSocket, gpointer userData) {
+    const InetSocket* inetSocket = voidInetSocket;
+    utility_alwaysAssert(inetSocket != NULL);
+    TCP* tcp = inetsocket_asLegacyTcp(inetSocket);
     MAGIC_ASSERT(tcp);
+
     tcp->send.delayedACKIsScheduled = FALSE;
     if(tcp->send.delayedACKCounter > 0) {
         trace("sending a delayed ACK now");
@@ -2310,10 +2333,12 @@ static void _tcp_processPacket(LegacySocket* socket, const Host* host, Packet* p
             if(tcp->send.delayedACKIsScheduled == FALSE) {
                 /* we need to send an ACK, lets schedule a task so we don't send an ACK
                  * for all packets that are received during this same simtime receiving round. */
-                TaskRef* sendACKTask = taskref_new_bound(
-                    host_getID(host), _tcp_sendACKTaskCallback, tcp, NULL, legacyfile_unref, NULL);
-                /* taks holds a ref to tcp */
-                legacyfile_ref(tcp);
+                utility_alwaysAssert(tcp->rustSocket != NULL);
+                const InetSocket* inetSocket = inetsocketweak_upgrade(tcp->rustSocket);
+                utility_alwaysAssert(inetSocket != NULL);
+                TaskRef* sendACKTask =
+                    taskref_new_bound(host_getID(host), _tcp_sendACKTaskCallback, (void*)inetSocket,
+                                      NULL, inetsocket_dropVoid, NULL);
 
                 /* figure out what we should use as delay */
                 CSimulationTime delay = 0;
@@ -2440,9 +2465,12 @@ gssize tcp_sendUserData(TCP* tcp, const Host* host, UntypedForeignPtr buffer, gs
     return (gssize)(bytesCopied == 0 && nBytes != 0 ? -EWOULDBLOCK : bytesCopied);
 }
 
-static void _tcp_sendWindowUpdate(const Host* host, gpointer voidTcp, gpointer data) {
-    TCP* tcp = voidTcp;
+static void _tcp_sendWindowUpdate(const Host* host, gpointer voidInetSocket, gpointer data) {
+    const InetSocket* inetSocket = voidInetSocket;
+    utility_alwaysAssert(inetSocket != NULL);
+    TCP* tcp = inetsocket_asLegacyTcp(inetSocket);
     MAGIC_ASSERT(tcp);
+
     trace("%s <-> %s: receive window opened, advertising the new "
             "receive window %"G_GUINT32_FORMAT" as an ACK control packet",
             tcp->super.boundString, tcp->super.peerString, tcp->receive.window);
@@ -2604,10 +2632,12 @@ gssize tcp_receiveUserData(TCP* tcp, const Host* host, UntypedForeignPtr buffer,
         /* our receive window just opened, make sure the sender knows it can
          * send more. otherwise we get into a deadlock situation!
          * make sure we don't send multiple events when read is called many times per instant */
-        legacyfile_ref(tcp);
-
-        TaskRef* updateWindowTask = taskref_new_bound(
-            host_getID(host), _tcp_sendWindowUpdate, tcp, NULL, legacyfile_unref, NULL);
+        utility_alwaysAssert(tcp->rustSocket != NULL);
+        const InetSocket* inetSocket = inetsocketweak_upgrade(tcp->rustSocket);
+        utility_alwaysAssert(inetSocket != NULL);
+        TaskRef* updateWindowTask =
+            taskref_new_bound(host_getID(host), _tcp_sendWindowUpdate, (void*)inetSocket, NULL,
+                              inetsocket_dropVoid, NULL);
         host_scheduleTaskWithDelay(host, updateWindowTask, 1);
         taskref_drop(updateWindowTask);
 
@@ -2663,6 +2693,11 @@ static void _tcp_free(LegacyFile* descriptor) {
 
     tcp->cong.hooks->tcp_cong_delete(tcp);
     retransmit_tally_destroy(tcp->retransmit.tally);
+
+    if (tcp->rustSocket != NULL) {
+        inetsocketweak_drop(tcp->rustSocket);
+        tcp->rustSocket = NULL;
+    }
 
     legacyfile_clear((LegacyFile*)tcp);
     MAGIC_CLEAR(tcp);
@@ -2778,6 +2813,12 @@ SocketFunctionTable tcp_functions = {_tcp_close,
                                      _tcp_connectToPeer,
                                      _tcp_dropPacket,
                                      MAGIC_VALUE};
+
+/* takes ownership of the `InetSocketWeak` */
+void tcp_setRustSocket(TCP* tcp, InetSocketWeak* rustSocket) {
+    utility_alwaysAssert(tcp->rustSocket == NULL);
+    tcp->rustSocket = rustSocket;
+}
 
 TCP* tcp_new(const Host* host, guint receiveBufferSize, guint sendBufferSize) {
     TCP* tcp = g_new0(TCP, 1);

--- a/src/main/host/descriptor/tcp.h
+++ b/src/main/host/descriptor/tcp.h
@@ -42,6 +42,8 @@ enum _TCPCongestionType {
 
 TCP* tcp_new(const Host* host, guint receiveBufferSize, guint sendBufferSize);
 
+void tcp_setRustSocket(TCP* tcp, InetSocketWeak* rustSocket);
+
 // clang-format off
 /* Returns a positive number to indicate that we have not yet sent a SYN
  * packet, i.e., connect() has not been called.


### PR DESCRIPTION
Previously the C `TCP` object would be added to the qdisc, but we want the rust `LegacyTcp` wrapper to be added instead. This requires a circular reference between the `TCP` and `LegacyTcp` objects since the `TCP` object adds itself to the qdisc, but the `TCP` object has been made to only hold a weak reference to the `LegacyTcp`.  Some additional changes needed to be made to prevent multiple mutable borrows of the `LegacyTcp`, and to extend the lifetime of the `LegacyTcp`, otherwise upgrading the weak reference won't work.