### PR TITLE
Rename `Packet` to `PacketRc` and other small changes

### DIFF
--- a/src/main/core/work/event.rs
+++ b/src/main/core/work/event.rs
@@ -3,7 +3,7 @@ use shadow_shim_helper_rs::HostId;
 
 use super::task::TaskRef;
 use crate::host::host::Host;
-use crate::network::packet::Packet;
+use crate::network::packet::PacketRc;
 use crate::utility::{Magic, ObjectCounter};
 
 #[derive(Debug)]
@@ -17,7 +17,7 @@ pub struct Event {
 impl Event {
     /// A new packet event, which is an event for packets arriving from the Internet. Packet events
     /// do not include packets on localhost.
-    pub fn new_packet(packet: Packet, time: EmulatedTime, src_host: &Host) -> Self {
+    pub fn new_packet(packet: PacketRc, time: EmulatedTime, src_host: &Host) -> Self {
         Self {
             magic: Magic::new(),
             time,
@@ -111,7 +111,7 @@ pub enum EventData {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PacketEventData {
-    packet: Packet,
+    packet: PacketRc,
     src_host_id: HostId,
     src_host_event_id: u64,
 }
@@ -122,7 +122,7 @@ pub struct LocalEventData {
     event_id: u64,
 }
 
-impl From<PacketEventData> for Packet {
+impl From<PacketEventData> for PacketRc {
     fn from(data: PacketEventData) -> Self {
         data.packet
     }

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -24,7 +24,7 @@ use crate::host::host::Host;
 use crate::host::process::{Process, ProcessId};
 use crate::host::thread::{Thread, ThreadId};
 use crate::network::graph::{IpAssignment, RoutingInfo};
-use crate::network::packet::Packet;
+use crate::network::packet::PacketRc;
 use crate::utility::childpid_watcher::ChildPidWatcher;
 use crate::utility::counter::Counter;
 use crate::utility::status_bar;
@@ -393,7 +393,7 @@ impl Worker {
         };
 
         // copy the packet
-        let packet = Packet::from_raw(unsafe { cshadow::packet_copy(packet) });
+        let packet = PacketRc::from_raw(unsafe { cshadow::packet_copy(packet) });
 
         // delay the packet until the next round
         let mut deliver_time = current_time + delay;
@@ -618,7 +618,7 @@ impl WorkerShared {
     /// (is outside of the current scheduling round, etc).
     pub fn push_packet_to_host(
         &self,
-        packet: Packet,
+        packet: PacketRc,
         dst_host_id: HostId,
         time: EmulatedTime,
         src_host: &Host,

--- a/src/main/host/network_interface.rs
+++ b/src/main/host/network_interface.rs
@@ -7,7 +7,7 @@ use shadow_shim_helper_rs::HostId;
 
 use crate::core::support::configuration::QDiscMode;
 use crate::cshadow as c;
-use crate::network::packet::Packet;
+use crate::network::packet::PacketRc;
 use crate::network::PacketDevice;
 use crate::utility::{self, HostTreePointer};
 
@@ -143,15 +143,15 @@ impl PacketDevice for NetworkInterface {
         self.addr
     }
 
-    fn pop(&self) -> Option<Packet> {
+    fn pop(&self) -> Option<PacketRc> {
         let packet_ptr = unsafe { c::networkinterface_pop(self.c_ptr.ptr()) };
         match packet_ptr.is_null() {
             true => None,
-            false => Some(Packet::from_raw(packet_ptr)),
+            false => Some(PacketRc::from_raw(packet_ptr)),
         }
     }
 
-    fn push(&self, packet: Packet) {
+    fn push(&self, packet: PacketRc) {
         let packet_ptr = packet.into_inner();
         unsafe { c::networkinterface_push(self.c_ptr.ptr(), packet_ptr) };
         unsafe { c::packet_unref(packet_ptr) };

--- a/src/main/network/mod.rs
+++ b/src/main/network/mod.rs
@@ -1,6 +1,6 @@
 use std::net::Ipv4Addr;
 
-use crate::network::packet::Packet;
+use crate::network::packet::PacketRc;
 
 pub mod graph;
 pub mod net_namespace;
@@ -10,8 +10,8 @@ pub mod router;
 
 pub trait PacketDevice {
     fn get_address(&self) -> Ipv4Addr;
-    fn pop(&self) -> Option<Packet>;
-    fn push(&self, packet: Packet);
+    fn pop(&self) -> Option<PacketRc>;
+    fn push(&self, packet: PacketRc);
 }
 
 #[cfg(test)]

--- a/src/main/network/packet.rs
+++ b/src/main/network/packet.rs
@@ -32,31 +32,31 @@ pub enum PacketStatus {
     RelayForwarded = c::_PacketDeliveryStatusFlags_PDS_RELAY_FORWARDED,
 }
 
-pub struct Packet {
+pub struct PacketRc {
     c_ptr: SyncSendPointer<c::Packet>,
 }
 
-impl std::fmt::Debug for Packet {
+impl std::fmt::Debug for PacketRc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Packet").finish_non_exhaustive()
     }
 }
 
-impl PartialEq for Packet {
+impl PartialEq for PacketRc {
     fn eq(&self, other: &Self) -> bool {
         self.c_ptr.ptr() == other.c_ptr.ptr()
     }
 }
 
-impl Eq for Packet {}
+impl Eq for PacketRc {}
 
-impl Packet {
+impl PacketRc {
     #[cfg(test)]
     /// Creates an empty packet for unit tests.
-    pub fn mock_new() -> Packet {
+    pub fn mock_new() -> PacketRc {
         let c_ptr = unsafe { c::packet_new_inner(1, 1) };
         unsafe { c::packet_setMock(c_ptr) };
-        Packet::from_raw(c_ptr)
+        PacketRc::from_raw(c_ptr)
     }
 
     pub fn total_size(&self) -> usize {
@@ -124,7 +124,7 @@ impl Packet {
     }
 }
 
-impl Drop for Packet {
+impl Drop for PacketRc {
     fn drop(&mut self) {
         if !self.c_ptr.ptr().is_null() {
             // If the rust packet is dropped before into_inner() is called,
@@ -134,7 +134,7 @@ impl Drop for Packet {
     }
 }
 
-impl PacketDisplay for Packet {
+impl PacketDisplay for PacketRc {
     fn display_bytes(&self, writer: impl Write) -> std::io::Result<()> {
         self.borrow_inner().cast_const().display_bytes(writer)
     }

--- a/src/main/network/relay/mod.rs
+++ b/src/main/network/relay/mod.rs
@@ -11,40 +11,40 @@ use crate::cshadow as c;
 use crate::host::host::Host;
 use crate::network::packet::PacketStatus;
 use crate::network::relay::token_bucket::TokenBucket;
-use crate::network::Packet;
+use crate::network::PacketRc;
 use crate::utility::ObjectCounter;
 
 mod token_bucket;
 
-/// A `Relay` forwards `Packet`s between `PacketDevice`s, optionally enforcing a
-/// bandwidth limit on the rate at which we forward `Packet`s between devices.
-/// The `Relay` is considered the "active" part of the `Packet` forwarding
-/// process: it initiates `Packet` forwarding and internally schedules tasks to
-/// ensure that `Packet`s are continually forwarded over time without exceeding
+/// A `Relay` forwards `PacketRc`s between `PacketDevice`s, optionally enforcing a
+/// bandwidth limit on the rate at which we forward `PacketRc`s between devices.
+/// The `Relay` is considered the "active" part of the `PacketRc` forwarding
+/// process: it initiates `PacketRc` forwarding and internally schedules tasks to
+/// ensure that `PacketRc`s are continually forwarded over time without exceeding
 /// the configured `RateLimit`.
 ///
 /// An `Ipv4Addr` associated with a source `PacketDevice` object is supplied
 /// when creating a `Relay`. This `Ipv4Addr` is only meaningful to the extent
 /// that the `Host` understands how to map this `Ipv4Addr` to the intended
 /// `PacketDevice` when `Host::get_packet_device(Ipv4Addr)` is called. This
-/// source `PacketDevice` supplies the `Relay` with a stream of `Packet`s
+/// source `PacketDevice` supplies the `Relay` with a stream of `PacketRc`s
 /// (through its implementation of `PacketDevice::pop()`) that the `Relay` will
 /// forward to a destination.
 ///
 /// `Relay::notify()` must be called whenever the source `PacketDevice` changes
 /// state from empty to non-empty, to trigger an idle `Relay` to start
-/// forwarding `Packet`s again.
+/// forwarding `PacketRc`s again.
 ///
-/// For each `Packet` that needs to be forwarded, the `Relay` uses the
-/// `Packet`'s destination `Ipv4Addr` to obtain the destination `PacketDevice`
+/// For each `PacketRc` that needs to be forwarded, the `Relay` uses the
+/// `PacketRc`'s destination `Ipv4Addr` to obtain the destination `PacketDevice`
 /// from the `Host` by calling its `Host::get_packet_device(Ipv4Addr)` function.
-/// The `Packet` is forwarded to the destination through the destination
+/// The `PacketRc` is forwarded to the destination through the destination
 /// `PacketDevice`'s implementation of `PacketDevice::push()`.
 ///
 /// This design allows the `Host` to use `Host::get_packet_device` to define its
 /// own routing table.
 ///
-/// Note that `Packet`s forwarded between identical source and destination
+/// Note that `PacketRc`s forwarded between identical source and destination
 /// `PacketDevices` are considered "local" to that device and exempt from any
 /// configured `RateLimit`.
 pub struct Relay {
@@ -58,7 +58,7 @@ struct RelayInternal {
     rate_limiter: Option<TokenBucket>,
     src_dev_address: Ipv4Addr,
     state: RelayState,
-    next_packet: Option<Packet>,
+    next_packet: Option<PacketRc>,
 }
 
 /// Track's the `Relay`s state, which typically moves from Idle to Pending to
@@ -82,7 +82,7 @@ pub enum RateLimit {
 }
 
 impl Relay {
-    /// Creates a new `Relay` that will forward `Packet`s following the given
+    /// Creates a new `Relay` that will forward `PacketRc`s following the given
     /// `RateLimit` from the `PacketDevice` returned by the `Host` when passing
     /// the given `src_dev_address` to `Host::get_packet_device()`. The `Relay`
     /// internally schedules tasks as needed to ensure packets continue to be

--- a/src/main/network/router/codel_queue.rs
+++ b/src/main/network/router/codel_queue.rs
@@ -206,10 +206,10 @@ impl CoDelQueue {
         match self.elements.pop_front() {
             Some(element) => {
                 // Found a packet.
-                debug_assert!(element.packet.size() <= self.total_bytes_stored);
+                debug_assert!(element.packet.total_size() <= self.total_bytes_stored);
                 self.total_bytes_stored = self
                     .total_bytes_stored
-                    .saturating_sub(element.packet.size());
+                    .saturating_sub(element.packet.total_size());
 
                 debug_assert!(now >= &element.enqueue_ts);
                 let standing_delay = now.saturating_duration_since(&element.enqueue_ts);
@@ -305,7 +305,7 @@ impl CoDelQueue {
     pub fn push(&mut self, mut packet: Packet, now: EmulatedTime) {
         if self.elements.len() < LIMIT {
             packet.add_status(PacketStatus::RouterEnqueued);
-            self.total_bytes_stored += packet.size();
+            self.total_bytes_stored += packet.total_size();
             self.elements.push_back(CoDelElement {
                 packet,
                 enqueue_ts: now,


### PR DESCRIPTION
The rust packet is a wrapper around a reference-counted `c::Packet`, so I think `PacketRc` better describes what the rust wrapper is.