### PR TITLE
Add more uses of the global callback queue

### DIFF
--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -572,7 +572,9 @@ impl OpenFileInner {
 impl std::ops::Drop for OpenFileInner {
     fn drop(&mut self) {
         // ignore any return value
-        let _ = CallbackQueue::queue_and_run(|cb_queue| self.close_helper(cb_queue));
+        let _ = crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
+            CallbackQueue::queue_and_run(|cb_queue| self.close_helper(cb_queue))
+        });
     }
 }
 

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1194,10 +1194,12 @@ impl Process {
             let mut descriptor_table = runnable.desc_table.borrow_mut();
             descriptor_table.shutdown_helper();
             let descriptors = descriptor_table.remove_all();
-            CallbackQueue::queue_and_run(|cb_queue| {
-                for desc in descriptors {
-                    desc.close(host, cb_queue);
-                }
+            crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
+                CallbackQueue::queue_and_run(|cb_queue| {
+                    for desc in descriptors {
+                        desc.close(host, cb_queue);
+                    }
+                })
             });
         }
 


### PR DESCRIPTION
This is split out of #2959. I thought this might change the network results since it may delay notifying some event listeners, but a benchmark shows no change.

![transfer_time_5242880 exit](https://github.com/shadow/shadow/assets/3708797/f87e4bd7-28a6-4508-b3cc-5f521ffb19a7)

![run_time](https://github.com/shadow/shadow/assets/3708797/983e0f47-969f-4777-82f5-28a225c797e7)