### PR TITLE
Delay "socket wants to send" notification

### DIFF
--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -418,7 +418,8 @@ gsize _legacysocket_getOutputBufferSpaceIncludingTCP(LegacySocket* socket) {
     return space;
 }
 
-gboolean legacysocket_addToOutputBuffer(LegacySocket* socket, const Host* host, Packet* packet) {
+gboolean legacysocket_addToOutputBuffer(LegacySocket* socket, CompatSocket compatSocket,
+                                        const Host* host, Packet* packet) {
     MAGIC_ASSERT(socket);
 
     /* check if the packet fits */
@@ -453,8 +454,7 @@ gboolean legacysocket_addToOutputBuffer(LegacySocket* socket, const Host* host, 
 
     /* tell the interface to include us when sending out to the network */
     in_addr_t ip = packet_getSourceIP(packet);
-    CompatSocket compat_socket = compatsocket_fromLegacySocket(socket);
-    host_socketWantsToSend(host, &compat_socket, ip);
+    socket_wants_to_send_with_global_cb_queue(host, compatSocket, ip);
 
     return TRUE;
 }

--- a/src/main/host/descriptor/socket.h
+++ b/src/main/host/descriptor/socket.h
@@ -114,7 +114,8 @@ gsize legacysocket_getOutputBufferSize(LegacySocket* socket);
 void legacysocket_setOutputBufferSize(LegacySocket* socket, gsize newSize);
 gsize legacysocket_getOutputBufferLength(LegacySocket* socket);
 gsize legacysocket_getOutputBufferSpace(LegacySocket* socket);
-gboolean legacysocket_addToOutputBuffer(LegacySocket* socket, const Host* host, Packet* packet);
+gboolean legacysocket_addToOutputBuffer(LegacySocket* socket, CompatSocket compatSocket,
+                                        const Host* host, Packet* packet);
 Packet* legacysocket_removeFromOutputBuffer(LegacySocket* socket, const Host* host);
 
 gboolean legacysocket_isBound(LegacySocket* socket);

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -1327,7 +1327,11 @@ static void _tcp_flush(TCP* tcp, const Host* host) {
         /* packet will get stored in retrans queue in tcp_networkInterfaceIsAboutToSendPacket */
 
         /* socket will queue it ASAP */
-        gboolean success = legacysocket_addToOutputBuffer(&(tcp->super), host, packet);
+        CompatSocket compatSocket = compatsocket_fromLegacySocket(&(tcp->super));
+        compatSocket = compatsocket_refAs(&compatSocket);
+        gboolean success =
+            legacysocket_addToOutputBuffer(&(tcp->super), compatSocket, host, packet);
+
         tcp->send.packetsSent++;
         tcp->send.highestSequence = (guint32)MAX(tcp->send.highestSequence, (guint)header->sequence);
 

--- a/src/main/utility/legacy_callback_queue.rs
+++ b/src/main/utility/legacy_callback_queue.rs
@@ -59,7 +59,11 @@ pub fn with_global_cb_queue<T>(f: impl FnOnce() -> T) -> T {
 }
 mod export {
     use super::*;
+
+    use std::net::Ipv4Addr;
+
     use crate::core::worker;
+    use crate::host::host::Host;
 
     /// Notify listeners using the global callback queue. If the queue hasn't been set using
     /// [`with_global_cb_queue`], the listeners will be notified here before returning.
@@ -82,6 +86,38 @@ mod export {
                     event_source.notify_listeners(status.into(), changed.into(), cb_queue)
                 })
                 .unwrap();
+            });
+        });
+    }
+
+    /// Tell the host that the socket wants to send packets using the global callback queue. If the
+    /// queue hasn't been set using [`with_global_cb_queue`], the host will be notified here before
+    /// returning.
+    #[no_mangle]
+    pub unsafe extern "C" fn socket_wants_to_send_with_global_cb_queue(
+        host: *const Host,
+        socket: c::CompatSocket,
+        ip: libc::in_addr_t,
+    ) {
+        let host = unsafe { host.as_ref() }.unwrap();
+        let ip = Ipv4Addr::from(u32::from_be(ip));
+
+        let host_id = host.id();
+
+        with_global_cb_queue(|| {
+            C_CALLBACK_QUEUE.with(|cb_queue| {
+                let mut cb_queue = cb_queue.borrow_mut();
+                // must not be `None` since it will be set to `Some` by `with_global_cb_queue`
+                let cb_queue = cb_queue.deref_mut().as_mut().unwrap();
+
+                cb_queue.add(move |_cb_queue| {
+                    worker::Worker::with_active_host(|host| {
+                        assert_eq!(host.id(), host_id);
+                        host.notify_socket_has_packets(ip, &socket);
+                        unsafe { c::compatsocket_unref(&socket) };
+                    })
+                    .unwrap();
+                });
             });
         });
     }


### PR DESCRIPTION
This is split out of #2959. This PR changes the sockets to use the global `C_CALLBACK_QUEUE` to notify the host that the socket wants to send packets. This is similar to how we delay status change events (ex: readable/writable/closed/etc) to prevent "multiple mutable borrow errors" due to circular references.

We'll need this in the future when we want TCP sockets to add their rust wrappers to the network interface rather than its C objects.

The network results change, but not significantly (it's similar to changes we'd expect if we simply changed the simulation seed).

![run_time](https://github.com/shadow/shadow/assets/3708797/6715e569-788e-4d50-a0fe-c83e958549b7)
![transfer_time_5242880 exit](https://github.com/shadow/shadow/assets/3708797/154db092-e001-4eb0-9a81-b1e8e3f43a3f)

https://github.com/shadow/benchmark-results/tree/master/tor/2023-05-24-T15-05-14