### PR TITLE
Make DescriptorTable clonable

### DIFF
--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -8,6 +8,7 @@ use crate::host::descriptor::Descriptor;
 pub const FD_MAX: u32 = i32::MAX as u32;
 
 /// Map of file handles to file descriptors. Typically owned by a Process.
+#[derive(Clone)]
 pub struct DescriptorTable {
     descriptors: HashMap<DescriptorHandle, Descriptor>,
 

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -587,7 +587,7 @@ impl std::ops::Drop for OpenFileInner {
 
 /// A file descriptor that reference an open file. Also contains flags that change the behaviour of
 /// this file descriptor.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Descriptor {
     /// The file that this descriptor points to.
     file: CompatFile,


### PR DESCRIPTION
When a Process is forked (without CLONE_FILES), the child gets a copy of the descriptor table. IIUC simply cloning the table should give us the right behavior - the child will gets its own table, with cloned references to the same descriptors.

Progress on https://github.com/shadow/shadow/issues/1987