### PR TITLE
Make Process's strace file shareable across Processes

### DIFF
--- a/src/lib/syscall-logger/src/lib.rs
+++ b/src/lib/syscall-logger/src/lib.rs
@@ -145,7 +145,7 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
         pub fn #syscall_name(
             #syscall_args_and_types
         ) #syscall_ret_type {
-            let Some(strace_fmt_options) = #context_arg_name.objs.process.strace_logging_options() else {
+            let Some(strace_fmt_options) = #context_arg_name.objs.process.strace_logging_options(#context_arg_name.objs.host.root()) else {
                 // exit early if strace logging is not enabled
                 return Self::#syscall_name_original(#(#syscall_args),*);
             };
@@ -186,7 +186,7 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
             let syscall_rv = SyscallResultFmt::<#(#rv_type)*>::new(&rv, #context_arg_name.args.args, strace_fmt_options, &*memory);
 
             if let Some(ref syscall_rv) = syscall_rv {
-                #context_arg_name.objs.process.with_strace_file(|file| {
+                #context_arg_name.objs.process.with_strace_file(#context_arg_name.objs.host.root(), |file| {
                     write_syscall(
                         file,
                         &Worker::current_time().unwrap(),

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1195,10 +1195,9 @@ impl Process {
             unreachable!("Tried to handle process exit of non-running process");
         };
 
-        runnable
-            .strace_logging
-            .take()
-            .map(|s| RootedRc::safely_drop(s, host.root()));
+        if let Some(s) = runnable.strace_logging.take() {
+            RootedRc::safely_drop(s, host.root())
+        }
 
         #[cfg(feature = "perf_timers")]
         debug!(

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -239,7 +239,7 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number, const
         _syscallhandler_post_syscall(sys, args->number, #s, &scr);                                 \
         if (straceLoggingMode != STRACE_FMT_MODE_OFF) {                                            \
             scr = log_syscall(                                                                     \
-                process, straceLoggingMode, sys->threadId, #s, "...", &args->args, scr);           \
+                host, process, straceLoggingMode, sys->threadId, #s, "...", &args->args, scr);     \
         }                                                                                          \
         break
 #define NATIVE(s)                                                                                  \
@@ -248,7 +248,7 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number, const
         scr = syscallreturn_makeNative();                                                          \
         if (straceLoggingMode != STRACE_FMT_MODE_OFF) {                                            \
             scr = log_syscall(                                                                     \
-                process, straceLoggingMode, sys->threadId, #s, "...", &args->args, scr);           \
+                host, process, straceLoggingMode, sys->threadId, #s, "...", &args->args, scr);     \
         }                                                                                          \
         break
 #define UNSUPPORTED(s)                                                                             \
@@ -258,7 +258,7 @@ static void _syscallhandler_post_syscall(SysCallHandler* sys, long number, const
         scr = syscallreturn_makeDoneErrno(ENOSYS);                                                 \
         if (straceLoggingMode != STRACE_FMT_MODE_OFF) {                                            \
             scr = log_syscall(                                                                     \
-                process, straceLoggingMode, sys->threadId, #s, "...", &args->args, scr);           \
+                host, process, straceLoggingMode, sys->threadId, #s, "...", &args->args, scr);     \
         }                                                                                          \
         break
 #define HANDLE_RUST(s)                                                                             \
@@ -567,8 +567,8 @@ SyscallReturn syscallhandler_make_syscall(SysCallHandler* sys, const SysCallArgs
                 if (straceLoggingMode != STRACE_FMT_MODE_OFF) {
                     char arg_str[20] = {0};
                     snprintf(arg_str, sizeof(arg_str), "%ld, ...", args->number);
-                    scr = log_syscall(process, straceLoggingMode, sys->threadId, "syscall", arg_str,
-                                      &args->args, scr);
+                    scr = log_syscall(host, process, straceLoggingMode, sys->threadId, "syscall",
+                                      arg_str, &args->args, scr);
                 }
 
                 break;


### PR DESCRIPTION
When we fork a Process, the child will use the same strace file (if any). This is analogous to `strace -f`.

Progress on https://github.com/shadow/shadow/issues/1987.