### PR TITLE
Remove some header dependencies

### DIFF
--- a/src/lib/logger/logger.c
+++ b/src/lib/logger/logger.c
@@ -12,6 +12,8 @@
 
 #define USEC_PER_SEC 1000000ULL
 
+_Noreturn void logger_abort() { abort(); }
+
 // Process start time, initialized explicitly or on first use.
 static pthread_once_t _start_time_once = PTHREAD_ONCE_INIT;
 static bool _start_time_initd = false;

--- a/src/lib/logger/logger.h
+++ b/src/lib/logger/logger.h
@@ -14,14 +14,13 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdlib.h>
 
 #include "lib/logger/log_level.h"
 
 /* convenience macros for logging messages at various levels */
 // clang-format off
 
-#define panic(...)    { logger_log(logger_getDefault(), LOGLEVEL_ERROR, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__); abort(); }
+#define panic(...)    { logger_log(logger_getDefault(), LOGLEVEL_ERROR, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__); logger_abort();}
 #define error(...)      logger_log(logger_getDefault(), LOGLEVEL_ERROR, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 #define warning(...)    logger_log(logger_getDefault(), LOGLEVEL_WARNING, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 #define info(...)       logger_log(logger_getDefault(), LOGLEVEL_INFO, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
@@ -48,6 +47,11 @@ struct _Logger {
     void (*setLevel)(Logger* logger, LogLevel level);
     bool (*isEnabled)(Logger* logger, LogLevel level);
 };
+
+// For internal  use by panic macro.
+// This lets us avoid include <stdlib.h> here in the header, where it can
+// cause conflicts with kernel headers.
+_Noreturn void logger_abort();
 
 // Not thread safe. The previously set logger, if any, will be destroyed.
 // `logger` may be NULL, which will effectively disable logging.

--- a/src/lib/shim/patch_vdso.c
+++ b/src/lib/shim/patch_vdso.c
@@ -2,6 +2,7 @@
 #include <elf.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>

--- a/src/main/host/descriptor/descriptor_types.h
+++ b/src/main/host/descriptor/descriptor_types.h
@@ -6,8 +6,6 @@
 #ifndef SRC_MAIN_HOST_DESCRIPTOR_DESCRIPTOR_TYPES_H_
 #define SRC_MAIN_HOST_DESCRIPTOR_DESCRIPTOR_TYPES_H_
 
-#include <glib.h>
-
 #include "main/bindings/c/bindings-opaque.h"
 
 typedef enum _LegacyFileType LegacyFileType;
@@ -49,9 +47,9 @@ struct _LegacyFile {
     LegacyFileType type;
     Status status;
     RootedRefCell_StateEventSource* event_source;
-    gint refCountStrong;
-    gint refCountWeak;
-    gint flags;
+    int refCountStrong;
+    int refCountWeak;
+    int flags;
     // Since this structure is shared with Rust, we should always include the magic struct
     // member so that the struct is always the same size regardless of compile-time options.
     MAGIC_DECLARE_ALWAYS;

--- a/src/main/host/syscall/mman.c
+++ b/src/main/host/syscall/mman.c
@@ -6,6 +6,7 @@
 #include "main/host/syscall/mman.h"
 
 #include <errno.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -6,13 +6,14 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <glib.h>
+#include <inttypes.h>
+#include <stdio.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
-#include <inttypes.h>
 
 #include "lib/logger/logger.h"
 #include "lib/shadow-shim-helper-rs/shim_helper.h"

--- a/src/main/utility/utility.c
+++ b/src/main/utility/utility.c
@@ -18,7 +18,7 @@
 #include "main/bindings/c/bindings.h"
 #include "main/utility/utility.h"
 
-void utility_handleError(const gchar* file, gint line, const gchar* function, const gchar* message,
+void utility_handleError(const char* file, int line, const char* function, const char* message,
                          ...) {
     va_list vargs;
     va_start(vargs, message);
@@ -26,7 +26,7 @@ void utility_handleError(const gchar* file, gint line, const gchar* function, co
     va_end(vargs);
 }
 
-gboolean utility_isRandomPath(const gchar* path) {
+bool utility_isRandomPath(const char* path) {
     if(path) {
         return !g_ascii_strcasecmp(path, "/dev/random") ||
            !g_ascii_strcasecmp(path, "/dev/urandom") ||
@@ -36,11 +36,11 @@ gboolean utility_isRandomPath(const gchar* path) {
     }
 }
 
-gchar* utility_strvToNewStr(gchar** strv) {
+char* utility_strvToNewStr(char** strv) {
     GString* strBuffer = g_string_new(NULL);
 
     if(strv) {
-        for(gint i = 0; strv[i] != NULL; i++) {
+        for (int i = 0; strv[i] != NULL; i++) {
             if(strv[i+1] == NULL) {
                 g_string_append_printf(strBuffer, "%s", strv[i]);
             } else {

--- a/src/main/utility/utility.h
+++ b/src/main/utility/utility.h
@@ -7,19 +7,17 @@
 #ifndef SHD_UTILITY_H_
 #define SHD_UTILITY_H_
 
-#include <glib.h>
-#include <stdio.h>
-#include <netinet/in.h>
+#include <stdint.h>
 
 #include "lib/shadow-shim-helper-rs/shim_helper.h"
 #include "main/core/support/definitions.h"
 
 #define utility_alwaysAssert(expr)                                                                 \
     do {                                                                                           \
-        if G_LIKELY (expr) {                                                                       \
+        if (expr) {                                                                                \
             ;                                                                                      \
         } else {                                                                                   \
-            utility_handleError(__FILE__, __LINE__, G_STRFUNC, "Assertion failed: %s", #expr);     \
+            utility_handleError(__FILE__, __LINE__, __FUNCTION__, "Assertion failed: %s", #expr);  \
         }                                                                                          \
     } while (0)
 
@@ -29,7 +27,7 @@
 #define utility_debugAssert(expr)
 #endif
 
-#define utility_panic(...) utility_handleError(__FILE__, __LINE__, G_STRFUNC, __VA_ARGS__);
+#define utility_panic(...) utility_handleError(__FILE__, __LINE__, __FUNCTION__, __VA_ARGS__);
 
 #ifdef DEBUG
 /**
@@ -54,8 +52,8 @@
  * the struct needs to have the same size in both debug and release mode, it
  * can use MAGIC_DECLARE_ALWAYS.
  */
-#define MAGIC_DECLARE        guint magic
-#define MAGIC_DECLARE_ALWAYS guint magic
+#define MAGIC_DECLARE uint32_t magic
+#define MAGIC_DECLARE_ALWAYS uint32_t magic
 
 /**
  * Initialize a value declared with MAGIC_DECLARE to MAGIC_VALUE. This is useful
@@ -82,19 +80,18 @@
 #else
 #define MAGIC_VALUE
 #define MAGIC_DECLARE
-#define MAGIC_DECLARE_ALWAYS guint magic
+#define MAGIC_DECLARE_ALWAYS uint32_t magic
 #define MAGIC_INITIALIZER
 #define MAGIC_INIT(object)
 #define MAGIC_ASSERT(object)
 #define MAGIC_CLEAR(object)
 #endif
 
-gboolean utility_isRandomPath(const gchar* path);
+bool utility_isRandomPath(const char* path);
 
-gchar* utility_strvToNewStr(gchar** strv);
+char* utility_strvToNewStr(char** strv);
 
-__attribute__((__format__(__printf__, 4, 5)))
-_Noreturn void utility_handleError(const gchar* file, gint line, const gchar* funtcion,
-                                   const gchar* message, ...);
+__attribute__((__format__(__printf__, 4, 5))) _Noreturn void
+utility_handleError(const char* file, int line, const char* funtcion, const char* message, ...);
 
 #endif /* SHD_UTILITY_H_ */


### PR DESCRIPTION
This is part of a larger attempt to switch the C code over to using Linux kernel headers where appropriate. I think switching everything over is going to be more than we want to bite off right now, but this PR removes some of the conflicts with `glib.h` and `stdlib.h`.

Related to #2919 