### PR TITLE
Add a rust UDP implementation

### DIFF
--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -312,6 +312,8 @@ impl LegacyTcpSocket {
         socket: &Arc<AtomicRefCell<Self>>,
         args: SendmsgArgs,
         mem: &mut MemoryManager,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
         _cb_queue: &mut CallbackQueue,
     ) -> Result<libc::ssize_t, SyscallError> {
         let socket_ref = socket.borrow_mut();

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -1034,7 +1034,7 @@ impl LegacyTcpSocket {
     }
 
     pub fn setsockopt(
-        &self,
+        &mut self,
         level: libc::c_int,
         optname: libc::c_int,
         optval_ptr: ForeignPtr<()>,

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -200,12 +200,6 @@ impl InetSocketRef<'_> {
                           optlen: libc::socklen_t, memory_manager: &mut MemoryManager)
         -> Result<libc::socklen_t, SyscallError>
     );
-
-    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp;
-        pub fn setsockopt(&self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
-                          optlen: libc::socklen_t, memory_manager: &MemoryManager)
-        -> Result<(), SyscallError>
-    );
 }
 
 // inet socket-specific functions
@@ -288,7 +282,7 @@ impl InetSocketRefMut<'_> {
     );
 
     enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp;
-        pub fn setsockopt(&self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
+        pub fn setsockopt(&mut self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
                           optlen: libc::socklen_t, memory_manager: &MemoryManager)
         -> Result<(), SyscallError>
     );

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -2,7 +2,6 @@ use std::net::SocketAddrV4;
 use std::sync::{Arc, Weak};
 
 use atomic_refcell::AtomicRefCell;
-use legacy_tcp::LegacyTcpSocket;
 use nix::errno::Errno;
 use nix::sys::socket::Shutdown;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
@@ -19,41 +18,51 @@ use crate::utility::callback_queue::CallbackQueue;
 use crate::utility::sockaddr::SockaddrStorage;
 use crate::utility::HostTreePointer;
 
+use self::legacy_tcp::LegacyTcpSocket;
+use self::udp::UdpSocket;
+
 pub mod legacy_tcp;
+pub mod udp;
 
 #[derive(Clone)]
 pub enum InetSocket {
     LegacyTcp(Arc<AtomicRefCell<LegacyTcpSocket>>),
+    Udp(Arc<AtomicRefCell<UdpSocket>>),
 }
 
 impl InetSocket {
     pub fn borrow(&self) -> InetSocketRef {
         match self {
             Self::LegacyTcp(ref f) => InetSocketRef::LegacyTcp(f.borrow()),
+            Self::Udp(ref f) => InetSocketRef::Udp(f.borrow()),
         }
     }
 
     pub fn try_borrow(&self) -> Result<InetSocketRef, atomic_refcell::BorrowError> {
         Ok(match self {
             Self::LegacyTcp(ref f) => InetSocketRef::LegacyTcp(f.try_borrow()?),
+            Self::Udp(ref f) => InetSocketRef::Udp(f.try_borrow()?),
         })
     }
 
     pub fn borrow_mut(&self) -> InetSocketRefMut {
         match self {
             Self::LegacyTcp(ref f) => InetSocketRefMut::LegacyTcp(f.borrow_mut()),
+            Self::Udp(ref f) => InetSocketRefMut::Udp(f.borrow_mut()),
         }
     }
 
     pub fn try_borrow_mut(&self) -> Result<InetSocketRefMut, atomic_refcell::BorrowMutError> {
         Ok(match self {
             Self::LegacyTcp(ref f) => InetSocketRefMut::LegacyTcp(f.try_borrow_mut()?),
+            Self::Udp(ref f) => InetSocketRefMut::Udp(f.try_borrow_mut()?),
         })
     }
 
     pub fn downgrade(&self) -> InetSocketWeak {
         match self {
             Self::LegacyTcp(x) => InetSocketWeak::LegacyTcp(Arc::downgrade(x)),
+            Self::Udp(x) => InetSocketWeak::Udp(Arc::downgrade(x)),
         }
     }
 
@@ -62,6 +71,7 @@ impl InetSocket {
             // usually we'd use `Arc::as_ptr()`, but we want to use the handle for the C `TCP`
             // object for consistency with the handle for the `LegacySocket`
             Self::LegacyTcp(f) => f.borrow().canonical_handle(),
+            Self::Udp(f) => Arc::as_ptr(f) as usize,
         }
     }
 
@@ -73,6 +83,7 @@ impl InetSocket {
     ) -> SyscallResult {
         match self {
             Self::LegacyTcp(socket) => LegacyTcpSocket::bind(socket, addr, net_ns, rng),
+            Self::Udp(socket) => UdpSocket::bind(socket, addr, net_ns, rng),
         }
     }
 
@@ -87,6 +98,7 @@ impl InetSocket {
             Self::LegacyTcp(socket) => {
                 LegacyTcpSocket::listen(socket, backlog, net_ns, rng, cb_queue)
             }
+            Self::Udp(socket) => UdpSocket::listen(socket, backlog, net_ns, rng, cb_queue),
         }
     }
 
@@ -101,6 +113,7 @@ impl InetSocket {
             Self::LegacyTcp(socket) => {
                 LegacyTcpSocket::connect(socket, addr, net_ns, rng, cb_queue)
             }
+            Self::Udp(socket) => UdpSocket::connect(socket, addr, net_ns, rng, cb_queue),
         }
     }
 
@@ -116,6 +129,9 @@ impl InetSocket {
             Self::LegacyTcp(socket) => {
                 LegacyTcpSocket::sendmsg(socket, args, memory_manager, net_ns, rng, cb_queue)
             }
+            Self::Udp(socket) => {
+                UdpSocket::sendmsg(socket, args, memory_manager, net_ns, rng, cb_queue)
+            }
         }
     }
 
@@ -129,6 +145,7 @@ impl InetSocket {
             Self::LegacyTcp(socket) => {
                 LegacyTcpSocket::recvmsg(socket, args, memory_manager, cb_queue)
             }
+            Self::Udp(socket) => UdpSocket::recvmsg(socket, args, memory_manager, cb_queue),
         }
     }
 }
@@ -137,6 +154,7 @@ impl std::fmt::Debug for InetSocket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::LegacyTcp(_) => write!(f, "LegacyTcp")?,
+            Self::Udp(_) => write!(f, "Udp")?,
         }
 
         if let Ok(file) = self.try_borrow() {
@@ -154,27 +172,29 @@ impl std::fmt::Debug for InetSocket {
 
 pub enum InetSocketRef<'a> {
     LegacyTcp(atomic_refcell::AtomicRef<'a, LegacyTcpSocket>),
+    Udp(atomic_refcell::AtomicRef<'a, UdpSocket>),
 }
 
 pub enum InetSocketRefMut<'a> {
     LegacyTcp(atomic_refcell::AtomicRefMut<'a, LegacyTcpSocket>),
+    Udp(atomic_refcell::AtomicRefMut<'a, UdpSocket>),
 }
 
 // file functions
 impl InetSocketRef<'_> {
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn state(&self) -> FileState
     );
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn mode(&self) -> FileMode
     );
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn get_status(&self) -> FileStatus
     );
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn has_open_file(&self) -> bool
     );
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn supports_sa_restart(&self) -> bool
     );
 }
@@ -184,20 +204,22 @@ impl InetSocketRef<'_> {
     pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
             Self::LegacyTcp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
+            Self::Udp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
         }
     }
 
     pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
             Self::LegacyTcp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
+            Self::Udp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
         }
     }
 
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn address_family(&self) -> nix::sys::socket::AddressFamily
     );
 
-    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp;
+    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp, Udp;
         pub fn getsockopt(&self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
                           optlen: libc::socklen_t, memory_manager: &mut MemoryManager)
         -> Result<libc::socklen_t, SyscallError>
@@ -206,54 +228,54 @@ impl InetSocketRef<'_> {
 
 // inet socket-specific functions
 impl InetSocketRef<'_> {
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn peek_next_out_packet(&self) -> Option<PacketRc>
     );
-    enum_passthrough!(self, (packet), LegacyTcp;
+    enum_passthrough!(self, (packet), LegacyTcp, Udp;
         pub fn update_packet_header(&self, packet: &mut PacketRc)
     );
 }
 
 // file functions
 impl InetSocketRefMut<'_> {
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn state(&self) -> FileState
     );
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn mode(&self) -> FileMode
     );
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn get_status(&self) -> FileStatus
     );
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn has_open_file(&self) -> bool
     );
-    enum_passthrough!(self, (val), LegacyTcp;
+    enum_passthrough!(self, (val), LegacyTcp, Udp;
         pub fn set_has_open_file(&mut self, val: bool)
     );
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn supports_sa_restart(&self) -> bool
     );
-    enum_passthrough!(self, (cb_queue), LegacyTcp;
+    enum_passthrough!(self, (cb_queue), LegacyTcp, Udp;
         pub fn close(&mut self, cb_queue: &mut CallbackQueue) -> Result<(), SyscallError>
     );
-    enum_passthrough!(self, (status), LegacyTcp;
+    enum_passthrough!(self, (status), LegacyTcp, Udp;
         pub fn set_status(&mut self, status: FileStatus)
     );
-    enum_passthrough!(self, (request, arg_ptr, memory_manager), LegacyTcp;
+    enum_passthrough!(self, (request, arg_ptr, memory_manager), LegacyTcp, Udp;
         pub fn ioctl(&mut self, request: u64, arg_ptr: ForeignPtr<()>, memory_manager: &mut MemoryManager) -> SyscallResult
     );
-    enum_passthrough!(self, (ptr), LegacyTcp;
+    enum_passthrough!(self, (ptr), LegacyTcp, Udp;
         pub fn add_legacy_listener(&mut self, ptr: HostTreePointer<c::StatusListener>)
     );
-    enum_passthrough!(self, (ptr), LegacyTcp;
+    enum_passthrough!(self, (ptr), LegacyTcp, Udp;
         pub fn remove_legacy_listener(&mut self, ptr: *mut c::StatusListener)
     );
-    enum_passthrough!(self, (iovs, offset, flags, mem, cb_queue), LegacyTcp;
+    enum_passthrough!(self, (iovs, offset, flags, mem, cb_queue), LegacyTcp, Udp;
         pub fn readv(&mut self, iovs: &[IoVec], offset: Option<libc::off_t>, flags: libc::c_int,
                      mem: &mut MemoryManager, cb_queue: &mut CallbackQueue) -> Result<libc::ssize_t, SyscallError>
     );
-    enum_passthrough!(self, (iovs, offset, flags, mem, cb_queue), LegacyTcp;
+    enum_passthrough!(self, (iovs, offset, flags, mem, cb_queue), LegacyTcp, Udp;
         pub fn writev(&mut self, iovs: &[IoVec], offset: Option<libc::off_t>, flags: libc::c_int,
                       mem: &mut MemoryManager, cb_queue: &mut CallbackQueue) -> Result<libc::ssize_t, SyscallError>
     );
@@ -264,26 +286,28 @@ impl InetSocketRefMut<'_> {
     pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
             Self::LegacyTcp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
+            Self::Udp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
         }
     }
 
     pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
             Self::LegacyTcp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
+            Self::Udp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
         }
     }
 
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn address_family(&self) -> nix::sys::socket::AddressFamily
     );
 
-    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp;
+    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp, Udp;
         pub fn getsockopt(&self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
                           optlen: libc::socklen_t, memory_manager: &mut MemoryManager)
         -> Result<libc::socklen_t, SyscallError>
     );
 
-    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp;
+    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp, Udp;
         pub fn setsockopt(&mut self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
                           optlen: libc::socklen_t, memory_manager: &MemoryManager)
         -> Result<(), SyscallError>
@@ -292,26 +316,27 @@ impl InetSocketRefMut<'_> {
     pub fn accept(&mut self, cb_queue: &mut CallbackQueue) -> Result<OpenFile, SyscallError> {
         match self {
             Self::LegacyTcp(socket) => socket.accept(cb_queue),
+            Self::Udp(socket) => socket.accept(cb_queue),
         }
     }
 
-    enum_passthrough!(self, (how, cb_queue), LegacyTcp;
+    enum_passthrough!(self, (how, cb_queue), LegacyTcp, Udp;
         pub fn shutdown(&mut self, how: Shutdown, cb_queue: &mut CallbackQueue) -> Result<(), SyscallError>
     );
 }
 
 // inet socket-specific functions
 impl InetSocketRefMut<'_> {
-    enum_passthrough!(self, (packet, cb_queue), LegacyTcp;
+    enum_passthrough!(self, (packet, cb_queue), LegacyTcp, Udp;
         pub fn push_in_packet(&mut self, packet: PacketRc, cb_queue: &mut CallbackQueue)
     );
-    enum_passthrough!(self, (cb_queue), LegacyTcp;
+    enum_passthrough!(self, (cb_queue), LegacyTcp, Udp;
         pub fn pull_out_packet(&mut self, cb_queue: &mut CallbackQueue) -> Option<PacketRc>
     );
-    enum_passthrough!(self, (), LegacyTcp;
+    enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn peek_next_out_packet(&self) -> Option<PacketRc>
     );
-    enum_passthrough!(self, (packet), LegacyTcp;
+    enum_passthrough!(self, (packet), LegacyTcp, Udp;
         pub fn update_packet_header(&self, packet: &mut PacketRc)
     );
 }
@@ -320,6 +345,7 @@ impl std::fmt::Debug for InetSocketRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::LegacyTcp(_) => write!(f, "LegacyTcp")?,
+            Self::Udp(_) => write!(f, "Udp")?,
         }
 
         write!(
@@ -335,6 +361,7 @@ impl std::fmt::Debug for InetSocketRefMut<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::LegacyTcp(_) => write!(f, "LegacyTcp")?,
+            Self::Udp(_) => write!(f, "Udp")?,
         }
 
         write!(
@@ -349,12 +376,14 @@ impl std::fmt::Debug for InetSocketRefMut<'_> {
 #[derive(Clone)]
 pub enum InetSocketWeak {
     LegacyTcp(Weak<AtomicRefCell<LegacyTcpSocket>>),
+    Udp(Weak<AtomicRefCell<UdpSocket>>),
 }
 
 impl InetSocketWeak {
     pub fn upgrade(&self) -> Option<InetSocket> {
         match self {
             Self::LegacyTcp(x) => x.upgrade().map(InetSocket::LegacyTcp),
+            Self::Udp(x) => x.upgrade().map(InetSocket::Udp),
         }
     }
 }
@@ -382,6 +411,7 @@ fn associate_socket(
 
     let protocol = match socket {
         InetSocket::LegacyTcp(_) => c::_ProtocolType_PTCP,
+        InetSocket::Udp(_) => c::_ProtocolType_PUDP,
     };
 
     // get a free ephemeral port if they didn't specify one

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -108,11 +108,13 @@ impl InetSocket {
         &self,
         args: SendmsgArgs,
         memory_manager: &mut MemoryManager,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
         cb_queue: &mut CallbackQueue,
     ) -> Result<libc::ssize_t, SyscallError> {
         match self {
             Self::LegacyTcp(socket) => {
-                LegacyTcpSocket::sendmsg(socket, args, memory_manager, cb_queue)
+                LegacyTcpSocket::sendmsg(socket, args, memory_manager, net_ns, rng, cb_queue)
             }
         }
     }

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -1,0 +1,867 @@
+use std::io::Read;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use nix::errno::Errno;
+use nix::sys::socket::{AddressFamily, MsgFlags, Shutdown, SockaddrIn};
+use shadow_shim_helper_rs::syscall_types::ForeignPtr;
+
+use crate::core::worker::Worker;
+use crate::cshadow as c;
+use crate::host::descriptor::socket::inet::{self, InetSocket};
+use crate::host::descriptor::socket::{RecvmsgArgs, RecvmsgReturn, SendmsgArgs};
+use crate::host::descriptor::{
+    File, FileMode, FileState, FileStatus, OpenFile, Socket, StateEventSource, StateListenerFilter,
+    SyscallResult,
+};
+use crate::host::memory_manager::MemoryManager;
+use crate::host::syscall::io::{write_partial, IoVec, IoVecReader};
+use crate::host::syscall_types::SyscallError;
+use crate::network::net_namespace::NetworkNamespace;
+use crate::network::packet::{PacketRc, PacketStatus};
+use crate::utility::callback_queue::{CallbackQueue, Handle};
+use crate::utility::sockaddr::SockaddrStorage;
+use crate::utility::{HostTreePointer, ObjectCounter};
+
+/// Maximum size of a datagram we are allowed to send out over the network.
+// 65,535 (2^16 - 1) - 20 (ip header) - 8 (udp header)
+const CONFIG_DATAGRAM_MAX_SIZE: usize = 65507;
+
+pub struct UdpSocket {
+    event_source: StateEventSource,
+    status: FileStatus,
+    state: FileState,
+    send_buffer: PacketBuffer,
+    recv_buffer: PacketBuffer,
+    peer_addr: Option<SocketAddrV4>,
+    bound_addr: Option<SocketAddrV4>,
+    // the (local addr, remote addr) network interface association
+    association: Option<(SocketAddrV4, SocketAddrV4)>,
+    // should only be used by `OpenFile` to make sure there is only ever one `OpenFile` instance for
+    // this file
+    has_open_file: bool,
+    _counter: ObjectCounter,
+}
+
+impl UdpSocket {
+    pub fn new(
+        status: FileStatus,
+        send_buf_size: usize,
+        recv_buf_size: usize,
+    ) -> Arc<AtomicRefCell<Self>> {
+        let mut socket = Self {
+            event_source: StateEventSource::new(),
+            status,
+            state: FileState::ACTIVE,
+            send_buffer: PacketBuffer::new(send_buf_size),
+            recv_buffer: PacketBuffer::new(recv_buf_size),
+            peer_addr: None,
+            bound_addr: None,
+            association: None,
+            has_open_file: false,
+            _counter: ObjectCounter::new("UdpSocket"),
+        };
+
+        CallbackQueue::queue_and_run(|cb_queue| socket.refresh_readable_writable(cb_queue));
+
+        Arc::new(AtomicRefCell::new(socket))
+    }
+
+    pub fn get_status(&self) -> FileStatus {
+        self.status
+    }
+
+    pub fn set_status(&mut self, status: FileStatus) {
+        self.status = status;
+    }
+
+    pub fn mode(&self) -> FileMode {
+        FileMode::READ | FileMode::WRITE
+    }
+
+    pub fn has_open_file(&self) -> bool {
+        self.has_open_file
+    }
+
+    pub fn supports_sa_restart(&self) -> bool {
+        true
+    }
+
+    pub fn set_has_open_file(&mut self, val: bool) {
+        self.has_open_file = val;
+    }
+
+    pub fn push_in_packet(&mut self, mut packet: PacketRc, cb_queue: &mut CallbackQueue) {
+        packet.add_status(PacketStatus::RcvSocketProcessed);
+
+        // get another reference to the packet so we can add a status later
+        let mut packetrc_clone = packet.clone();
+
+        if let Err(mut packet) = self.recv_buffer.add_packet(packet) {
+            // no space available
+            packet.add_status(PacketStatus::RcvSocketDropped);
+        } else {
+            log::debug!("Added a packet to the socket's recv buffer");
+            packetrc_clone.add_status(PacketStatus::RcvSocketBuffered);
+        }
+
+        self.refresh_readable_writable(cb_queue);
+    }
+
+    pub fn pull_out_packet(&mut self, cb_queue: &mut CallbackQueue) -> Option<PacketRc> {
+        let packet = self.send_buffer.remove_packet();
+
+        if packet.is_some() {
+            log::debug!("Removed a packet from the socket's send buffer");
+        } else {
+            log::debug!(
+                "Attempted to remove a packet from the socket's send buffer, but none available"
+            );
+        }
+
+        self.refresh_readable_writable(cb_queue);
+
+        packet
+    }
+
+    pub fn peek_next_out_packet(&self) -> Option<PacketRc> {
+        self.send_buffer.peek_packet().cloned()
+    }
+
+    pub fn update_packet_header(&self, _packet: &mut PacketRc) {
+        // do nothing for UDP
+    }
+
+    pub fn getsockname(&self) -> Result<Option<SockaddrIn>, SyscallError> {
+        let mut addr = self
+            .bound_addr
+            .unwrap_or(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0));
+
+        // if we are bound to INADDR_ANY, we should instead return the IP used to communicate with
+        // the connected peer (if we have one)
+        if *addr.ip() == Ipv4Addr::UNSPECIFIED {
+            if let Some(peer_addr) = self.peer_addr {
+                addr.set_ip(*peer_addr.ip());
+            }
+        }
+
+        Ok(Some(addr.into()))
+    }
+
+    pub fn getpeername(&self) -> Result<Option<SockaddrIn>, SyscallError> {
+        Ok(Some(self.peer_addr.ok_or(Errno::ENOTCONN)?.into()))
+    }
+
+    pub fn address_family(&self) -> AddressFamily {
+        AddressFamily::Inet
+    }
+
+    pub fn close(&mut self, cb_queue: &mut CallbackQueue) -> Result<(), SyscallError> {
+        if let Some((local_addr, remote_addr)) = self.association {
+            Worker::with_active_host(|host| {
+                let net_ns = host.network_namespace_borrow();
+                net_ns.disassociate_interface(c::_ProtocolType_PUDP, local_addr, remote_addr);
+            })
+            .unwrap();
+        }
+
+        self.copy_state(
+            /* mask= */ FileState::all(),
+            FileState::CLOSED,
+            cb_queue,
+        );
+        Ok(())
+    }
+
+    pub fn bind(
+        socket: &Arc<AtomicRefCell<Self>>,
+        addr: Option<&SockaddrStorage>,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
+    ) -> SyscallResult {
+        // if the address pointer was NULL
+        let Some(addr) = addr else {
+            return Err(Errno::EFAULT.into());
+        };
+
+        // if not an inet socket address
+        let Some(addr) = addr.as_inet() else {
+            return Err(Errno::EINVAL.into());
+        };
+
+        let addr: SocketAddrV4 = (*addr).into();
+
+        {
+            let socket = socket.borrow();
+
+            // if the socket is already bound
+            if socket.bound_addr.is_some() {
+                return Err(Errno::EINVAL.into());
+            }
+
+            // Since we're not bound, we must not have a peer. We may have a peer in the future if
+            // `connect()` is called on this socket.
+            assert!(socket.peer_addr.is_none());
+
+            // must not have been associated with the network interface
+            assert!(socket.association.is_none());
+        }
+
+        // this will allow us to receive packets from any peer
+        let peer_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
+
+        // associate the socket
+        let addr = inet::associate_socket(
+            InetSocket::Udp(Arc::clone(socket)),
+            addr,
+            peer_addr,
+            net_ns,
+            rng,
+        )?;
+
+        // update the socket's local address
+        {
+            let mut socket = socket.borrow_mut();
+            socket.bound_addr = Some(addr);
+            socket.association = Some((addr, peer_addr));
+        }
+
+        Ok(0.into())
+    }
+
+    pub fn readv(
+        &mut self,
+        _iovs: &[IoVec],
+        _offset: Option<libc::off_t>,
+        _flags: libc::c_int,
+        _mem: &mut MemoryManager,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<libc::ssize_t, SyscallError> {
+        // we could call UdpSocket::recvmsg() here, but for now we expect that there are no code
+        // paths that would call UdpSocket::readv() since the readv() syscall handler should have
+        // called UdpSocket::recvmsg() instead
+        panic!("Called UdpSocket::readv() on a UDP socket");
+    }
+
+    pub fn writev(
+        &mut self,
+        _iovs: &[IoVec],
+        _offset: Option<libc::off_t>,
+        _flags: libc::c_int,
+        _mem: &mut MemoryManager,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<libc::ssize_t, SyscallError> {
+        // we could call UdpSocket::sendmsg() here, but for now we expect that there are no code
+        // paths that would call UdpSocket::writev() since the writev() syscall handler should have
+        // called UdpSocket::sendmsg() instead
+        panic!("Called UdpSocket::writev() on a UDP socket");
+    }
+
+    pub fn sendmsg(
+        socket: &Arc<AtomicRefCell<Self>>,
+        args: SendmsgArgs,
+        mem: &mut MemoryManager,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
+        cb_queue: &mut CallbackQueue,
+    ) -> Result<libc::ssize_t, SyscallError> {
+        let mut socket_ref = socket.borrow_mut();
+
+        let Some(mut flags) = MsgFlags::from_bits(args.flags) else {
+            log::debug!("Unrecognized send flags: {:#b}", args.flags);
+            return Err(Errno::EINVAL.into());
+        };
+
+        let dst_addr = match args.addr {
+            Some(addr) => match addr.as_inet() {
+                // an inet socket address
+                Some(x) => (*x).into(),
+                // not an inet socket address
+                None => return Err(Errno::EAFNOSUPPORT.into()),
+            },
+            // no destination address provided
+            None => match socket_ref.peer_addr {
+                Some(x) => x,
+                None => return Err(Errno::EDESTADDRREQ.into()),
+            },
+        };
+
+        if socket_ref.get_status().contains(FileStatus::NONBLOCK) {
+            flags.insert(MsgFlags::MSG_DONTWAIT);
+        }
+
+        let len: libc::size_t = args.iovs.iter().map(|x| x.len).sum();
+
+        // TODO: should use IP fragmentation to make sure packets fit within the MTU
+        if len > CONFIG_DATAGRAM_MAX_SIZE {
+            return Err(nix::errno::Errno::EMSGSIZE.into());
+        }
+
+        // make sure that we're bound
+        if socket_ref.bound_addr.is_some() {
+            // we must have an association since we're bound
+            assert!(socket_ref.association.is_some());
+        } else {
+            // we can't be unbound but have a peer
+            assert!(socket_ref.peer_addr.is_none());
+            assert!(socket_ref.association.is_none());
+
+            // implicit bind (use default interface unless the remote peer is on loopback)
+            // TODO: is this correct? or should we bind to UNSPECIFIED?
+            let local_addr = if dst_addr.ip() == &std::net::Ipv4Addr::LOCALHOST {
+                SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)
+            } else {
+                SocketAddrV4::new(net_ns.default_ip, 0)
+            };
+
+            // this will allow us to receive packets from any peer
+            let peer_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
+
+            let local_addr = super::associate_socket(
+                InetSocket::Udp(Arc::clone(socket)),
+                local_addr,
+                peer_addr,
+                net_ns,
+                rng,
+            )?;
+
+            socket_ref.bound_addr = Some(local_addr);
+            socket_ref.association = Some((local_addr, peer_addr));
+        }
+
+        // run in a closure so that an early return doesn't skip checking if we should block
+        let result = (|| {
+            // read all of the bytes into a temporary buffer
+            let mut reader = IoVecReader::new(args.iovs, mem);
+            let mut bytes = Vec::with_capacity(len);
+            reader
+                .read_to_end(&mut bytes)
+                .map_err(|e| Errno::try_from(e).unwrap())?;
+
+            let mut packet = PacketRc::new();
+            packet.set_udp(socket_ref.bound_addr.unwrap(), dst_addr);
+            packet.set_payload(&bytes);
+            packet.add_status(PacketStatus::SndCreated);
+
+            // get another reference to the packet so we can add a status later
+            let mut packetrc_clone = packet.clone();
+
+            if let Err(_packet) = socket_ref.send_buffer.add_packet(packet) {
+                // no space available
+                return Err(Errno::EWOULDBLOCK);
+            }
+
+            packetrc_clone.add_status(PacketStatus::SndSocketBuffered);
+
+            // notify the host that this socket has packets to send
+            let socket = Arc::clone(socket);
+            let interface_ip = *socket_ref.bound_addr.unwrap().ip();
+            cb_queue.add(move |_cb_queue| {
+                Worker::with_active_host(|host| {
+                    let inet_socket = InetSocket::Udp(socket);
+                    let compat_socket = unsafe { c::compatsocket_fromInetSocket(&inet_socket) };
+                    host.notify_socket_has_packets(interface_ip, &compat_socket);
+                })
+                .unwrap();
+            });
+
+            Ok(len)
+        })();
+
+        socket_ref.refresh_readable_writable(cb_queue);
+
+        // if the syscall would block and we don't have the MSG_DONTWAIT flag
+        if result == Err(Errno::EWOULDBLOCK) && !flags.contains(MsgFlags::MSG_DONTWAIT) {
+            return Err(SyscallError::new_blocked(
+                File::Socket(Socket::Inet(InetSocket::Udp(socket.clone()))),
+                FileState::WRITABLE,
+                socket_ref.supports_sa_restart(),
+            ));
+        }
+
+        Ok(result?.try_into().unwrap())
+    }
+
+    pub fn recvmsg(
+        socket: &Arc<AtomicRefCell<Self>>,
+        args: RecvmsgArgs,
+        mem: &mut MemoryManager,
+        cb_queue: &mut CallbackQueue,
+    ) -> Result<RecvmsgReturn, SyscallError> {
+        let mut socket_ref = socket.borrow_mut();
+
+        let Some(mut flags) = MsgFlags::from_bits(args.flags) else {
+            log::debug!("Unrecognized recv flags: {:#b}", args.flags);
+            return Err(Errno::EINVAL.into());
+        };
+
+        if socket_ref.get_status().contains(FileStatus::NONBLOCK) {
+            flags.insert(MsgFlags::MSG_DONTWAIT);
+        }
+
+        // run in a closure so that an early return doesn't skip checking if we should block
+        let result = (|| {
+            let Some(mut packet) = socket_ref.recv_buffer.remove_packet() else {
+                return Err(Errno::EWOULDBLOCK);
+            };
+
+            packet.add_status(PacketStatus::RcvSocketDelivered);
+            let bytes_read = packet.copy_payload(args.iovs, mem)?;
+
+            Ok(RecvmsgReturn {
+                return_val: bytes_read.try_into().unwrap(),
+                addr: Some(packet.src_address().into()),
+                msg_flags: 0,
+                control_len: 0,
+            })
+        })();
+
+        socket_ref.refresh_readable_writable(cb_queue);
+
+        // if the syscall would block and we don't have the MSG_DONTWAIT flag
+        if result.as_ref().err() == Some(&Errno::EWOULDBLOCK)
+            && !flags.contains(MsgFlags::MSG_DONTWAIT)
+        {
+            return Err(SyscallError::new_blocked(
+                File::Socket(Socket::Inet(InetSocket::Udp(socket.clone()))),
+                FileState::READABLE,
+                socket_ref.supports_sa_restart(),
+            ));
+        }
+
+        Ok(result?)
+    }
+
+    pub fn ioctl(
+        &mut self,
+        request: u64,
+        arg_ptr: ForeignPtr<()>,
+        mem: &mut MemoryManager,
+    ) -> SyscallResult {
+        match request {
+            // equivalent to SIOCINQ
+            libc::FIONREAD => {
+                let len = self.recv_buffer.len_bytes().try_into().unwrap();
+
+                let arg_ptr = arg_ptr.cast::<libc::c_int>();
+                mem.write(arg_ptr, &len)?;
+
+                Ok(0.into())
+            }
+            // equivalent to SIOCOUTQ
+            libc::TIOCOUTQ => {
+                let len = self.send_buffer.len_bytes().try_into().unwrap();
+
+                let arg_ptr = arg_ptr.cast::<libc::c_int>();
+                mem.write(arg_ptr, &len)?;
+
+                Ok(0.into())
+            }
+            libc::FIONBIO => {
+                panic!("This should have been handled by the ioctl syscall handler");
+            }
+            libc::TCGETS
+            | libc::TCSETS
+            | libc::TCSETSW
+            | libc::TCSETSF
+            | libc::TCGETA
+            | libc::TCSETA
+            | libc::TCSETAW
+            | libc::TCSETAF
+            | libc::TIOCGWINSZ
+            | libc::TIOCSWINSZ => {
+                // not a terminal
+                Err(Errno::ENOTTY.into())
+            }
+            _ => {
+                log::debug!("We do not yet handle ioctl request {request} on tcp sockets");
+                Err(Errno::EINVAL.into())
+            }
+        }
+    }
+
+    pub fn listen(
+        _socket: &Arc<AtomicRefCell<Self>>,
+        _backlog: i32,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<(), SyscallError> {
+        Err(Errno::EOPNOTSUPP.into())
+    }
+
+    pub fn connect(
+        socket: &Arc<AtomicRefCell<Self>>,
+        peer_addr: &SockaddrStorage,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<(), SyscallError> {
+        // if not an inet socket address
+        // TODO: handle an AF_UNSPEC socket address
+        let Some(peer_addr) = peer_addr.as_inet() else {
+            return Err(Errno::EINVAL.into());
+        };
+
+        let mut peer_addr: std::net::SocketAddrV4 = (*peer_addr).into();
+
+        // https://stackoverflow.com/a/22425796
+        if peer_addr.ip().is_unspecified() {
+            peer_addr.set_ip(std::net::Ipv4Addr::LOCALHOST);
+        }
+
+        // NOTE: it would be nice to use `Ipv4Addr::is_loopback` in this code rather than comparing
+        // to `Ipv4Addr::LOCALHOST`, but the rest of Shadow probably can't handle other loopback
+        // addresses (ex: 127.0.0.2) and it's probably best not to change this behaviour
+
+        // make sure we will be able to route this later
+        // TODO: UDP sockets probably shouldn't return `ECONNREFUSED`
+        if peer_addr.ip() != &std::net::Ipv4Addr::LOCALHOST {
+            let is_routable =
+                Worker::is_routable(net_ns.default_ip.into(), (*peer_addr.ip()).into());
+
+            if !is_routable {
+                // can't route it - there is no node with this address
+                log::warn!(
+                    "Attempting to connect to address '{peer_addr}' for which no host exists"
+                );
+                return Err(Errno::ECONNREFUSED.into());
+            }
+        }
+
+        // if we were previously associated with the network interface, we need to disassociate so
+        // that we can re-associate with the correct peer address
+        //
+        // connect(2):
+        // > If the socket sockfd is of type SOCK_DGRAM, then addr is the address to which datagrams
+        // > are sent by default, and the only address from which datagrams are received.
+        if let Some((local_addr, remote_addr)) = socket.borrow().association {
+            net_ns.disassociate_interface(c::_ProtocolType_PUDP, local_addr, remote_addr);
+        }
+
+        // we need to associate with the network interface, but first we need a local ip/port to
+        // bind to
+        let local_addr = match socket.borrow().bound_addr {
+            // keep the same local binding
+            Some(x) => x,
+            // implicit bind (use default interface unless the remote peer is on loopback)
+            None => {
+                if peer_addr.ip() == &std::net::Ipv4Addr::LOCALHOST {
+                    SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)
+                } else {
+                    SocketAddrV4::new(net_ns.default_ip, 0)
+                }
+            }
+        };
+
+        // associate the socket (we may be sharing a port number with other udp sockets, but they
+        // won't have the same peer)
+        let local_addr = super::associate_socket(
+            InetSocket::Udp(Arc::clone(socket)),
+            local_addr,
+            peer_addr,
+            net_ns,
+            rng,
+        )?;
+
+        {
+            let mut socket = socket.borrow_mut();
+            socket.peer_addr = Some(peer_addr);
+            socket.bound_addr = Some(local_addr);
+            socket.association = Some((local_addr, peer_addr));
+        }
+
+        Ok(())
+    }
+
+    pub fn accept(&mut self, _cb_queue: &mut CallbackQueue) -> Result<OpenFile, SyscallError> {
+        Err(Errno::EOPNOTSUPP.into())
+    }
+
+    pub fn shutdown(
+        &mut self,
+        _how: Shutdown,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<(), SyscallError> {
+        // TODO: we're missing stuff here, since we have a lot of shutdown() tests that are disabled
+        // for udp
+        // TODO: what if we set a peer, then unset the peer, then call shutdown?
+        if self.peer_addr.is_none() {
+            return Err(Errno::ENOTCONN.into());
+        }
+
+        Ok(())
+    }
+
+    pub fn getsockopt(
+        &self,
+        level: libc::c_int,
+        optname: libc::c_int,
+        optval_ptr: ForeignPtr<()>,
+        optlen: libc::socklen_t,
+        mem: &mut MemoryManager,
+    ) -> Result<libc::socklen_t, SyscallError> {
+        match (level, optname) {
+            (libc::SOL_SOCKET, libc::SO_SNDBUF) => {
+                let sndbuf_size = self.send_buffer.soft_limit_bytes().try_into().unwrap();
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written = write_partial(mem, &sndbuf_size, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
+            (libc::SOL_SOCKET, libc::SO_RCVBUF) => {
+                let rcvbuf_size = self.recv_buffer.soft_limit_bytes().try_into().unwrap();
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written = write_partial(mem, &rcvbuf_size, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
+            (libc::SOL_SOCKET, libc::SO_ERROR) => {
+                let error = 0;
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written = write_partial(mem, &error, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
+            (libc::SOL_SOCKET, libc::SO_TYPE) => {
+                let sock_type = libc::SOCK_DGRAM;
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written = write_partial(mem, &sock_type, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
+            (libc::SOL_SOCKET, _) => {
+                log::debug!("getsockopt called with unsupported level {level} and opt {optname}");
+                Err(Errno::ENOPROTOOPT.into())
+            }
+            _ => {
+                log::debug!("getsockopt called with unsupported level {level} and opt {optname}");
+                Err(Errno::EOPNOTSUPP.into())
+            }
+        }
+    }
+
+    pub fn setsockopt(
+        &mut self,
+        level: libc::c_int,
+        optname: libc::c_int,
+        optval_ptr: ForeignPtr<()>,
+        optlen: libc::socklen_t,
+        mem: &MemoryManager,
+    ) -> Result<(), SyscallError> {
+        match (level, optname) {
+            (libc::SOL_SOCKET, libc::SO_SNDBUF) => {
+                type OptType = libc::c_int;
+
+                if usize::try_from(optlen).unwrap() < std::mem::size_of::<OptType>() {
+                    return Err(Errno::EINVAL.into());
+                }
+
+                let optval_ptr = optval_ptr.cast::<OptType>();
+                let val: u64 = mem.read(optval_ptr)?.try_into().or(Err(Errno::EINVAL))?;
+
+                // linux kernel doubles this value upon setting
+                let val = val * 2;
+
+                // Linux also has limits SOCK_MIN_SNDBUF (slightly greater than 4096) and the sysctl
+                // max limit. We choose a reasonable lower limit for Shadow. The minimum limit in
+                // man 7 socket is incorrect.
+                let val = std::cmp::max(val, 4096);
+
+                // This upper limit was added as an arbitrarily high number so that we don't change
+                // Shadow's behaviour, but also prevents an application from setting this to
+                // something unnecessarily large like INT_MAX.
+                let val = std::cmp::min(val, 268435456); // 2^28 = 256 MiB
+
+                self.send_buffer
+                    .set_soft_limit_bytes(val.try_into().unwrap());
+            }
+            (libc::SOL_SOCKET, libc::SO_RCVBUF) => {
+                type OptType = libc::c_int;
+
+                if usize::try_from(optlen).unwrap() < std::mem::size_of::<OptType>() {
+                    return Err(Errno::EINVAL.into());
+                }
+
+                let optval_ptr = optval_ptr.cast::<OptType>();
+                let val: u64 = mem.read(optval_ptr)?.try_into().or(Err(Errno::EINVAL))?;
+
+                // linux kernel doubles this value upon setting
+                let val = val * 2;
+
+                // Linux also has limits SOCK_MIN_RCVBUF (slightly greater than 2048) and the sysctl
+                // max limit. We choose a reasonable lower limit for Shadow. The minimum limit in
+                // man 7 socket is incorrect.
+                let val = std::cmp::max(val, 2048);
+
+                // This upper limit was added as an arbitrarily high number so that we don't change
+                // Shadow's behaviour, but also prevents an application from setting this to
+                // something unnecessarily large like INT_MAX.
+                let val = std::cmp::min(val, 268435456); // 2^28 = 256 MiB
+
+                self.recv_buffer
+                    .set_soft_limit_bytes(val.try_into().unwrap());
+            }
+            (libc::SOL_SOCKET, libc::SO_REUSEADDR) => {
+                // TODO: implement this, tor and tgen use it
+                log::warn!("setsockopt SO_REUSEADDR not yet implemented");
+            }
+            (libc::SOL_SOCKET, libc::SO_REUSEPORT) => {
+                // TODO: implement this, tgen uses it
+                log::warn!("setsockopt SO_REUSEPORT not yet implemented");
+            }
+            (libc::SOL_SOCKET, libc::SO_KEEPALIVE) => {
+                // TODO: implement this, libevent uses it in
+                // evconnlistener_new_bind()
+                log::warn!("setsockopt SO_KEEPALIVE not yet implemented");
+            }
+            (libc::SOL_SOCKET, libc::SO_BROADCAST) => {
+                // TODO: implement this, pkg.go.dev/net uses it
+                log::warn!("setsockopt SO_BROADCAST not yet implemented");
+            }
+            _ => {
+                log::debug!("setsockopt called with unsupported level {level} and opt {optname}");
+                return Err(Errno::ENOPROTOOPT.into());
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn add_listener(
+        &mut self,
+        monitoring: FileState,
+        filter: StateListenerFilter,
+        notify_fn: impl Fn(FileState, FileState, &mut CallbackQueue) + Send + Sync + 'static,
+    ) -> Handle<(FileState, FileState)> {
+        self.event_source
+            .add_listener(monitoring, filter, notify_fn)
+    }
+
+    pub fn add_legacy_listener(&mut self, ptr: HostTreePointer<c::StatusListener>) {
+        self.event_source.add_legacy_listener(ptr);
+    }
+
+    pub fn remove_legacy_listener(&mut self, ptr: *mut c::StatusListener) {
+        self.event_source.remove_legacy_listener(ptr);
+    }
+
+    pub fn state(&self) -> FileState {
+        self.state
+    }
+
+    fn refresh_readable_writable(&mut self, cb_queue: &mut CallbackQueue) {
+        let readable = !self.recv_buffer.is_empty();
+        let writable = self.send_buffer.has_space();
+
+        let readable = readable.then_some(FileState::READABLE).unwrap_or_default();
+        let writable = writable.then_some(FileState::WRITABLE).unwrap_or_default();
+
+        self.copy_state(
+            /* mask= */ FileState::READABLE | FileState::WRITABLE,
+            readable | writable,
+            cb_queue,
+        );
+    }
+
+    fn copy_state(&mut self, mask: FileState, state: FileState, cb_queue: &mut CallbackQueue) {
+        let old_state = self.state;
+
+        // remove the masked flags, then copy the masked flags
+        self.state.remove(mask);
+        self.state.insert(state & mask);
+
+        self.handle_state_change(old_state, cb_queue);
+    }
+
+    fn handle_state_change(&mut self, old_state: FileState, cb_queue: &mut CallbackQueue) {
+        let states_changed = self.state ^ old_state;
+
+        // if nothing changed
+        if states_changed.is_empty() {
+            return;
+        }
+
+        self.event_source
+            .notify_listeners(self.state, states_changed, cb_queue);
+    }
+}
+
+/// A buffer of packets.
+struct PacketBuffer {
+    /// The packets in the buffer.
+    buffer: std::collections::LinkedList<PacketRc>,
+    /// The number of payload bytes in this socket.
+    len_bytes: usize,
+    /// A soft limit for the maximum number of payload bytes this buffer can hold.
+    soft_limit_bytes: usize,
+}
+
+impl PacketBuffer {
+    pub fn new(soft_limit_bytes: usize) -> Self {
+        Self {
+            buffer: std::collections::LinkedList::new(),
+            len_bytes: 0,
+            soft_limit_bytes,
+        }
+    }
+
+    /// Add a packet to the buffer. Returns the packet as an `Err` if there wasn't enough space.
+    pub fn add_packet(&mut self, packet: PacketRc) -> Result<(), PacketRc> {
+        // TODO: i think udp allows at most one packet to exceed the buffer capacity; should confirm
+        // this
+        if !self.has_space() {
+            return Err(packet);
+        }
+
+        // TODO: on linux the socket buffer length also takes into account any header and struct
+        // overhead, otherwise the buffer would take an infinite amount of 0-len packets
+        self.len_bytes += packet.payload_size();
+        self.buffer.push_back(packet);
+
+        Ok(())
+    }
+
+    /// Remove the next packet from the buffer.
+    pub fn remove_packet(&mut self) -> Option<PacketRc> {
+        let packet = self.buffer.pop_front()?;
+        self.len_bytes -= packet.payload_size();
+        Some(packet)
+    }
+
+    /// Peek the next packet in the buffer.
+    pub fn peek_packet(&self) -> Option<&PacketRc> {
+        self.buffer.front()
+    }
+
+    /// The number of payload bytes contained in the buffer. A length of 0 does not mean that the
+    /// buffer is empty.
+    pub fn len_bytes(&self) -> usize {
+        self.len_bytes
+    }
+
+    /// Is there space for at least one more packet?
+    pub fn has_space(&self) -> bool {
+        self.len_bytes < self.soft_limit_bytes
+    }
+
+    /// Is the buffer empty (does it have 0 packets)?
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    /// The soft limit for the size of the buffer.
+    pub fn soft_limit_bytes(&self) -> usize {
+        self.soft_limit_bytes
+    }
+
+    /// Set the soft limit for the size of the buffer.
+    pub fn set_soft_limit_bytes(&mut self, soft_limit_bytes: usize) {
+        self.soft_limit_bytes = soft_limit_bytes;
+    }
+}

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -199,12 +199,6 @@ impl SocketRef<'_> {
                           optlen: libc::socklen_t, memory_manager: &mut MemoryManager)
         -> Result<libc::socklen_t, SyscallError>
     );
-
-    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), Unix, Inet;
-        pub fn setsockopt(&self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
-                          optlen: libc::socklen_t, memory_manager: &MemoryManager)
-        -> Result<(), SyscallError>
-    );
 }
 
 // file functions
@@ -279,7 +273,7 @@ impl SocketRefMut<'_> {
     );
 
     enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), Unix, Inet;
-        pub fn setsockopt(&self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
+        pub fn setsockopt(&mut self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
                           optlen: libc::socklen_t, memory_manager: &MemoryManager)
         -> Result<(), SyscallError>
     );

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -104,11 +104,17 @@ impl Socket {
         &self,
         args: SendmsgArgs,
         memory_manager: &mut MemoryManager,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
         cb_queue: &mut CallbackQueue,
     ) -> Result<libc::ssize_t, SyscallError> {
         match self {
-            Self::Unix(socket) => UnixSocket::sendmsg(socket, args, memory_manager, cb_queue),
-            Self::Inet(socket) => InetSocket::sendmsg(socket, args, memory_manager, cb_queue),
+            Self::Unix(socket) => {
+                UnixSocket::sendmsg(socket, args, memory_manager, net_ns, rng, cb_queue)
+            }
+            Self::Inet(socket) => {
+                InetSocket::sendmsg(socket, args, memory_manager, net_ns, rng, cb_queue)
+            }
         }
     }
 

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -20,6 +20,16 @@ pub mod abstract_unix_ns;
 pub mod inet;
 pub mod unix;
 
+bitflags::bitflags! {
+    /// Flags to represent if a socket has been shut down for reading and/or writing. An empty set
+    /// of flags implies that the socket *has not* been shut down for reading or writing.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    struct ShutdownFlags: u8 {
+        const READ = 0b00000001;
+        const WRITE = 0b00000010;
+    }
+}
+
 #[derive(Clone)]
 pub enum Socket {
     Unix(Arc<AtomicRefCell<UnixSocket>>),

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -262,7 +262,7 @@ impl UnixSocket {
     }
 
     pub fn setsockopt(
-        &self,
+        &mut self,
         _level: libc::c_int,
         _optname: libc::c_int,
         _optval_ptr: ForeignPtr<()>,

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -179,6 +179,8 @@ impl UnixSocket {
         socket: &Arc<AtomicRefCell<Self>>,
         args: SendmsgArgs,
         mem: &mut MemoryManager,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
         cb_queue: &mut CallbackQueue,
     ) -> Result<libc::ssize_t, SyscallError> {
         let socket_ref = &mut *socket.borrow_mut();

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -189,6 +189,8 @@ impl SyscallHandler {
         };
 
         let mut mem = ctx.objs.process.memory_borrow_mut();
+        let mut rng = ctx.objs.host.random_mut();
+        let net_ns = ctx.objs.host.network_namespace_borrow();
 
         let addr = io::read_sockaddr(&mem, addr_ptr, addr_len)?;
 
@@ -209,7 +211,7 @@ impl SyscallHandler {
         // call the socket's sendmsg(), and run any resulting events
         let mut result = crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
             CallbackQueue::queue_and_run(|cb_queue| {
-                Socket::sendmsg(socket, args, &mut mem, cb_queue)
+                Socket::sendmsg(socket, args, &mut mem, &net_ns, &mut *rng, cb_queue)
             })
         });
 
@@ -265,6 +267,8 @@ impl SyscallHandler {
         };
 
         let mut mem = ctx.objs.process.memory_borrow_mut();
+        let mut rng = ctx.objs.host.random_mut();
+        let net_ns = ctx.objs.host.network_namespace_borrow();
 
         let msg = io::read_msghdr(&mem, msg_ptr)?;
 
@@ -279,7 +283,7 @@ impl SyscallHandler {
         // call the socket's sendmsg(), and run any resulting events
         let mut result = crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
             CallbackQueue::queue_and_run(|cb_queue| {
-                Socket::sendmsg(socket, args, &mut mem, cb_queue)
+                Socket::sendmsg(socket, args, &mut mem, &net_ns, &mut *rng, cb_queue)
             })
         });
 

--- a/src/main/host/syscall/handler/uio.rs
+++ b/src/main/host/syscall/handler/uio.rs
@@ -471,6 +471,8 @@ impl SyscallHandler {
         flags: libc::c_int,
     ) -> Result<libc::ssize_t, SyscallError> {
         let mut mem = ctx.objs.process.memory_borrow_mut();
+        let mut rng = ctx.objs.host.random_mut();
+        let net_ns = ctx.objs.host.network_namespace_borrow();
 
         // if it's a socket, call sendmsg_helper() instead
         if let File::Socket(ref socket) = file {
@@ -490,7 +492,7 @@ impl SyscallHandler {
             let bytes_written =
                 crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
                     CallbackQueue::queue_and_run(|cb_queue| {
-                        Socket::sendmsg(socket, args, &mut mem, cb_queue)
+                        Socket::sendmsg(socket, args, &mut mem, &net_ns, &mut *rng, cb_queue)
                     })
                 })?;
 

--- a/src/main/routing/packet.c
+++ b/src/main/routing/packet.c
@@ -151,6 +151,19 @@ void packet_setPayloadWithMemoryManager(Packet* packet, const Host* host, Untype
     packet->priority = host_getNextPacketPriority(host);
 }
 
+void packet_setPayloadFromShadow(Packet* packet, const Host* host, const void* payload,
+                                 gsize payloadLength) {
+    MAGIC_ASSERT(packet);
+    utility_debugAssert(payload);
+    utility_debugAssert(!packet->payload);
+
+    /* the payload starts with 1 ref, which we hold */
+    packet->payload = payload_newFromShadow(payload, payloadLength);
+    utility_alwaysAssert(packet->payload != NULL);
+    /* application data needs a priority ordering for FIFO onto the wire */
+    packet->priority = host_getNextPacketPriority(host);
+}
+
 /* copy everything except the payload.
  * the payload will point to the same payload as the original packet.
  * the payload is protected so it is safe to send the copied packet to a different host. */

--- a/src/main/routing/packet.h
+++ b/src/main/routing/packet.h
@@ -46,6 +46,8 @@ void packet_setPayload(Packet* packet, const Thread* thread, UntypedForeignPtr p
                        gsize payloadLength);
 void packet_setPayloadWithMemoryManager(Packet* packet, const Host* host, UntypedForeignPtr payload,
                                         gsize payloadLength, const MemoryManager* mem);
+void packet_setPayloadFromShadow(Packet* packet, const Host* host, const void* payload,
+                                 gsize payloadLength);
 Packet* packet_copy(Packet* packet);
 
 // Exposed for unit testing only. Use `packet_new` outside of tests.

--- a/src/main/routing/payload.c
+++ b/src/main/routing/payload.c
@@ -73,6 +73,25 @@ Payload* payload_newWithMemoryManager(UntypedForeignPtr data, gsize dataLength,
     return payload;
 }
 
+Payload* payload_newFromShadow(const void* data, gsize dataLength) {
+    Payload* payload = g_new0(Payload, 1);
+    MAGIC_INIT(payload);
+
+    if (data && dataLength > 0) {
+        payload->data = g_malloc0(dataLength);
+        utility_debugAssert(payload->data != NULL);
+        memcpy(payload->data, data, dataLength);
+        payload->length = dataLength;
+    }
+
+    g_mutex_init(&(payload->lock));
+    payload->referenceCount = 1;
+
+    worker_count_allocation(Payload);
+
+    return payload;
+}
+
 static void _payload_free(Payload* payload) {
     MAGIC_ASSERT(payload);
 

--- a/src/main/routing/payload.h
+++ b/src/main/routing/payload.h
@@ -17,6 +17,7 @@ typedef struct _Payload Payload;
 Payload* payload_new(const Thread* thread, UntypedForeignPtr data, gsize dataLength);
 Payload* payload_newWithMemoryManager(UntypedForeignPtr data, gsize dataLength,
                                       const MemoryManager* mem);
+Payload* payload_newFromShadow(const void* data, gsize dataLength);
 
 void payload_ref(Payload* payload);
 void payload_unref(Payload* payload);

--- a/src/main/utility/sockaddr.rs
+++ b/src/main/utility/sockaddr.rs
@@ -247,6 +247,18 @@ impl From<nix::sys::socket::SockaddrIn6> for SockaddrStorage {
     }
 }
 
+impl From<std::net::SocketAddrV4> for SockaddrStorage {
+    fn from(addr: std::net::SocketAddrV4) -> Self {
+        nix::sys::socket::SockaddrIn::from(addr).into()
+    }
+}
+
+impl From<std::net::SocketAddrV6> for SockaddrStorage {
+    fn from(addr: std::net::SocketAddrV6) -> Self {
+        nix::sys::socket::SockaddrIn6::from(addr).into()
+    }
+}
+
 /// A Unix socket address. Typically will be used as an owned address
 /// `SockaddrUnix<libc::sockaddr_un>` or a borrowed address `SockaddrUnix<&libc::sockaddr_un>`, and
 /// you can convert between them using methods such as [`as_ref`](Self::as_ref) or

--- a/src/test/socket/send_recv/test_send_recv.rs
+++ b/src/test/socket/send_recv/test_send_recv.rs
@@ -136,11 +136,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                 test_utils::ShadowTest::new(
                     &append_args("test_send_after_dgram_peer_close"),
                     move || test_send_after_dgram_peer_close(sys_method, domain),
-                    match (sys_method, domain) {
-                        // TODO: dgram inet sockets aren't yet supported by msg syscalls
-                        (SendRecvMethod::Msg, libc::AF_INET) => set![TestEnv::Libc],
-                        _ => set![TestEnv::Libc, TestEnv::Shadow],
-                    },
+                    set![TestEnv::Libc, TestEnv::Shadow],
                 ),
             ]);
 
@@ -161,13 +157,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                 tests.extend(vec![test_utils::ShadowTest::new(
                     &append_args("test_not_connected"),
                     move || test_not_connected(sys_method, domain, sock_type),
-                    match (sys_method, domain, sock_type) {
-                        // TODO: dgram inet sockets aren't yet supported by msg syscalls
-                        (SendRecvMethod::Msg, libc::AF_INET, libc::SOCK_DGRAM) => {
-                            set![TestEnv::Libc]
-                        }
-                        _ => set![TestEnv::Libc, TestEnv::Shadow],
-                    },
+                    set![TestEnv::Libc, TestEnv::Shadow],
                 )]);
             }
         }
@@ -195,34 +185,26 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                     format!("{s} <sys_method={sys_method:?}, init_method={init_method:?}, sock_type={sock_type}>")
                 };
 
-                let passing = match (sys_method, init_method, sock_type) {
-                    // TODO: dgram inet sockets aren't yet supported by msg syscalls
-                    (SendRecvMethod::Msg, SocketInitMethod::Inet, libc::SOCK_DGRAM) => {
-                        set![TestEnv::Libc]
-                    }
-                    _ => set![TestEnv::Libc, TestEnv::Shadow],
-                };
-
                 tests.extend(vec![
                     test_utils::ShadowTest::new(
                         &append_args("test_null_buf"),
                         move || test_null_buf(sys_method, init_method, sock_type),
-                        passing.clone(),
+                        set![TestEnv::Libc, TestEnv::Shadow],
                     ),
                     test_utils::ShadowTest::new(
                         &append_args("test_zero_len_buf"),
                         move || test_zero_len_buf(sys_method, init_method, sock_type),
-                        passing.clone(),
+                        set![TestEnv::Libc, TestEnv::Shadow],
                     ),
                     test_utils::ShadowTest::new(
                         &append_args("test_flag_dontwait"),
                         move || test_flag_dontwait(sys_method, init_method, sock_type),
-                        passing.clone(),
+                        set![TestEnv::Libc, TestEnv::Shadow],
                     ),
                     test_utils::ShadowTest::new(
                         &append_args("test_blocking"),
                         move || test_blocking(sys_method, init_method, sock_type),
-                        passing,
+                        set![TestEnv::Libc, TestEnv::Shadow],
                     ),
                 ]);
             }
@@ -254,39 +236,31 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                         )
                     };
 
-                    let passing = match (sys_method, init_method, sock_type) {
-                        // TODO: dgram inet sockets aren't yet supported by msg syscalls
-                        (SendRecvMethod::Msg, SocketInitMethod::Inet, libc::SOCK_DGRAM) => {
-                            set![TestEnv::Libc]
-                        }
-                        _ => set![TestEnv::Libc, TestEnv::Shadow],
-                    };
-
                     tests.extend(vec![
                         test_utils::ShadowTest::new(
                             &append_args("test_null_addr"),
                             move || test_null_addr(sys_method, init_method, sock_type, flag),
-                            passing.clone(),
+                            set![TestEnv::Libc, TestEnv::Shadow],
                         ),
                         test_utils::ShadowTest::new(
                             &append_args("test_null_both"),
                             move || test_null_both(sys_method, init_method, sock_type, flag),
-                            passing.clone(),
+                            set![TestEnv::Libc, TestEnv::Shadow],
                         ),
                         test_utils::ShadowTest::new(
                             &append_args("test_nonnull_addr"),
                             move || test_nonnull_addr(sys_method, init_method, sock_type, flag),
-                            passing.clone(),
+                            set![TestEnv::Libc, TestEnv::Shadow],
                         ),
                         test_utils::ShadowTest::new(
                             &append_args("test_recv_addr <bind_client=false>"),
                             move || test_recv_addr(sys_method, init_method, sock_type, flag, false),
-                            passing.clone(),
+                            set![TestEnv::Libc, TestEnv::Shadow],
                         ),
                         test_utils::ShadowTest::new(
                             &append_args("test_recv_addr <bind_client=true>"),
                             move || test_recv_addr(sys_method, init_method, sock_type, flag, true),
-                            passing.clone(),
+                            set![TestEnv::Libc, TestEnv::Shadow],
                         ),
                         test_utils::ShadowTest::new(
                             &append_args("test_recv_flag_trunc"),
@@ -300,7 +274,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                         test_utils::ShadowTest::new(
                             &append_args("test_send_flag_trunc"),
                             move || test_send_flag_trunc(sys_method, init_method, sock_type, flag),
-                            passing.clone(),
+                            set![TestEnv::Libc, TestEnv::Shadow],
                         ),
                     ]);
 
@@ -319,7 +293,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                             test_utils::ShadowTest::new(
                                 &append_args("test_large_buf"),
                                 move || test_large_buf(sys_method, init_method, sock_type, flag),
-                                passing.clone(),
+                                set![TestEnv::Libc, TestEnv::Shadow],
                             ),
                             test_utils::ShadowTest::new(
                                 &append_args("test_after_peer_close_empty_buf"),
@@ -331,7 +305,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                                         flag,
                                     )
                                 },
-                                passing.clone(),
+                                set![TestEnv::Libc, TestEnv::Shadow],
                             ),
                             test_utils::ShadowTest::new(
                                 &append_args("test_after_peer_close_nonempty_buf"),
@@ -378,14 +352,14 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                                         flag,
                                     )
                                 },
-                                passing.clone(),
+                                set![TestEnv::Libc, TestEnv::Shadow],
                             ),
                             test_utils::ShadowTest::new(
                                 &append_args("test_msg_order_dgram"),
                                 move || {
                                     test_msg_order_dgram(sys_method, init_method, sock_type, flag)
                                 },
-                                passing.clone(),
+                                set![TestEnv::Libc, TestEnv::Shadow],
                             ),
                         ]);
                     }
@@ -401,7 +375,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                                     flag,
                                 )
                             },
-                            passing,
+                            set![TestEnv::Libc, TestEnv::Shadow],
                         )]);
                     }
                 }
@@ -411,11 +385,7 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
         tests.extend(vec![test_utils::ShadowTest::new(
             &append_args("test_large_buf_udp"),
             move || test_large_buf_udp(sys_method),
-            match sys_method {
-                // TODO: dgram inet sockets aren't yet supported by msg syscalls
-                SendRecvMethod::Msg => set![TestEnv::Libc],
-                _ => set![TestEnv::Libc, TestEnv::Shadow],
-            },
+            set![TestEnv::Libc, TestEnv::Shadow],
         )]);
     }
 


### PR DESCRIPTION
This adds a rust implementation of udp. A future PR will remove the C version, along with the C socket syscall handlers and other legacy code.

There are still some TODO comments in the udp code that should be looked at and have tests added for, but I'll leave those for future PRs. All of the existing udp tests pass with this new rust version, and it also supports `sendmsg`/`recvmsg` and `shutdown`. It should behave similar to the C version, but there are a few changes such as the socket buffer size acting as a soft limit rather than a hard limit. There are also some accesses of the host through the worker that shouldn't be there, but these are required until we rewrite the network interface in rust.