### PR TITLE
Partly fix raw clone test

### DIFF
--- a/ci/container_scripts/test.sh
+++ b/ci/container_scripts/test.sh
@@ -30,9 +30,10 @@ FLAGS+=("--")
 # We exclude some tests in some configurations.
 FLAGS+=("--exclude-regex" "$EXCLUDE")
 
-# Exclude tgen and tor tests as we test them in a different workflow
-# Exclude examples as we don't have all the required dependencies
-FLAGS+=("--label-exclude" "tgen|tor|example")
+# * Exclude tgen and tor tests as we test them in a different workflow.
+# * Exclude examples as we don't have all the required dependencies.
+# * Exclude flaky tests.
+FLAGS+=("--label-exclude" "tgen|tor|example|flaky")
 
 FLAGS+=("--output-on-failure")
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -762,10 +762,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-errno"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583acc33595c32cf8b0702115d4abdafecfabf257d28513499b93140db38a523"
+dependencies = [
+ "posix-errno",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+
+[[package]]
+name = "linux-syscall"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ca924c756acef088aa8d06e6a0b0d47d3ba5587b5bbc8a7255f10c1be10c30"
+dependencies = [
+ "linux-errno",
+]
 
 [[package]]
 name = "log"
@@ -1054,6 +1072,12 @@ checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "posix-errno"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3ed686be262618484b930cdbdf0db6e991de9a74aebb0855bfde058600927c"
 
 [[package]]
 name = "ppv-lite86"
@@ -1867,6 +1891,8 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "libc",
+ "linux-errno",
+ "linux-syscall",
  "loom",
  "nix",
  "rand",

--- a/src/lib/shim/shim_seccomp.c
+++ b/src/lib/shim/shim_seccomp.c
@@ -2,6 +2,7 @@
  * The Shadow Simulator
  * See LICENSE for licensing information
  */
+#include "shim_seccomp.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -91,18 +92,6 @@ void shim_seccomp_init() {
     if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
         panic("prctl: %s", strerror(errno));
     }
-
-    // These symbols are defined by the linker, and give the bounds of the code
-    // section `shadow_allow_syscalls`. If these become link errors, we may need to add/modify
-    // a linker script to explicitly define such symbols ourselves.
-    // https://stackoverflow.com/questions/4156585/how-to-get-the-length-of-a-function-in-bytes/22047976#comment83965391_22047976
-    //
-    // I wasn't able to find clear documentation from `ld` itself about how and
-    // when these symbols are generated, but [`ld(1)`](https://www.man7.org/linux/man-pages/man1/ld.1.html)
-    // does mention them in passing; e.g. the `start-stop-visibility` option controls
-    // their visibility.
-    extern char __start_shadow_allow_syscalls[];
-    extern char __stop_shadow_allow_syscalls[];
 
     /* A bpf program to be loaded as a `seccomp` filter. Unfortunately the
      * documentation for how to write this is pretty sparse. There's a useful

--- a/src/lib/shim/shim_seccomp.h
+++ b/src/lib/shim/shim_seccomp.h
@@ -15,4 +15,34 @@ void shim_seccomp_init();
 // execution after a clone syscall.
 ucontext_t* shim_parent_thread_ctx();
 
+// The name of the section from which the seccomp filter will allow syscalls.
+// Must be consistent with the `extern char` symbols below.
+#define SHADOW_ALLOW_NATIVE_SYSCALL_SECTION "shadow_allow_syscalls"
+
+// These symbols are defined by the linker, and give the bounds of the code
+// section `shadow_allow_syscalls`. If these become link errors, we may need to add/modify
+// a linker script to explicitly define such symbols ourselves.
+// https://stackoverflow.com/questions/4156585/how-to-get-the-length-of-a-function-in-bytes/22047976#comment83965391_22047976
+//
+// I wasn't able to find clear documentation from `ld` itself about how and
+// when these symbols are generated, but
+// [`ld(1)`](https://www.man7.org/linux/man-pages/man1/ld.1.html) does mention them in passing; e.g.
+// the `start-stop-visibility` option controls their visibility.
+//
+// These names must be consistent with `SHADOW_ALLOW_NATIVE_SYSCALL_SECTION`, above.
+extern char __start_shadow_allow_syscalls[];
+extern char __stop_shadow_allow_syscalls[];
+
+// Function attributes to add to a function so that the seccomp filter allows
+// it to make direct syscalls (using inline asm).
+//
+// Example:
+// ```
+// __attribute__((SHADOW_ALLOW_NATIVE_SYSCALL_FN_ATTRS)) my_fn() {
+//     pid_t tid = 0;
+//     __asm__("syscall" : "=a"(tid) : "a"(SYS_gettid) :);
+// }
+// ```
+#define SHADOW_ALLOW_NATIVE_SYSCALL_FN_ATTRS noinline, section(SHADOW_ALLOW_NATIVE_SYSCALL_SECTION)
+
 #endif // SRC_LIB_SHIM_SHIM_SECCOMP_H_

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -22,10 +22,7 @@
 // Helper macro for calculating immediate offsets in asm.
 #define MCTX_REG_OFFSET(i) (offsetof(mcontext_t, gregs) + sizeof(uint64_t) * (i))
 
-// Never inline, so that the seccomp filter can reliably whitelist a syscall from
-// this function.
-// TODO: Drop if/when we whitelist using /proc/self/maps
-__attribute__((noinline, section("shadow_allow_syscalls"))) static long
+__attribute__((SHADOW_ALLOW_NATIVE_SYSCALL_FN_ATTRS)) static long
 _shim_clone(const ucontext_t* ctx, int32_t flags, void* child_stack, pid_t* ptid, pid_t* ctid,
             uint64_t newtls) {
     if (!child_stack) {
@@ -116,7 +113,7 @@ _shim_clone(const ucontext_t* ctx, int32_t flags, void* child_stack, pid_t* ptid
 // Never inline, so that the seccomp filter can reliably whitelist a syscall from
 // this function.
 // TODO: Drop if/when we whitelist using /proc/self/maps
-__attribute__((noinline, section("shadow_allow_syscalls"))) static long
+__attribute__((SHADOW_ALLOW_NATIVE_SYSCALL_FN_ATTRS)) static long
 _shim_native_syscallv(const ucontext_t* ctx, long n, va_list args) {
     long arg1 = va_arg(args, long);
     long arg2 = va_arg(args, long);

--- a/src/lib/shim/shim_tls.c
+++ b/src/lib/shim/shim_tls.c
@@ -2,7 +2,9 @@
 
 #include "lib/logger/logger.h"
 #include "lib/shim/shim.h"
+#include "lib/shim/shim_seccomp.h"
 #include "lib/shim/shim_syscall.h"
+#include "main/utility/syscall.h"
 
 #include <assert.h>
 #include <stdalign.h>
@@ -13,24 +15,75 @@
 // thread. We fail at runtime if this limit is exceeded.
 #define BYTES_PER_THREAD 1024
 
+// Max threads for our slow TLS fallback mechanism.
+#define TLS_FALLBACK_MAX_THREADS 1000
+
 // Stores the TLS for a single thread.
 typedef struct ShimThreadLocalStorage {
     alignas(16) char _bytes[BYTES_PER_THREAD];
 } ShimThreadLocalStorage;
 
-// The shim's TLS for the current thread. We currently only store a pointer in
-// native TLS, which is dynamically allocated when the thread starts, and leaks
-// when the thread exits.
-//
-// Ideally we would allocate the ShimThreadLocalStorage itself in native TLS,
-// which would remove the leak, but changing the memory protections to set up
-// the stack guard page in _shim_init_signal_stack breaks glibc's TLS allocator.
-// If we want to do this in the future maybe we can try to revert the
-// protections just before the thread exits.
-//
-// We could alternatively change `_shim_init_signal_stack` to dynamically
-// allocate its stack instead of using TLS, but that'd just move the leak there.
-static __thread ShimThreadLocalStorage _tls = {0};
+// Get the shim's TLS for the current thread. We avoid directly using native
+// TLS throughout the shim, since this is a libc dependency.
+static ShimThreadLocalStorage* _tls_storage() {
+    // Linux's native TLS uses the %fs register when it's set up.
+    // When it's not in use, %fs should be 0.
+    void* fs = NULL;
+    __asm__("mov %%fs:0x0, %0" : "=r"(fs)::);
+
+    if (fs != NULL) {
+        // Native (libc) TLS seems to be set up properly. Use it.
+        static __thread ShimThreadLocalStorage _tls = {0};
+        return &_tls;
+    }
+
+    // Hacky, slow TLS to support bare calls to `clone`.
+    // Mostly to let us test bare clone calls; real programs
+    // will almost certainly use native TLS.
+
+    // Parallel arrays mapping thread IDS to backing storage.
+    static pid_t* thread_ids=NULL;
+    static ShimThreadLocalStorage* global_tls=NULL;
+
+    // Lazy allocation, since we normally don't need this.
+    // Allocate all at once for simplicity.
+    static bool initd = false;
+    if (!initd) {
+        thread_ids = (void*)shim_native_syscall(
+            NULL, SYS_mmap, NULL, sizeof(pid_t) * TLS_FALLBACK_MAX_THREADS, PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        global_tls = (void*)shim_native_syscall(
+            NULL, SYS_mmap, NULL, sizeof(ShimThreadLocalStorage) * TLS_FALLBACK_MAX_THREADS,
+            PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (syscall_rawReturnValueToErrno((long)thread_ids) != 0 ||
+            syscall_rawReturnValueToErrno((long)global_tls != 0)) {
+            // We failed to allocate. Crash.
+            shim_native_syscall(NULL, SYS_kill, 0, SIGABRT);
+            asm("ud2");
+        }
+        initd = true;
+    }
+
+    pid_t tid = (pid_t)shim_native_syscall(NULL, SYS_gettid);
+    for (size_t i = 0; i < TLS_FALLBACK_MAX_THREADS; ++i) {
+        if (thread_ids[i] == tid) {
+            // Already one allocated for this thread.
+            return &global_tls[i];
+        }
+        if (thread_ids[i] == 0) {
+            // Use this slot.
+            thread_ids[i] = tid;
+            return &global_tls[i];
+        }
+    }
+
+    // We ran out of slots. Either increase TLS_FALLBACK_MAX_THREADS, or extend
+    // to support reuse after thread exit and/or dynamic growth.
+    shim_native_syscall(NULL, SYS_kill, 0, SIGABRT);
+    asm("ud2");
+
+    return NULL;
+}
 
 // Each ShimTlsVar is assigned an offset in the ShimThreadLocalStorage's.
 // This is the next free offset.
@@ -57,5 +110,5 @@ void* shimtlsvar_ptr(ShimTlsVar* v, size_t sz) {
         }
         v->_initd = true;
     }
-    return &_tls._bytes[v->_offset];
+    return &_tls_storage()->_bytes[v->_offset];
 }

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 # https://github.com/shadow/shadow/issues/2919
 [dependencies]
 libc = "0.2"
+linux-errno = "1.0.1"
+linux-syscall = "1.0.0"
 nix = "0.26.2"
 rkyv = "0.7.41"
 static_assertions = "1.1.0"

--- a/src/lib/vasi-sync/src/sync.rs
+++ b/src/lib/vasi-sync/src/sync.rs
@@ -31,85 +31,106 @@ loom::lazy_static! {
 }
 
 #[cfg(not(loom))]
-pub fn futex_wait(futex_word: &AtomicU32, val: u32) -> nix::Result<i64> {
-    nix::errno::Errno::result(unsafe {
-        libc::syscall(
-            libc::SYS_futex,
-            futex_word as *const _,
-            libc::FUTEX_WAIT,
-            val,
-            core::ptr::null() as *const libc::timespec,
-            core::ptr::null_mut() as *mut u32,
-            0u32,
-        )
-    })
-}
-#[cfg(loom)]
-pub fn futex_wait(futex_word: &AtomicU32, val: u32) -> nix::Result<i64> {
-    // From futex(2):
-    //   This load, the comparison with the expected value, and starting to
-    //   sleep are performed atomically and totally ordered with
-    //   respect to other futex operations on the same futex word.
-    //
-    // We hold a lock on our FUTEXES to represent this.
-    // TODO: If we want to run loom tests with multiple interacting locks,
-    // we should have per-futex mutexes here, and not hold a lock over the
-    // whole list the whole time.
-    let mut hashmap = FUTEXES.lock().unwrap();
-    let futex_word_val = futex_word.load(Ordering::Relaxed);
-    if futex_word_val != val {
-        return Err(nix::errno::Errno::EAGAIN);
-    }
-    let condvar = hashmap
-        .entry(futex_word as *const _ as usize)
-        .or_insert(Arc::new(Condvar::new()))
-        .clone();
-    // We could get a spurious wakeup here, but that's ok.
-    // Futexes are subject to spurious wakeups too.
-    condvar.wait(hashmap).unwrap();
-    Ok(0)
-}
-
-#[cfg(not(loom))]
-pub fn futex_wake(futex_word: &AtomicU32) -> nix::Result<()> {
-    // The kernel just checks for equality of the value at `futex_word`,
-    // which it interprets as `* const u32`.
-    //
-    // This is safe since `AtomicU32` ["has the same in-memory
-    // representation as the underlying integer type,
-    // u32"](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicU32.html#).
-    //
-    // TODO: Consider using
-    // [`as_mut_ptr`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicU32.html#method.as_mut_ptr)
-    // here once it's stabilized.
+unsafe fn futex(futex_word: &AtomicU32, futex_operation: i32, val: u32) -> nix::Result<i64> {
     type SourceT = AtomicU32;
     type TargetT = u32;
     let futex_word: &SourceT = futex_word;
     static_assertions::assert_eq_size!(SourceT, TargetT);
     static_assertions::assert_eq_align!(SourceT, TargetT);
+    // TODO: Consider using
+    // [`as_mut_ptr`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicU32.html#method.as_mut_ptr)
+    // here once it's stabilized.
     let futex_word: *const TargetT = futex_word as *const SourceT as *const TargetT;
 
-    nix::errno::Errno::result(unsafe {
-        libc::syscall(
-            libc::SYS_futex,
-            futex_word,
-            libc::FUTEX_WAKE,
-            1,
-            core::ptr::null() as *const libc::timespec,
-            core::ptr::null_mut() as *mut u32,
-            0u32,
-        )
-    })?;
-    Ok(())
+    #[cfg(not(miri))]
+    {
+        use linux_syscall::Result64;
+
+        // We use linux_syscall here to avoid the libc dependency, and touching
+        // libc's `errno` in particular.
+        let raw_res = unsafe {
+            linux_syscall::syscall!(
+                linux_syscall::SYS_futex,
+                futex_word,
+                futex_operation,
+                val,
+                core::ptr::null() as *const libc::timespec,
+                core::ptr::null_mut() as *mut u32,
+                0u32,
+            )
+        };
+        raw_res
+            .try_i64()
+            .map_err(|e| nix::errno::Errno::from_i32(e.into()))
+    }
+    // Miri doesn't understands raw syscall assembly, but does understand
+    // futex syscalls made through the libc syscall wrapper.
+    // It's ok to depend on libc for miri testing.
+    #[cfg(miri)]
+    {
+        nix::errno::Errno::result(unsafe {
+            libc::syscall(
+                libc::SYS_futex,
+                futex_word,
+                futex_operation,
+                val,
+                core::ptr::null() as *const libc::timespec,
+                core::ptr::null_mut() as *mut u32,
+                0u32,
+            )
+        })
+    }
 }
-#[cfg(loom)]
+
+pub fn futex_wait(futex_word: &AtomicU32, val: u32) -> nix::Result<i64> {
+    // In "production" we use linux_syscall to avoid going through libc, and to
+    // avoid touching libc's `errno` in particular.
+    #[cfg(not(loom))]
+    {
+        unsafe { futex(futex_word, libc::FUTEX_WAIT, val) }
+    }
+    #[cfg(loom)]
+    {
+        // From futex(2):
+        //   This load, the comparison with the expected value, and starting to
+        //   sleep are performed atomically and totally ordered with
+        //   respect to other futex operations on the same futex word.
+        //
+        // We hold a lock on our FUTEXES to represent this.
+        // TODO: If we want to run loom tests with multiple interacting locks,
+        // we should have per-futex mutexes here, and not hold a lock over the
+        // whole list the whole time.
+        let mut hashmap = FUTEXES.lock().unwrap();
+        let futex_word_val = futex_word.load(Ordering::Relaxed);
+        if futex_word_val != val {
+            return Err(nix::errno::Errno::EAGAIN);
+        }
+        let condvar = hashmap
+            .entry(futex_word as *const _ as usize)
+            .or_insert(Arc::new(Condvar::new()))
+            .clone();
+        // We could get a spurious wakeup here, but that's ok.
+        // Futexes are subject to spurious wakeups too.
+        condvar.wait(hashmap).unwrap();
+        Ok(0)
+    }
+}
+
 pub fn futex_wake(futex_word: &AtomicU32) -> nix::Result<()> {
-    let hashmap = FUTEXES.lock().unwrap();
-    let Some(condvar) = hashmap.get(&(futex_word as *const _ as usize)) else {
-        return Ok(());
-    };
-    condvar.notify_one();
-    Ok(())
+    #[cfg(not(loom))]
+    {
+        unsafe { futex(futex_word, libc::FUTEX_WAKE, 1) }.map(|_| ())
+    }
+    // loom doesn't understand syscalls; emulate via loom primitives.
+    #[cfg(loom)]
+    {
+        let hashmap = FUTEXES.lock().unwrap();
+        let Some(condvar) = hashmap.get(&(futex_word as *const _ as usize)) else {
+            return Ok(());
+        };
+        condvar.notify_one();
+        Ok(())
+    }
 }
 
 #[cfg(not(loom))]

--- a/src/test/clone/CMakeLists.txt
+++ b/src/test/clone/CMakeLists.txt
@@ -4,14 +4,35 @@ target_compile_options(test_clone PUBLIC "-pthread")
 target_link_libraries(test_clone ${GLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 add_linux_tests(BASENAME clone COMMAND test_clone)
 
-# FIXME: This test doesn't implement native thread-local-storage, which the shim needs.
-# https://github.com/shadow/shadow/issues/1559
-# add_shadow_tests(BASENAME clone)
+add_shadow_tests(
+    BASENAME clone
+    # Shim-side logging and strace-logging use libc functions that assume native
+    # thread-local-storage is set up. We disable most logging to try to avoid resulting
+    # segfaults.
+    LOGLEVEL warning
+    ARGS --strace-logging-mode=off
+    PROPERTIES
+        # There are nonetheless stills sometimes segfaults when running in CI,
+        # but I haven't been able to reproduce them locally.
+        # https://github.com/shadow/shadow/issues/1559
+        LABELS flaky
+        CONFIGURATIONS extra
+)
 
 # The clone test exercises some corner cases in memory management, particularly
 # when the thread leader exits before all the threads. Useful to test it without
 # the memory manager (really the MemoryMapper) enabled.
-#
-# FIXME: This test doesn't implement native thread-local-storage, which the shim needs.
-# https://github.com/shadow/shadow/issues/1559
-# add_shadow_tests(BASENAME clone-nomm SKIP_METHODS preload ARGS --use-memory-manager=false)
+add_shadow_tests(
+    BASENAME clone-nomm
+    # Shim-side logging and strace-logging use libc functions that assume native
+    # thread-local-storage is set up. We disable most logging to try to avoid resulting
+    # segfaults.
+    LOGLEVEL warning
+    ARGS --strace-logging-mode=off
+    PROPERTIES
+        # There are nonetheless stills sometimes segfaults when running in CI,
+        # but I haven't been able to reproduce them locally.
+        # https://github.com/shadow/shadow/issues/1559
+        LABELS flaky
+        CONFIGURATIONS extra
+)


### PR DESCRIPTION
This removes some dependencies from the shim on native thread local storage (https://github.com/shadow/shadow/issues/1559). Together with modifying the clone test to explicitly set an empty TLS descriptor, this allows the clone tests to work under shadow... sometimes.

I haven't been able to reproduce the remaining failures locally, but I suspect it's due to usage of libc from the shim, which assumes that native thread local storage is set up. In particular, most libc functions will try to set `errno` on error, which it expects to be in native thread local storage. These accesses result in a segfault in the test.

It would be nice if we could set up proper native thread local storage in these tests, but the process for doing so is not well documented, and I think would conflict with the ones that libc sets up (global state is involved). 

Still, getting this at least partly working will make it easier to test different flags to `clone` individually; e.g. to test `clone` without `CLONE_FILES` as a step towards implementing a full `fork`.