### PR TITLE
Upgrade rustup toolchain to 1.70

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
           # Must be a version built with miri; check
           # https://rust-lang.github.io/rustup-components-history/
-          TOOLCHAIN=nightly-2023-03-13
+          TOOLCHAIN=nightly-2023-05-31
           rustup toolchain install ${TOOLCHAIN} --component miri
           rustup override set ${TOOLCHAIN}
           cargo miri setup

--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -62,7 +62,7 @@ source "$HOME/.cargo/env"
 if [ "${BUILDTYPE:-}" = coverage ]
 then
   # Add a directory override, which overrides rust-toolchain.toml
-  rustup override set nightly-2023-03-13
+  rustup override set nightly-2023-05-31
 fi
 
 # This forces installation of the toolchain required in Shadow's

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,4 +7,4 @@
 # that the newly specified version is baked in and doesn't have to be installed
 # (and rust deps rebuilt) during every incremental build.
 [toolchain]
-channel = "1.69.0"
+channel = "1.70.0"


### PR DESCRIPTION
The main reason is so we can start using the sparse registry.