### PR TITLE
Have UDP sockets drop packets from non-peers

### DIFF
--- a/src/test/socket/connect/test_connect.rs
+++ b/src/test/socket/connect/test_connect.rs
@@ -10,6 +10,8 @@ use test_utils::socket_utils::SockAddr;
 use test_utils::socket_utils::{self, SocketInitMethod};
 use test_utils::TestEnvironment as TestEnv;
 
+use nix::errno::Errno;
+
 struct ConnectArguments {
     fd: libc::c_int,
     addr: Option<SockAddr>, // if None, a null pointer should be used
@@ -97,6 +99,12 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                     &append_args("test_after_close"),
                     move || test_after_close(sock_type, flag),
                     set![TestEnv::Libc, TestEnv::Shadow],
+                ),
+                test_utils::ShadowTest::new(
+                    &append_args("test_two_sockets_same_port"),
+                    move || test_two_sockets_same_port(sock_type, flag),
+                    // TODO: this doesn't work in shadow
+                    set![TestEnv::Libc],
                 ),
                 test_utils::ShadowTest::new(
                     &append_args("test_interface_loopback"),
@@ -460,6 +468,58 @@ fn test_after_close(sock_type: libc::c_int, flag: libc::c_int) -> Result<(), Str
     check_connect_call(&args, Some(libc::EBADF))
 }
 
+/// Test associating two sockets with the same local ip/port, but with one socket having a wildcard
+/// peer association.
+fn test_two_sockets_same_port(sock_type: libc::c_int, flags: libc::c_int) -> Result<(), String> {
+    // since we don't explicitly bind the client, the client will be given an ephemeral port and
+    // associated using the specific 4-tuple (local_ip, local_port, peer_ip, peer_port) for TCP and
+    // the specific 2-tuple (local_ip, local_port) for UDP
+    let (fd_client, fd_peer) = socket_utils::socket_init_helper(
+        socket_utils::SocketInitMethod::Inet,
+        sock_type,
+        flags,
+        /* bind_client= */ false,
+    );
+
+    let fd_other = unsafe { libc::socket(libc::AF_INET, sock_type | flags, 0) };
+
+    test_utils::run_and_close_fds(&[fd_client, fd_peer, fd_other], || {
+        let mut client_addr: libc::sockaddr_in = unsafe { std::mem::zeroed() };
+        let mut client_addr_len: libc::socklen_t =
+            std::mem::size_of_val(&client_addr).try_into().unwrap();
+
+        // get the client address
+        {
+            let rv = unsafe {
+                libc::getsockname(
+                    fd_client,
+                    &mut client_addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
+                    &mut client_addr_len,
+                )
+            };
+            assert_eq!(rv, 0);
+        }
+
+        // try binding a new socket to the same ip/port as the client socket, which would associate
+        // using the wildcard 4-tuple (local_ip, local_port, *, *) for TCP and the 2-tuple (local_ip,
+        // local_port) for UDP
+        {
+            let rv = Errno::result(unsafe {
+                libc::bind(
+                    fd_other,
+                    &client_addr as *const libc::sockaddr_in as *const libc::sockaddr,
+                    client_addr_len,
+                )
+            });
+            // even though the TCP association is different, Linux doesn't allow this (although if this
+            // other socket had a specific peer rather than a wildcard peer, it would work)
+            assert_eq!(rv, Err(Errno::EADDRINUSE));
+        }
+
+        Ok(())
+    })
+}
+
 /// Test connect() to a server listening on the given interface (optionally overriding
 /// the interface the client connects on).
 fn test_interface(
@@ -714,7 +774,7 @@ fn test_recv_original_bind_port() -> Result<(), String> {
             &mut [0u8; 20][..],
             nix::sys::socket::MsgFlags::empty(),
         );
-        assert_eq!(rv, Err(nix::errno::Errno::EAGAIN));
+        assert_eq!(rv, Err(Errno::EAGAIN));
 
         // PART 5: connect server -> client
 


### PR DESCRIPTION
UDP sockets shouldn't rely on the network interface for dropping these packets.

This also adds another connect test, but it's disabled as it doesn't work in Shadow.