### PR TITLE
shim: allow native syscalls from shim's whole .text segment

### DIFF
--- a/src/lib/shim/shim_seccomp.h
+++ b/src/lib/shim/shim_seccomp.h
@@ -15,34 +15,4 @@ void shim_seccomp_init();
 // execution after a clone syscall.
 ucontext_t* shim_parent_thread_ctx();
 
-// The name of the section from which the seccomp filter will allow syscalls.
-// Must be consistent with the `extern char` symbols below.
-#define SHADOW_ALLOW_NATIVE_SYSCALL_SECTION "shadow_allow_syscalls"
-
-// These symbols are defined by the linker, and give the bounds of the code
-// section `shadow_allow_syscalls`. If these become link errors, we may need to add/modify
-// a linker script to explicitly define such symbols ourselves.
-// https://stackoverflow.com/questions/4156585/how-to-get-the-length-of-a-function-in-bytes/22047976#comment83965391_22047976
-//
-// I wasn't able to find clear documentation from `ld` itself about how and
-// when these symbols are generated, but
-// [`ld(1)`](https://www.man7.org/linux/man-pages/man1/ld.1.html) does mention them in passing; e.g.
-// the `start-stop-visibility` option controls their visibility.
-//
-// These names must be consistent with `SHADOW_ALLOW_NATIVE_SYSCALL_SECTION`, above.
-extern char __start_shadow_allow_syscalls[];
-extern char __stop_shadow_allow_syscalls[];
-
-// Function attributes to add to a function so that the seccomp filter allows
-// it to make direct syscalls (using inline asm).
-//
-// Example:
-// ```
-// __attribute__((SHADOW_ALLOW_NATIVE_SYSCALL_FN_ATTRS)) my_fn() {
-//     pid_t tid = 0;
-//     __asm__("syscall" : "=a"(tid) : "a"(SYS_gettid) :);
-// }
-// ```
-#define SHADOW_ALLOW_NATIVE_SYSCALL_FN_ATTRS noinline, section(SHADOW_ALLOW_NATIVE_SYSCALL_SECTION)
-
 #endif // SRC_LIB_SHIM_SHIM_SECCOMP_H_

--- a/src/lib/shim/shim_seccomp.h
+++ b/src/lib/shim/shim_seccomp.h
@@ -11,8 +11,4 @@
 // Initialize the seccomp filter and syscall signal handler function.
 void shim_seccomp_init();
 
-// Gets and resets the instruction pointer to which the child should resume
-// execution after a clone syscall.
-ucontext_t* shim_parent_thread_ctx();
-
 #endif // SRC_LIB_SHIM_SHIM_SECCOMP_H_

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -22,9 +22,8 @@
 // Helper macro for calculating immediate offsets in asm.
 #define MCTX_REG_OFFSET(i) (offsetof(mcontext_t, gregs) + sizeof(uint64_t) * (i))
 
-__attribute__((SHADOW_ALLOW_NATIVE_SYSCALL_FN_ATTRS)) static long
-_shim_clone(const ucontext_t* ctx, int32_t flags, void* child_stack, pid_t* ptid, pid_t* ctid,
-            uint64_t newtls) {
+static long _shim_clone(const ucontext_t* ctx, int32_t flags, void* child_stack, pid_t* ptid,
+                        pid_t* ctid, uint64_t newtls) {
     if (!child_stack) {
         panic("clone without a new stack not implemented");
     }
@@ -110,11 +109,7 @@ _shim_clone(const ucontext_t* ctx, int32_t flags, void* child_stack, pid_t* ptid
     return rv;
 }
 
-// Never inline, so that the seccomp filter can reliably whitelist a syscall from
-// this function.
-// TODO: Drop if/when we whitelist using /proc/self/maps
-__attribute__((SHADOW_ALLOW_NATIVE_SYSCALL_FN_ATTRS)) static long
-_shim_native_syscallv(const ucontext_t* ctx, long n, va_list args) {
+static long _shim_native_syscallv(const ucontext_t* ctx, long n, va_list args) {
     long arg1 = va_arg(args, long);
     long arg2 = va_arg(args, long);
     long arg3 = va_arg(args, long);


### PR DESCRIPTION
This fixes a performance regression introduced in 789f9f247cf9a87c55518cf735725001891f4f5d: making a direct syscall instead of a libc function call in vasi-sync caused us to go through the slow path of getting stopped by seccomp, and have to retry in our seccomp-handling.                   
    
Allowing native syscalls made from the shim's whole `.text` segment includes direct syscalls made from anything linked statically with the shim. This fixes the performance regression and likewise allows us to continue moving from libc to direct syscalls in the shim without sacrificing performance.    
    
We currently don't have a use-case of *wanting* syscalls made directly from the shim to be intercepted. e.g. the closest would be when we call a managed-code-provided signal handler from shim code, and want its syscalls to be intercepted. Those syscalls will still be intercepted though, since they won't be made *directly* from the shim.