### PR TITLE
Break Pod into its own crate

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -732,9 +732,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libloading"
@@ -1074,6 +1074,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "pod"
+version = "0.1.0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1485,6 +1492,7 @@ dependencies = [
  "nix",
  "once_cell",
  "petgraph",
+ "pod",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -1554,6 +1562,7 @@ dependencies = [
  "logger",
  "nix",
  "once_cell",
+ "pod",
  "shadow-build-common",
  "static_assertions",
  "vasi",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1077,13 +1077,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pod"
-version = "0.1.0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "posix-errno"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1460,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadow-pod"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "shadow-rs"
 version = "3.0.0"
 dependencies = [
@@ -1492,7 +1492,6 @@ dependencies = [
  "nix",
  "once_cell",
  "petgraph",
- "pod",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -1504,6 +1503,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shadow-build-common",
+ "shadow-pod",
  "shadow-shim-helper-rs",
  "shadow_shmem",
  "shadow_tsc",
@@ -1562,8 +1562,8 @@ dependencies = [
  "logger",
  "nix",
  "once_cell",
- "pod",
  "shadow-build-common",
+ "shadow-pod",
  "static_assertions",
  "vasi",
 ]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "lib/gml-parser",
     "lib/linux-api",
     "lib/logger",
+    "lib/pod",
     "lib/shmem",
     "lib/shadow-shim-helper-rs",
     "lib/std-util",

--- a/src/lib/pod/Cargo.toml
+++ b/src/lib/pod/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "pod"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libc = "0.2.146"

--- a/src/lib/pod/Cargo.toml
+++ b/src/lib/pod/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = "0.2.146"
+libc = { version = "0.2.146", default-features = false }

--- a/src/lib/pod/Cargo.toml
+++ b/src/lib/pod/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pod"
+name = "shadow-pod"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/lib/pod/src/lib.rs
+++ b/src/lib/pod/src/lib.rs
@@ -1,4 +1,6 @@
-use std::mem::MaybeUninit;
+#![no_std]
+
+use core::mem::MaybeUninit;
 
 /// Marker trait that the given type is Plain Old Data; i.e. that it is safe to
 /// interpret any pattern of bits as a value of this type.
@@ -24,9 +26,9 @@ where
 {
     // SAFETY: Any value and alignment is safe for u8.
     unsafe {
-        std::slice::from_raw_parts(
+        core::slice::from_raw_parts(
             slice.as_ptr() as *const MaybeUninit<u8>,
-            slice.len() * std::mem::size_of::<MaybeUninit<T>>(),
+            slice.len() * core::mem::size_of::<MaybeUninit<T>>(),
         )
     }
 }
@@ -38,7 +40,7 @@ pub fn as_u8_slice<T>(x: &T) -> &[MaybeUninit<u8>]
 where
     T: Pod,
 {
-    to_u8_slice(std::slice::from_ref(x))
+    to_u8_slice(core::slice::from_ref(x))
 }
 
 /// Convert to a mut slice of raw bytes.
@@ -55,9 +57,9 @@ where
 {
     // SAFETY: Any value and alignment is safe for u8.
     unsafe {
-        std::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             slice.as_mut_ptr() as *mut MaybeUninit<u8>,
-            slice.len() * std::mem::size_of::<MaybeUninit<T>>(),
+            slice.len() * core::mem::size_of::<MaybeUninit<T>>(),
         )
     }
 }
@@ -73,7 +75,7 @@ pub unsafe fn as_u8_slice_mut<T>(x: &mut T) -> &mut [MaybeUninit<u8>]
 where
     T: Pod,
 {
-    unsafe { to_u8_slice_mut(std::slice::from_mut(x)) }
+    unsafe { to_u8_slice_mut(core::slice::from_mut(x)) }
 }
 
 /// Create a value of type `T`, with contents initialized to 0s.
@@ -82,7 +84,7 @@ where
     T: Pod,
 {
     // SAFETY: Any value is legal for Pod.
-    unsafe { std::mem::zeroed() }
+    unsafe { core::mem::zeroed() }
 }
 
 // Integer primitives
@@ -103,7 +105,7 @@ unsafe impl Pod for usize {}
 // No! `char` must be a valid unicode value.
 // impl !Pod for char {}
 
-unsafe impl<T> Pod for std::mem::MaybeUninit<T> where T: Pod {}
+unsafe impl<T> Pod for core::mem::MaybeUninit<T> where T: Pod {}
 unsafe impl<T, const N: usize> Pod for [T; N] where T: Pod {}
 
 // libc types

--- a/src/lib/pod/src/lib.rs
+++ b/src/lib/pod/src/lib.rs
@@ -275,10 +275,3 @@ unsafe impl Pod for libc::utmpx {}
 unsafe impl Pod for libc::utsname {}
 unsafe impl Pod for libc::winsize {}
 unsafe impl Pod for libc::clone_args {}
-
-// shadow re-exports this definition from /usr/include/linux/tcp.h
-unsafe impl Pod for crate::cshadow::tcp_info {}
-
-// TODO: Move this module out of `main` so that `shadow_shmem` can use it,
-// and put this with the struct definition.
-unsafe impl Pod for shadow_shmem::allocator::ShMemBlockSerialized {}

--- a/src/lib/pod/src/lib.rs
+++ b/src/lib/pod/src/lib.rs
@@ -1,3 +1,5 @@
+//! Utilities for working with POD (Plain Old Data)
+
 #![no_std]
 
 use core::mem::MaybeUninit;
@@ -11,6 +13,11 @@ use core::mem::MaybeUninit;
 /// We require `Copy` to also rule out anything that implements `Drop`.
 ///
 /// References are inherently non-Pod, so we can require a 'static lifetime.
+///
+/// This is very *similar* in concept to `bytemuck::AnyBitPattern`. However,
+/// unlike `AnyBitPattern`, this trait does not say anything about how the type
+/// can be safely shared. e.g. while `bytemuck::AnyBitPattern` disallows pointer
+/// types, [`Pod`] does not.
 ///
 /// # Safety
 ///

--- a/src/lib/shmem/Cargo.toml
+++ b/src/lib/shmem/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 logger = { path = "../logger" }
+pod = { path = "../pod" }
 vasi = { path = "../vasi" }
 once_cell = "1.18.0"
 libc = "0.2"

--- a/src/lib/shmem/Cargo.toml
+++ b/src/lib/shmem/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 logger = { path = "../logger" }
-pod = { path = "../pod" }
+shadow-pod = { path = "../pod" }
 vasi = { path = "../vasi" }
 once_cell = "1.18.0"
 libc = "0.2"

--- a/src/lib/shmem/src/allocator.rs
+++ b/src/lib/shmem/src/allocator.rs
@@ -1,6 +1,7 @@
 use std::{marker::PhantomData, ops::Deref};
 
 use once_cell::sync::OnceCell;
+use pod::Pod;
 use vasi::VirtualAddressSpaceIndependent;
 
 use crate::c_bindings;
@@ -173,15 +174,12 @@ where
 /// A serialized descriptor for a `ShMemBlock`, suitable to be transferred
 /// across processes, which can be used to create a `ShMemBlockAlias` referencing
 /// the original `ShMemBlock`.
-///
-/// `[main::utility::pod::Pod]` is implemented for type.
-/// TODO: Move the implementation here, after moving the `pod` module
-/// out of `main`.
 #[derive(Copy, Clone, Debug, VirtualAddressSpaceIndependent)]
 #[repr(transparent)]
 pub struct ShMemBlockSerialized {
     internal: c_bindings::ShMemBlockSerialized,
 }
+unsafe impl Pod for ShMemBlockSerialized {}
 
 // SAFETY: This is a serialized blob, designed to be VASI.
 unsafe impl VirtualAddressSpaceIndependent for c_bindings::ShMemBlockSerialized {}

--- a/src/lib/shmem/src/allocator.rs
+++ b/src/lib/shmem/src/allocator.rs
@@ -1,7 +1,7 @@
 use std::{marker::PhantomData, ops::Deref};
 
 use once_cell::sync::OnceCell;
-use pod::Pod;
+use shadow_pod::Pod;
 use vasi::VirtualAddressSpaceIndependent;
 
 use crate::c_bindings;

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -31,6 +31,7 @@ lzma-rs = "0.3"
 memoffset = "0.9.0"
 merge = "0.1"
 nix = "0.26.2"
+pod = { path = "../lib/pod" }
 once_cell = "1.18"
 petgraph = "0.6"
 rand = "0.8.5"

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -31,7 +31,7 @@ lzma-rs = "0.3"
 memoffset = "0.9.0"
 merge = "0.1"
 nix = "0.26.2"
-pod = { path = "../lib/pod" }
+shadow-pod = { path = "../lib/pod" }
 once_cell = "1.18"
 petgraph = "0.6"
 rand = "0.8.5"

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -22,7 +22,6 @@ use crate::host::syscall_types::{ForeignArrayPtr, SyscallError};
 use crate::host::thread::ThreadId;
 use crate::network::packet::PacketRc;
 use crate::utility::callback_queue::{CallbackQueue, Handle};
-use crate::utility::pod;
 use crate::utility::sockaddr::SockaddrStorage;
 use crate::utility::{HostTreePointer, ObjectCounter};
 

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -819,7 +819,7 @@ impl LegacyTcpSocket {
             return Err(Errno::EINVAL.into());
         }
 
-        let mut peer_addr: libc::sockaddr_in = pod::zeroed();
+        let mut peer_addr: libc::sockaddr_in = shadow_pod::zeroed();
         peer_addr.sin_family = libc::AF_INET as u16;
         let mut accepted_fd = -1;
 
@@ -924,7 +924,7 @@ impl LegacyTcpSocket {
     ) -> Result<libc::socklen_t, SyscallError> {
         match (level, optname) {
             (libc::SOL_TCP, libc::TCP_INFO) => {
-                let mut info = pod::zeroed();
+                let mut info = shadow_pod::zeroed();
                 unsafe { c::tcp_getInfo(self.as_legacy_tcp(), &mut info) };
 
                 let optval_ptr = optval_ptr.cast::<crate::cshadow::tcp_info>();

--- a/src/main/host/managed_thread.rs
+++ b/src/main/host/managed_thread.rs
@@ -23,7 +23,7 @@ use crate::core::scheduler;
 use crate::core::worker::{Worker, WORKER_SHARED};
 use crate::cshadow;
 use crate::host::syscall_types::SyscallReturn;
-use crate::utility::{pod, syscall};
+use crate::utility::syscall;
 
 /// The ManagedThread's state after having been allowed to execute some code.
 #[derive(Debug)]

--- a/src/main/host/managed_thread.rs
+++ b/src/main/host/managed_thread.rs
@@ -519,7 +519,7 @@ impl ManagedThread {
             .chain(std::iter::once(std::ptr::null_mut()))
             .collect();
 
-        let mut file_actions: libc::posix_spawn_file_actions_t = pod::zeroed();
+        let mut file_actions: libc::posix_spawn_file_actions_t = shadow_pod::zeroed();
         Errno::result(unsafe { libc::posix_spawn_file_actions_init(&mut file_actions) }).unwrap();
 
         // Dup straceFd; the dup'd descriptor won't have O_CLOEXEC set.
@@ -576,7 +576,7 @@ impl ManagedThread {
         })
         .unwrap();
 
-        let mut spawn_attr: libc::posix_spawnattr_t = pod::zeroed();
+        let mut spawn_attr: libc::posix_spawnattr_t = shadow_pod::zeroed();
         Errno::result(unsafe { libc::posix_spawnattr_init(&mut spawn_attr) }).unwrap();
 
         // In versions of glibc before 2.24, we need this to tell posix_spawn

--- a/src/main/host/memory_manager/memory_copier.rs
+++ b/src/main/host/memory_manager/memory_copier.rs
@@ -2,12 +2,11 @@ use std::fmt::Debug;
 
 use log::*;
 use nix::{errno::Errno, unistd::Pid};
+use pod::Pod;
 
 use crate::core::worker::Worker;
 use crate::host::memory_manager::page_size;
 use crate::host::syscall_types::ForeignArrayPtr;
-use crate::utility::pod;
-use crate::utility::pod::Pod;
 
 /// A utility for copying data to and from a process's memory.
 #[derive(Debug, Clone)]

--- a/src/main/host/memory_manager/memory_copier.rs
+++ b/src/main/host/memory_manager/memory_copier.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use log::*;
 use nix::{errno::Errno, unistd::Pid};
-use pod::Pod;
+use shadow_pod::Pod;
 
 use crate::core::worker::Worker;
 use crate::host::memory_manager::page_size;
@@ -58,7 +58,7 @@ impl MemoryCopier {
     {
         // Convert to u8
         // SAFETY: We do not write uninitialized data into `buf`.
-        let buf: &mut [std::mem::MaybeUninit<u8>] = unsafe { pod::to_u8_slice_mut(dst) };
+        let buf: &mut [std::mem::MaybeUninit<u8>] = unsafe { shadow_pod::to_u8_slice_mut(dst) };
         // SAFETY: this buffer is write-only.
         // TODO: Fix or move away from nix's process_vm_readv wrapper so that we
         // don't need to construct this slice, and can instead only ever operate
@@ -104,7 +104,7 @@ impl MemoryCopier {
     ) -> Result<(), Errno> {
         assert_eq!(dst.len(), src.len());
         // SAFETY: We do not write uninitialized data into `buf`.
-        let buf = unsafe { pod::to_u8_slice_mut(dst) };
+        let buf = unsafe { shadow_pod::to_u8_slice_mut(dst) };
         // SAFETY: this buffer is write-only.
         // TODO: Fix or move away from nix's process_vm_readv wrapper so that we
         // don't need to construct this slice, and can instead only ever operate
@@ -195,7 +195,7 @@ impl MemoryCopier {
         src: &[T],
     ) -> Result<(), Errno> {
         let dst = dst.cast_u8();
-        let src: &[std::mem::MaybeUninit<u8>] = pod::to_u8_slice(src);
+        let src: &[std::mem::MaybeUninit<u8>] = shadow_pod::to_u8_slice(src);
         // SAFETY: We *should* never actually read from this buffer in this process;
         // ultimately its pointer will be passed to the process_vm_writev syscall,
         // for which unitialized data is ok.

--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -14,6 +14,7 @@ use log::*;
 use nix::sys::memfd::MemFdCreateFlag;
 use nix::unistd::Pid;
 use nix::{fcntl, sys};
+use pod::Pod;
 use shadow_shim_helper_rs::notnull::*;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
@@ -22,7 +23,6 @@ use crate::host::context::ThreadContext;
 use crate::host::memory_manager::{page_size, MemoryManager};
 use crate::host::syscall_types::{ForeignArrayPtr, SyscallResult};
 use crate::utility::interval_map::{Interval, IntervalMap, Mutation};
-use crate::utility::pod::Pod;
 use crate::utility::proc_maps;
 use crate::utility::proc_maps::{MappingPath, Sharing};
 

--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -14,7 +14,7 @@ use log::*;
 use nix::sys::memfd::MemFdCreateFlag;
 use nix::unistd::Pid;
 use nix::{fcntl, sys};
-use pod::Pod;
+use shadow_pod::Pod;
 use shadow_shim_helper_rs::notnull::*;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -24,7 +24,7 @@ use log::*;
 use memory_copier::MemoryCopier;
 use memory_mapper::MemoryMapper;
 use nix::{errno::Errno, unistd::Pid};
-use pod::Pod;
+use shadow_pod::Pod;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use super::context::ThreadContext;
@@ -553,7 +553,7 @@ impl MemoryManager {
             ProcessMemoryRefMut::new_mapped(mref)
         } else {
             let mut v = Vec::with_capacity(ptr.len());
-            v.resize(ptr.len(), pod::zeroed());
+            v.resize(ptr.len(), shadow_pod::zeroed());
             ProcessMemoryRefMut::new_copied(MemoryCopier::new(pid), ptr, v)
         };
 
@@ -562,7 +562,7 @@ impl MemoryManager {
         // back to the process without initializing it.
         if cfg!(debug_assertions) {
             // SAFETY: We do not write uninitialized data into `bytes`.
-            let bytes = unsafe { pod::to_u8_slice_mut(&mut mref[..]) };
+            let bytes = unsafe { shadow_pod::to_u8_slice_mut(&mut mref[..]) };
             for byte in bytes {
                 unsafe { byte.as_mut_ptr().write(0x42) }
             }

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -24,13 +24,12 @@ use log::*;
 use memory_copier::MemoryCopier;
 use memory_mapper::MemoryMapper;
 use nix::{errno::Errno, unistd::Pid};
+use pod::Pod;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use super::context::ThreadContext;
 use crate::host::syscall_types::{ForeignArrayPtr, SyscallError, SyscallResult};
 use crate::host::thread::Thread;
-use crate::utility::pod;
-use crate::utility::pod::Pod;
 
 mod memory_copier;
 mod memory_mapper;

--- a/src/main/host/syscall/handler/sched.rs
+++ b/src/main/host/syscall/handler/sched.rs
@@ -1,12 +1,12 @@
 use log::warn;
 use nix::errno::Errno;
+use pod::Pod;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use syscall_logger::log_syscall;
 
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
 use crate::host::syscall_types::{ForeignArrayPtr, SyscallError};
 use crate::host::thread::ThreadId;
-use crate::utility::pod::Pod;
 
 // We always report that the thread is running on CPU 0, Node 0
 const CURRENT_CPU: u32 = 0;

--- a/src/main/host/syscall/handler/sched.rs
+++ b/src/main/host/syscall/handler/sched.rs
@@ -1,6 +1,6 @@
 use log::warn;
 use nix::errno::Errno;
-use pod::Pod;
+use shadow_pod::Pod;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use syscall_logger::log_syscall;
 

--- a/src/main/host/syscall/handler/sysinfo.rs
+++ b/src/main/host/syscall/handler/sysinfo.rs
@@ -16,7 +16,7 @@ impl SyscallHandler {
             .as_secs();
 
         // Get a zeroed struct to make sure we init all fields.
-        let mut info = pod::zeroed::<libc::sysinfo>();
+        let mut info = shadow_pod::zeroed::<libc::sysinfo>();
 
         // These values are chosen arbitrarily; we don't think it matters too
         // much, except to maintain determinism. For example, Tor make decisions

--- a/src/main/host/syscall/handler/sysinfo.rs
+++ b/src/main/host/syscall/handler/sysinfo.rs
@@ -5,7 +5,6 @@ use syscall_logger::log_syscall;
 use crate::core::worker::Worker;
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
 use crate::host::syscall_types::SyscallResult;
-use crate::utility::pod;
 
 impl SyscallHandler {
     #[log_syscall(/* rv */ libc::c_int, /* info */ *const libc::sysinfo)]

--- a/src/main/host/syscall/io.rs
+++ b/src/main/host/syscall/io.rs
@@ -139,7 +139,7 @@ pub fn read_sockaddr(
 /// # Ok(())
 /// # }
 /// ```
-pub fn write_partial<T: pod::Pod>(
+pub fn write_partial<T: shadow_pod::Pod>(
     mem: &mut MemoryManager,
     val: &T,
     val_ptr: ForeignPtr<T>,
@@ -147,7 +147,7 @@ pub fn write_partial<T: pod::Pod>(
 ) -> Result<usize, Errno> {
     let val_len_bytes = std::cmp::min(val_len_bytes, std::mem::size_of_val(val));
 
-    let val = &pod::as_u8_slice(val)[..val_len_bytes];
+    let val = &shadow_pod::as_u8_slice(val)[..val_len_bytes];
 
     let val_ptr = val_ptr.cast::<MaybeUninit<u8>>();
     let val_ptr = ForeignArrayPtr::new(val_ptr, val_len_bytes);

--- a/src/main/host/syscall/io.rs
+++ b/src/main/host/syscall/io.rs
@@ -6,7 +6,6 @@ use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::host::memory_manager::MemoryManager;
 use crate::host::syscall_types::ForeignArrayPtr;
-use crate::utility::pod;
 use crate::utility::sockaddr::SockaddrStorage;
 
 /// Writes the socket address into a buffer at `plugin_addr` with length `plugin_addr_len`, and

--- a/src/main/lib.rs
+++ b/src/main/lib.rs
@@ -21,6 +21,10 @@ pub mod cshadow {
     include!(concat!(env!("OUT_DIR"), "/cshadow.rs"));
 }
 
+// shadow re-exports this definition from /usr/include/linux/tcp.h
+// TODO: Provide this via the linux-api crate instead.
+unsafe impl pod::Pod for crate::cshadow::tcp_info {}
+
 // check that the size and alignment of `CompatUntypedForeignPtr` and `ForeignPtr<()>` are the same`
 static_assertions::assert_eq_size!(
     cshadow::CompatUntypedForeignPtr,

--- a/src/main/lib.rs
+++ b/src/main/lib.rs
@@ -23,7 +23,7 @@ pub mod cshadow {
 
 // shadow re-exports this definition from /usr/include/linux/tcp.h
 // TODO: Provide this via the linux-api crate instead.
-unsafe impl pod::Pod for crate::cshadow::tcp_info {}
+unsafe impl shadow_pod::Pod for crate::cshadow::tcp_info {}
 
 // check that the size and alignment of `CompatUntypedForeignPtr` and `ForeignPtr<()>` are the same`
 static_assertions::assert_eq_size!(

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -13,7 +13,6 @@ pub mod interval_map;
 pub mod legacy_callback_queue;
 pub mod pcap_writer;
 pub mod perf_timer;
-pub mod pod;
 pub mod proc_maps;
 pub mod shm_cleanup;
 pub mod sockaddr;


### PR DESCRIPTION
We need to be able to implement this trait from crates outside of `main`. It also makes the crate `no_std`, since we'll need it from `no_std` crates like `linux-api`.