### PR TITLE
Add an `AssociationHandle` which disassociates the socket when dropped

### DIFF
--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -263,13 +263,17 @@ impl LegacyTcpSocket {
         let peer_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
 
         // associate the socket
-        let addr = inet::associate_socket(
+        let (addr, handle) = inet::associate_socket(
             InetSocket::LegacyTcp(Arc::clone(socket)),
             addr,
             peer_addr,
             net_ns,
             rng,
         )?;
+
+        // the handle normally disassociates the socket when dropped, but the C TCP code does it's
+        // own manual disassociation, so we'll just let it do its own thing
+        std::mem::forget(handle);
 
         // update the socket's local address
         let socket = socket.borrow_mut();
@@ -629,13 +633,17 @@ impl LegacyTcpSocket {
             let peer_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
 
             // associate the socket
-            let local_addr = super::associate_socket(
+            let (local_addr, handle) = super::associate_socket(
                 super::InetSocket::LegacyTcp(socket.clone()),
                 local_addr,
                 peer_addr,
                 net_ns,
                 rng,
             )?;
+
+            // the handle normally disassociates the socket when dropped, but the C TCP code does
+            // it's own manual disassociation, so we'll just let it do its own thing
+            std::mem::forget(handle);
 
             unsafe {
                 c::legacysocket_setSocketName(
@@ -728,13 +736,17 @@ impl LegacyTcpSocket {
             };
 
             // associate the socket
-            let local_addr = super::associate_socket(
+            let (local_addr, handle) = super::associate_socket(
                 super::InetSocket::LegacyTcp(socket.clone()),
                 local_addr,
                 peer_addr,
                 net_ns,
                 rng,
             )?;
+
+            // the handle normally disassociates the socket when dropped, but the C TCP code does
+            // it's own manual disassociation, so we'll just let it do its own thing
+            std::mem::forget(handle);
 
             unsafe {
                 c::legacysocket_setSocketName(

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -1085,34 +1085,6 @@ mod export {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn host_associateInterface(
-        hostrc: *const Host,
-        socket: *const cshadow::CompatSocket,
-        protocol: cshadow::ProtocolType,
-        bind_ip: in_addr_t,
-        bind_port: in_port_t,
-        peer_ip: in_addr_t,
-        peer_port: in_port_t,
-    ) {
-        let hostrc = unsafe { hostrc.as_ref().unwrap() };
-
-        let bind_ip = Ipv4Addr::from(u32::from_be(bind_ip));
-        let peer_ip = Ipv4Addr::from(u32::from_be(peer_ip));
-        let bind_port = u16::from_be(bind_port);
-        let peer_port = u16::from_be(peer_port);
-
-        let bind_addr = SocketAddrV4::new(bind_ip, bind_port);
-        let peer_addr = SocketAddrV4::new(peer_ip, peer_port);
-
-        // associate the interfaces corresponding to bind_addr with socket
-        unsafe {
-            hostrc
-                .net_ns
-                .associate_interface(socket, protocol, bind_addr, peer_addr)
-        };
-    }
-
-    #[no_mangle]
     pub unsafe extern "C" fn host_disassociateInterface(
         hostrc: *const Host,
         protocol: cshadow::ProtocolType,


### PR DESCRIPTION
The purpose of the handle is to make it harder to accidentally forget to disassociate the socket, to have multiple associations, or to disassociate a different socket address than what was originally associated. For example when re-associating a socket with another address. See for example #2590. This could be made nicer if the network interface was in rust, but I think this is good enough for the time being.