### PR TITLE
Support more sockopts for TCP and UDP

### DIFF
--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -1054,6 +1054,15 @@ impl LegacyTcpSocket {
 
                 Ok(bytes_written as libc::socklen_t)
             }
+            (libc::SOL_SOCKET, libc::SO_PROTOCOL) => {
+                let protocol = libc::IPPROTO_TCP;
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written =
+                    write_partial(memory_manager, &protocol, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
             _ => {
                 log::warn!("getsockopt called with unsupported level {level} and opt {optname}");
                 Err(Errno::ENOPROTOOPT.into())

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -1025,6 +1025,15 @@ impl LegacyTcpSocket {
 
                 Ok(bytes_written as libc::socklen_t)
             }
+            (libc::SOL_SOCKET, libc::SO_DOMAIN) => {
+                let domain = libc::AF_INET;
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written =
+                    write_partial(memory_manager, &domain, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
             (libc::SOL_SOCKET, libc::SO_TYPE) => {
                 let protocol = unsafe { c::legacysocket_getProtocol(self.as_legacy_socket()) };
 

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -1035,18 +1035,7 @@ impl LegacyTcpSocket {
                 Ok(bytes_written as libc::socklen_t)
             }
             (libc::SOL_SOCKET, libc::SO_TYPE) => {
-                let protocol = unsafe { c::legacysocket_getProtocol(self.as_legacy_socket()) };
-
-                let sock_type = match protocol {
-                    c::_ProtocolType_PMOCK => {
-                        panic!("mock socket should not appear outside of tests")
-                    }
-                    c::_ProtocolType_PNONE => panic!("socket has no protocol"),
-                    c::_ProtocolType_PLOCAL => panic!("socket is a PLOCAL socket"),
-                    c::_ProtocolType_PTCP => libc::SOCK_STREAM,
-                    c::_ProtocolType_PUDP => libc::SOCK_DGRAM,
-                    _ => unimplemented!(),
-                };
+                let sock_type = libc::SOCK_STREAM;
 
                 let optval_ptr = optval_ptr.cast::<libc::c_int>();
                 let bytes_written =

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -1063,6 +1063,15 @@ impl LegacyTcpSocket {
 
                 Ok(bytes_written as libc::socklen_t)
             }
+            (libc::SOL_SOCKET, libc::SO_ACCEPTCONN) => {
+                let is_listener = unsafe { c::tcp_isValidListener(self.as_legacy_tcp()) };
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written =
+                    write_partial(memory_manager, &is_listener, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
             _ => {
                 log::warn!("getsockopt called with unsupported level {level} and opt {optname}");
                 Err(Errno::ENOPROTOOPT.into())

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -690,6 +690,14 @@ impl UdpSocket {
 
                 Ok(bytes_written as libc::socklen_t)
             }
+            (libc::SOL_SOCKET, libc::SO_PROTOCOL) => {
+                let protocol = libc::IPPROTO_UDP;
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written = write_partial(mem, &protocol, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
             (libc::SOL_SOCKET, _) => {
                 log::debug!("getsockopt called with unsupported level {level} and opt {optname}");
                 Err(Errno::ENOPROTOOPT.into())

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -674,6 +674,14 @@ impl UdpSocket {
 
                 Ok(bytes_written as libc::socklen_t)
             }
+            (libc::SOL_SOCKET, libc::SO_DOMAIN) => {
+                let domain = libc::AF_INET;
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written = write_partial(mem, &domain, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
             (libc::SOL_SOCKET, libc::SO_TYPE) => {
                 let sock_type = libc::SOCK_DGRAM;
 

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -698,6 +698,12 @@ impl UdpSocket {
 
                 Ok(bytes_written as libc::socklen_t)
             }
+            (libc::SOL_SOCKET, libc::SO_ACCEPTCONN) => {
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written = write_partial(mem, &0, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
             (libc::SOL_SOCKET, _) => {
                 log::debug!("getsockopt called with unsupported level {level} and opt {optname}");
                 Err(Errno::ENOPROTOOPT.into())

--- a/src/test/socket/sockopt/test_sockopt.rs
+++ b/src/test/socket/sockopt/test_sockopt.rs
@@ -171,6 +171,11 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                     set![TestEnv::Libc, TestEnv::Shadow],
                 ),
                 test_utils::ShadowTest::new(
+                    &append_args("test_so_domain"),
+                    move || test_so_domain(domain, sock_type),
+                    set![TestEnv::Libc, TestEnv::Shadow],
+                ),
+                test_utils::ShadowTest::new(
                     &append_args("test_tcp_info"),
                     move || test_tcp_info(domain, sock_type),
                     set![TestEnv::Libc, TestEnv::Shadow],
@@ -653,6 +658,31 @@ fn test_so_type(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), Strin
             i32::from_ne_bytes(get_args.optval.as_ref().unwrap()[..].try_into().unwrap());
 
         test_utils::result_assert_eq(returned_optval, sock_type, "Wrong socket type")?;
+
+        Ok(())
+    })
+}
+
+/// Test getsockopt() and setsockopt() using the SO_DOMAIN option.
+fn test_so_domain(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), String> {
+    let fd = unsafe { libc::socket(domain, sock_type | libc::SOCK_NONBLOCK, 0) };
+    assert!(fd >= 0);
+
+    let level = libc::SOL_SOCKET;
+    let optname = libc::SO_DOMAIN;
+    let optval = 0i32.to_ne_bytes();
+
+    let mut get_args = GetsockoptArguments::new(fd, level, optname, Some(optval.into()));
+    let mut set_args = SetsockoptArguments::new(fd, level, optname, Some(optval.into()));
+
+    test_utils::run_and_close_fds(&[fd], || {
+        check_getsockopt_call(&mut get_args, &[])?;
+        check_setsockopt_call(&mut set_args, &[libc::ENOPROTOOPT])?;
+
+        let returned_optval =
+            i32::from_ne_bytes(get_args.optval.as_ref().unwrap()[..].try_into().unwrap());
+
+        test_utils::result_assert_eq(returned_optval, domain, "Wrong socket domain")?;
 
         Ok(())
     })

--- a/src/test/socket/sockopt/test_sockopt.rs
+++ b/src/test/socket/sockopt/test_sockopt.rs
@@ -181,6 +181,11 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                     set![TestEnv::Libc, TestEnv::Shadow],
                 ),
                 test_utils::ShadowTest::new(
+                    &append_args("test_so_acceptconn"),
+                    move || test_so_acceptconn(domain, sock_type),
+                    set![TestEnv::Libc, TestEnv::Shadow],
+                ),
+                test_utils::ShadowTest::new(
                     &append_args("test_tcp_info"),
                     move || test_tcp_info(domain, sock_type),
                     set![TestEnv::Libc, TestEnv::Shadow],
@@ -720,6 +725,52 @@ fn test_so_protocol(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), S
         };
 
         test_utils::result_assert_eq(returned_optval, expected_optval, "Wrong socket protocol")?;
+
+        Ok(())
+    })
+}
+
+/// Test getsockopt() and setsockopt() using the SO_ACCEPTCONN option.
+fn test_so_acceptconn(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), String> {
+    let fd = unsafe { libc::socket(domain, sock_type | libc::SOCK_NONBLOCK, 0) };
+    assert!(fd >= 0);
+
+    let level = libc::SOL_SOCKET;
+    let optname = libc::SO_ACCEPTCONN;
+    let optval = 0i32.to_ne_bytes();
+
+    let mut get_args = GetsockoptArguments::new(fd, level, optname, Some(optval.into()));
+    let mut set_args = SetsockoptArguments::new(fd, level, optname, Some(optval.into()));
+
+    test_utils::run_and_close_fds(&[fd], || {
+        check_getsockopt_call(&mut get_args, &[])?;
+        check_setsockopt_call(&mut set_args, &[libc::ENOPROTOOPT])?;
+
+        let returned_optval =
+            i32::from_ne_bytes(get_args.optval.as_ref().unwrap()[..].try_into().unwrap());
+
+        test_utils::result_assert_eq(
+            returned_optval,
+            0,
+            "Wrong value returned for SO_ACCEPTCONN before listen()",
+        )?;
+
+        let listen_rv = unsafe { libc::listen(fd, 100) };
+
+        check_getsockopt_call(&mut get_args, &[])?;
+        check_setsockopt_call(&mut set_args, &[libc::ENOPROTOOPT])?;
+
+        let returned_optval =
+            i32::from_ne_bytes(get_args.optval.as_ref().unwrap()[..].try_into().unwrap());
+
+        // if listen() was successful, then expecting the sockopt val to be 1
+        let expected_optval = if listen_rv == 0 { 1 } else { 0 };
+
+        test_utils::result_assert_eq(
+            returned_optval,
+            expected_optval,
+            "Wrong value returned for SO_ACCEPTCONN after listen()",
+        )?;
 
         Ok(())
     })

--- a/src/test/socket/sockopt/test_sockopt.rs
+++ b/src/test/socket/sockopt/test_sockopt.rs
@@ -176,6 +176,11 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                     set![TestEnv::Libc, TestEnv::Shadow],
                 ),
                 test_utils::ShadowTest::new(
+                    &append_args("test_so_protocol"),
+                    move || test_so_protocol(domain, sock_type),
+                    set![TestEnv::Libc, TestEnv::Shadow],
+                ),
+                test_utils::ShadowTest::new(
                     &append_args("test_tcp_info"),
                     move || test_tcp_info(domain, sock_type),
                     set![TestEnv::Libc, TestEnv::Shadow],
@@ -683,6 +688,38 @@ fn test_so_domain(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), Str
             i32::from_ne_bytes(get_args.optval.as_ref().unwrap()[..].try_into().unwrap());
 
         test_utils::result_assert_eq(returned_optval, domain, "Wrong socket domain")?;
+
+        Ok(())
+    })
+}
+
+/// Test getsockopt() and setsockopt() using the SO_PROTOCOL option.
+fn test_so_protocol(domain: libc::c_int, sock_type: libc::c_int) -> Result<(), String> {
+    let fd = unsafe { libc::socket(domain, sock_type | libc::SOCK_NONBLOCK, 0) };
+    assert!(fd >= 0);
+
+    let level = libc::SOL_SOCKET;
+    let optname = libc::SO_PROTOCOL;
+    let optval = 0i32.to_ne_bytes();
+
+    let mut get_args = GetsockoptArguments::new(fd, level, optname, Some(optval.into()));
+    let mut set_args = SetsockoptArguments::new(fd, level, optname, Some(optval.into()));
+
+    test_utils::run_and_close_fds(&[fd], || {
+        check_getsockopt_call(&mut get_args, &[])?;
+        check_setsockopt_call(&mut set_args, &[libc::ENOPROTOOPT])?;
+
+        let returned_optval =
+            i32::from_ne_bytes(get_args.optval.as_ref().unwrap()[..].try_into().unwrap());
+
+        let expected_optval = match (domain, sock_type) {
+            (libc::AF_INET, libc::SOCK_STREAM) => libc::IPPROTO_TCP,
+            (libc::AF_INET, libc::SOCK_DGRAM) => libc::IPPROTO_UDP,
+            (libc::AF_UNIX, _) => 0,
+            _ => unimplemented!(),
+        };
+
+        test_utils::result_assert_eq(returned_optval, expected_optval, "Wrong socket protocol")?;
 
         Ok(())
     })


### PR DESCRIPTION
This adds support for `SO_DOMAIN`, `SO_PROTOCOL`, and `SO_ACCEPTCONN` for tcp and udp.