### PR TITLE
libc_preload: check for C library/kernel differences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ PATCH changes (bugfixes):
 * Updated documentation and tests to reflect that shadow no longer requires
 `/dev/shm` to be executable. (This requirement was actually removed in v3.0.0)
 
+* Removed several incorrect libc syscall wrappers. These wrappers are a "fast
+path" for intercepting syscalls at the library level instead of via seccomp. The removed wrappers were for syscalls whose glibc functions have different semantics than the underlying syscall.
+
 Full changelog since v3.0.0:
 
 - [Merged PRs v3.0.0..HEAD](https://github.com/shadow/shadow/pulls?q=is%3Apr+merged%3A2023-05-18T18%3A00-0400..2033-05-18T18%3A00-0400)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ PATCH changes (bugfixes):
 * Removed several incorrect libc syscall wrappers. These wrappers are a "fast
 path" for intercepting syscalls at the library level instead of via seccomp. The removed wrappers were for syscalls whose glibc functions have different semantics than the underlying syscall.
 
+* Fixed a bug in `sched_getaffinity`. This bug was previously mostly latent due to an incorrectly generated libc syscall wrapper, though would have affected managed programs that
+made the syscall without going through libc.
+
 Full changelog since v3.0.0:
 
 - [Merged PRs v3.0.0..HEAD](https://github.com/shadow/shadow/pulls?q=is%3Apr+merged%3A2023-05-18T18%3A00-0400..2033-05-18T18%3A00-0400)

--- a/src/lib/libc_preload/gen_syscall_wrappers_c.py
+++ b/src/lib/libc_preload/gen_syscall_wrappers_c.py
@@ -1,4 +1,5 @@
 import urllib.request
+import subprocess
 
 '''
 This script is meant to generate our interpose list containing all x86_64
@@ -17,36 +18,158 @@ remap['eventfd'] = 'eventfd2' # libc eventfd() calls SYS_eventfd2
 
 # syscalls we should not generate C wrappers for
 skip = set()
+
 # glibc doesn't have these wrappers
-skip.add('eventfd2')
-skip.add('pselect6')
-skip.add('pread64')
-skip.add('pwrite64')
-skip.add('getdents')
-skip.add('getdents64')
-skip.add('restart_syscall')
-skip.add('kcmp')
-skip.add('kexec_file_load')
-skip.add('rseq')
-# the offset is split into two arguments
-skip.add('preadv')
-skip.add('preadv2')
-skip.add('pwritev')
-skip.add('pwritev2')
-# `exit` has a non-trivial wrapper that calls `atexit` hooks, flushes open
-# `FILE*` objects, etc.
-skip.add('exit')
+skip.update([
+    'close_range',
+    'eventfd2',
+    'fadvise64',
+    'futex_waitv',
+    'memfd_secret',
+    'newfstatat',
+    'getdents',
+    'getdents64',
+    'kcmp',
+    'kexec_file_load',
+    'open_tree',
+    'pread64',
+    'pselect6',
+    'pwrite64',
+    'restart_syscall',
+    'rseq',
+    'rt_sigaction',
+    'rt_sigprocmask',
+    'rt_sigpending',
+    'rt_sigreturn',
+    'rt_sigsuspend',
+    'rt_sigtimedwait',
+])
 
-# These have an optional `mode` argument, which the wrappers should initialize
-# to 0 when not provided by the caller.
-skip.add('open')
-skip.add('openat')
+# Manually implemented in libc_impls.c
+skip.update([
+    'open',
+    'openat',
+])
 
-# Returns NULL instead of -1 on error
-skip.add('getcwd')
+# Confirmed C library/kernel differences
+skip.update([
+    'brk',
+    'chmod',
+    'clone',
+    'clone3',
+    'epoll_pwait',
+    'epoll_pwait2',
+    'faccessat',
+    'faccessat2',
+    'fork',
+    'fstat',
+    'exit',
+    'getcwd',
+    'lstat',
+    'mq_notify',
+    'mq_open',
+    'poll',
+    'ppoll',
+    'preadv',
+    'preadv2',
+    'pwritev',
+    'pwritev2',
+    'sched_getaffinity',
+    'sched_setaffinity',
+    'select',
+    'setuid',
+    'sigaction',
+    'sigprocmask',
+    'signalfd',
+    'signalfd4',
+    'stat',
+    'timer_create',
+    'uname',
+    'wait4',
+    'waitid',
+])
 
-# Nontrivial wrapper
-skip.add('clone')
+# man page has "C library/kernel differences" or was missing. Skip pending review.
+skip.update([
+    'fchmod',
+    'fchmodat',
+    'fsconfig',
+    'fsmount',
+    'fsopen',
+    'fspick',
+    'getgroups',
+    'getpriority',
+    'io_pgetevents',
+    'io_uring_enter',
+    'io_uring_register',
+    'io_uring_setup',
+    'landlock_add_rule',
+    'landlock_create_ruleset',
+    'landlock_restrict_self',
+    'mount_setattr',
+    'move_mount',
+    'process_madvise',
+    'process_mrelease',
+    'ptrace',
+    'quotactl_fd',
+    'set_mempolicy_home_node',
+    'setfsgid',
+    'setfsuid',
+    'setgid',
+    'setgroups',
+    'sethostname',
+    'setpriority',
+    'setregid',
+    'setresgid',
+    'setresuid',
+    'setreuid',
+])
+
+ignore_differences = set([
+    # man page notes that clock_gettime may go through VDSO. That's ok.
+    'clock_gettime',
+    'clock_getres',
+    'clock_settime',
+
+    # man page notes that gettimeofday may go through VDSO. That's ok.
+    'gettimeofday',
+    'settimeofday',
+
+    # man page notes that it may go through VDSO. That's ok.
+    'time',
+
+    # man page notes differences for other syscalls on same page.
+    'creat',
+
+    # eventfd uses eventfd2 syscall. We remap this correctly.
+    'eventfd',
+
+    # man page notes that epoll_pwait has differences. epoll_wait should be ok.
+    'epoll_wait',
+
+    # man page notes that some versions of libc cache the pid. Skipping that
+    # behavior shouldn't break anything.
+    'getpid',
+    'getppid',
+
+    # the glibc wrapper actually uses the mmap2 syscall. Using the mmap
+    # syscall shouldn't hurt anything, though.
+    'mmap',
+    'munmap',
+
+    # man page notes that preadv and pwritev have differences. These ones
+    # are on the same page but don't have documented differences.
+    'readv',
+    'writev',
+
+    # man page notes that faccessat and faccessat2 have differences.
+    'access',
+
+    # man page says to *check for* sections called "C library/kernel differences"
+    # when intercepting syscalls.
+    # Doesn't actually have such a section itself.
+    'seccomp',
+])
 
 # syscall wrappers that return errors directly instead of through errno.
 direct_errors = set()
@@ -96,14 +219,21 @@ with open('syscall_wrappers.c', 'w') as outf:
         num, entry = syscalls[name]
         if name in skip:
             print(f'// Skipping SYS_{name}', file=outf)
+            continue
+        if name not in ignore_differences:
+            try:
+                man = subprocess.check_output(["man", "2", name], encoding="utf8", stderr=subprocess.DEVNULL)
+            except subprocess.CalledProcessError:
+                print(f"Warning: SYS_{name}: couldn't find man page")
+            if "C library/kernel differences" in man:
+                print(f"Warning: SYS_{name}: man page has 'C library/kernel differences'")
+        print(f'#ifdef SYS_{name} // kernel entry: num={num} func={entry}', file=outf)
+        if name in remap:
+            print(f'INTERPOSE_REMAP({name}, {remap[name]});', file=outf)
+        elif name in direct_errors:
+            print(f'INTERPOSE_DIRECT_ERRORS({name});', file=outf)
         else:
-            print(f'#ifdef SYS_{name} // kernel entry: num={num} func={entry}', file=outf)
-            if name in remap:
-                print(f'INTERPOSE_REMAP({name}, {remap[name]});', file=outf)
-            elif name in direct_errors:
-                print(f'INTERPOSE_DIRECT_ERRORS({name});', file=outf)
-            else:
-                print(f'INTERPOSE({name});', file=outf)
-            print('#endif', file=outf)
+            print(f'INTERPOSE({name});', file=outf)
+        print('#endif', file=outf)
 
     print('// clang-format on', file=outf)

--- a/src/lib/libc_preload/gen_syscall_wrappers_c.py
+++ b/src/lib/libc_preload/gen_syscall_wrappers_c.py
@@ -62,10 +62,8 @@ skip.update([
     'faccessat',
     'faccessat2',
     'fork',
-    'fstat',
     'exit',
     'getcwd',
-    'lstat',
     'mq_notify',
     'mq_open',
     'poll',
@@ -82,7 +80,6 @@ skip.update([
     'sigprocmask',
     'signalfd',
     'signalfd4',
-    'stat',
     'timer_create',
     'uname',
     'wait4',
@@ -169,6 +166,21 @@ ignore_differences = set([
     # when intercepting syscalls.
     # Doesn't actually have such a section itself.
     'seccomp',
+
+    # stat(2):
+    # > Over  time,  increases  in the size of the stat structure have led to
+    # > three successive versions of stat(): sys_stat() (slot __NR_oldstat),
+    # > sys_newstat() (slot __NR_stat), and sys_stat64() (slot __NR_stat64) on
+    # > 32-bit platforms such as i386.  The first two ver‐ #  sions were already
+    # > present in Linux 1.0 (albeit with different names); the last was added in
+    # > Linux 2.4.  Similar remarks apply for fstat() and lstat().
+    #
+    # Since we only support 64 bit systems and relatively new versions of glibc
+    # we want the stat library call to map to call syscall number __NR_stat;
+    # i.e. the default-generated wrapper should be correct.
+    'stat',
+    'lstat',
+    'fstat',
 ])
 
 # syscall wrappers that return errors directly instead of through errno.

--- a/src/lib/libc_preload/gen_syscall_wrappers_c.py
+++ b/src/lib/libc_preload/gen_syscall_wrappers_c.py
@@ -81,7 +81,6 @@ skip.update([
     'signalfd',
     'signalfd4',
     'timer_create',
-    'uname',
     'wait4',
     'waitid',
 ])
@@ -181,6 +180,18 @@ ignore_differences = set([
     'stat',
     'lstat',
     'fstat',
+
+    # uname(2):
+    # > Over  time,  increases  in  the size of the utsname structure have led to
+    # > three successive versions of uname(): sys_olduname() (slot
+    # > __NR_oldolduname), sys_uname() (slot __NR_olduname), and sys_newuname()
+    # > (slot __NR_uname).  The first one used length 9 for all fields; the second
+    # > used 65; the third also uses 65 but adds the domainname field.  The glibc
+    # > uname() wrapper function hides these details from applications, invoking
+    # > the most recent version of the system call provided by the kernel.
+    #
+    # We want __NR_uname, so the generated wrapper should be correct.
+    'uname',
 ])
 
 # syscall wrappers that return errors directly instead of through errno.

--- a/src/lib/libc_preload/syscall_wrappers.c
+++ b/src/lib/libc_preload/syscall_wrappers.c
@@ -184,7 +184,9 @@ INTERPOSE(fsetxattr);
 // Skipping SYS_fsmount
 // Skipping SYS_fsopen
 // Skipping SYS_fspick
-// Skipping SYS_fstat
+#ifdef SYS_fstat // kernel entry: num=5 func=sys_newfstat
+INTERPOSE(fstat);
+#endif
 #ifdef SYS_fstatfs // kernel entry: num=138 func=sys_fstatfs
 INTERPOSE(fstatfs);
 #endif
@@ -374,7 +376,9 @@ INTERPOSE(lseek);
 #ifdef SYS_lsetxattr // kernel entry: num=189 func=sys_lsetxattr
 INTERPOSE(lsetxattr);
 #endif
-// Skipping SYS_lstat
+#ifdef SYS_lstat // kernel entry: num=6 func=sys_newlstat
+INTERPOSE(lstat);
+#endif
 #ifdef SYS_madvise // kernel entry: num=28 func=sys_madvise
 INTERPOSE(madvise);
 #endif
@@ -752,7 +756,9 @@ INTERPOSE(socketpair);
 #ifdef SYS_splice // kernel entry: num=275 func=sys_splice
 INTERPOSE(splice);
 #endif
-// Skipping SYS_stat
+#ifdef SYS_stat // kernel entry: num=4 func=sys_newstat
+INTERPOSE(stat);
+#endif
 #ifdef SYS_statfs // kernel entry: num=137 func=sys_statfs
 INTERPOSE(statfs);
 #endif

--- a/src/lib/libc_preload/syscall_wrappers.c
+++ b/src/lib/libc_preload/syscall_wrappers.c
@@ -841,7 +841,9 @@ INTERPOSE(umask);
 #ifdef SYS_umount2 // kernel entry: num=166 func=sys_umount
 INTERPOSE(umount2);
 #endif
-// Skipping SYS_uname
+#ifdef SYS_uname // kernel entry: num=63 func=sys_newuname
+INTERPOSE(uname);
+#endif
 #ifdef SYS_unlink // kernel entry: num=87 func=sys_unlink
 INTERPOSE(unlink);
 #endif

--- a/src/lib/libc_preload/syscall_wrappers.c
+++ b/src/lib/libc_preload/syscall_wrappers.c
@@ -45,9 +45,7 @@ INTERPOSE(bind);
 #ifdef SYS_bpf // kernel entry: num=321 func=sys_bpf
 INTERPOSE(bpf);
 #endif
-#ifdef SYS_brk // kernel entry: num=12 func=sys_brk
-INTERPOSE(brk);
-#endif
+// Skipping SYS_brk
 #ifdef SYS_capget // kernel entry: num=125 func=sys_capget
 INTERPOSE(capget);
 #endif
@@ -57,9 +55,7 @@ INTERPOSE(capset);
 #ifdef SYS_chdir // kernel entry: num=80 func=sys_chdir
 INTERPOSE(chdir);
 #endif
-#ifdef SYS_chmod // kernel entry: num=90 func=sys_chmod
-INTERPOSE(chmod);
-#endif
+// Skipping SYS_chmod
 #ifdef SYS_chown // kernel entry: num=92 func=sys_chown
 INTERPOSE(chown);
 #endif
@@ -82,15 +78,11 @@ INTERPOSE_DIRECT_ERRORS(clock_nanosleep);
 INTERPOSE(clock_settime);
 #endif
 // Skipping SYS_clone
-#ifdef SYS_clone3 // kernel entry: num=435 func=sys_clone3
-INTERPOSE(clone3);
-#endif
+// Skipping SYS_clone3
 #ifdef SYS_close // kernel entry: num=3 func=sys_close
 INTERPOSE(close);
 #endif
-#ifdef SYS_close_range // kernel entry: num=436 func=sys_close_range
-INTERPOSE(close_range);
-#endif
+// Skipping SYS_close_range
 #ifdef SYS_connect // kernel entry: num=42 func=sys_connect
 INTERPOSE(connect);
 #endif
@@ -121,12 +113,8 @@ INTERPOSE(epoll_create1);
 #ifdef SYS_epoll_ctl // kernel entry: num=233 func=sys_epoll_ctl
 INTERPOSE(epoll_ctl);
 #endif
-#ifdef SYS_epoll_pwait // kernel entry: num=281 func=sys_epoll_pwait
-INTERPOSE(epoll_pwait);
-#endif
-#ifdef SYS_epoll_pwait2 // kernel entry: num=441 func=sys_epoll_pwait2
-INTERPOSE(epoll_pwait2);
-#endif
+// Skipping SYS_epoll_pwait
+// Skipping SYS_epoll_pwait2
 #ifdef SYS_epoll_wait // kernel entry: num=232 func=sys_epoll_wait
 INTERPOSE(epoll_wait);
 #endif
@@ -144,15 +132,9 @@ INTERPOSE(execveat);
 #ifdef SYS_exit_group // kernel entry: num=231 func=sys_exit_group
 INTERPOSE(exit_group);
 #endif
-#ifdef SYS_faccessat // kernel entry: num=269 func=sys_faccessat
-INTERPOSE(faccessat);
-#endif
-#ifdef SYS_faccessat2 // kernel entry: num=439 func=sys_faccessat2
-INTERPOSE(faccessat2);
-#endif
-#ifdef SYS_fadvise64 // kernel entry: num=221 func=sys_fadvise64
-INTERPOSE(fadvise64);
-#endif
+// Skipping SYS_faccessat
+// Skipping SYS_faccessat2
+// Skipping SYS_fadvise64
 #ifdef SYS_fallocate // kernel entry: num=285 func=sys_fallocate
 INTERPOSE(fallocate);
 #endif
@@ -165,12 +147,8 @@ INTERPOSE(fanotify_mark);
 #ifdef SYS_fchdir // kernel entry: num=81 func=sys_fchdir
 INTERPOSE(fchdir);
 #endif
-#ifdef SYS_fchmod // kernel entry: num=91 func=sys_fchmod
-INTERPOSE(fchmod);
-#endif
-#ifdef SYS_fchmodat // kernel entry: num=268 func=sys_fchmodat
-INTERPOSE(fchmodat);
-#endif
+// Skipping SYS_fchmod
+// Skipping SYS_fchmodat
 #ifdef SYS_fchown // kernel entry: num=93 func=sys_fchown
 INTERPOSE(fchown);
 #endif
@@ -195,30 +173,18 @@ INTERPOSE(flistxattr);
 #ifdef SYS_flock // kernel entry: num=73 func=sys_flock
 INTERPOSE(flock);
 #endif
-#ifdef SYS_fork // kernel entry: num=57 func=sys_fork
-INTERPOSE(fork);
-#endif
+// Skipping SYS_fork
 #ifdef SYS_fremovexattr // kernel entry: num=199 func=sys_fremovexattr
 INTERPOSE(fremovexattr);
 #endif
-#ifdef SYS_fsconfig // kernel entry: num=431 func=sys_fsconfig
-INTERPOSE(fsconfig);
-#endif
+// Skipping SYS_fsconfig
 #ifdef SYS_fsetxattr // kernel entry: num=190 func=sys_fsetxattr
 INTERPOSE(fsetxattr);
 #endif
-#ifdef SYS_fsmount // kernel entry: num=432 func=sys_fsmount
-INTERPOSE(fsmount);
-#endif
-#ifdef SYS_fsopen // kernel entry: num=430 func=sys_fsopen
-INTERPOSE(fsopen);
-#endif
-#ifdef SYS_fspick // kernel entry: num=433 func=sys_fspick
-INTERPOSE(fspick);
-#endif
-#ifdef SYS_fstat // kernel entry: num=5 func=sys_newfstat
-INTERPOSE(fstat);
-#endif
+// Skipping SYS_fsmount
+// Skipping SYS_fsopen
+// Skipping SYS_fspick
+// Skipping SYS_fstat
 #ifdef SYS_fstatfs // kernel entry: num=138 func=sys_fstatfs
 INTERPOSE(fstatfs);
 #endif
@@ -231,9 +197,7 @@ INTERPOSE(ftruncate);
 #ifdef SYS_futex // kernel entry: num=202 func=sys_futex
 INTERPOSE(futex);
 #endif
-#ifdef SYS_futex_waitv // kernel entry: num=449 func=sys_futex_waitv
-INTERPOSE(futex_waitv);
-#endif
+// Skipping SYS_futex_waitv
 #ifdef SYS_futimesat // kernel entry: num=261 func=sys_futimesat
 INTERPOSE(futimesat);
 #endif
@@ -258,9 +222,7 @@ INTERPOSE(geteuid);
 #ifdef SYS_getgid // kernel entry: num=104 func=sys_getgid
 INTERPOSE(getgid);
 #endif
-#ifdef SYS_getgroups // kernel entry: num=115 func=sys_getgroups
-INTERPOSE(getgroups);
-#endif
+// Skipping SYS_getgroups
 #ifdef SYS_getitimer // kernel entry: num=36 func=sys_getitimer
 INTERPOSE(getitimer);
 #endif
@@ -279,9 +241,7 @@ INTERPOSE(getpid);
 #ifdef SYS_getppid // kernel entry: num=110 func=sys_getppid
 INTERPOSE(getppid);
 #endif
-#ifdef SYS_getpriority // kernel entry: num=140 func=sys_getpriority
-INTERPOSE(getpriority);
-#endif
+// Skipping SYS_getpriority
 #ifdef SYS_getrandom // kernel entry: num=318 func=sys_getrandom
 INTERPOSE(getrandom);
 #endif
@@ -342,24 +302,16 @@ INTERPOSE(io_destroy);
 #ifdef SYS_io_getevents // kernel entry: num=208 func=sys_io_getevents
 INTERPOSE(io_getevents);
 #endif
-#ifdef SYS_io_pgetevents // kernel entry: num=333 func=sys_io_pgetevents
-INTERPOSE(io_pgetevents);
-#endif
+// Skipping SYS_io_pgetevents
 #ifdef SYS_io_setup // kernel entry: num=206 func=sys_io_setup
 INTERPOSE(io_setup);
 #endif
 #ifdef SYS_io_submit // kernel entry: num=209 func=sys_io_submit
 INTERPOSE(io_submit);
 #endif
-#ifdef SYS_io_uring_enter // kernel entry: num=426 func=sys_io_uring_enter
-INTERPOSE(io_uring_enter);
-#endif
-#ifdef SYS_io_uring_register // kernel entry: num=427 func=sys_io_uring_register
-INTERPOSE(io_uring_register);
-#endif
-#ifdef SYS_io_uring_setup // kernel entry: num=425 func=sys_io_uring_setup
-INTERPOSE(io_uring_setup);
-#endif
+// Skipping SYS_io_uring_enter
+// Skipping SYS_io_uring_register
+// Skipping SYS_io_uring_setup
 #ifdef SYS_ioctl // kernel entry: num=16 func=sys_ioctl
 INTERPOSE(ioctl);
 #endif
@@ -386,15 +338,9 @@ INTERPOSE(keyctl);
 #ifdef SYS_kill // kernel entry: num=62 func=sys_kill
 INTERPOSE(kill);
 #endif
-#ifdef SYS_landlock_add_rule // kernel entry: num=445 func=sys_landlock_add_rule
-INTERPOSE(landlock_add_rule);
-#endif
-#ifdef SYS_landlock_create_ruleset // kernel entry: num=444 func=sys_landlock_create_ruleset
-INTERPOSE(landlock_create_ruleset);
-#endif
-#ifdef SYS_landlock_restrict_self // kernel entry: num=446 func=sys_landlock_restrict_self
-INTERPOSE(landlock_restrict_self);
-#endif
+// Skipping SYS_landlock_add_rule
+// Skipping SYS_landlock_create_ruleset
+// Skipping SYS_landlock_restrict_self
 #ifdef SYS_lchown // kernel entry: num=94 func=sys_lchown
 INTERPOSE(lchown);
 #endif
@@ -428,9 +374,7 @@ INTERPOSE(lseek);
 #ifdef SYS_lsetxattr // kernel entry: num=189 func=sys_lsetxattr
 INTERPOSE(lsetxattr);
 #endif
-#ifdef SYS_lstat // kernel entry: num=6 func=sys_newlstat
-INTERPOSE(lstat);
-#endif
+// Skipping SYS_lstat
 #ifdef SYS_madvise // kernel entry: num=28 func=sys_madvise
 INTERPOSE(madvise);
 #endif
@@ -443,9 +387,7 @@ INTERPOSE(membarrier);
 #ifdef SYS_memfd_create // kernel entry: num=319 func=sys_memfd_create
 INTERPOSE(memfd_create);
 #endif
-#ifdef SYS_memfd_secret // kernel entry: num=447 func=sys_memfd_secret
-INTERPOSE(memfd_secret);
-#endif
+// Skipping SYS_memfd_secret
 #ifdef SYS_migrate_pages // kernel entry: num=256 func=sys_migrate_pages
 INTERPOSE(migrate_pages);
 #endif
@@ -482,12 +424,8 @@ INTERPOSE(modify_ldt);
 #ifdef SYS_mount // kernel entry: num=165 func=sys_mount
 INTERPOSE(mount);
 #endif
-#ifdef SYS_mount_setattr // kernel entry: num=442 func=sys_mount_setattr
-INTERPOSE(mount_setattr);
-#endif
-#ifdef SYS_move_mount // kernel entry: num=429 func=sys_move_mount
-INTERPOSE(move_mount);
-#endif
+// Skipping SYS_mount_setattr
+// Skipping SYS_move_mount
 #ifdef SYS_move_pages // kernel entry: num=279 func=sys_move_pages
 INTERPOSE(move_pages);
 #endif
@@ -497,12 +435,8 @@ INTERPOSE(mprotect);
 #ifdef SYS_mq_getsetattr // kernel entry: num=245 func=sys_mq_getsetattr
 INTERPOSE(mq_getsetattr);
 #endif
-#ifdef SYS_mq_notify // kernel entry: num=244 func=sys_mq_notify
-INTERPOSE(mq_notify);
-#endif
-#ifdef SYS_mq_open // kernel entry: num=240 func=sys_mq_open
-INTERPOSE(mq_open);
-#endif
+// Skipping SYS_mq_notify
+// Skipping SYS_mq_open
 #ifdef SYS_mq_timedreceive // kernel entry: num=243 func=sys_mq_timedreceive
 INTERPOSE(mq_timedreceive);
 #endif
@@ -545,16 +479,12 @@ INTERPOSE(name_to_handle_at);
 #ifdef SYS_nanosleep // kernel entry: num=35 func=sys_nanosleep
 INTERPOSE(nanosleep);
 #endif
-#ifdef SYS_newfstatat // kernel entry: num=262 func=sys_newfstatat
-INTERPOSE(newfstatat);
-#endif
+// Skipping SYS_newfstatat
 // Skipping SYS_open
 #ifdef SYS_open_by_handle_at // kernel entry: num=304 func=sys_open_by_handle_at
 INTERPOSE(open_by_handle_at);
 #endif
-#ifdef SYS_open_tree // kernel entry: num=428 func=sys_open_tree
-INTERPOSE(open_tree);
-#endif
+// Skipping SYS_open_tree
 // Skipping SYS_openat
 #ifdef SYS_openat2 // kernel entry: num=437 func=sys_openat2
 INTERPOSE(openat2);
@@ -595,12 +525,8 @@ INTERPOSE(pkey_free);
 #ifdef SYS_pkey_mprotect // kernel entry: num=329 func=sys_pkey_mprotect
 INTERPOSE(pkey_mprotect);
 #endif
-#ifdef SYS_poll // kernel entry: num=7 func=sys_poll
-INTERPOSE(poll);
-#endif
-#ifdef SYS_ppoll // kernel entry: num=271 func=sys_ppoll
-INTERPOSE(ppoll);
-#endif
+// Skipping SYS_poll
+// Skipping SYS_ppoll
 #ifdef SYS_prctl // kernel entry: num=157 func=sys_prctl
 INTERPOSE(prctl);
 #endif
@@ -610,12 +536,8 @@ INTERPOSE(prctl);
 #ifdef SYS_prlimit64 // kernel entry: num=302 func=sys_prlimit64
 INTERPOSE(prlimit64);
 #endif
-#ifdef SYS_process_madvise // kernel entry: num=440 func=sys_process_madvise
-INTERPOSE(process_madvise);
-#endif
-#ifdef SYS_process_mrelease // kernel entry: num=448 func=sys_process_mrelease
-INTERPOSE(process_mrelease);
-#endif
+// Skipping SYS_process_madvise
+// Skipping SYS_process_mrelease
 #ifdef SYS_process_vm_readv // kernel entry: num=310 func=sys_process_vm_readv
 INTERPOSE(process_vm_readv);
 #endif
@@ -623,18 +545,14 @@ INTERPOSE(process_vm_readv);
 INTERPOSE(process_vm_writev);
 #endif
 // Skipping SYS_pselect6
-#ifdef SYS_ptrace // kernel entry: num=101 func=sys_ptrace
-INTERPOSE(ptrace);
-#endif
+// Skipping SYS_ptrace
 // Skipping SYS_pwrite64
 // Skipping SYS_pwritev
 // Skipping SYS_pwritev2
 #ifdef SYS_quotactl // kernel entry: num=179 func=sys_quotactl
 INTERPOSE(quotactl);
 #endif
-#ifdef SYS_quotactl_fd // kernel entry: num=443 func=sys_quotactl_fd
-INTERPOSE(quotactl_fd);
-#endif
+// Skipping SYS_quotactl_fd
 #ifdef SYS_read // kernel entry: num=0 func=sys_read
 INTERPOSE(read);
 #endif
@@ -685,27 +603,15 @@ INTERPOSE(request_key);
 INTERPOSE(rmdir);
 #endif
 // Skipping SYS_rseq
-#ifdef SYS_rt_sigaction // kernel entry: num=13 func=sys_rt_sigaction
-INTERPOSE(rt_sigaction);
-#endif
-#ifdef SYS_rt_sigpending // kernel entry: num=127 func=sys_rt_sigpending
-INTERPOSE(rt_sigpending);
-#endif
-#ifdef SYS_rt_sigprocmask // kernel entry: num=14 func=sys_rt_sigprocmask
-INTERPOSE(rt_sigprocmask);
-#endif
+// Skipping SYS_rt_sigaction
+// Skipping SYS_rt_sigpending
+// Skipping SYS_rt_sigprocmask
 #ifdef SYS_rt_sigqueueinfo // kernel entry: num=129 func=sys_rt_sigqueueinfo
 INTERPOSE(rt_sigqueueinfo);
 #endif
-#ifdef SYS_rt_sigreturn // kernel entry: num=15 func=sys_rt_sigreturn
-INTERPOSE(rt_sigreturn);
-#endif
-#ifdef SYS_rt_sigsuspend // kernel entry: num=130 func=sys_rt_sigsuspend
-INTERPOSE(rt_sigsuspend);
-#endif
-#ifdef SYS_rt_sigtimedwait // kernel entry: num=128 func=sys_rt_sigtimedwait
-INTERPOSE(rt_sigtimedwait);
-#endif
+// Skipping SYS_rt_sigreturn
+// Skipping SYS_rt_sigsuspend
+// Skipping SYS_rt_sigtimedwait
 #ifdef SYS_rt_tgsigqueueinfo // kernel entry: num=297 func=sys_rt_tgsigqueueinfo
 INTERPOSE(rt_tgsigqueueinfo);
 #endif
@@ -715,9 +621,7 @@ INTERPOSE(sched_get_priority_max);
 #ifdef SYS_sched_get_priority_min // kernel entry: num=147 func=sys_sched_get_priority_min
 INTERPOSE(sched_get_priority_min);
 #endif
-#ifdef SYS_sched_getaffinity // kernel entry: num=204 func=sys_sched_getaffinity
-INTERPOSE(sched_getaffinity);
-#endif
+// Skipping SYS_sched_getaffinity
 #ifdef SYS_sched_getattr // kernel entry: num=315 func=sys_sched_getattr
 INTERPOSE(sched_getattr);
 #endif
@@ -730,9 +634,7 @@ INTERPOSE(sched_getscheduler);
 #ifdef SYS_sched_rr_get_interval // kernel entry: num=148 func=sys_sched_rr_get_interval
 INTERPOSE(sched_rr_get_interval);
 #endif
-#ifdef SYS_sched_setaffinity // kernel entry: num=203 func=sys_sched_setaffinity
-INTERPOSE(sched_setaffinity);
-#endif
+// Skipping SYS_sched_setaffinity
 #ifdef SYS_sched_setattr // kernel entry: num=314 func=sys_sched_setattr
 INTERPOSE(sched_setattr);
 #endif
@@ -748,9 +650,7 @@ INTERPOSE(sched_yield);
 #ifdef SYS_seccomp // kernel entry: num=317 func=sys_seccomp
 INTERPOSE(seccomp);
 #endif
-#ifdef SYS_select // kernel entry: num=23 func=sys_select
-INTERPOSE(select);
-#endif
+// Skipping SYS_select
 #ifdef SYS_semctl // kernel entry: num=66 func=sys_semctl
 INTERPOSE(semctl);
 #endif
@@ -778,9 +678,7 @@ INTERPOSE(sendto);
 #ifdef SYS_set_mempolicy // kernel entry: num=238 func=sys_set_mempolicy
 INTERPOSE(set_mempolicy);
 #endif
-#ifdef SYS_set_mempolicy_home_node // kernel entry: num=450 func=sys_set_mempolicy_home_node
-INTERPOSE(set_mempolicy_home_node);
-#endif
+// Skipping SYS_set_mempolicy_home_node
 #ifdef SYS_set_robust_list // kernel entry: num=273 func=sys_set_robust_list
 INTERPOSE(set_robust_list);
 #endif
@@ -790,21 +688,11 @@ INTERPOSE(set_tid_address);
 #ifdef SYS_setdomainname // kernel entry: num=171 func=sys_setdomainname
 INTERPOSE(setdomainname);
 #endif
-#ifdef SYS_setfsgid // kernel entry: num=123 func=sys_setfsgid
-INTERPOSE(setfsgid);
-#endif
-#ifdef SYS_setfsuid // kernel entry: num=122 func=sys_setfsuid
-INTERPOSE(setfsuid);
-#endif
-#ifdef SYS_setgid // kernel entry: num=106 func=sys_setgid
-INTERPOSE(setgid);
-#endif
-#ifdef SYS_setgroups // kernel entry: num=116 func=sys_setgroups
-INTERPOSE(setgroups);
-#endif
-#ifdef SYS_sethostname // kernel entry: num=170 func=sys_sethostname
-INTERPOSE(sethostname);
-#endif
+// Skipping SYS_setfsgid
+// Skipping SYS_setfsuid
+// Skipping SYS_setgid
+// Skipping SYS_setgroups
+// Skipping SYS_sethostname
 #ifdef SYS_setitimer // kernel entry: num=38 func=sys_setitimer
 INTERPOSE(setitimer);
 #endif
@@ -814,21 +702,11 @@ INTERPOSE(setns);
 #ifdef SYS_setpgid // kernel entry: num=109 func=sys_setpgid
 INTERPOSE(setpgid);
 #endif
-#ifdef SYS_setpriority // kernel entry: num=141 func=sys_setpriority
-INTERPOSE(setpriority);
-#endif
-#ifdef SYS_setregid // kernel entry: num=114 func=sys_setregid
-INTERPOSE(setregid);
-#endif
-#ifdef SYS_setresgid // kernel entry: num=119 func=sys_setresgid
-INTERPOSE(setresgid);
-#endif
-#ifdef SYS_setresuid // kernel entry: num=117 func=sys_setresuid
-INTERPOSE(setresuid);
-#endif
-#ifdef SYS_setreuid // kernel entry: num=113 func=sys_setreuid
-INTERPOSE(setreuid);
-#endif
+// Skipping SYS_setpriority
+// Skipping SYS_setregid
+// Skipping SYS_setresgid
+// Skipping SYS_setresuid
+// Skipping SYS_setreuid
 #ifdef SYS_setrlimit // kernel entry: num=160 func=sys_setrlimit
 INTERPOSE(setrlimit);
 #endif
@@ -841,9 +719,7 @@ INTERPOSE(setsockopt);
 #ifdef SYS_settimeofday // kernel entry: num=164 func=sys_settimeofday
 INTERPOSE(settimeofday);
 #endif
-#ifdef SYS_setuid // kernel entry: num=105 func=sys_setuid
-INTERPOSE(setuid);
-#endif
+// Skipping SYS_setuid
 #ifdef SYS_setxattr // kernel entry: num=188 func=sys_setxattr
 INTERPOSE(setxattr);
 #endif
@@ -865,12 +741,8 @@ INTERPOSE(shutdown);
 #ifdef SYS_sigaltstack // kernel entry: num=131 func=sys_sigaltstack
 INTERPOSE(sigaltstack);
 #endif
-#ifdef SYS_signalfd // kernel entry: num=282 func=sys_signalfd
-INTERPOSE(signalfd);
-#endif
-#ifdef SYS_signalfd4 // kernel entry: num=289 func=sys_signalfd4
-INTERPOSE(signalfd4);
-#endif
+// Skipping SYS_signalfd
+// Skipping SYS_signalfd4
 #ifdef SYS_socket // kernel entry: num=41 func=sys_socket
 INTERPOSE(socket);
 #endif
@@ -880,9 +752,7 @@ INTERPOSE(socketpair);
 #ifdef SYS_splice // kernel entry: num=275 func=sys_splice
 INTERPOSE(splice);
 #endif
-#ifdef SYS_stat // kernel entry: num=4 func=sys_newstat
-INTERPOSE(stat);
-#endif
+// Skipping SYS_stat
 #ifdef SYS_statfs // kernel entry: num=137 func=sys_statfs
 INTERPOSE(statfs);
 #endif
@@ -928,9 +798,7 @@ INTERPOSE(tgkill);
 #ifdef SYS_time // kernel entry: num=201 func=sys_time
 INTERPOSE(time);
 #endif
-#ifdef SYS_timer_create // kernel entry: num=222 func=sys_timer_create
-INTERPOSE(timer_create);
-#endif
+// Skipping SYS_timer_create
 #ifdef SYS_timer_delete // kernel entry: num=226 func=sys_timer_delete
 INTERPOSE(timer_delete);
 #endif
@@ -967,9 +835,7 @@ INTERPOSE(umask);
 #ifdef SYS_umount2 // kernel entry: num=166 func=sys_umount
 INTERPOSE(umount2);
 #endif
-#ifdef SYS_uname // kernel entry: num=63 func=sys_newuname
-INTERPOSE(uname);
-#endif
+// Skipping SYS_uname
 #ifdef SYS_unlink // kernel entry: num=87 func=sys_unlink
 INTERPOSE(unlink);
 #endif
@@ -1003,12 +869,8 @@ INTERPOSE(vhangup);
 #ifdef SYS_vmsplice // kernel entry: num=278 func=sys_vmsplice
 INTERPOSE(vmsplice);
 #endif
-#ifdef SYS_wait4 // kernel entry: num=61 func=sys_wait4
-INTERPOSE(wait4);
-#endif
-#ifdef SYS_waitid // kernel entry: num=247 func=sys_waitid
-INTERPOSE(waitid);
-#endif
+// Skipping SYS_wait4
+// Skipping SYS_waitid
 #ifdef SYS_write // kernel entry: num=1 func=sys_write
 INTERPOSE(write);
 #endif

--- a/src/main/host/syscall/handler/sched.rs
+++ b/src/main/host/syscall/handler/sched.rs
@@ -40,12 +40,12 @@ impl SyscallHandler {
         let mut mask = mem.memory_ref_mut(mask_ptr)?;
 
         // this assumes little endian
-        mask.fill(0);
+        let bytes_written = 1;
         mask[0] = 1;
 
         mask.flush()?;
 
-        Ok(0)
+        Ok(bytes_written)
     }
 
     #[log_syscall(/* rv */ i32, /* pid */ kernel_pid_t, /* cpusetsize */ libc::size_t, /* mask */ *const std::ffi::c_void)]


### PR DESCRIPTION
This adds an advisory check in our script for generating syscall wrappers that warns when we generate wrappers for syscalls whose man pages note "C library/kernel differences".

Suppressed most of the syscalls that it was warning about; reviewed some, adding those to either a "definitely suppress" list, or an "allow list".

Removing an incorrect wrapper for `sched_getaffinity` uncovered a bug in our `sched_getaffinity` syscall implementation. Fixes the bug.