### PR TITLE
Hack things up to get tor-minimal-test working with asan'd tor

### DIFF
--- a/src/lib/shim/shim_seccomp.c
+++ b/src/lib/shim/shim_seccomp.c
@@ -162,8 +162,8 @@ void shim_seccomp_init() {
          * TODO: Remove this exception, as it could interfere with escaping busy-loops
          * in managed code.
          */
-        BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SYS_sched_yield, /*true-skip=*/0, /*false-skip=*/1),
-        BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW),
+        //BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SYS_sched_yield, /*true-skip=*/0, /*false-skip=*/1),
+        //BPF_STMT(BPF_RET + BPF_K, SECCOMP_RET_ALLOW),
 
         /* Allow syscalls made from the `.text` section.
          * We allow-list native syscalls made from this region both for correctness

--- a/src/lib/shim/shim_tls.c
+++ b/src/lib/shim/shim_tls.c
@@ -31,7 +31,8 @@ static ShimThreadLocalStorage* _tls_storage() {
     void* fs = NULL;
     __asm__("mov %%fs:0x0, %0" : "=r"(fs)::);
 
-    if (fs != NULL) {
+    // Native TLS results in a recursion loop under asan
+    if (false && fs != NULL) {
         // Native (libc) TLS seems to be set up properly. Use it.
         static __thread ShimThreadLocalStorage _tls = {0};
         return &_tls;

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -240,7 +240,7 @@ pub struct GeneralOptions {
     /// under Shadow.
     #[clap(long, value_name = "bool")]
     #[clap(help = GENERAL_HELP.get("model_unblocked_syscall_latency").unwrap().as_str())]
-    #[serde(default = "default_some_false")]
+    #[serde(default = "default_some_true")]
     pub model_unblocked_syscall_latency: Option<bool>,
 }
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -480,7 +480,7 @@ impl Default for ExperimentalOptions {
             // Actual latencies vary from ~40 to ~400 CPU cycles. https://stackoverflow.com/a/13096917
             // Default to the lower end to minimize effect in simualations without busy loops.
             unblocked_vdso_latency: Some(units::Time::new(10, units::TimePrefix::Nano)),
-            use_memory_manager: Some(true),
+            use_memory_manager: Some(false),
             use_cpu_pinning: Some(true),
             use_worker_spinning: Some(true),
             runahead: Some(NullableOption::Value(units::Time::new(

--- a/src/main/host/managed_thread.rs
+++ b/src/main/host/managed_thread.rs
@@ -584,7 +584,9 @@ impl ManagedThread {
         Errno::result(unsafe {
             libc::posix_spawnattr_setflags(
                 &mut spawn_attr,
-                libc::POSIX_SPAWN_USEVFORK.try_into().unwrap(),
+                // HAX: set a flag *incompatible* with vfork so that
+                // it will use fork.
+                libc::POSIX_SPAWN_RESETIDS.try_into().unwrap(),
             )
         })
         .unwrap();

--- a/src/main/host/syscall/futex.c
+++ b/src/main/host/syscall/futex.c
@@ -225,5 +225,6 @@ SyscallReturn syscallhandler_set_robust_list(SysCallHandler* sys, const SysCallA
 
     debug("set_robust_list was called but we don't yet support it");
 
-    return syscallreturn_makeDoneErrno(ENOSYS);
+    // asan deadlocks here if we return an error?
+    return syscallreturn_makeDoneI64(0);
 }

--- a/src/test/tor/minimal/tor-minimal.yaml
+++ b/src/test/tor/minimal/tor-minimal.yaml
@@ -1,5 +1,7 @@
 general:
   stop_time: 30 min
+  # asan uses a spin loop in thread creation
+  model_unblocked_syscall_latency: true
 network:
   graph:
     type: gml
@@ -25,9 +27,9 @@ hosts:
     processes:
     - path: tgen
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
-      environment: { OPENBLAS_NUM_THREADS: "1" }
+      environment: { OPENBLAS_NUM_THREADS: "1"}
       args: ../../../conf/tgen.server.graphml.xml
-      start_time: 1
+      start_time: 2
       expected_final_state: running
   hiddenserver:
     network_node_id: 0
@@ -36,9 +38,10 @@ hosts:
       # See https://shadow.github.io/docs/guide/compatibility_notes.html#libopenblas
       environment: { OPENBLAS_NUM_THREADS: "1" }
       args: ../../../conf/tgen.hiddenserver.graphml.xml
-      start_time: 1
+      start_time: 2
       expected_final_state: running
     - path: tor
+      environment: { ASAN_OPTIONS: verify_asan_link_order=0}
       args: --Address hiddenserver --Nickname hiddenserver
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
@@ -48,6 +51,7 @@ hosts:
     ip_addr: 100.0.0.1
     processes:
     - path: tor
+      environment: { ASAN_OPTIONS: verify_asan_link_order=0}
       args: --Address 4uthority --Nickname 4uthority
             --defaults-torrc torrc-defaults -f torrc
       start_time: 1
@@ -56,6 +60,7 @@ hosts:
     network_node_id: 0
     processes:
     - path: tor
+      environment: { ASAN_OPTIONS: verify_asan_link_order=0}
       args: --Address exit1 --Nickname exit1
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
@@ -64,6 +69,7 @@ hosts:
     network_node_id: 0
     processes:
     - path: tor
+      environment: { ASAN_OPTIONS: verify_asan_link_order=0}
       args: --Address exit2 --Nickname exit2
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
@@ -72,6 +78,7 @@ hosts:
     network_node_id: 0
     processes:
     - path: tor
+      environment: { ASAN_OPTIONS: verify_asan_link_order=0}
       args: --Address relay1 --Nickname relay1
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
@@ -80,6 +87,7 @@ hosts:
     network_node_id: 0
     processes:
     - path: tor
+      environment: { ASAN_OPTIONS: verify_asan_link_order=0}
       args: --Address relay2 --Nickname relay2
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
@@ -88,6 +96,7 @@ hosts:
     network_node_id: 0
     processes:
     - path: tor
+      environment: { ASAN_OPTIONS: verify_asan_link_order=0}
       args: --Address relay3 --Nickname relay3
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
@@ -96,6 +105,7 @@ hosts:
     network_node_id: 0
     processes:
     - path: tor
+      environment: { ASAN_OPTIONS: verify_asan_link_order=0}
       args: --Address relay4 --Nickname relay4
             --defaults-torrc torrc-defaults -f torrc
       start_time: 60
@@ -112,6 +122,7 @@ hosts:
     network_node_id: 0
     processes:
     - path: tor
+      environment: { ASAN_OPTIONS: verify_asan_link_order=0}
       args: --Address torclient --Nickname torclient
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900
@@ -125,6 +136,7 @@ hosts:
     network_node_id: 0
     processes:
     - path: tor
+      environment: { ASAN_OPTIONS: verify_asan_link_order=0}
       args: --Address torbridgeclient --Nickname torbridgeclient
             --UseBridges 1 --Bridge 100.0.0.1:9111
             --defaults-torrc torrc-defaults -f torrc
@@ -139,6 +151,7 @@ hosts:
     network_node_id: 0
     processes:
     - path: tor
+      environment: { ASAN_OPTIONS: verify_asan_link_order=0}
       args: --Address torhiddenclient --Nickname torhiddenclient
             --defaults-torrc torrc-defaults -f torrc
       start_time: 900


### PR DESCRIPTION
~mergeable changes:

* Enable unblocked syscall latency in the tor minimal test. asan uses a spin loop during thread creation.

* Drop the sched_yield exception from our seccomp filter. asan uses an inlined sched_yield syscall in its spin loop which we otherwise weren't intercepting. Luckily we don't need this exception anymore.

Hacks:

* Hack up shim initialization to try again later if env variables don't work yet. (Real fix is to finish migrating off of env variable usage).

* Hard-code the shim *not* to use native thread local storage even if it appears to be available. asan intercepts internal function calls used to access thread-local-storage.

Maybe not needed:

* Change set_robust_list to return 0 instead of ENOSYS. I think this ended up not being needed.

* Hack up our posix_spawn call to force it *not* to use vfork. This was just to make gdb behave better while I was debugging.

* Start some processes slightly later. This was just for debugging so that the first process to start was a tor process, and nothing else tried to start simultaneously.

* Set "ASAN_OPTIONS: verify_asan_link_order=0" so that asan doesn't complain about the shadow shim being first in LD_PRELOAD order.