### PR TITLE
Use `linux_api::errno::Errno` in eventfd and clone syscall handlers

### DIFF
--- a/src/lib/linux-api/src/errno.rs
+++ b/src/lib/linux-api/src/errno.rs
@@ -153,6 +153,7 @@ fn errno_to_str(e: Errno) -> Option<&'static str> {
         Errno::ERFKILL => Some("ERFKILL"),
         Errno::EHWPOISON => Some("EHWPOISON"),
         Errno::EINTR => Some("EINTR"),
+        Errno::ENFILE => Some("ENFILE"),
         _ => None,
     }
 }
@@ -279,6 +280,7 @@ impl Errno {
     pub const ERFKILL: Self = Self::from_u32_const(bindings::LINUX_ERFKILL);
     pub const EHWPOISON: Self = Self::from_u32_const(bindings::LINUX_EHWPOISON);
     pub const EINTR: Self = Self::from_u32_const(bindings::LINUX_EINTR);
+    pub const ENFILE: Self = Self::from_u32_const(bindings::LINUX_ENFILE);
 
     // Aliases
     pub const EDEADLOCK: Self = Self::from_u32_const(bindings::LINUX_EDEADLOCK);

--- a/src/main/host/syscall/handler/clone.rs
+++ b/src/main/host/syscall/handler/clone.rs
@@ -1,7 +1,7 @@
+use linux_api::errno::Errno;
 use linux_api::posix_types::kernel_pid_t;
 use linux_api::sched::CloneFlags;
 use log::{debug, trace, warn};
-use nix::errno::Errno;
 use nix::sys::signal::Signal;
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;


### PR DESCRIPTION
We could do this in more syscall handlers, but I don't want to make too much of a mess of mixing the nix and linux_api `Errno` types in many places. It's probably best to do the remaining conversion in one go.