### PR TITLE
Support `SIOCGSTAMP` for inet sockets

### DIFF
--- a/src/main/host/descriptor/compat_socket.c
+++ b/src/main/host/descriptor/compat_socket.c
@@ -150,12 +150,13 @@ bool compatsocket_hasDataToSend(const CompatSocket* socket) {
     utility_panic("Invalid CompatSocket type");
 }
 
-void compatsocket_pushInPacket(const CompatSocket* socket, const Host* host, Packet* packet) {
+void compatsocket_pushInPacket(const CompatSocket* socket, const Host* host, Packet* packet,
+                               CEmulatedTime recvTime) {
     switch (socket->type) {
         case CST_LEGACY_SOCKET:
             return legacysocket_pushInPacket(socket->object.as_legacy_socket, host, packet);
         case CST_INET_SOCKET:
-            return inetsocket_pushInPacket(socket->object.as_inet_socket, packet);
+            return inetsocket_pushInPacket(socket->object.as_inet_socket, packet, recvTime);
         case CST_NONE: utility_panic("Unexpected CompatSocket type");
     }
 

--- a/src/main/host/descriptor/compat_socket.h
+++ b/src/main/host/descriptor/compat_socket.h
@@ -47,7 +47,8 @@ CompatSocket compatsocket_fromTagged(uintptr_t ptr);
 /* compatability wrappers */
 int compatsocket_peekNextPacketPriority(const CompatSocket* socket, uint64_t* priorityOut);
 bool compatsocket_hasDataToSend(const CompatSocket* socket);
-void compatsocket_pushInPacket(const CompatSocket* socket, const Host* host, Packet* packet);
+void compatsocket_pushInPacket(const CompatSocket* socket, const Host* host, Packet* packet,
+                               CEmulatedTime recvTime);
 Packet* compatsocket_pullOutPacket(const CompatSocket* socket, const Host* host);
 void compatsocket_updatePacketHeader(const CompatSocket* socket, const Host* host, Packet* packet);
 

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -589,6 +589,8 @@ impl LegacyTcpSocket {
 
                 Ok(0.into())
             }
+            // this isn't supported by tcp
+            IoctlRequest::SIOCGSTAMP => Err(Errno::ENOENT.into()),
             IoctlRequest::FIONBIO => {
                 panic!("This should have been handled by the ioctl syscall handler");
             }

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -6,6 +6,7 @@ use atomic_refcell::AtomicRefCell;
 use linux_api::errno::Errno;
 use linux_api::ioctls::IoctlRequest;
 use nix::sys::socket::{MsgFlags, Shutdown, SockaddrIn};
+use shadow_shim_helper_rs::emulated_time::EmulatedTime;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::core::worker::Worker;
@@ -129,7 +130,12 @@ impl LegacyTcpSocket {
         self.has_open_file = val;
     }
 
-    pub fn push_in_packet(&mut self, packet: PacketRc, _cb_queue: &mut CallbackQueue) {
+    pub fn push_in_packet(
+        &mut self,
+        packet: PacketRc,
+        _cb_queue: &mut CallbackQueue,
+        _recv_time: EmulatedTime,
+    ) {
         Worker::with_active_host(|host| {
             // the C code should ref the inner `Packet`, so it's fine to drop the `PacketRc`
             unsafe {

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -8,6 +8,7 @@ use bytes::{Bytes, BytesMut};
 use linux_api::errno::Errno;
 use linux_api::ioctls::IoctlRequest;
 use nix::sys::socket::{AddressFamily, MsgFlags, Shutdown, SockaddrIn};
+use shadow_shim_helper_rs::emulated_time::EmulatedTime;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::core::worker::Worker;
@@ -97,7 +98,12 @@ impl UdpSocket {
         self.has_open_file = val;
     }
 
-    pub fn push_in_packet(&mut self, mut packet: PacketRc, cb_queue: &mut CallbackQueue) {
+    pub fn push_in_packet(
+        &mut self,
+        mut packet: PacketRc,
+        cb_queue: &mut CallbackQueue,
+        _recv_time: EmulatedTime,
+    ) {
         packet.add_status(PacketStatus::RcvSocketProcessed);
 
         if let Some(peer_addr) = self.peer_addr {

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -43,6 +43,9 @@ pub struct UdpSocket {
     peer_addr: Option<SocketAddrV4>,
     bound_addr: Option<SocketAddrV4>,
     association: Option<AssociationHandle>,
+    /// The receive time of the last packet returned to the managed process during a call to
+    /// `recvmsg()`. Used for `SIOCGSTAMP`.
+    recv_time_of_last_read_packet: Option<EmulatedTime>,
     // should only be used by `OpenFile` to make sure there is only ever one `OpenFile` instance for
     // this file
     has_open_file: bool,
@@ -65,6 +68,7 @@ impl UdpSocket {
             peer_addr: None,
             bound_addr: None,
             association: None,
+            recv_time_of_last_read_packet: None,
             has_open_file: false,
             _counter: ObjectCounter::new("UdpSocket"),
         };
@@ -102,7 +106,7 @@ impl UdpSocket {
         &mut self,
         mut packet: PacketRc,
         cb_queue: &mut CallbackQueue,
-        _recv_time: EmulatedTime,
+        recv_time: EmulatedTime,
     ) {
         packet.add_status(PacketStatus::RcvSocketProcessed);
 
@@ -145,6 +149,7 @@ impl UdpSocket {
         let header = MessageRecvHeader {
             src: packet.src_address(),
             dst: packet.dst_address(),
+            recv_time,
         };
 
         // push the message to the receive buffer (shouldn't fail since we checked for available
@@ -461,7 +466,7 @@ impl UdpSocket {
         mem: &mut MemoryManager,
         cb_queue: &mut CallbackQueue,
     ) -> Result<RecvmsgReturn, SyscallError> {
-        let mut socket_ref = socket.borrow_mut();
+        let socket_ref = &mut *socket.borrow_mut();
 
         let Some(mut flags) = MsgFlags::from_bits(args.flags) else {
             log::debug!("Unrecognized recv flags: {:#b}", args.flags);
@@ -514,6 +519,9 @@ impl UdpSocket {
 
             let mut return_flags = MsgFlags::empty();
             return_flags.set(MsgFlags::MSG_TRUNC, truncated_message.len() < message.len());
+
+            // update the cache of the last recv time
+            socket_ref.recv_time_of_last_read_packet = Some(header.recv_time);
 
             Ok(RecvmsgReturn {
                 return_val: return_val.try_into().unwrap(),
@@ -577,6 +585,26 @@ impl UdpSocket {
 
                 let arg_ptr = arg_ptr.cast::<libc::c_int>();
                 mem.write(arg_ptr, &len)?;
+
+                Ok(0.into())
+            }
+            IoctlRequest::SIOCGSTAMP => {
+                // socket(7): "Return a struct timeval with the receive timestamp of the last packet
+                // passed to the user. [...] This ioctl should only be used if the socket option
+                // SO_TIMESTAMP is not set on the socket. Otherwise, it returns the timestamp of the
+                // last packet that was received while SO_TIMESTAMP was not set, or it fails if no
+                // such packet has been received, (i.e., ioctl(2) returns -1 with errno set to
+                // ENOENT)."
+                let Some(last_recv_time) = self.recv_time_of_last_read_packet else {
+                    return Err(Errno::ENOENT.into());
+                };
+
+                let last_recv_time = (last_recv_time - EmulatedTime::UNIX_EPOCH)
+                    .try_into()
+                    .unwrap();
+
+                let arg_ptr = arg_ptr.cast::<libc::timeval>();
+                mem.write(arg_ptr, &last_recv_time)?;
 
                 Ok(0.into())
             }
@@ -976,6 +1004,8 @@ struct MessageRecvHeader {
     /// `IP_PKTINFO` to get the packet destination address.
     #[allow(dead_code)]
     dst: SocketAddrV4,
+    /// The time when the network interface received the message.
+    recv_time: EmulatedTime,
 }
 
 /// A buffer of UDP messages and message headers.

--- a/src/main/host/network/network_interface.c
+++ b/src/main/host/network/network_interface.c
@@ -168,7 +168,7 @@ static CompatSocket _boundsockets_lookup(GHashTable* table, gchar* key) {
     return compatsocket_fromTagged((uintptr_t)ptr);
 }
 
-void networkinterface_push(NetworkInterface* interface, Packet* packet) {
+void networkinterface_push(NetworkInterface* interface, Packet* packet, CEmulatedTime recvTime) {
     MAGIC_ASSERT(interface);
 
     const Host* host = worker_getCurrentHost();
@@ -215,7 +215,7 @@ void networkinterface_push(NetworkInterface* interface, Packet* packet) {
 
     /* if the socket closed, just drop the packet */
     if (socket.type != CST_NONE) {
-        compatsocket_pushInPacket(&socket, host, packet);
+        compatsocket_pushInPacket(&socket, host, packet, recvTime);
     } else {
         packet_addDeliveryStatus(packet, PDS_RCV_INTERFACE_DROPPED);
     }

--- a/src/main/host/network/network_interface.h
+++ b/src/main/host/network/network_interface.h
@@ -36,7 +36,7 @@ void networkinterface_disassociate(NetworkInterface* interface, ProtocolType typ
 void networkinterface_wantsSend(NetworkInterface* interface, const CompatSocket* socket);
 
 Packet* networkinterface_pop(NetworkInterface* interface);
-void networkinterface_push(NetworkInterface* interface, Packet* packet);
+void networkinterface_push(NetworkInterface* interface, Packet* packet, CEmulatedTime recvTime);
 
 /* Disassociate all bound sockets and remove sockets from the sending queue. */
 void networkinterface_removeAllSockets(NetworkInterface* interface);

--- a/src/test/socket/ioctl/test_ioctl.rs
+++ b/src/test/socket/ioctl/test_ioctl.rs
@@ -81,8 +81,12 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                 test_utils::ShadowTest::new(
                     &append_args("test_siocgstamp"),
                     move || test_siocgstamp(init_method, sock_type),
-                    // TODO: this isn't supported yet in shadow
-                    set![TestEnv::Libc],
+                    // TODO: this isn't supported yet in shadow for unix sockets
+                    if init_method.domain() == libc::AF_UNIX {
+                        set![TestEnv::Libc]
+                    } else {
+                        set![TestEnv::Libc, TestEnv::Shadow]
+                    },
                 ),
             ]);
         }

--- a/src/test/socket/ioctl/test_ioctl.rs
+++ b/src/test/socket/ioctl/test_ioctl.rs
@@ -3,6 +3,8 @@
  * See LICENSE for licensing information
  */
 
+use std::time::Duration;
+
 use test_utils::set;
 use test_utils::socket_utils::{socket_init_helper, SocketInitMethod};
 use test_utils::TestEnvironment as TestEnv;
@@ -65,16 +67,24 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
             let append_args =
                 |s| format!("{s} <init_method={init_method:?}, sock_type={sock_type}>");
 
-            tests.extend(vec![test_utils::ShadowTest::new(
-                &append_args("test_fionread"),
-                move || test_fionread(init_method, sock_type),
-                // TODO: this isn't supported yet in shadow for unix sockets
-                if init_method.domain() == libc::AF_UNIX {
-                    set![TestEnv::Libc]
-                } else {
-                    set![TestEnv::Libc, TestEnv::Shadow]
-                },
-            )]);
+            tests.extend(vec![
+                test_utils::ShadowTest::new(
+                    &append_args("test_fionread"),
+                    move || test_fionread(init_method, sock_type),
+                    // TODO: this isn't supported yet in shadow for unix sockets
+                    if init_method.domain() == libc::AF_UNIX {
+                        set![TestEnv::Libc]
+                    } else {
+                        set![TestEnv::Libc, TestEnv::Shadow]
+                    },
+                ),
+                test_utils::ShadowTest::new(
+                    &append_args("test_siocgstamp"),
+                    move || test_siocgstamp(init_method, sock_type),
+                    // TODO: this isn't supported yet in shadow
+                    set![TestEnv::Libc],
+                ),
+            ]);
         }
     }
 
@@ -180,6 +190,123 @@ fn test_fionread(init_method: SocketInitMethod, sock_type: libc::c_int) -> Resul
             peer_expected_result,
             "Unexpected FIONREAD result",
         )?;
+
+        Ok(())
+    })
+}
+
+/// Test ioctl() using the `SIOCGSTAMP` ioctl request.
+fn test_siocgstamp(init_method: SocketInitMethod, sock_type: libc::c_int) -> Result<(), String> {
+    let (fd_client, fd_peer) = socket_init_helper(
+        init_method,
+        sock_type,
+        libc::SOCK_NONBLOCK,
+        /* bind_client = */ false,
+    );
+
+    /// Returns the value if successful, otherwise returns the errno.
+    fn ioctl_siocgstamp(fd: libc::c_int) -> Result<libc::timeval, libc::c_int> {
+        // not currently available in the libc crate
+        use linux_api::ioctls::IoctlRequest::SIOCGSTAMP;
+
+        let mut out: libc::timeval = unsafe { std::mem::zeroed() };
+        let rv = unsafe { libc::ioctl(fd, SIOCGSTAMP as u64, &mut out) };
+        if rv != 0 {
+            return Err(test_utils::get_errno());
+        }
+        Ok(out)
+    }
+
+    test_utils::run_and_close_fds(&[fd_client, fd_peer], || {
+        // neither socket has received any data, so should return ENOENT for inet sockets
+        let expected_result = match (init_method.domain(), sock_type) {
+            (libc::AF_INET, _) => Err(libc::ENOENT),
+            (libc::AF_UNIX, _) => Err(libc::ENOTTY),
+            _ => unimplemented!(),
+        };
+        test_utils::result_assert_eq(
+            ioctl_siocgstamp(fd_client),
+            expected_result,
+            "Unexpected SIOCGSTAMP result",
+        )?;
+        test_utils::result_assert_eq(
+            ioctl_siocgstamp(fd_peer),
+            expected_result,
+            "Unexpected SIOCGSTAMP result",
+        )?;
+
+        // send data from the client to the peer
+        let flags = nix::sys::socket::MsgFlags::empty();
+        nix::sys::socket::send(fd_client, &[1, 2, 3], flags).unwrap();
+
+        // approximately the time that we sent the message
+        let send_time = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap();
+
+        // shadow needs to run events, but we also sleep so that we make the recv() call much later
+        // than the send() call
+        std::thread::sleep(Duration::from_millis(50));
+
+        // use use a small threshold when comparing the send time to the recv time below since the
+        // message is only travelling over localhost; should be much shorter than the sleep above
+        let threshold = Duration::from_millis(1);
+
+        // recv() has not been called on the socket, so should still return ENOENT for inet sockets
+        let expected_result = match (init_method.domain(), sock_type) {
+            (libc::AF_INET, _) => Err(libc::ENOENT),
+            (libc::AF_UNIX, _) => Err(libc::ENOTTY),
+            _ => unimplemented!(),
+        };
+        test_utils::result_assert_eq(
+            ioctl_siocgstamp(fd_peer),
+            expected_result,
+            "Unexpected SIOCGSTAMP result",
+        )?;
+
+        // receive data at the peer
+        let flags = nix::sys::socket::MsgFlags::empty();
+        nix::sys::socket::recv(fd_peer, &mut [0u8; 3], flags).unwrap();
+
+        // check the result of SIOCGSTAMP on the peer; only supported by udp sockets
+        let expected_err = match (init_method.domain(), sock_type) {
+            (libc::AF_INET, libc::SOCK_DGRAM) => None,
+            (libc::AF_INET, _) => Some(libc::ENOENT),
+            (libc::AF_UNIX, _) => Some(libc::ENOTTY),
+            _ => unimplemented!(),
+        };
+        match expected_err {
+            None => {
+                // the receive time reported by the kernel
+                let recv_time = ioctl_siocgstamp(fd_peer).unwrap();
+                let recv_time = Duration::from_secs(recv_time.tv_sec.try_into().unwrap())
+                    + Duration::from_micros(recv_time.tv_usec.try_into().unwrap());
+
+                // Get the time difference between the send and receive. We can't know if the
+                // receive or send time will be smaller since the send time was measured after the
+                // send() call completed, and the message may have already been received before we
+                // take the send-time measurement. For example:
+                //
+                // 1. `send()` call
+                //   a. since it's localhost, the packet is given directly to the receiving socket
+                //      within the `send()` call
+                //   b. receive time is recorded by the kernel here
+                // 2. shadow records the send time with:
+                //    let send_time = std::time::SystemTime::now()
+                //
+                // In this case the send time is later than the receive time.
+                let difference = test_utils::time::duration_abs_diff(send_time, recv_time);
+
+                // since it was sent over localhost, the difference between the send time and
+                // receive time should be very small
+                test_utils::result_assert(difference < threshold, "Time difference was too large")?;
+            }
+            Some(e) => test_utils::result_assert_eq(
+                ioctl_siocgstamp(fd_peer),
+                Err(e),
+                "Unexpected SIOCGSTAMP result",
+            )?,
+        }
 
         Ok(())
     })


### PR DESCRIPTION
This is only supported by Linux for udp sockets, so tcp has been updated to only return `ENOENT`.