### PR TITLE
Add `linux_api::errno::Errno`/`std::io::Error` conversions

### DIFF
--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+std = []
+
 [dependencies]
 bitflags = "2.3.1"
 log = { version = "0.4.18", default-features = false }

--- a/src/lib/linux-api/src/errno.rs
+++ b/src/lib/linux-api/src/errno.rs
@@ -335,3 +335,22 @@ impl core::convert::From<linux_errno::Error> for Errno {
         Self::try_from(value.get()).unwrap()
     }
 }
+
+#[cfg(feature = "std")]
+impl core::convert::From<Errno> for std::io::Error {
+    fn from(e: Errno) -> Self {
+        Self::from_raw_os_error(e.into())
+    }
+}
+
+#[cfg(feature = "std")]
+impl core::convert::TryFrom<std::io::Error> for Errno {
+    type Error = std::io::Error;
+
+    fn try_from(e: std::io::Error) -> Result<Self, Self::Error> {
+        e.raw_os_error()
+            .and_then(|x| u16::try_from(x).ok())
+            .and_then(|x| x.try_into().ok())
+            .ok_or(e)
+    }
+}

--- a/src/lib/linux-api/src/lib.rs
+++ b/src/lib/linux-api/src/lib.rs
@@ -34,7 +34,7 @@
 //!   Kernel constants such as `O_WRONLY` are typically defined as instants of
 //!   such types, and are convertible to and from the original integer types.
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 // https://github.com/rust-lang/rfcs/blob/master/text/2585-unsafe-block-in-unsafe-fn.md
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.3.3", features = ["derive", "wrap_help"] }
 crossbeam = "0.8.2"
 gml-parser = { path = "../lib/gml-parser" }
 libc = "0.2"
-linux-api = { path = "../lib/linux-api" }
+linux-api = { path = "../lib/linux-api", features = ["std"] }
 # don't log debug or trace levels in release mode
 log = { version = "0.4", features = ["release_max_level_debug"] }
 log-c2rust = { path = "../lib/log-c2rust" }


### PR DESCRIPTION
This adds a "std" feature to linux-api, which if enabled adds a `From<errno::Errno> std::io::Error` conversion and a `TryFrom<std::io::Error> for errno::Errno` conversion.

Since we build shadow and the shim separately, I don't think enabling the "std" feature in shadow should affect the shim which is no_std.