### PR TITLE
Replace uses of nix's `Errno` with linux_api's `Errno` in syscall handlers, memory manager, process, etc

### DIFF
--- a/src/lib/linux-api/src/errno.rs
+++ b/src/lib/linux-api/src/errno.rs
@@ -408,3 +408,6 @@ impl core::convert::TryFrom<std::io::Error> for Errno {
             .ok_or(e)
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for Errno {}

--- a/src/main/host/descriptor/eventfd.rs
+++ b/src/main/host/descriptor/eventfd.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 
+use linux_api::errno::Errno;
 use linux_api::ioctls::IoctlRequest;
-use nix::errno::Errno;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::cshadow as c;

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -1093,7 +1093,7 @@ mod tests {
     fn test_syscallresult_roundtrip() {
         for val in vec![
             Ok(1.into()),
-            Err(nix::errno::Errno::EPERM.into()),
+            Err(linux_api::errno::Errno::EPERM.into()),
             Err(SyscallError::Failed(Failed {
                 errno: linux_api::errno::Errno::EINTR,
                 restartable: true,

--- a/src/main/host/descriptor/pipe.rs
+++ b/src/main/host/descriptor/pipe.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use linux_api::errno::Errno;
 use linux_api::ioctls::IoctlRequest;
-use nix::errno::Errno;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::cshadow as c;
@@ -130,12 +130,12 @@ impl Pipe {
     ) -> Result<libc::ssize_t, SyscallError> {
         // pipes don't support seeking
         if offset.is_some() {
-            return Err(nix::errno::Errno::ESPIPE.into());
+            return Err(linux_api::errno::Errno::ESPIPE.into());
         }
 
         // if the file is not open for reading, return EBADF
         if !self.mode.contains(FileMode::READ) {
-            return Err(nix::errno::Errno::EBADF.into());
+            return Err(linux_api::errno::Errno::EBADF.into());
         }
 
         let num_bytes_to_read: libc::size_t = iovs.iter().map(|x| x.len).sum();
@@ -173,18 +173,18 @@ impl Pipe {
     ) -> Result<libc::ssize_t, SyscallError> {
         // pipes don't support seeking
         if offset.is_some() {
-            return Err(nix::errno::Errno::ESPIPE.into());
+            return Err(linux_api::errno::Errno::ESPIPE.into());
         }
 
         // if the file is not open for writing, return EBADF
         if !self.mode.contains(FileMode::WRITE) {
-            return Err(nix::errno::Errno::EBADF.into());
+            return Err(linux_api::errno::Errno::EBADF.into());
         }
 
         let mut buffer = self.buffer.as_ref().unwrap().borrow_mut();
 
         if buffer.num_readers() == 0 {
-            return Err(nix::errno::Errno::EPIPE.into());
+            return Err(linux_api::errno::Errno::EPIPE.into());
         }
 
         if self.write_mode == WriteMode::Packet && !self.status.contains(FileStatus::DIRECT) {

--- a/src/main/host/descriptor/shared_buf.rs
+++ b/src/main/host/descriptor/shared_buf.rs
@@ -1,4 +1,4 @@
-use nix::errno::Errno;
+use linux_api::errno::Errno;
 
 use crate::utility::byte_queue::ByteQueue;
 use crate::utility::callback_queue::{CallbackQueue, EventSource, Handle};

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -3,8 +3,8 @@ use std::net::{Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use linux_api::errno::Errno;
 use linux_api::ioctls::IoctlRequest;
-use nix::errno::Errno;
 use nix::sys::socket::{MsgFlags, Shutdown, SockaddrIn};
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
@@ -408,7 +408,7 @@ impl LegacyTcpSocket {
 
                 if rv < 0 {
                     if bytes_sent == 0 {
-                        return Err(Errno::from_i32(-rv as i32));
+                        return Err(Errno::try_from(-rv).unwrap());
                     } else {
                         break;
                     }
@@ -508,7 +508,7 @@ impl LegacyTcpSocket {
 
                 if rv < 0 {
                     if bytes_read == 0 {
-                        return Err(Errno::from_i32(-rv as i32));
+                        return Err(Errno::try_from(-rv).unwrap());
                     } else {
                         break;
                     }
@@ -792,7 +792,7 @@ impl LegacyTcpSocket {
         assert!(errcode <= 0);
 
         let mut errcode = if errcode < 0 {
-            Err(Errno::from_i32(-errcode))
+            Err(Errno::try_from(-errcode).unwrap())
         } else {
             Ok(())
         };
@@ -863,7 +863,7 @@ impl LegacyTcpSocket {
 
         if errcode < 0 {
             log::trace!("TCP error when accepting connection");
-            return Err(Errno::from_i32(-errcode).into());
+            return Err(Errno::try_from(-errcode).unwrap().into());
         }
 
         // we accepted something!
@@ -932,7 +932,7 @@ impl LegacyTcpSocket {
         assert!(errcode <= 0);
 
         if errcode < 0 {
-            return Err(Errno::from_i32(-errcode).into());
+            return Err(Errno::try_from(-errcode).unwrap().into());
         }
 
         Ok(())

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -2,8 +2,8 @@ use std::net::SocketAddrV4;
 use std::sync::{Arc, Weak};
 
 use atomic_refcell::AtomicRefCell;
+use linux_api::errno::Errno;
 use linux_api::ioctls::IoctlRequest;
-use nix::errno::Errno;
 use nix::sys::socket::Shutdown;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use bytes::{Bytes, BytesMut};
+use linux_api::errno::Errno;
 use linux_api::ioctls::IoctlRequest;
-use nix::errno::Errno;
 use nix::sys::socket::{AddressFamily, MsgFlags, Shutdown, SockaddrIn};
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
@@ -324,7 +324,7 @@ impl UdpSocket {
 
         // if the file's writing has been shut down, return EPIPE
         if socket_ref.shutdown_status.contains(ShutdownFlags::WRITE) {
-            return Err(nix::errno::Errno::EPIPE.into());
+            return Err(linux_api::errno::Errno::EPIPE.into());
         }
 
         let Some(mut flags) = MsgFlags::from_bits(args.flags) else {
@@ -354,7 +354,7 @@ impl UdpSocket {
 
         // TODO: should use IP fragmentation to make sure packets fit within the MTU
         if len > CONFIG_DATAGRAM_MAX_SIZE {
-            return Err(nix::errno::Errno::EMSGSIZE.into());
+            return Err(linux_api::errno::Errno::EMSGSIZE.into());
         }
 
         // make sure that we're bound

--- a/src/main/host/descriptor/timerfd.rs
+++ b/src/main/host/descriptor/timerfd.rs
@@ -2,9 +2,9 @@ use std::io::Write;
 use std::sync::{Arc, Weak};
 
 use atomic_refcell::AtomicRefCell;
+use linux_api::errno::Errno;
 use linux_api::ioctls::IoctlRequest;
 use linux_api::posix_types::kernel_off_t;
-use nix::errno::Errno;
 use shadow_shim_helper_rs::{
     emulated_time::EmulatedTime, simulation_time::SimulationTime, syscall_types::ForeignPtr,
 };

--- a/src/main/host/memory_manager/memory_copier.rs
+++ b/src/main/host/memory_manager/memory_copier.rs
@@ -1,7 +1,8 @@
 use std::fmt::Debug;
 
+use linux_api::errno::Errno;
 use log::*;
-use nix::{errno::Errno, unistd::Pid};
+use nix::unistd::Pid;
 use shadow_pod::Pod;
 
 use crate::core::worker::Worker;
@@ -181,7 +182,8 @@ impl MemoryCopier {
         })
         .unwrap();
 
-        let nread = nix::sys::uio::process_vm_readv(tid, dsts, srcs)?;
+        let nread = nix::sys::uio::process_vm_readv(tid, dsts, srcs)
+            .map_err(|e| Errno::try_from(e as i32).unwrap())?;
 
         Ok(nread)
     }
@@ -229,7 +231,8 @@ impl MemoryCopier {
         })
         .unwrap();
 
-        let nwritten = nix::sys::uio::process_vm_writev(tid, &local, &remote)?;
+        let nwritten = nix::sys::uio::process_vm_writev(tid, &local, &remote)
+            .map_err(|e| Errno::try_from(e as i32).unwrap())?;
         // There shouldn't be any partial writes with a single remote iovec.
         assert_eq!(nwritten, towrite);
         Ok(())

--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -21,7 +21,7 @@ use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use crate::host::context::ProcessContext;
 use crate::host::context::ThreadContext;
 use crate::host::memory_manager::{page_size, MemoryManager};
-use crate::host::syscall_types::{ForeignArrayPtr, SyscallResult};
+use crate::host::syscall_types::{ForeignArrayPtr, SyscallError};
 use crate::utility::interval_map::{Interval, IntervalMap, Mutation};
 use crate::utility::proc_maps;
 use crate::utility::proc_maps::{MappingPath, Sharing};
@@ -628,7 +628,7 @@ impl MemoryMapper {
         new_size: usize,
         flags: i32,
         new_address: ForeignPtr<u8>,
-    ) -> SyscallResult {
+    ) -> Result<ForeignPtr<u8>, SyscallError> {
         let new_address = {
             let (ctx, thread) = ctx.split_thread();
             thread.native_mremap(&ctx, old_address, old_size, new_size, flags, new_address)?
@@ -652,7 +652,7 @@ impl MemoryMapper {
             assert_eq!(region.shadow_base, std::ptr::null_mut());
             let mutations = self.regions.insert(new_interval, region);
             self.unmap_mutations(mutations);
-            return Ok(new_address.into());
+            return Ok(new_address);
         }
 
         // Clear and retrieve the old mapping.
@@ -744,20 +744,24 @@ impl MemoryMapper {
         let mutations = self.regions.insert(new_interval, region);
         assert_eq!(mutations.len(), 0);
 
-        Ok(new_address.into())
+        Ok(new_address)
     }
 
     /// Execute the requested `brk` and update our mappings accordingly. May invalidate outstanding
     /// pointers. (Rust won't allow mutable methods such as this one to be called with outstanding
     /// borrowed references).
-    pub fn handle_brk(&mut self, ctx: &ThreadContext, ptr: ForeignPtr<u8>) -> SyscallResult {
+    pub fn handle_brk(
+        &mut self,
+        ctx: &ThreadContext,
+        ptr: ForeignPtr<u8>,
+    ) -> Result<ForeignPtr<u8>, SyscallError> {
         let requested_brk = usize::from(ptr);
 
         // On error, brk syscall returns current brk (end of heap). The only errors we specifically
         // handle is trying to set the end of heap before the start. In practice this case is
         // generally triggered with a NULL argument to get the current brk value.
         if requested_brk < self.heap.start {
-            return Ok(ForeignPtr::from(self.heap.end).into());
+            return Ok(ForeignPtr::from(self.heap.end).cast::<u8>());
         }
 
         // Unclear how to handle a non-page-size increment. panic for now.
@@ -766,7 +770,7 @@ impl MemoryMapper {
         // Not aware of this happening in practice, but handle this case specifically so we can
         // assume it's not the case below.
         if requested_brk == self.heap.end {
-            return Ok(ptr.into());
+            return Ok(ptr);
         }
 
         let opt_heap_interval_and_region = self.regions.get(self.heap.start);
@@ -859,7 +863,7 @@ impl MemoryMapper {
         }
         self.heap = new_heap;
 
-        Ok(ForeignPtr::from(requested_brk).into())
+        Ok(ForeignPtr::from(requested_brk).cast::<u8>())
     }
 
     /// Shadow should delegate a plugin's call to mprotect to this method.
@@ -879,7 +883,7 @@ impl MemoryMapper {
         addr: ForeignPtr<u8>,
         size: usize,
         prot: i32,
-    ) -> SyscallResult {
+    ) -> Result<i32, SyscallError> {
         let (ctx, thread) = ctx.split_thread();
         trace!("mprotect({:?}, {}, {:?})", addr, size, prot);
         thread.native_mprotect(&ctx, addr, size, prot)?;
@@ -996,7 +1000,7 @@ impl MemoryMapper {
                 }
             }
         }
-        Ok(0.into())
+        Ok(0)
     }
 
     // Get a raw pointer to the plugin's memory, if it's been remapped into Shadow.

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -613,7 +613,11 @@ impl MemoryManager {
         }
     }
 
-    pub fn handle_brk(&mut self, ctx: &ThreadContext, ptr: ForeignPtr<u8>) -> SyscallResult {
+    pub fn handle_brk(
+        &mut self,
+        ctx: &ThreadContext,
+        ptr: ForeignPtr<u8>,
+    ) -> Result<ForeignPtr<u8>, SyscallError> {
         match &mut self.memory_mapper {
             Some(mm) => mm.handle_brk(ctx, ptr),
             None => Err(SyscallError::Native),
@@ -680,7 +684,7 @@ impl MemoryManager {
         new_size: usize,
         flags: i32,
         new_address: ForeignPtr<u8>,
-    ) -> SyscallResult {
+    ) -> Result<ForeignPtr<u8>, SyscallError> {
         match &mut self.memory_mapper {
             Some(mm) => mm.handle_mremap(ctx, old_address, old_size, new_size, flags, new_address),
             None => Err(SyscallError::Native),
@@ -693,7 +697,7 @@ impl MemoryManager {
         addr: ForeignPtr<u8>,
         size: usize,
         prot: i32,
-    ) -> SyscallResult {
+    ) -> Result<i32, SyscallError> {
         match &mut self.memory_mapper {
             Some(mm) => mm.handle_mprotect(ctx, addr, size, prot),
             None => Err(SyscallError::Native),

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -619,7 +619,7 @@ impl MemoryManager {
         ptr: ForeignPtr<u8>,
     ) -> Result<ForeignPtr<u8>, SyscallError> {
         match &mut self.memory_mapper {
-            Some(mm) => mm.handle_brk(ctx, ptr),
+            Some(mm) => Ok(mm.handle_brk(ctx, ptr)?),
             None => Err(SyscallError::Native),
         }
     }
@@ -667,7 +667,7 @@ impl MemoryManager {
         ctx: &ThreadContext,
         addr: ForeignPtr<u8>,
         length: usize,
-    ) -> nix::Result<()> {
+    ) -> Result<(), Errno> {
         let (ctx, thread) = ctx.split_thread();
         thread.native_munmap(&ctx, addr, length)?;
         if let Some(mm) = &mut self.memory_mapper {
@@ -686,7 +686,9 @@ impl MemoryManager {
         new_address: ForeignPtr<u8>,
     ) -> Result<ForeignPtr<u8>, SyscallError> {
         match &mut self.memory_mapper {
-            Some(mm) => mm.handle_mremap(ctx, old_address, old_size, new_size, flags, new_address),
+            Some(mm) => {
+                Ok(mm.handle_mremap(ctx, old_address, old_size, new_size, flags, new_address)?)
+            }
             None => Err(SyscallError::Native),
         }
     }
@@ -699,7 +701,7 @@ impl MemoryManager {
         prot: i32,
     ) -> Result<i32, SyscallError> {
         match &mut self.memory_mapper {
-            Some(mm) => mm.handle_mprotect(ctx, addr, size, prot),
+            Some(mm) => Ok(mm.handle_mprotect(ctx, addr, size, prot)?),
             None => Err(SyscallError::Native),
         }
     }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1797,9 +1797,10 @@ mod export {
                     flags,
                     new_addr.cast::<u8>(),
                 )
-                .into()
+                .map(Into::into)
         })
         .unwrap()
+        .into()
     }
 
     #[no_mangle]
@@ -1821,9 +1822,10 @@ mod export {
                     size,
                     prot,
                 )
-                .into()
+                .map(Into::into)
         })
         .unwrap()
+        .into()
     }
 
     /// Fully handles the `brk` syscall, keeping the "heap" mapped in our shared mem file.
@@ -1842,9 +1844,10 @@ mod export {
                     &ThreadContext::new(host, process, thread),
                     plugin_src.cast::<u8>(),
                 )
-                .into()
+                .map(Into::into)
         })
         .unwrap()
+        .into()
     }
 
     /// Initialize the MemoryMapper if it isn't already initialized. `thread` must

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -1,6 +1,6 @@
+use linux_api::errno::Errno;
 use linux_api::fcntl::{DescriptorFlags, FcntlCommand, OFlag};
 use log::debug;
-use nix::errno::Errno;
 use shadow_shim_helper_rs::syscall_types::SysCallReg;
 use syscall_logger::log_syscall;
 

--- a/src/main/host/syscall/handler/ioctl.rs
+++ b/src/main/host/syscall/handler/ioctl.rs
@@ -1,7 +1,7 @@
+use linux_api::errno::Errno;
 use linux_api::fcntl::DescriptorFlags;
 use linux_api::ioctls::IoctlRequest;
 use log::debug;
-use nix::errno::Errno;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use syscall_logger::log_syscall;
 

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -1,4 +1,4 @@
-use nix::errno::Errno;
+use linux_api::errno::Errno;
 use shadow_shim_helper_rs::syscall_types::SysCallArgs;
 use shadow_shim_helper_rs::syscall_types::SysCallReg;
 
@@ -118,13 +118,13 @@ impl SyscallHandler {
     fn get_descriptor(
         descriptor_table: &DescriptorTable,
         fd: impl TryInto<DescriptorHandle>,
-    ) -> Result<&Descriptor, nix::errno::Errno> {
+    ) -> Result<&Descriptor, linux_api::errno::Errno> {
         // check that fd is within bounds
-        let fd = fd.try_into().or(Err(nix::errno::Errno::EBADF))?;
+        let fd = fd.try_into().or(Err(linux_api::errno::Errno::EBADF))?;
 
         match descriptor_table.get(fd) {
             Some(desc) => Ok(desc),
-            None => Err(nix::errno::Errno::EBADF),
+            None => Err(linux_api::errno::Errno::EBADF),
         }
     }
 
@@ -133,13 +133,13 @@ impl SyscallHandler {
     fn get_descriptor_mut(
         descriptor_table: &mut DescriptorTable,
         fd: impl TryInto<DescriptorHandle>,
-    ) -> Result<&mut Descriptor, nix::errno::Errno> {
+    ) -> Result<&mut Descriptor, linux_api::errno::Errno> {
         // check that fd is within bounds
-        let fd = fd.try_into().or(Err(nix::errno::Errno::EBADF))?;
+        let fd = fd.try_into().or(Err(linux_api::errno::Errno::EBADF))?;
 
         match descriptor_table.get_mut(fd) {
             Some(desc) => Ok(desc),
-            None => Err(nix::errno::Errno::EBADF),
+            None => Err(linux_api::errno::Errno::EBADF),
         }
     }
 

--- a/src/main/host/syscall/handler/random.rs
+++ b/src/main/host/syscall/handler/random.rs
@@ -1,5 +1,5 @@
+use linux_api::errno::Errno;
 use log::*;
-use nix::errno::Errno;
 use rand::RngCore;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use syscall_logger::log_syscall;

--- a/src/main/host/syscall/handler/sched.rs
+++ b/src/main/host/syscall/handler/sched.rs
@@ -1,7 +1,7 @@
+use linux_api::errno::Errno;
 use linux_api::posix_types::kernel_pid_t;
 use linux_api::rseq::rseq;
 use log::warn;
-use nix::errno::Errno;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use syscall_logger::log_syscall;
 

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -1,6 +1,6 @@
+use linux_api::errno::Errno;
 use linux_api::fcntl::DescriptorFlags;
 use log::*;
-use nix::errno::Errno;
 use nix::sys::socket::{Shutdown, SockFlag};
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use syscall_logger::log_syscall;

--- a/src/main/host/syscall/handler/time.rs
+++ b/src/main/host/syscall/handler/time.rs
@@ -1,6 +1,6 @@
+use linux_api::errno::Errno;
 use linux_api::time::{ClockId, ClockNanosleepFlags, ITimerId};
 use log::*;
-use nix::errno::Errno;
 use shadow_shim_helper_rs::emulated_time::EmulatedTime;
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;

--- a/src/main/host/syscall/handler/timerfd.rs
+++ b/src/main/host/syscall/handler/timerfd.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use linux_api::errno::Errno;
 use linux_api::fcntl::DescriptorFlags;
 use linux_api::time::{itimerspec, ClockId};
-use nix::errno::Errno;
 use nix::sys::timerfd::{TimerFlags, TimerSetTimeFlags};
 use shadow_shim_helper_rs::{
     emulated_time::EmulatedTime, simulation_time::SimulationTime, syscall_types::ForeignPtr,

--- a/src/main/host/syscall/handler/uio.rs
+++ b/src/main/host/syscall/handler/uio.rs
@@ -1,4 +1,4 @@
-use nix::errno::Errno;
+use linux_api::errno::Errno;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use syscall_logger::log_syscall;
 

--- a/src/main/host/syscall/io.rs
+++ b/src/main/host/syscall/io.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
 
-use nix::errno::Errno;
+use linux_api::errno::Errno;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::host::memory_manager::MemoryManager;

--- a/src/main/host/syscall_types.rs
+++ b/src/main/host/syscall_types.rs
@@ -185,18 +185,6 @@ impl From<SyscallResult> for SyscallReturn {
     }
 }
 
-impl From<nix::errno::Errno> for SyscallError {
-    fn from(e: nix::errno::Errno) -> Self {
-        SyscallError::Failed(Failed {
-            // the nix Errno is an enum that only contains valid errno values and 0, so this
-            // should only panic for 0 values (Errno::UnknownErrno) which we wouldn't want to use
-            // anyway
-            errno: Errno::try_from(u16::try_from(e as i32).unwrap()).unwrap(),
-            restartable: false,
-        })
-    }
-}
-
 impl From<linux_api::errno::Errno> for SyscallError {
     fn from(e: linux_api::errno::Errno) -> Self {
         SyscallError::Failed(Failed {

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -1,7 +1,7 @@
 use std::cell::{Cell, RefCell};
 use std::ops::Deref;
 
-use nix::errno::Errno;
+use linux_api::errno::Errno;
 use nix::unistd::Pid;
 use shadow_shim_helper_rs::shim_shmem::{HostShmemProtected, ThreadShmem};
 use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SysCallReg};

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -74,8 +74,8 @@ impl Thread {
         ctx: &ProcessContext,
         n: i64,
         args: &[SysCallReg],
-    ) -> nix::Result<SysCallReg> {
-        syscall::raw_return_value_to_nix_result(self.native_syscall_raw(ctx, n, args))
+    ) -> Result<SysCallReg, Errno> {
+        syscall::raw_return_value_to_result(self.native_syscall_raw(ctx, n, args))
     }
 
     pub fn process_id(&self) -> ProcessId {
@@ -150,7 +150,7 @@ impl Thread {
         ctx: &ProcessContext,
         ptr: ForeignPtr<u8>,
         size: usize,
-    ) -> nix::Result<()> {
+    ) -> Result<(), Errno> {
         self.native_syscall(ctx, libc::SYS_munmap, &[ptr.into(), size.into()])?;
         Ok(())
     }
@@ -165,7 +165,7 @@ impl Thread {
         flags: i32,
         fd: i32,
         offset: i64,
-    ) -> nix::Result<ForeignPtr<u8>> {
+    ) -> Result<ForeignPtr<u8>, Errno> {
         Ok(self
             .native_syscall(
                 ctx,
@@ -191,7 +191,7 @@ impl Thread {
         new_len: usize,
         flags: i32,
         new_addr: ForeignPtr<u8>,
-    ) -> nix::Result<ForeignPtr<u8>> {
+    ) -> Result<ForeignPtr<u8>, Errno> {
         Ok(self
             .native_syscall(
                 ctx,
@@ -214,7 +214,7 @@ impl Thread {
         addr: ForeignPtr<u8>,
         len: usize,
         prot: i32,
-    ) -> nix::Result<()> {
+    ) -> Result<(), Errno> {
         self.native_syscall(
             ctx,
             libc::SYS_mprotect,
@@ -234,7 +234,7 @@ impl Thread {
         pathname: ForeignPtr<u8>,
         flags: i32,
         mode: i32,
-    ) -> nix::Result<i32> {
+    ) -> Result<i32, Errno> {
         let res = self.native_syscall(
             ctx,
             libc::SYS_open,
@@ -248,7 +248,7 @@ impl Thread {
     }
 
     /// Natively execute close(2) on the given thread.
-    pub fn native_close(&self, ctx: &ProcessContext, fd: i32) -> nix::Result<()> {
+    pub fn native_close(&self, ctx: &ProcessContext, fd: i32) -> Result<(), Errno> {
         self.native_syscall(ctx, libc::SYS_close, &[SysCallReg::from(fd)])?;
         Ok(())
     }
@@ -258,7 +258,7 @@ impl Thread {
         &self,
         ctx: &ProcessContext,
         addr: ForeignPtr<u8>,
-    ) -> nix::Result<ForeignPtr<u8>> {
+    ) -> Result<ForeignPtr<u8>, Errno> {
         let res = self.native_syscall(ctx, libc::SYS_brk, &[SysCallReg::from(addr)])?;
         Ok(ForeignPtr::from(res))
     }
@@ -269,7 +269,7 @@ impl Thread {
         &self,
         ctx: &ProcessContext,
         size: usize,
-    ) -> nix::Result<ForeignPtr<u8>> {
+    ) -> Result<ForeignPtr<u8>, Errno> {
         // SAFETY: No pointer specified; can't pass a bad one.
         self.native_mmap(
             ctx,
@@ -288,7 +288,7 @@ impl Thread {
         ctx: &ProcessContext,
         ptr: ForeignPtr<u8>,
         size: usize,
-    ) -> nix::Result<()> {
+    ) -> Result<(), Errno> {
         self.native_munmap(ctx, ptr, size)?;
         Ok(())
     }

--- a/src/main/network/packet.rs
+++ b/src/main/network/packet.rs
@@ -8,7 +8,7 @@ use crate::host::network::interface::FifoPacketPriority;
 use crate::host::syscall::io::IoVec;
 use crate::utility::pcap_writer::PacketDisplay;
 
-use nix::errno::Errno;
+use linux_api::errno::Errno;
 use shadow_shim_helper_rs::util::SyncSendPointer;
 
 #[repr(i32)]
@@ -126,7 +126,7 @@ impl PacketRc {
         &self,
         iovs: impl IntoIterator<Item = &'a IoVec>,
         mem: &mut MemoryManager,
-    ) -> Result<usize, nix::errno::Errno> {
+    ) -> Result<usize, linux_api::errno::Errno> {
         let iovs = iovs.into_iter();
         let mut bytes_copied = 0;
 
@@ -142,7 +142,7 @@ impl PacketRc {
             };
 
             if rv < 0 {
-                return Err(Errno::from_i32(i32::try_from(-rv).unwrap()));
+                return Err(Errno::try_from(-rv).unwrap());
             }
 
             let rv = rv as u64;

--- a/src/main/utility/syscall.rs
+++ b/src/main/utility/syscall.rs
@@ -20,12 +20,3 @@ pub fn raw_return_value_to_result(rv: i64) -> Result<SysCallReg, linux_api::errn
 
     Ok(rv.into())
 }
-
-/// For legacy code that uses the nix [`Errno`](nix::errno::Errno).
-pub fn raw_return_value_to_nix_result(rv: i64) -> Result<SysCallReg, nix::errno::Errno> {
-    if (-MAX_ERRNO..=-1).contains(&rv) {
-        return Err(nix::errno::Errno::from_i32(-rv as i32));
-    }
-
-    Ok(rv.into())
-}


### PR DESCRIPTION
There are still a few places we use the nix type, but this gets rid of most of them.