### PR TITLE
Correctly fail for unsupported udp sockopts

### DIFF
--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -921,21 +921,29 @@ impl UdpSocket {
                     .set_soft_limit_bytes(val.try_into().unwrap());
             }
             (libc::SOL_SOCKET, libc::SO_REUSEADDR) => {
-                // TODO: implement this, tor and tgen use it
-                log::warn!("setsockopt SO_REUSEADDR not yet implemented");
+                // TODO: implement this
+                warn_once_then_debug!(
+                    "(LOG_ONCE) setsockopt SO_REUSEADDR not yet implemented for udp"
+                );
+                return Err(Errno::ENOPROTOOPT.into());
             }
             (libc::SOL_SOCKET, libc::SO_REUSEPORT) => {
-                // TODO: implement this, tgen uses it
-                log::warn!("setsockopt SO_REUSEPORT not yet implemented");
+                // TODO: implement this
+                warn_once_then_debug!(
+                    "(LOG_ONCE) setsockopt SO_REUSEPORT not yet implemented for udp"
+                );
+                return Err(Errno::ENOPROTOOPT.into());
             }
             (libc::SOL_SOCKET, libc::SO_KEEPALIVE) => {
-                // TODO: implement this, libevent uses it in
-                // evconnlistener_new_bind()
-                log::warn!("setsockopt SO_KEEPALIVE not yet implemented");
+                // TODO: implement this
+                warn_once_then_debug!(
+                    "(LOG_ONCE) setsockopt SO_KEEPALIVE not yet implemented for udp"
+                );
+                return Err(Errno::ENOPROTOOPT.into());
             }
             (libc::SOL_SOCKET, libc::SO_BROADCAST) => {
                 // TODO: implement this, pkg.go.dev/net uses it
-                log::warn!("setsockopt SO_BROADCAST not yet implemented");
+                warn_once_then_debug!("(LOG_ONCE) setsockopt SO_BROADCAST not yet implemented for udp; ignoring and returning 0");
             }
             _ => {
                 log::debug!("setsockopt called with unsupported level {level} and opt {optname}");


### PR DESCRIPTION
UDP ignores some `setsockopt()` arguments with comments that tor/tgen/libevent use them, but these must have been incorrectly applied to UDP sockets since tor/tgen don't use UDP. UDP sockets now will fail if `setsockopt()` is used with `SO_REUSEADDR`, `SO_REUSEPORT`, or `SO_KEEPALIVE`, instead of just ignoring them. We continue to ignore `SO_BROADCAST` instead of failing since that is needed with UDP sockets for Go.

This may break some existing applications, but I think that's fine since we didn't correctly handle these sockopts anyways.