### PR TITLE
add shadow-shim-helper-rs to build deps

### DIFF
--- a/src/lib/shim/Cargo.toml
+++ b/src/lib/shim/Cargo.toml
@@ -27,6 +27,9 @@ bindgen = { version = "0.66.1" }
 cbindgen = { version = "0.24.5" }
 cc = { version = "1.0", features = ["parallel"] }
 shadow-build-common = { path = "../shadow-build-common" }
+# Building the C code from this crate's build script requires
+# that these bindings have been generated.
+shadow-shim-helper-rs = { path = "../shadow-shim-helper-rs" }
 system-deps = "6.1"
 
 [package.metadata.system-deps]

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -72,6 +72,9 @@ bindgen = { version = "0.66.1" }
 cbindgen = { version = "0.24.5" }
 cc = { version = "1.0", features = ["parallel"] }
 system-deps = "6.1"
+# Building the C code from this crate's build script requires
+# that these bindings have been generated.
+shadow-shim-helper-rs = { path = "../lib/shadow-shim-helper-rs" }
 
 [package.metadata.system-deps]
 # Keep consistent with the minimum version number in /CMakeLists.txt


### PR DESCRIPTION
Both the shim and main crates need `shadow-shim-helper-rs` to have already been built when their build scripts run, so that `shadow-shim-helper-rs`'s generated bindings files are already built.