### PR TITLE
Fake support of TOS

### DIFF
--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -1226,6 +1226,14 @@ impl LegacyTcpSocket {
                 // TODO: implement this, pkg.go.dev/net uses it
                 log::trace!("setsockopt SO_BROADCAST not yet implemented");
             }
+            (libc::IPPROTO_IP, libc::IP_TOS) => {
+                // this is used by linux to encode ecn
+                log::trace!("setsockopt IP_TOS not yet implemented");
+            }
+            (libc::IPPROTO_IP, libc::IP_RECVTOS) => {
+                // this is used by linux to decode ecn
+                log::trace!("setsockopt IP_RECVTOS not yet implemented");
+            }
             _ => {
                 log::warn!("setsockopt called with unsupported level {level} and opt {optname}");
                 return Err(Errno::ENOPROTOOPT.into());

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -915,6 +915,14 @@ impl UdpSocket {
                 // TODO: implement this, pkg.go.dev/net uses it
                 log::warn!("setsockopt SO_BROADCAST not yet implemented");
             }
+            (libc::IPPROTO_IP, libc::IP_TOS) => {
+                // this is used by linux to encode ecn
+                log::warn!("setsockopt IP_TOS not yet implemented");
+            }
+            (libc::IPPROTO_IP, libc::IP_RECVTOS) => {
+                // this is used by linux to decode ecn
+                log::warn!("setsockopt IP_RECVTOS not yet implemented");
+            }
             _ => {
                 log::debug!("setsockopt called with unsupported level {level} and opt {optname}");
                 return Err(Errno::ENOPROTOOPT.into());


### PR DESCRIPTION
Some QUIC implementations won't run if the system does not support Explicit Congestion Notification.
Type Of Service is used by Linux to implement ECN. As long as ECN is not implemented in Shadow, no process will receive a congestion notification. So, there should not be any harm with a fake ECN support.
Process using specific TOS features could be impacted by the scheduling of messages not taking into account TOS, but, as a warning is issued, there is no difference with no support of TOS at all.