### PR TITLE
loom tests: Move preemption bound into individual tests

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -77,6 +77,5 @@ jobs:
         # to substantially speed it up, at the cost of losing some coverage of possible
         # execution paths.
         RUST_BACKTRACE=1 \
-          LOOM_MAX_PREEMPTIONS=3 \
           RUSTFLAGS="--cfg loom" \
           cargo test -p vasi-sync

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -76,7 +76,7 @@ jobs:
         # If this ever gets too slow, we can consider reducing `LOOM_MAX_PREEMPTIONS`
         # to substantially speed it up, at the cost of losing some coverage of possible
         # execution paths.
-        for PKG in vasi-sync
-        do
-          RUST_BACKTRACE=1 LOOM_MAX_PREEMPTIONS=3 RUSTFLAGS="--cfg loom" cargo test -p "$PKG"
-        done
+        RUST_BACKTRACE=1 \
+          LOOM_MAX_PREEMPTIONS=3 \
+          RUSTFLAGS="--cfg loom" \
+          cargo test -p vasi-sync

--- a/src/lib/vasi-sync/tests/scchannel-tests.rs
+++ b/src/lib/vasi-sync/tests/scchannel-tests.rs
@@ -87,7 +87,7 @@ mod scchannel_tests {
 
     #[test]
     fn test_writer_close_watchdog_with_write() {
-        sync::model(|| {
+        sync::model_with_max_preemptions(3, || {
             let channel = sync::Arc::new(SelfContainedChannel::<u32>::new());
             let writer = {
                 let channel = channel.clone();
@@ -133,7 +133,7 @@ mod scchannel_tests {
     fn test_channel_reuse() {
         // Test reusing channels, using another channel to synchronize.
         // This is analagous to how shadow communicates with a plugin.
-        sync::model(|| {
+        sync::model_with_max_preemptions(3, || {
             let alpha_to_beta = sync::Arc::new(SelfContainedChannel::<u32>::new());
             let beta_to_alpha = sync::Arc::new(SelfContainedChannel::<u32>::new());
 

--- a/src/lib/vasi-sync/tests/scmutex-tests.rs
+++ b/src/lib/vasi-sync/tests/scmutex-tests.rs
@@ -7,7 +7,7 @@ use vasi_sync::scmutex::{SelfContainedMutex, SelfContainedMutexGuard};
 
 mod sync;
 
-mod tests {
+mod scmutex_tests {
     use super::*;
 
     #[test]
@@ -56,7 +56,7 @@ mod tests {
 
     #[test]
     fn test_threads() {
-        sync::model(|| {
+        sync::model_with_max_preemptions(3, || {
             let mutex = sync::Arc::new(SelfContainedMutex::new(0));
 
             // We can only create up to one fewer than loom's MAX_THREADS, which is currently 4.

--- a/src/lib/vasi-sync/tests/sync/mod.rs
+++ b/src/lib/vasi-sync/tests/sync/mod.rs
@@ -6,21 +6,16 @@
 // Items in here may not end up being used by every test.
 #![allow(unused)]
 
-#[cfg(loom)]
 pub fn model<F>(f: F)
 where
     F: Fn() + Sync + Send + 'static,
 {
+    #[cfg(loom)]
     loom::model(move || {
         f();
         vasi_sync::sync::loom_reset();
     });
-}
-#[cfg(not(loom))]
-pub fn model<F>(f: F)
-where
-    F: Fn() + Sync + Send + 'static,
-{
+    #[cfg(not(loom))]
     f()
 }
 


### PR DESCRIPTION
This gives a little more flexibility, e.g. allowing new tests to be added that need a lower bound without having to change the bound for all the tests.