### PR TITLE
Create a specialized hash table for the shim's TLS

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -76,6 +76,9 @@ jobs:
         # If this ever gets too slow, we can consider reducing `LOOM_MAX_PREEMPTIONS`
         # to substantially speed it up, at the cost of losing some coverage of possible
         # execution paths.
+        #
+        # We use `--test-threads 1` as a workaround for
+        # <https://github.com/tokio-rs/loom/issues/316>
         RUST_BACKTRACE=1 \
           RUSTFLAGS="--cfg loom" \
-          cargo test -p vasi-sync
+          cargo test -p vasi-sync -- --test-threads 1

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1925,6 +1925,7 @@ dependencies = [
  "loom",
  "num_enum",
  "rand",
+ "rustc-hash",
  "rustix",
  "static_assertions",
  "vasi",

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -10,6 +10,7 @@ num_enum = { version = "0.6.1", default-features=false }
 rustix = { version = "0.37.19", default-features = false, features=["fs", "thread", "process"] }
 static_assertions = "1.1.0"
 vasi = { path = "../vasi" }
+rustc-hash = { version = "1.1.0", default-features=false }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/lib/vasi-sync/src/atomic_tls_map.rs
+++ b/src/lib/vasi-sync/src/atomic_tls_map.rs
@@ -1,0 +1,290 @@
+use crate::sync::{atomic, AtomicUsize, Cell, ConstPtr, UnsafeCell};
+
+use core::hash::{BuildHasher, Hasher};
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
+use core::ops::Deref;
+
+/// A lockless, no_std, no-alloc hash table. Allows insertion and removal from
+/// an immutable reference, but does not support getting mutable references to
+/// internal values, and requires that a particular key is only ever accessed
+/// from the thread that inserted it, until that thread removes it.
+///
+/// Uses linear probing, and doesn't support resizing.  Lookup is `Θ(1)`
+/// (average case) if the key is present and the key hasn't been forced far away
+/// from its "home" location, but is `O(N)` worst case. Lookup of a non-present
+/// key is always `O(N)`; we need to scan the whole table.
+///
+/// This is designed mostly for use by `shadow_shim::tls` to help implement
+/// thread-local storage.
+pub struct AtomicTlsMap<const N: usize, V, H = core::hash::BuildHasherDefault<rustc_hash::FxHasher>>
+where
+    H: BuildHasher,
+{
+    keys: [AtomicOptionNonZeroUsize; N],
+    values: [UnsafeCell<MaybeUninit<V>>; N],
+    // This lets us enforce that a still-referenced key is not removed.
+    // TODO: Consider storing `RefCell<V>` in `values` instead. That'd be a bit
+    // more idiomatic, and is probably a better layout for cache performance.
+    refcounts: [Cell<usize>; N],
+    build_hasher: H,
+}
+/// Override default of `UnsafeCell` and `Cell` not being `Sync`.  We
+/// synchronize access to these (if partly by requiring users to guarantee no
+/// parallel access to a given key from multiple threads).
+/// Likewise `V` only needs to be `Send`.
+unsafe impl<const N: usize, V, H> Sync for AtomicTlsMap<N, V, H>
+where
+    // Requires for the Drop implementation to be able to drop values that were
+    // inserted by a different thread. Also if we want to support values being
+    // accessed by multiple threads with some kind of external synchronization,
+    // but I don't think we do.
+    //
+    // Alternatively we could only have this bound on the `Drop` implemenation,
+    // and document that the final contents aren't dropped if `V` isn't send. Or
+    // just remove the `Drop` impementation altogether.
+    V: Send,
+    H: Sync + BuildHasher,
+{
+}
+
+/// Adapter for `Option<NonZeroUsize>` around `AtomicUsize`
+struct AtomicOptionNonZeroUsize(AtomicUsize);
+impl AtomicOptionNonZeroUsize {
+    fn to_usize(val: Option<NonZeroUsize>) -> usize {
+        val.map(NonZeroUsize::get).unwrap_or(0)
+    }
+
+    fn from_usize(val: usize) -> Option<NonZeroUsize> {
+        NonZeroUsize::new(val)
+    }
+
+    pub fn new(val: Option<NonZeroUsize>) -> Self {
+        Self(AtomicUsize::new(Self::to_usize(val)))
+    }
+
+    pub fn load(&self, order: atomic::Ordering) -> Option<NonZeroUsize> {
+        Self::from_usize(self.0.load(order))
+    }
+
+    pub fn store(&self, val: Option<NonZeroUsize>, order: atomic::Ordering) {
+        self.0.store(Self::to_usize(val), order)
+    }
+
+    pub fn compare_exchange(
+        &self,
+        current: Option<NonZeroUsize>,
+        new: Option<NonZeroUsize>,
+        success: atomic::Ordering,
+        failure: atomic::Ordering,
+    ) -> Result<Option<NonZeroUsize>, Option<NonZeroUsize>> {
+        self.0
+            .compare_exchange(
+                Self::to_usize(current),
+                Self::to_usize(new),
+                success,
+                failure,
+            )
+            .map(Self::from_usize)
+            .map_err(Self::from_usize)
+    }
+}
+
+impl<const N: usize, V, H> AtomicTlsMap<N, V, H>
+where
+    H: BuildHasher,
+{
+    pub fn new_with_hasher(build_hasher: H) -> Self {
+        Self {
+            keys: core::array::from_fn(|_| AtomicOptionNonZeroUsize::new(None)),
+            values: core::array::from_fn(|_| UnsafeCell::new(MaybeUninit::uninit())),
+            refcounts: core::array::from_fn(|_| Cell::new(0)),
+            build_hasher,
+        }
+    }
+
+    /// All indexes starting from the hash position of `key`.
+    fn indexes_from(&self, key: NonZeroUsize) -> impl Iterator<Item = usize> {
+        let mut hasher = self.build_hasher.build_hasher();
+        hasher.write_usize(key.get());
+        let hash = hasher.finish();
+        let start_idx = usize::try_from(hash).unwrap() % N;
+        (start_idx..N).chain(0..start_idx)
+    }
+
+    /// The index containing `key`, if any. No synchronization.
+    ///
+    /// TODO: Consider keeping track of whether/where we saw vacancies along the
+    /// way in linear search, and moving the value if its refcount is currently
+    /// 0.
+    fn idx(&self, key: NonZeroUsize) -> Option<usize> {
+        self.indexes_from(key).find(|idx| {
+            // Relaxed because of requirement that only one thread ever accesses
+            // a given key at once.
+            self.keys[*idx].load(atomic::Ordering::Relaxed) == Some(key)
+        })
+    }
+
+    /// # Safety
+    ///
+    /// The value at `key`, if any, must have been inserted by the current thread.
+    #[inline]
+    pub unsafe fn get(&self, key: NonZeroUsize) -> Option<Ref<V>> {
+        // SAFETY: Ensured by caller
+        let idx = self.idx(key)?;
+        let ptr = self.values[idx].get();
+        Some(unsafe { Ref::new(ptr, &self.refcounts[idx]) })
+    }
+
+    /// Insert `(key, value)`.
+    ///
+    /// If `key` is already present in `self`, the previous value would shadow
+    /// the newly inserted value. We don't expose this function in the public
+    /// API since this behavior would be confusing.
+    ///
+    /// Returns a reference to the newly inserted value.
+    ///
+    /// Panics if the table is full.
+    ///
+    /// # Safety
+    ///
+    /// There must not be a value at `key` that was inserted by a different
+    /// thread.
+    unsafe fn insert(&self, key: NonZeroUsize, value: V) -> Ref<V> {
+        let idx = self
+            .indexes_from(key)
+            .find(|idx| {
+                self.keys[*idx]
+                    .compare_exchange(
+                        None,
+                        Some(key),
+                        // Syncs with `Release` on removal
+                        atomic::Ordering::Acquire,
+                        atomic::Ordering::Relaxed,
+                    )
+                    .is_ok()
+            })
+            .unwrap();
+        self.values[idx].get_mut().with(|table_value| {
+            let table_value = unsafe { &mut *table_value };
+            table_value.write(value)
+        });
+        unsafe { Ref::new(self.values[idx].get(), &self.refcounts[idx]) }
+    }
+
+    /// Retrieve the value associated with `key`, initializing it with `init` if `key`
+    /// is not already present.
+    ///
+    /// Panics if the table is full and `key` is not already present.
+    ///
+    /// # Safety
+    ///
+    /// There must not be a value at `key` that was inserted by a different
+    /// thread.
+    #[inline]
+    pub unsafe fn get_or_insert_with(&self, key: NonZeroUsize, init: impl FnOnce() -> V) -> Ref<V> {
+        let val = unsafe { self.get(key) };
+        val.unwrap_or_else(|| {
+            let val = init();
+            // SAFETY: Ensured by caller
+            unsafe { self.insert(key, val) }
+        })
+    }
+
+    /// Removes the value still for `key`, if any. Panics if this thread has
+    /// any outstanding references for `key`.
+    ///
+    /// # Safety
+    ///
+    /// The value at `key`, if any, must have been inserted by the current thread.
+    pub unsafe fn remove(&self, key: NonZeroUsize) -> Option<V> {
+        let idx = self.idx(key)?;
+        assert_eq!(self.refcounts[idx].get(), 0);
+        let value = self.values[idx].get_mut().with(|value| {
+            let value = unsafe { &mut *value };
+            unsafe { value.assume_init_read() }
+        });
+
+        // Careful not to panic between `assume_init_read` above and the `store`
+        // below; doing so would cause `value` to be dropped twice.
+
+        // Syncs with `Acquire` on insertion
+        self.keys[idx].store(None, atomic::Ordering::Release);
+        Some(value)
+    }
+}
+
+impl<const N: usize, V, H> AtomicTlsMap<N, V, H>
+where
+    H: BuildHasher + Default,
+{
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self::new_with_hasher(Default::default())
+    }
+}
+
+impl<const N: usize, V, H> Drop for AtomicTlsMap<N, V, H>
+where
+    H: BuildHasher,
+{
+    fn drop(&mut self) {
+        for idx in 0..N {
+            // No special synchronization requirements here since we have a
+            // `mut` reference to self. Even values that were inserted by other
+            // threads should now be safe to access; for us to have obtained a
+            // `mut` reference some external synchronization must have occurred,
+            // which should make the values safely accessible by this thread.
+            if self.keys[idx].load(atomic::Ordering::Relaxed).is_some() {
+                self.values[idx].get_mut().with(|value| {
+                    assert_eq!(self.refcounts[idx].get(), 0);
+                    // SAFETY: We have exclusive access to `self`.
+                    let value = unsafe { &mut *value };
+                    // SAFETY: We know the value is initialized.
+                    unsafe { value.assume_init_drop() }
+                })
+            }
+        }
+    }
+}
+
+pub struct Ref<'a, V> {
+    ptr: ConstPtr<MaybeUninit<V>>,
+    refcount: &'a Cell<usize>,
+    _phantom: PhantomData<&'a V>,
+}
+static_assertions::assert_not_impl_any!(Ref<'static, ()>: Send, Sync);
+
+impl<'a, V> Ref<'a, V> {
+    /// # Safety
+    ///
+    /// Current thread must be the only one to access `refcount`
+    unsafe fn new(ptr: ConstPtr<MaybeUninit<V>>, refcount: &'a Cell<usize>) -> Self {
+        refcount.set(refcount.get() + 1);
+        Self {
+            ptr,
+            refcount,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, V> Deref for Ref<'a, V> {
+    type Target = V;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: The table ensures no mutable accesses to this value as long
+        // as `Ref`s exist.
+        let val = unsafe { self.ptr.deref() };
+        // SAFETY: The table ensures that the value is initialized before
+        // constructing this `Ref`.
+        unsafe { val.assume_init_ref() }
+    }
+}
+
+impl<'a, V> Drop for Ref<'a, V> {
+    fn drop(&mut self) {
+        self.refcount.set(self.refcount.get() - 1)
+    }
+}

--- a/src/lib/vasi-sync/src/lib.rs
+++ b/src/lib/vasi-sync/src/lib.rs
@@ -34,10 +34,11 @@
 
 // https://github.com/rust-lang/rfcs/blob/master/text/2585-unsafe-block-in-unsafe-fn.md
 #![deny(unsafe_op_in_unsafe_fn)]
-// no_std except when testing under loom.
+// no_std except when testing.
 // https://github.com/shadow/shadow/issues/2919
-#![cfg_attr(not(loom), no_std)]
+#![cfg_attr(all(not(test), not(loom)), no_std)]
 
+pub mod atomic_tls_map;
 pub mod lazy_lock;
 pub mod scchannel;
 pub mod scmutex;

--- a/src/lib/vasi-sync/src/sync.rs
+++ b/src/lib/vasi-sync/src/sync.rs
@@ -8,10 +8,15 @@
 #[cfg(not(loom))]
 pub use core::{
     sync::atomic,
-    sync::atomic::{AtomicI32, AtomicI8, AtomicU32, Ordering},
+    sync::atomic::{AtomicBool, AtomicI32, AtomicI8, AtomicU32, AtomicUsize, Ordering},
 };
 #[cfg(loom)]
 use std::collections::HashMap;
+
+#[cfg(not(loom))]
+pub use core::cell::Cell;
+#[cfg(loom)]
+pub use loom::cell::Cell;
 
 // Map a *virtual* address to a list of Condvars. This doesn't support mapping into multiple
 // processes, or into different virtual addresses in the same process, etc.
@@ -20,7 +25,7 @@ use loom::sync::{Condvar, Mutex};
 #[cfg(loom)]
 pub use loom::{
     sync::atomic,
-    sync::atomic::{AtomicI32, AtomicI8, AtomicU32, Ordering},
+    sync::atomic::{AtomicBool, AtomicI32, AtomicI8, AtomicU32, AtomicUsize, Ordering},
     sync::Arc,
 };
 #[cfg(not(loom))]
@@ -246,7 +251,7 @@ impl<T: ?Sized> ConstPtr<T> {
 #[cfg(loom)]
 pub use loom::cell::ConstPtr;
 
-// From https://docs.rs/loom/latest/loom/#handling-loom-api-differences
+/// From <https://docs.rs/loom/latest/loom/#handling-loom-api-differences>
 #[cfg(not(loom))]
 #[derive(Debug, VirtualAddressSpaceIndependent)]
 #[repr(transparent)]
@@ -258,6 +263,9 @@ impl<T> UnsafeCell<T> {
         UnsafeCell(core::cell::UnsafeCell::new(data))
     }
 
+    /// Note that this has a different signature from the method
+    /// of the same name in `core::cell::UnsafeCell`.
+    /// See <https://docs.rs/loom/latest/loom/#handling-loom-api-differences>
     #[inline]
     pub fn get_mut(&self) -> MutPtr<T> {
         MutPtr(self.0.get())

--- a/src/lib/vasi-sync/tests/atomic-tls-map-tests.rs
+++ b/src/lib/vasi-sync/tests/atomic-tls-map-tests.rs
@@ -180,15 +180,16 @@ mod atomic_tls_map_tests {
         })
     }
 
+    // This test seems to cause mysterious crashes in loom itself when running tests
+    // with `--test-threads` > 1. Reducing max_preemptions or NTHREADS has
+    // temporarily fixed it in the past, and then adding or changing *some other
+    // test* brings the failure back.
+    // <https://github.com/tokio-rs/loom/issues/316>
     #[test]
     fn test_reuse_keys_after_thread_exit() {
         sync::model_with_max_preemptions(2, || {
-            // NTHREADS > 2 *crashes* loom. 2 should be sufficient for this test, though.
-            // e.g. test_get_and_remove_threaded should already cover concurrent insert +
-            // remove + lookup.
-            // <https://github.com/tokio-rs/loom/issues/316>
             #[cfg(loom)]
-            const NTHREADS: usize = 2;
+            const NTHREADS: usize = 3;
             #[cfg(not(loom))]
             const NTHREADS: usize = 100;
 

--- a/src/lib/vasi-sync/tests/atomic-tls-map-tests.rs
+++ b/src/lib/vasi-sync/tests/atomic-tls-map-tests.rs
@@ -1,0 +1,237 @@
+//! This file contains tests intended to be run using [loom]. See the
+//! [crate-level documentation](crate) for details about running these under
+//! loom.
+//!
+//! [loom]: <https://docs.rs/loom/latest/loom/>
+
+mod sync;
+
+mod atomic_tls_map_tests {
+    use std::num::NonZeroUsize;
+
+    use super::sync;
+
+    use vasi_sync::atomic_tls_map::AtomicTlsMap;
+
+    #[test]
+    fn test_empty() {
+        sync::model(|| {
+            let _table = AtomicTlsMap::<10, u32>::new();
+        })
+    }
+
+    #[test]
+    fn test_store_and_load() {
+        sync::model(|| {
+            let table = AtomicTlsMap::<10, u32>::new();
+            unsafe {
+                assert_eq!(
+                    *table.get_or_insert_with(NonZeroUsize::try_from(1).unwrap(), || 11),
+                    11
+                );
+                assert_eq!(
+                    *table.get_or_insert_with(NonZeroUsize::try_from(2).unwrap(), || 12),
+                    12
+                );
+
+                // `get_or_insert_with` again with the same keys should return the previous
+                // values.
+                assert_eq!(
+                    *table.get_or_insert_with(NonZeroUsize::try_from(1).unwrap(), || 1000),
+                    11
+                );
+                assert_eq!(
+                    *table.get_or_insert_with(NonZeroUsize::try_from(2).unwrap(), || 1000),
+                    12
+                );
+
+                // Likewise `get` should return the inserted values.
+                assert_eq!(
+                    table
+                        .get(NonZeroUsize::try_from(1).unwrap())
+                        .as_deref()
+                        .copied(),
+                    Some(11)
+                );
+                assert_eq!(
+                    table
+                        .get(NonZeroUsize::try_from(2).unwrap())
+                        .as_deref()
+                        .copied(),
+                    Some(12)
+                );
+            }
+        })
+    }
+
+    #[test]
+    fn test_store_load_remove() {
+        sync::model(|| {
+            let table = AtomicTlsMap::<10, u32>::new();
+            unsafe {
+                assert_eq!(
+                    *table.get_or_insert_with(NonZeroUsize::try_from(1).unwrap(), || 11),
+                    11
+                );
+                assert_eq!(
+                    *table.get_or_insert_with(NonZeroUsize::try_from(2).unwrap(), || 12),
+                    12
+                );
+
+                assert_eq!(table.remove(NonZeroUsize::try_from(1).unwrap()), Some(11));
+
+                assert_eq!(
+                    table
+                        .get(NonZeroUsize::try_from(NonZeroUsize::try_from(1).unwrap()).unwrap())
+                        .as_deref()
+                        .copied(),
+                    None
+                );
+                assert_eq!(
+                    table
+                        .get(NonZeroUsize::try_from(NonZeroUsize::try_from(2).unwrap()).unwrap())
+                        .as_deref()
+                        .copied(),
+                    Some(12)
+                );
+            }
+        })
+    }
+
+    #[test]
+    fn test_drop() {
+        sync::model(|| {
+            let value = sync::Arc::new(());
+            unsafe {
+                let table = AtomicTlsMap::<10, sync::Arc<()>>::new();
+                let key = NonZeroUsize::try_from(1).unwrap();
+                table.get_or_insert_with(key, || value.clone());
+                assert_eq!(sync::Arc::strong_count(&value), 2);
+                table.remove(key);
+                assert_eq!(sync::Arc::strong_count(&value), 1);
+                table.get_or_insert_with(key, || value.clone());
+                assert_eq!(sync::Arc::strong_count(&value), 2);
+            };
+            // Dropping the table should reduce the count back to 1.
+            assert_eq!(sync::Arc::strong_count(&value), 1);
+        })
+    }
+
+    #[test]
+    fn test_cross_thread_drop() {
+        sync::model(|| {
+            let value = sync::Arc::new(());
+            let table = sync::Arc::new(AtomicTlsMap::<10, sync::Arc<()>>::new());
+
+            let thread = {
+                let value = value.clone();
+                let table = table.clone();
+                sync::thread::spawn(move || {
+                    unsafe {
+                        let key = NonZeroUsize::try_from(1).unwrap();
+                        table.get_or_insert_with(key, || value.clone());
+                    };
+                })
+            };
+            thread.join().unwrap();
+
+            assert_eq!(sync::Arc::strong_count(&value), 2);
+            drop(table);
+            assert_eq!(sync::Arc::strong_count(&value), 1);
+        })
+    }
+
+    #[test]
+    fn test_get_and_remove_threaded() {
+        sync::model_with_max_preemptions(2, || {
+            // Even with the preemption bound, this test takes a long time with
+            // any more than 3 threads in loom.
+            #[cfg(loom)]
+            const NTHREADS: usize = 3;
+            #[cfg(not(loom))]
+            const NTHREADS: usize = 100;
+
+            type Table = AtomicTlsMap<NTHREADS, usize>;
+            let table = sync::Arc::new(Table::new());
+
+            let threads: Vec<_> = (0..NTHREADS)
+                .map(|i| {
+                    let table = table.clone();
+                    let key = NonZeroUsize::try_from(i + 1).unwrap();
+                    let value_offset = 10;
+                    sync::thread::Builder::new()
+                        .name(format!("{key:?}"))
+                        .spawn(move || unsafe {
+                            sync::rand_sleep();
+                            assert_eq!(
+                                *table.get_or_insert_with(key, || key.get() + value_offset),
+                                key.get() + value_offset
+                            );
+                            sync::rand_sleep();
+                            assert_eq!(table.remove(key), Some(key.get() + value_offset));
+                            sync::rand_sleep();
+                        })
+                        .unwrap()
+                })
+                .collect();
+            for thread in threads {
+                thread.join().unwrap();
+            }
+        })
+    }
+
+    #[test]
+    fn test_reuse_keys_after_thread_exit() {
+        sync::model_with_max_preemptions(2, || {
+            // NTHREADS > 2 *crashes* loom. 2 should be sufficient for this test, though.
+            // e.g. test_get_and_remove_threaded should already cover concurrent insert +
+            // remove + lookup.
+            // <https://github.com/tokio-rs/loom/issues/316>
+            #[cfg(loom)]
+            const NTHREADS: usize = 2;
+            #[cfg(not(loom))]
+            const NTHREADS: usize = 100;
+
+            type Table = AtomicTlsMap<NTHREADS, usize>;
+            let table = sync::Arc::new(Table::new());
+
+            let keys: Vec<_> = (0..NTHREADS)
+                .map(|i| NonZeroUsize::try_from(i + 1).unwrap())
+                .collect();
+
+            fn thread_fn(key: NonZeroUsize, table: &Table, value_offset: usize) {
+                unsafe {
+                    sync::rand_sleep();
+                    assert_eq!(
+                        *table.get_or_insert_with(key, || key.get() + value_offset),
+                        key.get() + value_offset
+                    );
+                    sync::rand_sleep();
+                    assert_eq!(table.remove(key), Some(key.get() + value_offset));
+                    sync::rand_sleep();
+                }
+            }
+
+            fn thread_for_key(
+                key: NonZeroUsize,
+                table: sync::Arc<Table>,
+            ) -> sync::thread::JoinHandle<()> {
+                sync::thread::Builder::new()
+                    .name(format!("{key:?}"))
+                    .spawn(move || thread_fn(key, &table, 10))
+                    .unwrap()
+            }
+
+            let keys_and_threads: Vec<_> = keys
+                .iter()
+                .map(|key| (*key, thread_for_key(*key, table.clone())))
+                .collect();
+
+            // As threads finish, reuse their keys on this thread.
+            for (key, thread) in keys_and_threads {
+                thread.join().unwrap();
+                thread_fn(key, &table, 20);
+            }
+        })
+    }
+}


### PR DESCRIPTION
This should be able to replace the ad-hoc hash table implemented in `shadow_shim::tls`.

It still has somewhat scary safety requirements for users, but should ultimately be an improvement over the current implementation. It also adds refcounting to let us catch some issues.