### PR TITLE
Shim TLS improvements

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -20,3 +20,11 @@ members = [
     "lib/vasi-macro",
     "lib/vasi-sync",
 ]
+
+[profile.dev]
+# shim/src/tls.rs, and maybe other places, needs this
+# to avoid smashing the stack with a large immediate temporary.
+# opt-level 1 is enough to optimize away the offending temporary.
+# 
+# See https://stackoverflow.com/questions/25805174/creating-a-fixed-size-array-on-heap-in-rust/68122278#68122278
+opt-level = 1 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -20,11 +20,3 @@ members = [
     "lib/vasi-macro",
     "lib/vasi-sync",
 ]
-
-[profile.dev]
-# shim/src/tls.rs, and maybe other places, needs this
-# to avoid smashing the stack with a large immediate temporary.
-# opt-level 1 is enough to optimize away the offending temporary.
-# 
-# See https://stackoverflow.com/questions/25805174/creating-a-fixed-size-array-on-heap-in-rust/68122278#68122278
-opt-level = 1 

--- a/src/lib/linux-api/src/exit.rs
+++ b/src/lib/linux-api/src/exit.rs
@@ -1,0 +1,16 @@
+use linux_syscall::Result as LinuxSyscallResult;
+
+use crate::errno::Errno;
+
+/// Exits the current thread, setting `val & 0xff` as the exit code.
+pub fn exit_raw(val: i32) -> Result<(), Errno> {
+    unsafe { linux_syscall::syscall!(linux_syscall::SYS_exit, val) }
+        .check()
+        .map_err(Errno::from)
+}
+
+/// Exits the current thread, setting `val` as the exit code.
+pub fn exit(val: i8) -> ! {
+    exit_raw(val.into()).unwrap();
+    unreachable!()
+}

--- a/src/lib/linux-api/src/lib.rs
+++ b/src/lib/linux-api/src/lib.rs
@@ -52,6 +52,7 @@
 mod bindings;
 
 pub mod errno;
+pub mod exit;
 pub mod fcntl;
 pub mod inet;
 pub mod ioctls;

--- a/src/lib/shim/build.rs
+++ b/src/lib/shim/build.rs
@@ -28,8 +28,8 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .blocklist_type("ShimShmem.*")
         .raw_line("use shadow_shim_helper_rs::shim_shmem::*;")
         .raw_line("use shadow_shim_helper_rs::shim_shmem::export::*;")
-        .blocklist_type("ShimThreadLocalStorage")
-        .raw_line("use crate::tls::ShimThreadLocalStorage;")
+        .blocklist_type("ShimThreadLocalStorageAllocation")
+        .raw_line("use crate::tls::ShimThreadLocalStorageAllocation;")
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.
@@ -76,7 +76,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
                 // Manual declaration above
                 "shim_api_syscall".into(),
             ],
-            include: vec!["ShimThreadLocalStorage".into()],
+            include: vec!["ShimThreadLocalStorageAllocation".into()],
             ..base_config.export.clone()
         },
         layout: cbindgen::LayoutConfig {

--- a/src/lib/shim/build.rs
+++ b/src/lib/shim/build.rs
@@ -28,8 +28,8 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .blocklist_type("ShimShmem.*")
         .raw_line("use shadow_shim_helper_rs::shim_shmem::*;")
         .raw_line("use shadow_shim_helper_rs::shim_shmem::export::*;")
-        .blocklist_type("ShimThreadLocalStorageAllocation")
-        .raw_line("use crate::tls::ShimThreadLocalStorageAllocation;")
+        .blocklist_type("TlsOneThreadStorageAllocation")
+        .raw_line("use crate::tls::TlsOneThreadStorageAllocation;")
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.
@@ -76,7 +76,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
                 // Manual declaration above
                 "shim_api_syscall".into(),
             ],
-            include: vec!["ShimThreadLocalStorageAllocation".into()],
+            include: vec!["TlsOneThreadStorageAllocation".into()],
             ..base_config.export.clone()
         },
         layout: cbindgen::LayoutConfig {

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -133,7 +133,7 @@ static long _shim_native_syscallv(const ucontext_t* ctx, long n, va_list args) {
         // This thread is exiting. Arrange for its thread-local-storage and
         // signal stack to be freed.
         shim_freeSignalStack();
-        shim_tls_unregister_and_exit_current_thread(arg1);
+        shim_release_and_exit_current_thread(arg1);
     } else {
         // r8, r9, and r10 aren't supported as register-constraints in
         // extended asm templates. We have to use [local register

--- a/src/lib/shim/shim_tls.c
+++ b/src/lib/shim/shim_tls.c
@@ -1,6 +1,6 @@
 #include "lib/shim/shim_tls.h"
 
-ShimThreadLocalStorage* shim_native_tls() {
-    static __thread ShimThreadLocalStorage _tls = {0};
+ShimThreadLocalStorageAllocation* shim_native_tls() {
+    static __thread ShimThreadLocalStorageAllocation _tls = {0};
     return &_tls;
 }

--- a/src/lib/shim/shim_tls.c
+++ b/src/lib/shim/shim_tls.c
@@ -1,6 +1,6 @@
 #include "lib/shim/shim_tls.h"
 
-ShimThreadLocalStorageAllocation* shim_native_tls() {
-    static __thread ShimThreadLocalStorageAllocation _tls = {0};
+TlsOneThreadStorageAllocation* shim_native_tls() {
+    static __thread TlsOneThreadStorageAllocation _tls = {0};
     return &_tls;
 }

--- a/src/lib/shim/shim_tls.h
+++ b/src/lib/shim/shim_tls.h
@@ -4,8 +4,8 @@
 #include "lib/shim/shim_api.h"
 
 // Return a pointer to a native thread-local instance of
-// `ShimThreadLocalStorage`. The full implementation (in Rust), uses this as a
-// backing store when native thread local storage is available.
-ShimThreadLocalStorage* shim_native_tls();
+// `ShimThreadLocalStorageAllocation`. The full implementation (in Rust), uses
+// this as a backing store when native thread local storage is available.
+ShimThreadLocalStorageAllocation* shim_native_tls();
 
 #endif

--- a/src/lib/shim/shim_tls.h
+++ b/src/lib/shim/shim_tls.h
@@ -6,6 +6,6 @@
 // Return a pointer to a native thread-local instance of
 // `ShimThreadLocalStorageAllocation`. The full implementation (in Rust), uses
 // this as a backing store when native thread local storage is available.
-ShimThreadLocalStorageAllocation* shim_native_tls();
+TlsOneThreadStorageAllocation* shim_native_tls();
 
 #endif

--- a/src/lib/shim/src/lib.rs
+++ b/src/lib/shim/src/lib.rs
@@ -24,6 +24,7 @@ mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
+mod mmap_box;
 mod shimlogger;
 pub use shimlogger::export as shimlogger_export;
 

--- a/src/lib/shim/src/lib.rs
+++ b/src/lib/shim/src/lib.rs
@@ -6,10 +6,12 @@ use core::ffi::CStr;
 
 use crate::tls::ShimTlsVar;
 
+use linux_api::signal::{rt_sigprocmask, SigProcMaskAction};
 use shadow_shim_helper_rs::ipc::IPCData;
 use shadow_shim_helper_rs::shim_shmem::{HostShmem, ManagerShmem, ProcessShmem, ThreadShmem};
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
 use shadow_shmem::allocator::{Serializer, ShMemBlockAlias, ShMemBlockSerialized};
+use tls::ThreadLocalStorage;
 use vasi_sync::lazy_lock::LazyLock;
 use vasi_sync::scmutex::SelfContainedMutex;
 
@@ -37,7 +39,8 @@ pub fn simtime() -> Option<SimulationTime> {
 mod global_allow_native_syscalls {
     use super::*;
 
-    static ALLOW_NATIVE_SYSCALLS: ShimTlsVar<Cell<bool>> = ShimTlsVar::new(|| Cell::new(false));
+    static ALLOW_NATIVE_SYSCALLS: ShimTlsVar<Cell<bool>> =
+        ShimTlsVar::new(&SHIM_TLS, || Cell::new(false));
 
     pub fn get() -> bool {
         ALLOW_NATIVE_SYSCALLS.get().get()
@@ -56,7 +59,7 @@ mod tls_thread_signal_stack {
     use super::*;
 
     static THREAD_SIGNAL_STACK: ShimTlsVar<Cell<*mut core::ffi::c_void>> =
-        ShimTlsVar::new(|| Cell::new(core::ptr::null_mut()));
+        ShimTlsVar::new(&SHIM_TLS, || Cell::new(core::ptr::null_mut()));
 
     // Shouldn't need to make this very large, but needs to be big enough to run the
     // managed process's signal handlers as well - possibly recursively.
@@ -158,7 +161,7 @@ mod tls_thread_signal_stack {
 mod tls_ipc {
     use super::*;
     static IPC_DATA_BLOCK: ShimTlsVar<RefCell<Option<ShMemBlockAlias<IPCData>>>> =
-        ShimTlsVar::new(|| RefCell::new(None));
+        ShimTlsVar::new(&SHIM_TLS, || RefCell::new(None));
 
     // Panics if this thread's IPC hasn't been initialized yet.
     pub fn with<O>(f: impl FnOnce(&IPCData) -> O) -> O {
@@ -201,7 +204,7 @@ mod tls_thread_shmem {
     use super::*;
 
     static THREAD_SHMEM: ShimTlsVar<RefCell<Option<ShMemBlockAlias<ThreadShmem>>>> =
-        ShimTlsVar::new(|| RefCell::new(None));
+        ShimTlsVar::new(&SHIM_TLS, || RefCell::new(None));
 
     // Panics if not initialized yet.
     pub fn with<O>(f: impl FnOnce(&ThreadShmem) -> O) -> O {
@@ -364,16 +367,44 @@ extern crate shadow_shim_helper_rs;
 extern crate shadow_shmem;
 extern crate shadow_tsc;
 
-fn load() {
-    // First ensure thread local storage is initialized.
-    // TODO: Make the preferred mode configurable at runtime.
-    static TLS_INIT_DONE: LazyLock<()> = LazyLock::const_new(||
-        // SAFETY: LazyLock ensures this is only called once.
-        unsafe { tls::global_preferred_mode::set(tls::Mode::Native) });
-    TLS_INIT_DONE.force();
+/// Global instance of thread local storage for use in the shim.
+///
+/// SAFETY: We ensure that every thread unregisters itself before exiting,
+/// via [`release_and_exit_current_thread`].
+static SHIM_TLS: ThreadLocalStorage = unsafe { ThreadLocalStorage::new(tls::Mode::Native) };
 
+/// Release this thread's shim thread local storage and exit the thread.
+///
+/// Should be called by every thread that accesses thread local storage.
+///
+/// Panics if there are still any live references to this thread's [`ShimTlsVar`]s.
+///
+/// # Safety
+///
+/// In the case that this function somehow panics, caller must not
+/// access thread local storage again from the current thread, e.g.
+/// using `std::panic::catch_unwind` or a custom panic hook.
+pub unsafe fn release_and_exit_current_thread(exit_status: i32) -> ! {
+    // Block all signals, to ensure a signal handler can't run and attempt to
+    // access thread local storage.
+    rt_sigprocmask(
+        SigProcMaskAction::SIG_BLOCK,
+        &linux_api::signal::sigset_t::FULL,
+        None,
+    )
+    .unwrap();
+
+    // SAFETY: No code can access thread local storage in between deregistration
+    // and exit, unless `unregister_curren_thread` itself panics.
+    unsafe { SHIM_TLS.unregister_current_thread() }
+
+    linux_api::exit::exit_raw(exit_status).unwrap();
+    unreachable!()
+}
+
+fn load() {
     static STARTED_THREAD_INIT: ShimTlsVar<LazyLock<()>> =
-        ShimTlsVar::new(|| LazyLock::const_new(|| ()));
+        ShimTlsVar::new(&SHIM_TLS, || LazyLock::const_new(|| ()));
     if STARTED_THREAD_INIT.get().initd() {
         // Avoid recursion in initialization.
         //
@@ -385,7 +416,7 @@ fn load() {
 
     // Once-per-thread initialization. We use a `LazyLock` object to cheaply
     // ensure this runs at most once.
-    static THREAD_INIT: ShimTlsVar<LazyLock<()>> = ShimTlsVar::new(|| {
+    static THREAD_INIT: ShimTlsVar<LazyLock<()>> = ShimTlsVar::new(&SHIM_TLS, || {
         // Flag to check whether we've initialized *any* thread in the current
         // process.  The first thread initialized in the process has to do some
         // extra initialization, but isn't quite a pure superset of later
@@ -564,6 +595,18 @@ pub mod export {
     #[no_mangle]
     pub extern "C" fn _shim_load() {
         load();
+    }
+
+    /// Should be used to exit every thread in the shim.
+    ///
+    /// # Safety
+    ///
+    /// In the case that this function somehow panics, caller must not
+    /// access thread local storage again from the current thread, e.g.
+    /// using `std::panic::catch_unwind` or a custom panic hook.
+    #[no_mangle]
+    pub unsafe extern "C" fn shim_release_and_exit_current_thread(status: i32) {
+        unsafe { release_and_exit_current_thread(status) }
     }
 
     /// # Safety

--- a/src/lib/shim/src/lib.rs
+++ b/src/lib/shim/src/lib.rs
@@ -26,11 +26,11 @@ mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
-mod mmap_box;
-mod shimlogger;
-pub use shimlogger::export as shimlogger_export;
+pub mod mmap_box;
+pub mod shimlogger;
+pub mod tls;
 
-mod tls;
+pub use shimlogger::export as shimlogger_export;
 
 pub fn simtime() -> Option<SimulationTime> {
     SimulationTime::from_c_simtime(unsafe { bindings::shim_sys_get_simtime_nanos() })

--- a/src/lib/shim/src/mmap_box.rs
+++ b/src/lib/shim/src/mmap_box.rs
@@ -1,0 +1,145 @@
+use core::ptr::NonNull;
+
+use rustix::mm::{MapFlags, ProtFlags};
+
+/// Analogous to `alloc::boxed::Box`, but directly uses `mmap` instead of a
+/// global allocator. Useful since we don't currently have a global allocator in
+/// the shim, and probably don't want to install one that makes direct `mmap`
+/// calls for every allocation, since that would be a performance footgun.
+///
+/// We should be able to replace this with `alloc::boxed::Box<T>` if and when we
+/// implement a global allocator suitable for the shim.  (Or with
+/// `alloc::boxed::Box<T, MmapAllocator>` when non-global allocators are
+/// stabilized)
+pub struct MmapBox<T> {
+    ptr: Option<NonNull<T>>,
+}
+unsafe impl<T> Send for MmapBox<T> where T: Send {}
+unsafe impl<T> Sync for MmapBox<T> where T: Sync {}
+
+impl<T> MmapBox<T> {
+    pub fn new(x: T) -> Self {
+        #[cfg(not(miri))]
+        {
+            let ptr: *mut core::ffi::c_void = unsafe {
+                rustix::mm::mmap_anonymous(
+                    core::ptr::null_mut(),
+                    core::mem::size_of::<T>(),
+                    ProtFlags::READ | ProtFlags::WRITE,
+                    MapFlags::PRIVATE,
+                )
+            }
+            .unwrap();
+            assert!(!ptr.is_null());
+
+            // Memory returned by mmap is page-aligned, which is generally at least
+            // 4096.  This should be enough for most types.
+            assert_eq!(ptr.align_offset(core::mem::align_of::<T>()), 0);
+
+            let ptr: *mut T = ptr.cast();
+            unsafe { ptr.write(x) };
+            Self {
+                ptr: Some(NonNull::new(ptr).unwrap()),
+            }
+        }
+        #[cfg(miri)]
+        {
+            Self {
+                ptr: Some(NonNull::new(std::boxed::Box::into_raw(
+                    std::boxed::Box::new(x),
+                )).unwrap()),
+            }
+        }
+    }
+
+    #[allow(unused)]
+    pub fn leak(mut this: MmapBox<T>) -> *mut T {
+        this.ptr.take().unwrap().as_ptr()
+    }
+}
+
+impl<T> core::ops::Deref for MmapBox<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.ptr.as_ref().unwrap().as_ref() }
+    }
+}
+
+impl<T> core::ops::DerefMut for MmapBox<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { self.ptr.as_mut().unwrap().as_mut() }
+    }
+}
+
+impl<T> Drop for MmapBox<T> {
+    fn drop(&mut self) {
+        let Some(ptr) = self.ptr else {
+            return;
+        };
+        let ptr = ptr.as_ptr();
+
+        #[cfg(not(miri))]
+        {
+            unsafe { ptr.drop_in_place() }
+            unsafe {
+                rustix::mm::munmap(ptr.cast::<core::ffi::c_void>(), core::mem::size_of::<T>())
+                    .unwrap()
+            }
+        }
+        #[cfg(miri)]
+        {
+            drop(unsafe { Box::from_raw(ptr) })
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use vasi_sync::lazy_lock::LazyLock;
+
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let x = MmapBox::new(42);
+        assert_eq!(*x, 42);
+    }
+
+    #[test]
+    fn test_large_alloc() {
+        // This should span multiple pages.
+        let val = [0; 100_000];
+
+        let x = MmapBox::new(val);
+        assert_eq!(*x, val);
+    }
+
+    #[test]
+    fn test_mutate() {
+        let mut x = MmapBox::new(42);
+        assert_eq!(*x, 42);
+        *x += 1;
+        assert_eq!(*x, 43);
+    }
+
+    #[test]
+    fn test_drop() {
+        let arc = Arc::new(());
+        assert_eq!(Arc::strong_count(&arc), 1);
+        {
+            let _clone = MmapBox::new(arc.clone());
+            assert_eq!(Arc::strong_count(&arc), 2);
+        }
+        assert_eq!(Arc::strong_count(&arc), 1);
+    }
+
+    #[test]
+    fn test_leak() {
+        static MY_LEAKED: LazyLock<&'static u32> =
+            LazyLock::const_new(|| unsafe { &*MmapBox::leak(MmapBox::new(42)) });
+        assert_eq!(**MY_LEAKED.force(), 42);
+    }
+}

--- a/src/lib/shim/src/mmap_box.rs
+++ b/src/lib/shim/src/mmap_box.rs
@@ -45,9 +45,7 @@ impl<T> MmapBox<T> {
         #[cfg(miri)]
         {
             Self {
-                ptr: Some(NonNull::new(std::boxed::Box::into_raw(
-                    std::boxed::Box::new(x),
-                )).unwrap()),
+                ptr: Some(NonNull::new(Box::into_raw(Box::new(x))).unwrap()),
             }
         }
     }

--- a/src/lib/shim/src/tls.rs
+++ b/src/lib/shim/src/tls.rs
@@ -657,6 +657,16 @@ mod test {
         }
     }
 
+    #[test]
+    #[should_panic(expected = "Removed key while references still held")]
+    fn test_panic() {
+        let tls = unsafe { ThreadLocalStorage::new(Mode::Gettid) };
+        let var: ShimTlsVar<u32> = ShimTlsVar::new(&tls, || 0);
+        let _var_ref = var.get();
+        // This should panic since we still have a reference
+        unsafe { tls.unregister_current_thread() };
+    }
+
     #[test_log::test]
     fn test_single_thread_mutate() {
         for mode in MODES {

--- a/src/lib/vasi-sync/src/atomic_tls_map.rs
+++ b/src/lib/vasi-sync/src/atomic_tls_map.rs
@@ -30,7 +30,7 @@ where
     refcounts: [Cell<usize>; N],
     build_hasher: H,
 }
-/// Override default of `UnsafeCell` and `Cell` not being `Sync`.  We
+/// Override default of `UnsafeCell`, `Cell`, and `V` not being `Sync`.  We
 /// synchronize access to these (if partly by requiring users to guarantee no
 /// parallel access to a given key from multiple threads).
 /// Likewise `V` only needs to be `Send`.

--- a/src/lib/vasi-sync/src/atomic_tls_map.rs
+++ b/src/lib/vasi-sync/src/atomic_tls_map.rs
@@ -219,6 +219,12 @@ impl<const N: usize, V, H> AtomicTlsMap<N, V, H>
 where
     H: BuildHasher + Default,
 {
+    // This `inline` is important when allocating large instances, since
+    // otherwise the compiler can't avoid create a temporary copy on the stack,
+    // which might not fit.
+    //
+    // See https://stackoverflow.com/questions/25805174/creating-a-fixed-size-array-on-heap-in-rust/68122278#68122278
+    #[inline]
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self::new_with_hasher(Default::default())

--- a/src/lib/vasi-sync/src/atomic_tls_map.rs
+++ b/src/lib/vasi-sync/src/atomic_tls_map.rs
@@ -200,7 +200,11 @@ where
     /// The value at `key`, if any, must have been inserted by the current thread.
     pub unsafe fn remove(&self, key: NonZeroUsize) -> Option<V> {
         let idx = self.idx(key)?;
-        assert_eq!(self.refcounts[idx].get(), 0);
+        assert_eq!(
+            self.refcounts[idx].get(),
+            0,
+            "Removed key while references still held: {key:?}"
+        );
         let value = self.values[idx].get_mut().with(|value| {
             let value = unsafe { &mut *value };
             unsafe { value.assume_init_read() }

--- a/src/lib/vasi-sync/src/sync.rs
+++ b/src/lib/vasi-sync/src/sync.rs
@@ -275,6 +275,15 @@ impl<T> UnsafeCell<T> {
     pub fn get(&self) -> ConstPtr<T> {
         ConstPtr(self.0.get())
     }
+
+    /// This is analogous to `core::UnsafeCell::get` in that it returns
+    /// a raw pointer instead of an object.
+    ///
+    /// We can't provide this method under loom without giving up some of loom's
+    /// analysis.
+    pub fn untracked_get(&self) -> *mut T {
+        self.0.get()
+    }
 }
 #[cfg(loom)]
 #[derive(Debug)]

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -221,7 +221,8 @@ static char* _regularfile_getAbsolutePath(RegularFile* dir, const char* pathname
 #define CHECK_FLAG(flag)                                                                           \
     if (flags & flag) {                                                                            \
         if (!flag_str) {                                                                           \
-            asprintf(&flag_str, #flag);                                                            \
+            int rv = asprintf(&flag_str, #flag);                                                   \
+            utility_alwaysAssert(rv >= 0);                                                         \
         } else {                                                                                   \
             char* str = _regularfile_getConcatStr(flag_str, '|', #flag);                           \
             free(flag_str);                                                                        \
@@ -248,7 +249,8 @@ static void _regularfile_print_flags(int flags) {
     CHECK_FLAG(O_TMPFILE);
     CHECK_FLAG(O_TRUNC);
     if (!flag_str) {
-        asprintf(&flag_str, "0");
+        int rv = asprintf(&flag_str, "0");
+        utility_alwaysAssert(rv >= 0);
     }
     trace("Found flags: %s", flag_str);
     if (flag_str) {

--- a/src/test/golang/CMakeLists.txt
+++ b/src/test/golang/CMakeLists.txt
@@ -91,4 +91,6 @@ add_shadow_tests(
     ARGS
       --strace-logging-mode off
     PROPERTIES
+      # This test can take a bit longer in debug builds
+      TIMEOUT 40
       LABELS golang)


### PR DESCRIPTION
* use `AtomicTlsMap` instead of an ad-hoc equivalent
* Have individual references to thread-local-storage hold a borrowed reference to the corresponding `AtomicTlsMap` entry, which results in a panic if the thread is unregistered while still holding such a reference (instead of undefined behavior)
* Add `MmapBox` and use it for allocations instead of using `mmap` directly; allocate and deallocate the storage for individual threads as needed instead of allocating all up front.
* Get rid of the `static` state in `tls.rs` so that unit tests can be hermetic- no longer need a global lock, and we're able to add  `should_panic` tests (which previously would have poisoned the lock and possibly other state).