### PR TITLE
Shim: Move shared memory objects into Rust

### DIFF
--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -41,14 +41,6 @@ static ShMemBlock* _shim_process_shared_mem_blk() {
 }
 const ShimShmemProcess* shim_processSharedMem() { return _shim_process_shared_mem_blk()->p; }
 
-// Per-host state shared with Shadow.
-// Must remain valid for the lifetime of this process once initialized.
-static ShMemBlock* _shim_host_shared_mem_blk() {
-    static ShMemBlock block = {0};
-    return &block;
-}
-const ShimShmemHost* shim_hostSharedMem() { return _shim_host_shared_mem_blk()->p; }
-
 // Held from the time of starting to initialize _startThread, to being done with
 // it. i.e. ensure we don't try to start more than one thread at once.
 //
@@ -130,8 +122,7 @@ static void _shim_parent_init_manager_shm() {
 }
 
 static void _shim_parent_init_host_shm() {
-    *_shim_host_shared_mem_blk() = shmemserializer_globalBlockDeserialize(
-        shimshmem_getProcessHostShmem(shim_processSharedMem()));
+    _shim_set_host_shmem(shimshmem_getProcessHostShmem(shim_processSharedMem()));
     assert(shim_hostSharedMem());
 }
 

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -49,14 +49,6 @@ static ShMemBlock* _shim_host_shared_mem_blk() {
 }
 const ShimShmemHost* shim_hostSharedMem() { return _shim_host_shared_mem_blk()->p; }
 
-// Per-manager state shared with Shadow.
-// Must remain valid for the lifetime of this process once initialized.
-static ShMemBlock* _shim_manager_shared_mem_blk() {
-    static ShMemBlock block = {0};
-    return &block;
-}
-const ShimShmemManager* shim_managerSharedMem() { return _shim_manager_shared_mem_blk()->p; }
-
 // Held from the time of starting to initialize _startThread, to being done with
 // it. i.e. ensure we don't try to start more than one thread at once.
 //
@@ -133,8 +125,7 @@ static void _shim_parent_init_death_signal() {
 }
 
 static void _shim_parent_init_manager_shm() {
-    *_shim_manager_shared_mem_blk() =
-        shmemserializer_globalBlockDeserialize(shimshmem_getHostManagerShmem(shim_hostSharedMem()));
+    _shim_set_manager_shmem(shimshmem_getHostManagerShmem(shim_hostSharedMem()));
     assert(shim_managerSharedMem());
 }
 

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -33,14 +33,6 @@
 #include "lib/shim/shim_syscall.h"
 #include "main/host/syscall_numbers.h" // for SYS_shadow_* defs
 
-// Per-process state shared with Shadow.
-// Must remain valid for the lifetime of this process once initialized.
-static ShMemBlock* _shim_process_shared_mem_blk() {
-    static ShMemBlock block = {0};
-    return &block;
-}
-const ShimShmemProcess* shim_processSharedMem() { return _shim_process_shared_mem_blk()->p; }
-
 // Held from the time of starting to initialize _startThread, to being done with
 // it. i.e. ensure we don't try to start more than one thread at once.
 //
@@ -216,8 +208,7 @@ static void _shim_ipc_wait_for_start_event() {
     assert(shimevent2shim_getId(&start_res) == SHIM_EVENT_TO_SHIM_START_RES);
 
     _shim_set_thread_shmem(&thread_blk_serialized);
-    *_shim_process_shared_mem_blk() =
-        shmemserializer_globalBlockDeserialize(&process_blk_serialized);
+    _shim_set_process_shmem(&process_blk_serialized);
 }
 
 static void _shim_parent_init_seccomp() {

--- a/src/lib/shim/src/lib.rs
+++ b/src/lib/shim/src/lib.rs
@@ -168,8 +168,8 @@ mod tls_ipc {
 
     /// # Safety
     ///
-    /// `blk` must contained a serialized block of
-    /// type `IPCData`, which outlives the current thread.
+    /// `blk` must contained a serialized block referencing a `ShMemBlock` of type `IPCData`.
+    /// The `ShMemBlock` must outlive the current thread.
     pub unsafe fn set(blk: &ShMemBlockSerialized) {
         let blk: ShMemBlockAlias<IPCData> = unsafe { Serializer::global().deserialize(blk) };
         assert!(IPC_DATA_BLOCK.get().replace(Some(blk)).is_none());
@@ -211,8 +211,8 @@ mod tls_thread_shmem {
 
     /// # Safety
     ///
-    /// `blk` must contained a serialized block of
-    /// type `ThreadShmem`, which outlives the current thread.
+    /// `blk` must contained a serialized block referencing a `ShMemBlock` of
+    /// type `ThreadShmem`.  The `ShMemBlock` must outlive the current thread.
     pub unsafe fn set(blk: &ShMemBlockSerialized) {
         let blk: ShMemBlockAlias<ThreadShmem> = unsafe { Serializer::global().deserialize(blk) };
         assert!(THREAD_SHMEM.get().replace(Some(blk)).is_none());

--- a/src/lib/shim/src/lib.rs
+++ b/src/lib/shim/src/lib.rs
@@ -7,7 +7,7 @@ use core::ffi::CStr;
 use crate::tls::ShimTlsVar;
 
 use shadow_shim_helper_rs::ipc::IPCData;
-use shadow_shim_helper_rs::shim_shmem::{ManagerShmem, ThreadShmem, HostShmem};
+use shadow_shim_helper_rs::shim_shmem::{HostShmem, ManagerShmem, ProcessShmem, ThreadShmem};
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
 use shadow_shmem::allocator::{Serializer, ShMemBlockAlias, ShMemBlockSerialized};
 use vasi_sync::lazy_lock::LazyLock;
@@ -293,13 +293,58 @@ mod global_host_shmem {
     }
 
     /// Panics if `set` hasn't been called yet.
-    pub fn get() -> impl core::ops::Deref<Target = ShMemBlockAlias<'static, HostShmem>> + 'static
+    pub fn get() -> impl core::ops::Deref<Target = ShMemBlockAlias<'static, HostShmem>> + 'static {
+        SHMEM.force()
+    }
+
+    pub fn try_get(
+    ) -> Option<impl core::ops::Deref<Target = ShMemBlockAlias<'static, HostShmem>> + 'static> {
+        if !SHMEM.initd() {
+            // No need to do the more-expensive `INITIALIZER` check; `set`
+            // forces `SHMEM` to initialize.
+            None
+        } else {
+            Some(get())
+        }
+    }
+}
+
+// TODO: we'll probably need to make this per-thread to support fork.
+mod global_process_shmem {
+    use super::*;
+
+    // This is set explicitly, so needs a Mutex.
+    static INITIALIZER: SelfContainedMutex<Option<ShMemBlockSerialized>> =
+        SelfContainedMutex::const_new(None);
+
+    // The actual block is in a `LazyLock`, which is much faster to access.
+    // It uses `INITIALIZER` to do its one-time init.
+    static SHMEM: LazyLock<ShMemBlockAlias<ProcessShmem>> = LazyLock::const_new(|| {
+        let serialized = INITIALIZER.lock().take().unwrap();
+        unsafe { Serializer::global().deserialize(&serialized) }
+    });
+
+    /// # Safety
+    ///
+    /// `blk` must contained a serialized block referencing a `ShMemBlock` of type `ProcessShmem`.
+    /// The `ShMemBlock` must outlive this process.
+    pub unsafe fn set(blk: &ShMemBlockSerialized) {
+        assert!(!SHMEM.initd());
+        assert!(INITIALIZER.lock().replace(*blk).is_none());
+        // Ensure that `try_get` returns true (without it having to take the
+        // `INITIALIZER` lock to check), and that we fail early if `SHMEM` can't
+        // actually be initialized.
+        SHMEM.force();
+    }
+
+    /// Panics if `set` hasn't been called yet.
+    pub fn get() -> impl core::ops::Deref<Target = ShMemBlockAlias<'static, ProcessShmem>> + 'static
     {
         SHMEM.force()
     }
 
     pub fn try_get(
-    ) -> Option<impl core::ops::Deref<Target = ShMemBlockAlias<'static, HostShmem>> + 'static>
+    ) -> Option<impl core::ops::Deref<Target = ShMemBlockAlias<'static, ProcessShmem>> + 'static>
     {
         if !SHMEM.initd() {
             None
@@ -308,7 +353,6 @@ mod global_host_shmem {
         }
     }
 }
-
 
 // Force cargo to link against crates that aren't (yet) referenced from Rust
 // code (but are referenced from this crate's C code).
@@ -561,6 +605,30 @@ pub mod export {
         let rv = global_host_shmem::try_get();
         rv.map(|x| {
             let rv: &shadow_shim_helper_rs::shim_shmem::export::ShimShmemHost = x.deref();
+            // We know this pointer will be live for the lifetime of the
+            // process, and that we never construct a mutable reference to the
+            // underlying data.
+            rv as *const _
+        })
+        .unwrap_or(core::ptr::null())
+    }
+
+    /// # Safety
+    ///
+    /// `blk` must contained a serialized block of
+    /// type `ProcessShmem`, which outlives the current process.
+    #[no_mangle]
+    pub unsafe extern "C" fn _shim_set_process_shmem(shmem: *const ShMemBlockSerialized) {
+        let shmem = unsafe { shmem.as_ref().unwrap() };
+        unsafe { global_process_shmem::set(shmem) };
+    }
+
+    #[no_mangle]
+    pub extern "C" fn shim_processSharedMem(
+    ) -> *const shadow_shim_helper_rs::shim_shmem::export::ShimShmemProcess {
+        let rv = global_process_shmem::try_get();
+        rv.map(|x| {
+            let rv: &shadow_shim_helper_rs::shim_shmem::export::ShimShmemProcess = x.deref();
             // We know this pointer will be live for the lifetime of the
             // process, and that we never construct a mutable reference to the
             // underlying data.

--- a/src/lib/shim/src/shimlogger.rs
+++ b/src/lib/shim/src/shimlogger.rs
@@ -79,7 +79,7 @@ impl log::Log for ShimLogger {
 
         let mut writer = ShimLoggerWriter::new();
 
-        match crate::manager_shmem() {
+        match crate::global_manager_shmem::try_get() {
             Some(m) => {
                 // rustix's `clock_gettime` goes through VDSO, which is overwritten with our trampoline,
                 // which would end up trying to log and recurse.


### PR DESCRIPTION
We need at least the Process shared memory in Rust to be able to migrate the signal handling to Rust. Might as well move the others too.