### PR TITLE
Fix and reenable clone tests

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -20,3 +20,16 @@ members = [
     "lib/vasi-macro",
     "lib/vasi-sync",
 ]
+
+[profile.dev]
+# Without this, the shim requires a relatively large stack, especially during
+# initialization.  Rust makes it difficult to avoid putting objects temporarily
+# on the stack, even if it'll ultimately live in heap or static memory, but
+# opt-level 1 is enough to optimize a lot of those away.
+# 
+# See https://stackoverflow.com/questions/25805174/creating-a-fixed-size-array-on-heap-in-rust/68122278#68122278
+#
+# In our test suite the main place we see failures without this is in the
+# `clone-shadow` test, but it could also affect golang or other environments
+# with "light" user-space threading.
+opt-level = 1 

--- a/src/lib/shim/src/tls.rs
+++ b/src/lib/shim/src/tls.rs
@@ -96,7 +96,7 @@ pub const BYTES_PER_THREAD: usize = 1024;
 // Max threads for our slow TLS fallback mechanism.  We support recycling
 // storage of exited threads, so this is the max *concurrent* threads per
 // process.
-const TLS_FALLBACK_MAX_THREADS: usize = 1000;
+const TLS_FALLBACK_MAX_THREADS: usize = 100;
 
 /// An ELF thread pointer, as specified in
 /// <https://www.akkadia.org/drepper/tls.pdf)>

--- a/src/test/clone/CMakeLists.txt
+++ b/src/test/clone/CMakeLists.txt
@@ -6,10 +6,11 @@ add_linux_tests(BASENAME clone COMMAND test_clone)
 
 add_shadow_tests(
     BASENAME clone
-    # Shim-side logging and strace-logging use libc functions that assume native
-    # thread-local-storage is set up. We disable most logging to try to avoid resulting
-    # segfaults.
-    LOGLEVEL warning
+    # Shim-side strace-logging use libc functions that assume native
+    # thread-local-storage is set up. It *usually* works in practice, but is a
+    # potential source of hard-to-debug errors.
+    #
+    # See https://github.com/shadow/shadow/issues/2919
     ARGS --strace-logging-mode=off
 )
 
@@ -18,9 +19,10 @@ add_shadow_tests(
 # the memory manager (really the MemoryMapper) enabled.
 add_shadow_tests(
     BASENAME clone-nomm
-    # Shim-side logging and strace-logging use libc functions that assume native
-    # thread-local-storage is set up. We disable most logging to try to avoid resulting
-    # segfaults.
-    LOGLEVEL warning
+    # Shim-side strace-logging use libc functions that assume native
+    # thread-local-storage is set up. It *usually* works in practice, but is a
+    # potential source of hard-to-debug errors.
+    #
+    # See https://github.com/shadow/shadow/issues/2919
     ARGS --strace-logging-mode=off
 )

--- a/src/test/clone/CMakeLists.txt
+++ b/src/test/clone/CMakeLists.txt
@@ -11,12 +11,6 @@ add_shadow_tests(
     # segfaults.
     LOGLEVEL warning
     ARGS --strace-logging-mode=off
-    PROPERTIES
-        # There are nonetheless stills sometimes segfaults when running in CI,
-        # but I haven't been able to reproduce them locally.
-        # https://github.com/shadow/shadow/issues/1559
-        LABELS flaky
-        CONFIGURATIONS extra
 )
 
 # The clone test exercises some corner cases in memory management, particularly
@@ -29,10 +23,4 @@ add_shadow_tests(
     # segfaults.
     LOGLEVEL warning
     ARGS --strace-logging-mode=off
-    PROPERTIES
-        # There are nonetheless stills sometimes segfaults when running in CI,
-        # but I haven't been able to reproduce them locally.
-        # https://github.com/shadow/shadow/issues/1559
-        LABELS flaky
-        CONFIGURATIONS extra
 )


### PR DESCRIPTION
These tests *appear* to no longer be flaky with the new implementation of shim thread local storage. I did have to make some changes to avoid smashing the relatively small stack we use in this test though:

* Enable minimal optimizations in debug builds. Rust has a tendency to put more temporaries on the stack than in C code. Enabling some optimizations lets us optimize many of those away, e.g. when initializing an object that will ultimately live in static or heap memory.
* Reduced the max threads supported by shim TLS from 1000 to 100. 1000 was from when this was a maximum number of threads *ever* for a process. In the new implementation this limit is for *simultaneous* threads per process, so 1000 is probably excessive. This reduces the size of the corresponding table, which seems to end up as a temporary on the stack even with optimizations enabled.

I verified that neither of those alone were sufficient to fix the test.

We could theoretically increase the stack size in the test from 16 KB instead of one or both of those  changes, but I think it's worth avoiding a requirement for a relatively large stack for initialization. e.g. on my machine libc defines `MINSIGSTKSZ` as 2048 and `SIGSTKSZ` as 8192, so requiring 16 KB could already be pushing it.

I also reenabled shim logging in these tests; that should no longer risk trying to touch native thread local storage now that logging has been migrated to no-std no-libc rust.