### PR TITLE
Rework Rust version pinning

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,6 @@
 **/.git
 **/build
 **/target
+# local selection of rust toolchain
+rust-toolchain.toml
+

--- a/.github/workflows/ci_maintenance.yml
+++ b/.github/workflows/ci_maintenance.yml
@@ -25,9 +25,8 @@ jobs:
             body:
           `The Shadow CI environment has hard-coded versions of some tools. These versions should be periodically updated, and any compatibility issues fixed.
 
-          - rust default stable version (\`rust-toolchain.toml\`)
-          - rust nightly version for coverage builds (\`ci/container_scripts/install_extra_deps.sh\` — \`RUST_TOOLCHAIN\`)
-          - rust nightly version for miri tests (\`.github/workflows/sanitizers.yml\`)
+          - rust default stable version (\`ci/rust-toolchain-stable.toml\`)
+          - rust default nightly version (\`ci/rust-toolchain-nightly.toml\`)
           - python version for the python lint (\`.github/workflows/lint.yml\`)
           - tor and tgen versions for the tor tests (\`.github/workflows/extra_tests.yml\`)
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,8 @@ jobs:
           # date with target branch before merging, anyway.
           # See https://github.com/shadow/shadow/issues/2166
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set Rust toolchain
+        run: ln -s ci/rust-toolchain-stable.toml rust-toolchain.toml
       - name: check rust version
         run: cargo --version
       - name: Add rustfmt
@@ -57,6 +59,9 @@ jobs:
           # date with target branch before merging, anyway.
           # See https://github.com/shadow/shadow/issues/2166
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set Rust toolchain
+        run: ln -s ci/rust-toolchain-stable.toml rust-toolchain.toml
 
       # No need to fully build shadow, but we need to run cmake to generate shd-config.h,
       # which is required for some of the rust modules' build scripts that compile C code.
@@ -97,6 +102,8 @@ jobs:
           # date with target branch before merging, anyway.
           # See https://github.com/shadow/shadow/issues/2166
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set Rust toolchain
+        run: ln -s ci/rust-toolchain-stable.toml rust-toolchain.toml
       - name: check rust version
         run: cargo --version
       - name: Add rustdoc

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -23,15 +23,14 @@ jobs:
         # See https://github.com/shadow/shadow/issues/2166
         ref: ${{ github.event.pull_request.head.sha }}
 
-    # From https://github.com/rust-lang/miri#running-miri-on-ci
+    - name: Set Rust toolchain
+      run: ln -s ci/rust-toolchain-nightly.toml rust-toolchain.toml
+
+    # See https://github.com/rust-lang/miri#running-miri-on-ci
     - name: Install miri
       run: |
-          # Must be a version built with miri; check
-          # https://rust-lang.github.io/rustup-components-history/
-          TOOLCHAIN=nightly-2023-05-31
-          rustup toolchain install ${TOOLCHAIN} --component miri
-          rustup override set ${TOOLCHAIN}
-          cargo miri setup
+        rustup component add miri
+        cargo miri setup
 
     # No need to fully build shadow, but we need to run cmake to generate shd-config.h,
     # which is required for some of the rust modules' build scripts that compile C code.
@@ -65,6 +64,9 @@ jobs:
         # date with target branch before merging, anyway.
         # See https://github.com/shadow/shadow/issues/2166
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Set Rust toolchain
+      run: ln -s ci/rust-toolchain-stable.toml rust-toolchain.toml
 
     - name: Test
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ __pycache__
 # don't track the Cargo lock files of libraries
 /src/lib/logger/rust_bindings/Cargo.lock
 /src/lib/gml-parser/Cargo.lock
+# local selection of rust toolchain
+/rust-toolchain.toml

--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -59,10 +59,12 @@ esac
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain none --profile minimal
 source "$HOME/.cargo/env"
 
+# Pin the Rust toolchain to either our pinned nightly or stable version.
 if [ "${BUILDTYPE:-}" = coverage ]
 then
-  # Add a directory override, which overrides rust-toolchain.toml
-  rustup override set nightly-2023-05-31
+  ln -s ci/rust-toolchain-nightly.toml rust-toolchain.toml
+else
+  ln -s ci/rust-toolchain-stable.toml rust-toolchain.toml
 fi
 
 # This forces installation of the toolchain required in Shadow's

--- a/ci/rust-toolchain-nightly.toml
+++ b/ci/rust-toolchain-nightly.toml
@@ -1,0 +1,19 @@
+# This file can be used to pin the rust toolchain to the "nightly" version used by shadow CI.
+#
+# ```sh
+# ln -s ci/rust-toolchain-nightly.toml rust-toolchain.toml
+# ```
+#
+# See
+# https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+#
+# After updating this version, it's a good idea to re-build the base images for
+# our incremental CI tests (.github/workflows/run_tests_incremental.yml), so
+# that the newly specified version is baked in and doesn't have to be installed
+# (and rust deps rebuilt) during every incremental build.
+[toolchain]
+# Must be a version built with miri; check
+# https://rust-lang.github.io/rustup-components-history/
+channel = "nightly-2023-05-31"
+# We don't add individual components here. CI individually
+# adds the ones they need (e.g. clippy, miri).

--- a/ci/rust-toolchain-stable.toml
+++ b/ci/rust-toolchain-stable.toml
@@ -1,5 +1,10 @@
-# This file overrides rustup's default toolchain, but can itself be overridden
-# locally if desired.
+# This file can be used to pin the rust toolchain to the "stable" version used by shadow CI.
+#
+# ```sh
+# ln -s ci/rust-toolchain-stable.toml rust-toolchain.toml
+# ```
+#
+# See
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 #
 # After updating this version, it's a good idea to re-build the base images for

--- a/docs/install_dependencies.md
+++ b/docs/install_dependencies.md
@@ -32,7 +32,7 @@ sudo apt-get install -y \
     g++
 
 # rustup: https://rustup.rs
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 On older versions of Debian or Ubuntu, the default version of libclang is too
@@ -67,5 +67,5 @@ sudo dnf install -y \
     gcc-c++
 
 # rustup: https://rustup.rs
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```


### PR DESCRIPTION
Replaces `rust-toolchain.toml` with `rust-toolchain-stable.toml` and `rust-toolchain-nightly.toml`. This consolidates the pinning of the nightly version (used in some CI tests) to one place.

For users/developers, this means the version won't be automatically pinned anymore; they can choose to pin to the CI stable or nightly version by creating a symbolic link to one of these two files.

Alternatively we could check in a symbolic link to pin to the stable version by default, but then if a user wants to change the link to point to the nightly version, it'd be easy to accidentally check in the new link as well.