### PR TITLE
Remove syscall shadow_get_shm_blk

### DIFF
--- a/src/main/host/syscall/shadow.c
+++ b/src/main/host/syscall/shadow.c
@@ -90,16 +90,6 @@ SyscallReturn syscallhandler_shadow_hostname_to_addr_ipv4(SysCallHandler* sys,
     }
 }
 
-SyscallReturn syscallhandler_shadow_get_shm_blk(SysCallHandler* sys, const SysCallArgs* args) {
-    utility_debugAssert(sys && args);
-    trace("handling shadow_get_shm_blk syscall");
-    UntypedForeignPtr shm_blk_pptr = args->args[0].as_ptr;
-    ShMemBlockSerialized* shm_blk_ptr = process_getWriteablePtr(
-        _syscallhandler_getProcess(sys), shm_blk_pptr, sizeof(*shm_blk_ptr));
-    thread_getShMBlockSerialized(_syscallhandler_getThread(sys), shm_blk_ptr);
-    return syscallreturn_makeDoneI64(0);
-}
-
 SyscallReturn syscallhandler_shadow_init_memory_manager(SysCallHandler* sys,
                                                         const SysCallArgs* args) {
     utility_debugAssert(sys && args);

--- a/src/main/host/syscall/shadow.h
+++ b/src/main/host/syscall/shadow.h
@@ -9,7 +9,6 @@
 #include "main/host/syscall/protected.h"
 
 // Handle the custom shadow-specific syscalls defined in syscall_numbers.h
-SYSCALL_HANDLER(shadow_get_shm_blk);
 SYSCALL_HANDLER(shadow_hostname_to_addr_ipv4);
 SYSCALL_HANDLER(shadow_init_memory_manager);
 SYSCALL_HANDLER(shadow_yield);

--- a/src/main/host/syscall_handler.c
+++ b/src/main/host/syscall_handler.c
@@ -420,7 +420,6 @@ SyscallReturn syscallhandler_make_syscall(SysCallHandler* sys, const SysCallArgs
             HANDLE_RUST(sched_getaffinity);
             HANDLE_RUST(sched_setaffinity);
             SHIM_ONLY(sched_yield);
-            HANDLE_C(shadow_get_shm_blk);
             HANDLE_C(shadow_hostname_to_addr_ipv4);
             HANDLE_C(shadow_init_memory_manager);
             HANDLE_C(shadow_yield);

--- a/src/main/host/syscall_numbers.h
+++ b/src/main/host/syscall_numbers.h
@@ -12,7 +12,7 @@ typedef enum {
     SYS_shadow_min = 1000,
     SYS_shadow_set_ptrace_allow_native_syscalls = 1000,
     // Deprecated: SYS_shadow_get_ipc_blk = 1001,
-    SYS_shadow_get_shm_blk = 1002,
+    // Deprecated: SYS_shadow_get_shm_blk = 1002,
     SYS_shadow_hostname_to_addr_ipv4 = 1003,
     SYS_shadow_init_memory_manager = 1004,
     // Conceptually similar to SYS_sched_yield, but made by the shim to return


### PR DESCRIPTION
We don't use this anymore, and it's one of the few remaining C references to the shmem allocator.