### PR TITLE
Updates to rust builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -169,6 +169,8 @@ ExternalProject_Add(
     INSTALL_COMMAND ""
     LOG_BUILD OFF
 )
+# build the shim after shadow (cargo already parallelizes the build)
+add_dependencies(rust-shadow-shim-project rust-workspace-project)
 add_library(shadow-shim SHARED IMPORTED GLOBAL)
 add_dependencies(shadow-shim rust-shadow-shim-project)
 set_target_properties(shadow-shim PROPERTIES IMPORTED_LOCATION_DEBUG ${TARGETDIR}/${RUST_TARGET}/debug/libshadow_shim.so)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,7 +59,8 @@ ExternalProject_Add(
     BUILD_ALWAYS 1
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND bash -c " \
+    BUILD_COMMAND echo "Building workspace..."
+    COMMAND bash -c " \
         ${CARGO_ENV_VARS} \
         cargo build \
         --workspace --exclude shadow-tests --exclude shadow-shim \
@@ -69,7 +70,10 @@ ExternalProject_Add(
         --target-dir \"${TARGETDIR}\" \
         --features \"${RUST_FEATURES}\" \
         "
-    # always build shadow-tests with the debug profile, even when shadow is built in release mode.
+    COMMAND echo "Building shadow-tests..."
+    # Always build shadow-tests with the debug profile, even when shadow is built in release mode.
+    # TODO: we should build tests without optimizations, which are automatically enabled for
+    # debug builds due to the 'opt-level' option in the workspace.
     # Omit RUST_FEATURES, since the shadow-tests package doesn't define any of the optional features
     # that we trigger via this wrapper.
     COMMAND bash -c " \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,10 +18,8 @@ foreach(DEFINITION IN LISTS COMPILE_DEFINITIONS)
   set(RUST_CXXFLAGS "${RUST_CXXFLAGS} -D${DEFINITION}")
 endforeach()
 
+# don't build unit tests since they'll have to be rebuilt when we run the 'rust-unit-tests' test anyways
 set(RUST_TARGETS "--lib --bins")
-if(SHADOW_TEST STREQUAL ON)
-  set(RUST_TARGETS "${RUST_TARGETS} --tests")
-endif()
 
 if(SHADOW_COVERAGE STREQUAL ON)
     # https://github.com/shadow/shadow/issues/1236


### PR DESCRIPTION
- build the shim after shadow

    When we run two 'cargo build's at the same time, the build output gets jumbled and things like 'cargo build --timings' don't work as intended. Cargo already parallelizes the builds, so we don't gain much from overcommitting the CPU.

- don't build unit tests twice

    The unit tests always need to be rebuilt when we run `cargo test` during our 'rust-unit-tests' test, so there's not much point in building them twice (once during `cargo build` and once during `cargo test`).

- update build comments

    We're supposed to be building integration tests without optimizations, but we're currently building them with optimizations. This just adds a TODO since our build script would need to be reorganized to support this.