### PR TITLE
simple_latch tests: increase test timing threshold

### DIFF
--- a/src/main/utility/synchronization/simple_latch.rs
+++ b/src/main/utility/synchronization/simple_latch.rs
@@ -202,7 +202,7 @@ mod tests {
 
         let wait_duration = t.join().unwrap();
 
-        let threshold = Duration::from_millis(20);
+        let threshold = Duration::from_millis(40);
         assert!(wait_duration > sleep_duration - threshold);
         assert!(wait_duration < sleep_duration + threshold);
     }


### PR DESCRIPTION
This test has been having occasional spurious failures under miri. e.g. https://github.com/shadow/shadow/actions/runs/5588856718/jobs/10216246666?pr=3077