### PR TITLE
Extra tests workflow: tweaks to sccache

### DIFF
--- a/.github/workflows/extra_tests.yml
+++ b/.github/workflows/extra_tests.yml
@@ -53,6 +53,8 @@ jobs:
           # See https://github.com/shadow/shadow/issues/2166
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+      - name: Set Rust toolchain
+        run: ln -s shadow/ci/rust-toolchain-stable.toml rust-toolchain.toml
       - name: Install dependencies
         run: |
           cd shadow

--- a/.github/workflows/extra_tests.yml
+++ b/.github/workflows/extra_tests.yml
@@ -92,7 +92,7 @@ jobs:
           apt-get install -y curl
           SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
           mkdir -p $HOME/.local/bin
-          curl -L "$LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          curl -v -L "$LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
           mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
           chmod +x $HOME/.local/bin/sccache
           echo "$HOME/.local/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Fetch of sccache release was failing: https://support.github.com/ticket/personal/0/2258460

Was going to disable it in this PR, but it looks like the issue has been resolved. Still worth merging the other couple small tweaks I made to the related code though, I think.