### PR TITLE
Rm shutdown helper

### DIFF
--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -270,14 +270,6 @@ void legacyfile_removeFlags(LegacyFile* descriptor, gint flags) {
     descriptor->flags &= ~flags;
 }
 
-void legacyfile_shutdownHelper(LegacyFile* legacyDesc) {
-    MAGIC_ASSERT(legacyDesc);
-
-    if (legacyDesc->type == DT_EPOLL) {
-        epoll_clearWatchListeners((Epoll*)legacyDesc);
-    }
-}
-
 bool legacyfile_supportsSaRestart(LegacyFile* legacyDesc) {
     switch (legacyDesc->type) {
         case DT_TCPSOCKET:

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -74,16 +74,6 @@ void legacyfile_addListener(LegacyFile* descriptor, StatusListener* listener);
  * transitions (bit flips). */
 void legacyfile_removeListener(LegacyFile* descriptor, StatusListener* listener);
 
-/* This is a helper function that handles some corner cases where some
- * descriptors are linked to each other and we must remove that link in
- * order to ensure that the reference count reaches zero and they are properly
- * freed. Otherwise the circular reference will prevent the free operation.
- * TODO: remove this once the TCP layer is better designed.
- *
- * Intended to be called only from descriptor_table.rs.
- */
-void legacyfile_shutdownHelper(LegacyFile* legacyDesc);
-
 /* Whether the descriptor's operations are restartable in conjunction with
  * SA_RESTART. See signal(7).
  */

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -2,8 +2,7 @@ use std::collections::{BTreeSet, HashMap};
 
 use log::*;
 
-use crate::cshadow as c;
-use crate::host::descriptor::{CompatFile, Descriptor};
+use crate::host::descriptor::Descriptor;
 
 /// POSIX requires fds to be assigned as `libc::c_int`, so we can't allow any fds larger than this.
 pub const FD_MAX: u32 = i32::MAX as u32;
@@ -176,20 +175,6 @@ impl DescriptorTable {
         self.available_indices.insert(fd.val());
         self.trim_tail();
         maybe_descriptor
-    }
-
-    /// This is a helper function that handles some corner cases where some
-    /// descriptors are linked to each other and we must remove that link in
-    /// order to ensure that the reference count reaches zero and they are properly
-    /// freed. Otherwise the circular reference will prevent the free operation.
-    /// TODO: remove this once the TCP layer is better designed.
-    pub fn shutdown_helper(&mut self) {
-        for descriptor in self.descriptors.values() {
-            match descriptor.file() {
-                CompatFile::New(_) => continue,
-                CompatFile::Legacy(f) => unsafe { c::legacyfile_shutdownHelper(f.ptr()) },
-            };
-        }
     }
 
     /// Remove and return all descriptors.

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -213,6 +213,7 @@ static EpollWatch* _epollwatch_new(Epoll* epoll, int fd, EpollWatchTypes type,
     watch->listener = statuslistener_new(
         (StatusCallbackFunc)_epoll_fileStatusChanged, epoll, NULL, key, g_free, host);
 
+    worker_count_allocation(EpollWatch);
     return watch;
 }
 
@@ -229,6 +230,7 @@ static void _epollwatch_free(EpollWatch* watch) {
 
     statuslistener_unref(watch->listener);
 
+    worker_count_deallocation(EpollWatch);
     MAGIC_CLEAR(watch);
     g_free(watch);
 }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1168,7 +1168,6 @@ impl Process {
 
         {
             let mut descriptor_table = runnable.desc_table.borrow_mut();
-            descriptor_table.shutdown_helper();
             let descriptors = descriptor_table.remove_all();
             crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
                 CallbackQueue::queue_and_run(|cb_queue| {


### PR DESCRIPTION
Add reference counts for `EpollWatch` and `Descriptor`, and remove `DescriptorTable::shutdown_helper`.

Calling `DescriptorTable::shutdown_helper`, which unregisters all epoll descriptors' listeners, would be incorrect if there are still open descriptors to the same epoll file description (e.g. in a forked process).