### PR TITLE
Fix shell scripts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,20 @@ jobs:
       - run: pip install flake8
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude src/external
 
+  lint-shell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          # Run on PR head instead of merge result. Running on the merge
+          # result can give confusing results, and we require PR to be up to
+          # date with target branch before merging, anyway.
+          # See https://github.com/shadow/shadow/issues/2166
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: sudo apt-get install shellcheck
+      - run: find . -name '*.sh' | xargs shellcheck
+
   lint-rust:
     runs-on: ubuntu-latest
     steps:

--- a/ci/container_scripts/build_and_install.sh
+++ b/ci/container_scripts/build_and_install.sh
@@ -20,13 +20,13 @@ esac
 
 case "$BUILDTYPE" in
     "release")
-        OPTIONS=""
+        OPTIONS=()
         ;;
     "debug")
-        OPTIONS="--debug"
+        OPTIONS=(--debug)
         ;;
     "coverage")
-        OPTIONS="--debug --coverage"
+        OPTIONS=(--debug --coverage)
         ;;
     *)
         echo "Unknown BUILDTYPE $BUILDTYPE"
@@ -34,7 +34,5 @@ case "$BUILDTYPE" in
         ;;
 esac
 
-# We *want* word splitting
-# shellcheck disable=2086
-./setup build -j4 --test --extra --werror $OPTIONS
+./setup build -j4 --test --extra --werror "${OPTIONS[@]}"
 ./setup install

--- a/ci/container_scripts/build_and_install.sh
+++ b/ci/container_scripts/build_and_install.sh
@@ -34,5 +34,7 @@ case "$BUILDTYPE" in
         ;;
 esac
 
+# We *want* word splitting
+# shellcheck disable=2086
 ./setup build -j4 --test --extra --werror $OPTIONS
 ./setup install

--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-APT_PACKAGES="
+APT_PACKAGES=(
   cmake
   findutils
   golang-go
@@ -17,36 +17,30 @@ APT_PACKAGES="
   python3-pip
   xz-utils
   util-linux
-  "
+  )
 
 case "$CONTAINER" in
   # We need to force a newer-than-default version of libclang
   # on some platforms. Some older versions have trouble finding
   # compiler header files in bindgen, when compiling with gcc.
   ubuntu:18*)
-    APT_PACKAGES+="
-      libclang-9-dev
-    "
+    APT_PACKAGES+=(libclang-9-dev)
     ;;
   debian:10*)
-    APT_PACKAGES+="
-      libclang-13-dev
-    "
+    APT_PACKAGES+=(libclang-13-dev)
     ;;
   *)
-    APT_PACKAGES+="
-      libclang-dev
-    "
+    APT_PACKAGES+=(libclang-dev)
     ;;
 esac
 
 # packages that are only required for our CI environment
-APT_CI_PACKAGES="
+APT_CI_PACKAGES=(
   curl
   rsync
-  "
+  )
 
-RPM_PACKAGES="
+RPM_PACKAGES=(
   clang-devel
   cmake
   findutils
@@ -63,26 +57,24 @@ RPM_PACKAGES="
   diffutils
   util-linux
   glibc-static
-  "
+  )
 
 # packages that are only required for our CI environment
-RPM_CI_PACKAGES="
+RPM_CI_PACKAGES=(
   curl
   rsync
-  "
+  )
 
-PYTHON_PACKAGES="
+PYTHON_PACKAGES=(
   PyYaml
-  networkx>=2.5
-  "
+  "networkx>=2.5"
+  )
 
 case "$CONTAINER" in
     ubuntu:*|debian:*)
         sed -i '/deb-src/s/^# //' /etc/apt/sources.list
         DEBIAN_FRONTEND=noninteractive apt-get update
-        # We *want* word splitting
-        # shellcheck disable=2086
-        DEBIAN_FRONTEND=noninteractive apt-get install -y $APT_PACKAGES $APT_CI_PACKAGES
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -- "${APT_PACKAGES[@]}" "${APT_CI_PACKAGES[@]}"
 
         # Handle dict ordering of src/tools/convert.py and allow diff on its tests
         # Before Python3.6, dict ordering was not predictable
@@ -96,9 +88,7 @@ case "$CONTAINER" in
         fi
         ;;
     fedora:*)
-        # We *want* word splitting
-        # shellcheck disable=2086
-        dnf install --best -y $RPM_PACKAGES $RPM_CI_PACKAGES
+        dnf install --best -y -- "${RPM_PACKAGES[@]}" "${RPM_CI_PACKAGES[@]}"
         ;;
     *)
         echo "Unhandled container $CONTAINER"
@@ -107,6 +97,4 @@ case "$CONTAINER" in
 esac
 
 
-# We *want* word splitting
-# shellcheck disable=2086
-python3 -m pip install $PYTHON_PACKAGES
+python3 -m pip install -- "${PYTHON_PACKAGES[@]}"

--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -80,6 +80,8 @@ case "$CONTAINER" in
     ubuntu:*|debian:*)
         sed -i '/deb-src/s/^# //' /etc/apt/sources.list
         DEBIAN_FRONTEND=noninteractive apt-get update
+        # We *want* word splitting
+        # shellcheck disable=2086
         DEBIAN_FRONTEND=noninteractive apt-get install -y $APT_PACKAGES $APT_CI_PACKAGES
 
         # Handle dict ordering of src/tools/convert.py and allow diff on its tests
@@ -94,6 +96,8 @@ case "$CONTAINER" in
         fi
         ;;
     fedora:*)
+        # We *want* word splitting
+        # shellcheck disable=2086
         dnf install --best -y $RPM_PACKAGES $RPM_CI_PACKAGES
         ;;
     *)
@@ -103,4 +107,6 @@ case "$CONTAINER" in
 esac
 
 
+# We *want* word splitting
+# shellcheck disable=2086
 python3 -m pip install $PYTHON_PACKAGES

--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -86,7 +86,7 @@ case "$CONTAINER" in
 
         # Handle dict ordering of src/tools/convert.py and allow diff on its tests
         # Before Python3.6, dict ordering was not predictable
-        if [[ `python3 --version` == *" 3.5"* ]]; then
+        if [[ $(python3 --version) == *" 3.5"* ]]; then
           apt-get install -y software-properties-common
           add-apt-repository -y ppa:deadsnakes/ppa
           apt-get update

--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -57,6 +57,8 @@ case "$CC" in
 esac
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain none --profile minimal
+# We don't need shellcheck to validate this file.
+# shellcheck disable=1091
 source "$HOME/.cargo/env"
 
 # Pin the Rust toolchain to either our pinned nightly or stable version.

--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -8,10 +8,10 @@ set -euo pipefail
 install_packages () {
     case "$CONTAINER" in
         ubuntu:*|debian:*)
-            DEBIAN_FRONTEND=noninteractive apt-get install -y $@
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -- "$@"
             ;;
         fedora:*)
-            dnf install --best -y $@
+            dnf install --best -y "$@"
             ;;
         *)
             echo "Unhandled container $CONTAINER"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -71,7 +71,7 @@ run_one () {
     TAG="$REPO:$CONTAINER_FOR_TAG-$CC-$BUILDTYPE"
 
     if [ "${DRYTAG}" == "1" ]; then
-        echo $TAG
+        echo "$TAG"
         return 0
     fi
 
@@ -145,7 +145,7 @@ EOF
     # them here allows tests to pass in cases where new system dependencies have
     # been added without having to rebuild the base images. In the common case
     # where nothing new is installed they are usually fairly fast no-ops.
-    CONTAINER_ID="$(docker create ${DOCKER_CREATE_FLAGS[@]} ${TAG} /bin/bash -c \
+    CONTAINER_ID=$(docker create ${DOCKER_CREATE_FLAGS[@]} "${TAG}" /bin/bash -c \
         "echo '' \
          && echo 'Changes (see https://stackoverflow.com/a/36851784 for details):' \
          && rsync --delete --exclude-from=.dockerignore --itemize-changes -c -rlpgoD --no-owner --no-group /mnt/shadow/ . \
@@ -153,7 +153,7 @@ EOF
          && ci/container_scripts/install_deps.sh \
          && ci/container_scripts/install_extra_deps.sh \
          && ci/container_scripts/build_and_install.sh \
-         && ci/container_scripts/test.sh")"
+         && ci/container_scripts/test.sh")
 
     # Start the container (build, install, and test)
     RV=0

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -10,7 +10,7 @@ PUSH=0
 NOCACHE=
 REPO=shadowsim/shadow-ci
 
-CONTAINER=ubuntu:18.04
+CONTAINER=ubuntu:20.04
 CC=gcc
 BUILDTYPE=debug
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -145,7 +145,7 @@ EOF
     # them here allows tests to pass in cases where new system dependencies have
     # been added without having to rebuild the base images. In the common case
     # where nothing new is installed they are usually fairly fast no-ops.
-    CONTAINER_ID=$(docker create ${DOCKER_CREATE_FLAGS[@]} "${TAG}" /bin/bash -c \
+    CONTAINER_ID=$(docker create "${DOCKER_CREATE_FLAGS[@]}" "${TAG}" /bin/bash -c \
         "echo '' \
          && echo 'Changes (see https://stackoverflow.com/a/36851784 for details):' \
          && rsync --delete --exclude-from=.dockerignore --itemize-changes -c -rlpgoD --no-owner --no-group /mnt/shadow/ . \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -98,14 +98,14 @@ run_one () {
         COPY ci/container_scripts/install_extra_deps.sh /root/install_extra_deps.sh
         # Set the default rust toolchain to be installed by the script.
         #
-        # Copying just this config file before we copy the whole shadow source
+        # Copying just these config files before we copy the whole shadow source
         # allows us to reuse this image layer when iterating locally,
         # saving us from necessarily reinstalling the rust toolchain.
         #
         # In an incremental build with an updated rust-toolchain.toml, the
         # specified rust version will still correctly be installed and used
         # at run-time.
-        COPY rust-toolchain.toml /
+        COPY ci/rust-toolchain-*.toml ci/
         RUN /root/install_extra_deps.sh
         ENV PATH /root/.cargo/bin:\$PATH
 

--- a/src/test/legacy/run_plugin_test.sh
+++ b/src/test/legacy/run_plugin_test.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
-gcc `pkg-config --cflags --libs glib-2.0` -I/home/rob/.shadow/include -shared -Wl,-soname,testplugin.so -fPIC -o testplugin.so shd-test-plugin.c
+# We *want* word splitting
+# shellcheck disable=SC2046
+gcc $(pkg-config --cflags --libs glib-2.0) -I/home/rob/.shadow/include -shared -Wl,-soname,testplugin.so -fPIC -o testplugin.so shd-test-plugin.c
 cp testplugin.so /tmp/testplugin1.so
 cp testplugin.so /tmp/testplugin2.so
 cp testplugin.so /tmp/testplugin3.so
 cp testplugin.so /tmp/testplugin4.so
-gcc `pkg-config --cflags --libs glib-2.0 gthread-2.0 gmodule-2.0` -ldl shd-test-module.c -o shd-test-module
+# We *want* word splitting
+# shellcheck disable=SC2046
+gcc $(pkg-config --cflags --libs glib-2.0 gthread-2.0 gmodule-2.0) -ldl shd-test-module.c -o shd-test-module
 ./shd-test-module
 rm /tmp/testplugin*

--- a/src/test/tgen/fixed_duration/verify.sh
+++ b/src/test/tgen/fixed_duration/verify.sh
@@ -26,8 +26,8 @@ client_Bps_read="$(grep -r --include="tgen.*.stdout" "driver-heartbeat" ./hosts/
     | sort -n \
     | tail -1)"
 
-printf "Server bytes per second=${server_Bps_read}\n"
-printf "Client bytes per second=${client_Bps_read}\n"
+echo "Server bytes per second=${server_Bps_read}"
+echo "Client bytes per second=${client_Bps_read}"
 
 # Test passes if tgen application achieves >= 85% of configured speed, allowing
 # for TCP overhead. We use a 89% threshold since it's the highest that allowed
@@ -47,15 +47,15 @@ elif [[ "${network}" == "100mbit"* ]]; then
 elif [[ "${network}" == "1gbit"* ]]; then
     expected=106250000
 else
-    printf "Verification ${RED}failed${NC}: unable to determine expected connection speed\n"
+    printf "Verification %bfailed%b: unable to determine expected connection speed\n" "$RED" "$NC"
     exit 1
 fi
 
 result="${network} net expected ${expected} got client=${client_Bps_read} server=${server_Bps_read}"
 if [[ ${client_Bps_read} < ${expected} || ${server_Bps_read} < ${expected} ]]; then
-    printf "Verification ${RED}failed${NC}: ${result}\n"
+    printf "Verification %bfailed%b: ${result}\n" "$RED" "$NC"
     exit 1
 else
-    printf "Verification ${GREEN}succeeded${NC}: ${result}; Yay :)\n"
+    printf "Verification %bsucceeded%b: ${result}; Yay :)\n" "$GREEN" "$NC"
     exit 0
 fi

--- a/src/test/tgen/fixed_duration/verify.sh
+++ b/src/test/tgen/fixed_duration/verify.sh
@@ -4,9 +4,9 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
-printf "TGen configuration: network=$1 client=$2\n"
 network=$1
 client=$2
+echo "TGen configuration: network=$network client=$client"
 
 # read speed of server is the effective write speed of client
 # read speed of client is the effective write speed of server

--- a/src/test/tgen/fixed_size/verify.sh
+++ b/src/test/tgen/fixed_size/verify.sh
@@ -4,9 +4,9 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
-printf "TGen configuration: network=$1 client=$2\n"
 network=$1
 client=$2
+echo "TGen configuration: network=$network client=$client"
 
 # make sure all of the fixed-size transfers were successful
 expected_count="$(echo ${client} | cut -d'_' -f3 | cut -d'x' -f1)"

--- a/src/test/tgen/fixed_size/verify.sh
+++ b/src/test/tgen/fixed_size/verify.sh
@@ -12,11 +12,11 @@ client=$2
 expected_count="$(echo ${client} | cut -d'_' -f3 | cut -d'x' -f1)"
 actual_count="$(grep -r --include="tgen.*.stdout" "stream-success" ./hosts/client/ | wc -l)"
 
-printf "Successful tgen stream count: ${actual_count}/${expected_count}\n"
+echo "Successful tgen stream count: ${actual_count}/${expected_count}"
 
 if [[ "${actual_count}" != "${expected_count}" ]]; then
-    printf "Verification ${RED}failed${NC}: Not all tgen streams were successful :(\n"
+    printf "Verification %bfailed%b: Not all tgen streams were successful :(\n" "$RED" "$NC"
     exit 1
 fi
 
-printf "Verification ${GREEN}succeeded${NC}: Yay :)\n"
+printf "Verification %bsucceeded%b: Yay :)\n" "$GREEN" "$NC"

--- a/src/test/tgen/fixed_size/verify.sh
+++ b/src/test/tgen/fixed_size/verify.sh
@@ -9,8 +9,8 @@ client=$2
 echo "TGen configuration: network=$network client=$client"
 
 # make sure all of the fixed-size transfers were successful
-expected_count="$(echo ${client} | cut -d'_' -f3 | cut -d'x' -f1)"
-actual_count="$(grep -r --include="tgen.*.stdout" "stream-success" ./hosts/client/ | wc -l)"
+expected_count=$(echo "${client}" | cut -d'_' -f3 | cut -d'x' -f1)
+actual_count=$(grep -r --include="tgen.*.stdout" "stream-success" ./hosts/client/ | wc -l)
 
 echo "Successful tgen stream count: ${actual_count}/${expected_count}"
 

--- a/src/test/tor/minimal/run.sh
+++ b/src/test/tor/minimal/run.sh
@@ -1,2 +1,4 @@
+#!/usr/bin/env bash
+
 # Run the Tor minimal test and store output in shadow.log
 shadow --template-directory shadow.data.template tor-minimal.yaml > shadow.log

--- a/src/test/tor/minimal/verify.sh
+++ b/src/test/tor/minimal/verify.sh
@@ -38,6 +38,6 @@ check_host fileserver 30 30
 # Only require half of the streams to succeed, to mitigate
 # https://github.com/shadow/shadow/issues/2544
 check_host torhiddenclient 5 10
-check_host torhiddenserver 5 10
+check_host hiddenserver 5 10
 
 printf "Verification ${GREEN}succeeded${NC}: Yay :)\n"

--- a/src/test/tor/minimal/verify.sh
+++ b/src/test/tor/minimal/verify.sh
@@ -8,9 +8,9 @@ NC='\033[0m' # No Color
 
 EXPECTED_BOOTSTRAP_COUNT=11
 bootstrapped_count="$(grep -r --include="tor.*.stdout" "Bootstrapped 100" | wc -l)"
-printf "Bootstrapped count: ${bootstrapped_count}/$EXPECTED_BOOTSTRAP_COUNT\n"
+echo "Bootstrapped count: ${bootstrapped_count}/$EXPECTED_BOOTSTRAP_COUNT"
 if [ "${bootstrapped_count}" != "$EXPECTED_BOOTSTRAP_COUNT" ]; then
-    printf "Verification ${RED}failed${NC}: Not all tor processes bootstrapped :(\n"
+    printf "Verification %bfailed%b: Not all tor processes bootstrapped :(\n" "$RED" "$NC"
     exit 1
 fi
 
@@ -25,7 +25,7 @@ check_host () {
     stream_count=$(grep -c stream-success hosts/$NAME/tgen.*.stdout)
     printf "Successful $NAME stream count: ${stream_count}/$TOTAL_STREAMS (minimum $MINIMUM_STREAMS)\n"
     if [ "${stream_count}" -lt "$MINIMUM_STREAMS" ]; then
-        printf "Verification ${RED}failed${NC}: Not enough $NAME streams were successful :(\n"
+        printf "Verification %bfailed%b: Not enough $NAME streams were successful :(\n" "$RED" "$NC"
         exit 1
     fi
 }
@@ -40,4 +40,4 @@ check_host fileserver 30 30
 check_host torhiddenclient 5 10
 check_host hiddenserver 5 10
 
-printf "Verification ${GREEN}succeeded${NC}: Yay :)\n"
+printf "Verification %bsucceeded%b: Yay :)\n" "$GREEN" "$NC"

--- a/src/test/tor/minimal/verify.sh
+++ b/src/test/tor/minimal/verify.sh
@@ -18,7 +18,11 @@ check_host () {
     local NAME=$1
     local MINIMUM_STREAMS=$2
     local TOTAL_STREAMS=$3
-    local stream_count=$(grep -c stream-success hosts/$NAME/tgen.*.stdout)
+    # Careful to declare the local separately from assigning the value;
+    # otherwise we miss errors from `grep` such as if the files don't exist.
+    # https://unix.stackexchange.com/a/343259
+    local stream_count
+    stream_count=$(grep -c stream-success hosts/$NAME/tgen.*.stdout)
     printf "Successful $NAME stream count: ${stream_count}/$TOTAL_STREAMS (minimum $MINIMUM_STREAMS)\n"
     if [ "${stream_count}" -lt "$MINIMUM_STREAMS" ]; then
         printf "Verification ${RED}failed${NC}: Not enough $NAME streams were successful :(\n"

--- a/src/test/tor/minimal/verify.sh
+++ b/src/test/tor/minimal/verify.sh
@@ -21,10 +21,10 @@ check_host () {
     # Careful to declare the local separately from assigning the value;
     # otherwise we miss errors from `grep` such as if the files don't exist.
     # https://unix.stackexchange.com/a/343259
-    local stream_count
-    stream_count=$(grep -c stream-success hosts/"$NAME"/tgen.*.stdout)
-    echo "Successful $NAME stream count: ${stream_count}/$TOTAL_STREAMS (minimum $MINIMUM_STREAMS)"
-    if [ "${stream_count}" -lt "$MINIMUM_STREAMS" ]; then
+    local stream_success_count
+    stream_success_count=$(grep -c stream-success hosts/"$NAME"/tgen.*.stdout)
+    echo "Successful $NAME stream count: ${stream_success_count}/$TOTAL_STREAMS (minimum $MINIMUM_STREAMS)"
+    if [ "${stream_success_count}" -lt "$MINIMUM_STREAMS" ]; then
         printf "Verification %bfailed%b: Not enough $NAME streams were successful :(\n" "$RED" "$NC"
         exit 1
     fi

--- a/src/test/tor/minimal/verify.sh
+++ b/src/test/tor/minimal/verify.sh
@@ -22,8 +22,8 @@ check_host () {
     # otherwise we miss errors from `grep` such as if the files don't exist.
     # https://unix.stackexchange.com/a/343259
     local stream_count
-    stream_count=$(grep -c stream-success hosts/$NAME/tgen.*.stdout)
-    printf "Successful $NAME stream count: ${stream_count}/$TOTAL_STREAMS (minimum $MINIMUM_STREAMS)\n"
+    stream_count=$(grep -c stream-success hosts/"$NAME"/tgen.*.stdout)
+    echo "Successful $NAME stream count: ${stream_count}/$TOTAL_STREAMS (minimum $MINIMUM_STREAMS)"
     if [ "${stream_count}" -lt "$MINIMUM_STREAMS" ]; then
         printf "Verification %bfailed%b: Not enough $NAME streams were successful :(\n" "$RED" "$NC"
         exit 1


### PR DESCRIPTION
We had a subtle issue in our tor minimal test validation script causing it to ignore some errors.

trinity @ Tor pointed out that shellcheck would've caught it. Tor uses shellcheck in their CI in general.

So I also added a shellcheck lint to our CI and fixed various warnings. I don't think any of these were currently causing issues, but they could potentially have caused issues in the future (e.g. if an unquoted variable value later ended up having spaces in it).

I locally tested `ci/run.sh` since some of the related scripts were being modified. It turns out there were some issues with the rust toolchain files from a previous commit, so I also fixed those.