### PR TITLE
Remove `updatePacketHeader` function

### DIFF
--- a/src/main/host/descriptor/compat_socket.c
+++ b/src/main/host/descriptor/compat_socket.c
@@ -174,23 +174,3 @@ Packet* compatsocket_pullOutPacket(const CompatSocket* socket, const Host* host)
 
     utility_panic("Invalid CompatSocket type");
 }
-
-void compatsocket_updatePacketHeader(const CompatSocket* socket, const Host* host, Packet* packet) {
-    switch (socket->type) {
-        case CST_LEGACY_SOCKET: {
-            LegacySocket* legacySocket = socket->object.as_legacy_socket;
-
-            if (legacysocket_getProtocol(legacySocket) == PTCP) {
-                TCP* tcp = (TCP*)legacySocket;
-                tcp_networkInterfaceIsAboutToSendPacket(tcp, host, packet);
-            }
-
-            return;
-        }
-        case CST_INET_SOCKET:
-            return inetsocket_updatePacketHeader(socket->object.as_inet_socket, packet);
-        case CST_NONE: utility_panic("Unexpected CompatSocket type");
-    }
-
-    utility_panic("Invalid CompatSocket type");
-}

--- a/src/main/host/descriptor/compat_socket.h
+++ b/src/main/host/descriptor/compat_socket.h
@@ -50,6 +50,5 @@ bool compatsocket_hasDataToSend(const CompatSocket* socket);
 void compatsocket_pushInPacket(const CompatSocket* socket, const Host* host, Packet* packet,
                                CEmulatedTime recvTime);
 Packet* compatsocket_pullOutPacket(const CompatSocket* socket, const Host* host);
-void compatsocket_updatePacketHeader(const CompatSocket* socket, const Host* host, Packet* packet);
 
 #endif /* SRC_MAIN_HOST_DESCRIPTOR_COMPAT_SOCKET_H_ */

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -155,6 +155,11 @@ impl LegacyTcpSocket {
             return None;
         }
 
+        Worker::with_active_host(|host| unsafe {
+            c::tcp_networkInterfaceIsAboutToSendPacket(self.as_legacy_tcp(), host, packet);
+        })
+        .unwrap();
+
         Some(PacketRc::from_raw(packet))
     }
 
@@ -176,17 +181,6 @@ impl LegacyTcpSocket {
 
     pub fn has_data_to_send(&self) -> bool {
         self.peek_packet().is_some()
-    }
-
-    pub fn update_packet_header(&self, packet: &mut PacketRc) {
-        Worker::with_active_host(|host| unsafe {
-            c::tcp_networkInterfaceIsAboutToSendPacket(
-                self.as_legacy_tcp(),
-                host,
-                packet.borrow_inner(),
-            );
-        })
-        .unwrap();
     }
 
     pub fn getsockname(&self) -> Result<Option<SockaddrIn>, SyscallError> {

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -237,9 +237,6 @@ impl InetSocketRef<'_> {
     enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn has_data_to_send(&self) -> bool
     );
-    enum_passthrough!(self, (packet), LegacyTcp, Udp;
-        pub fn update_packet_header(&self, packet: &mut PacketRc)
-    );
 }
 
 // file functions
@@ -344,9 +341,6 @@ impl InetSocketRefMut<'_> {
     );
     enum_passthrough!(self, (), LegacyTcp, Udp;
         pub fn has_data_to_send(&self) -> bool
-    );
-    enum_passthrough!(self, (packet), LegacyTcp, Udp;
-        pub fn update_packet_header(&self, packet: &mut PacketRc)
     );
 }
 
@@ -548,17 +542,6 @@ mod export {
     pub extern "C" fn inetsocket_hasDataToSend(socket: *const InetSocket) -> bool {
         let socket = unsafe { socket.as_ref() }.unwrap();
         socket.borrow().has_data_to_send()
-    }
-
-    #[no_mangle]
-    pub extern "C" fn inetsocket_updatePacketHeader(
-        socket: *const InetSocket,
-        packet: *mut c::Packet,
-    ) {
-        let socket = unsafe { socket.as_ref() }.unwrap();
-        let mut packet = PacketRc::from_raw(packet);
-        socket.borrow().update_packet_header(&mut packet);
-        packet.into_inner();
     }
 
     /// Get a legacy C [`TCP`](c::TCP) pointer for the socket. Will panic if `socket` is not a

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -199,10 +199,6 @@ impl UdpSocket {
         !self.send_buffer.is_empty()
     }
 
-    pub fn update_packet_header(&self, _packet: &mut PacketRc) {
-        // do nothing for UDP
-    }
-
     pub fn getsockname(&self) -> Result<Option<SockaddrIn>, SyscallError> {
         let mut addr = self
             .bound_addr

--- a/src/main/host/network/network_interface.c
+++ b/src/main/host/network/network_interface.c
@@ -256,8 +256,6 @@ static Packet* _networkinterface_selectRoundRobin(NetworkInterface* interface, c
         /* we're returning the socket, so we must ref it */
         *socketOut = compatsocket_refAs(&socket);
 
-        compatsocket_updatePacketHeader(&socket, host, packet);
-
         if (compatsocket_hasDataToSend(&socket)) {
             /* socket has more packets, and is still reffed from before */
             rrsocketqueue_push(&interface->rrQueue, &socket);
@@ -298,8 +296,6 @@ static Packet* _networkinterface_selectFirstInFirstOut(NetworkInterface* interfa
 
         /* we're returning the socket, so we must ref it */
         *socketOut = compatsocket_refAs(&socket);
-
-        compatsocket_updatePacketHeader(&socket, host, packet);
 
         if (compatsocket_hasDataToSend(&socket)) {
             /* socket has more packets, and is still reffed from before */


### PR DESCRIPTION
@robgjansen You had mentioned a long time ago why this `updatePacketHeader` function existed, but I can't remember anymore and I can't find an issue for it. Regardless, I don't think it's needed anymore as its own separate function since it's currently only called immediately after a `pullOutPacket()` and we can just merge them into a single operation (just `pullOutPacket`).

Since this is only relevant to the C TCP sockets, `tcp_networkInterfaceIsAboutToSendPacket` is now called from `LegacyTcpSocket::pull_out_packet`.

(This was added in 840234d0a3a92292.)