### PR TITLE
Log errors to stderr in addition to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ MAJOR changes (breaking):
 
 MINOR changes (backwards-compatible):
 
-* `ERROR`-level log lines are now logged to `stderr` in addition to `stdout`. This helps
-make errors more visible in the common case that `stdout` is redirected to a log file.
-This can currently be disabled via the (unstable) option `log-errors-to-stderr`.
+* `ERROR`-level log lines are now logged to `stderr` in addition to `stdout` if `stdout`
+is not a tty but `stderr` is. This helps make errors more visible in the common
+case that `stdout` is redirected to a log file but `stderr` is not. This can
+currently be disabled via the (unstable) option `log-errors-to-tty`.
 
 PATCH changes (bugfixes):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ MAJOR changes (breaking):
 
 MINOR changes (backwards-compatible):
 
-*
+* `ERROR`-level log lines are now logged to `stderr` in addition to `stdout`. This helps
+make errors more visible in the common case that `stdout` is redirected to a log file.
+This can currently be disabled via the (unstable) option `log-errors-to-stderr`.
 
 PATCH changes (bugfixes):
 

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -531,12 +531,13 @@ if not using the thread-per-core scheduler.
 
 This may improve runtime performance in some environments.
 
-#### `experimental.log_errors_to_stderr`
+#### `experimental.log_errors_to_tty`
 
 Default: true  
 Type: Bool
 
-Log `Error`-level log lines to shadow's `stderr` in addition to `stdout`.
+Log `Error`-level log lines to shadow's `stderr` in addition to `stdout`, if
+`stdout` is not a tty but `stderr` is.
 
 #### `host_option_defaults`
 

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -96,6 +96,7 @@ hosts:
 - [`experimental.use_sched_fifo`](#experimentaluse_sched_fifo)
 - [`experimental.use_syscall_counters`](#experimentaluse_syscall_counters)
 - [`experimental.use_worker_spinning`](#experimentaluse_worker_spinning)
+- [`experimental.log_errors_to_stderr`](#experimentallog_errors_to_stderr)
 - [`host_option_defaults`](#host_option_defaults)
 - [`host_option_defaults.log_level`](#host_option_defaultslog_level)
 - [`host_option_defaults.pcap_capture_size`](#host_option_defaultspcap_capture_size)
@@ -529,6 +530,13 @@ Each worker thread will spin in a `sched_yield` loop while waiting for a new tas
 if not using the thread-per-core scheduler.
 
 This may improve runtime performance in some environments.
+
+#### `experimental.log_errors_to_stderr`
+
+Default: true  
+Type: Bool
+
+Log `Error`-level log lines to shadow's `stderr` in addition to `stdout`.
 
 #### `host_option_defaults`
 

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 use std::ffi::{CStr, OsStr};
+use std::os::fd::AsRawFd;
 use std::os::unix::ffi::OsStrExt;
 use std::thread;
 
@@ -141,11 +142,10 @@ pub fn run_shadow(build_info: &ShadowBuildInfo, args: Vec<&OsStr>) -> anyhow::Re
     let log_level: log::Level = log_level.into();
 
     // start up the logging subsystem to handle all future messages
-    shadow_logger::init(
-        log_level.to_level_filter(),
-        shadow_config.experimental.log_errors_to_stderr.unwrap(),
-    )
-    .unwrap();
+    let log_errors_to_stderr = shadow_config.experimental.log_errors_to_tty.unwrap()
+        && !nix::unistd::isatty(std::io::stdout().as_raw_fd()).unwrap()
+        && nix::unistd::isatty(std::io::stderr().as_raw_fd()).unwrap();
+    shadow_logger::init(log_level.to_level_filter(), log_errors_to_stderr).unwrap();
 
     // disable log buffering during startup so that we see every message immediately in the terminal
     shadow_logger::set_buffering_enabled(false);

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -141,7 +141,11 @@ pub fn run_shadow(build_info: &ShadowBuildInfo, args: Vec<&OsStr>) -> anyhow::Re
     let log_level: log::Level = log_level.into();
 
     // start up the logging subsystem to handle all future messages
-    shadow_logger::init(log_level.to_level_filter()).unwrap();
+    shadow_logger::init(
+        log_level.to_level_filter(),
+        shadow_config.experimental.log_errors_to_stderr.unwrap(),
+    )
+    .unwrap();
 
     // disable log buffering during startup so that we see every message immediately in the terminal
     shadow_logger::set_buffering_enabled(false);

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -453,6 +453,12 @@ pub struct ExperimentalOptions {
     #[clap(long, value_name = "name")]
     #[clap(help = EXP_HELP.get("scheduler").unwrap().as_str())]
     pub scheduler: Option<Scheduler>,
+
+    /// When true, log error-level log messages to stderr in addition to stdout.
+    #[clap(hide_short_help = true)]
+    #[clap(long, value_name = "bool")]
+    #[clap(help = EXP_HELP.get("log_errors_to_stderr").unwrap().as_str())]
+    pub log_errors_to_stderr: Option<bool>,
 }
 
 impl ExperimentalOptions {
@@ -501,6 +507,7 @@ impl Default for ExperimentalOptions {
             ))),
             strace_logging_mode: Some(StraceLoggingMode::Off),
             scheduler: Some(Scheduler::ThreadPerCore),
+            log_errors_to_stderr: Some(true),
         }
     }
 }

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -454,11 +454,12 @@ pub struct ExperimentalOptions {
     #[clap(help = EXP_HELP.get("scheduler").unwrap().as_str())]
     pub scheduler: Option<Scheduler>,
 
-    /// When true, log error-level log messages to stderr in addition to stdout.
+    /// When true, log error-level messages to stderr in addition to stdout when
+    /// stdout is not a tty but stderr is.
     #[clap(hide_short_help = true)]
     #[clap(long, value_name = "bool")]
-    #[clap(help = EXP_HELP.get("log_errors_to_stderr").unwrap().as_str())]
-    pub log_errors_to_stderr: Option<bool>,
+    #[clap(help = EXP_HELP.get("log_errors_to_tty").unwrap().as_str())]
+    pub log_errors_to_tty: Option<bool>,
 }
 
 impl ExperimentalOptions {
@@ -507,7 +508,7 @@ impl Default for ExperimentalOptions {
             ))),
             strace_logging_mode: Some(StraceLoggingMode::Off),
             scheduler: Some(Scheduler::ThreadPerCore),
-            log_errors_to_stderr: Some(true),
+            log_errors_to_tty: Some(true),
         }
     }
 }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -118,6 +118,7 @@ macro(add_shadow_tests)
       && ${INVERT_ERROR_CODE} ${CMAKE_BINARY_DIR}/src/main/shadow \
       --data-directory=${SHADOW_TEST_NAME}.data \
       --log-level=${SHADOW_TEST_LOGLEVEL} \
+      --log-errors-to-stderr=false \
       ${SHADOW_TEST_ARGS} \
       ${SHADOW_TEST_SHADOW_CONFIG} \
       && (${POST_CMD}) \

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -118,7 +118,6 @@ macro(add_shadow_tests)
       && ${INVERT_ERROR_CODE} ${CMAKE_BINARY_DIR}/src/main/shadow \
       --data-directory=${SHADOW_TEST_NAME}.data \
       --log-level=${SHADOW_TEST_LOGLEVEL} \
-      --log-errors-to-stderr=false \
       ${SHADOW_TEST_ARGS} \
       ${SHADOW_TEST_SHADOW_CONFIG} \
       && (${POST_CMD}) \

--- a/src/test/cli/help-long-expected
+++ b/src/test/cli/help-long-expected
@@ -95,6 +95,9 @@ Experimental (Unstable and may change or be removed at any time, regardless of S
       --interface-qdisc <mode>
           The queueing discipline to use at the network interface [default: "fifo"]
 
+      --log-errors-to-stderr <bool>
+          When true, log error-level log messages to stderr in addition to stdout. [default: true]
+
       --max-unapplied-cpu-latency <seconds>
           Max amount of execution-time latency allowed to accumulate before the clock is moved
           forward. Moving the clock forward is a potentially expensive operation, so larger values

--- a/src/test/cli/help-long-expected
+++ b/src/test/cli/help-long-expected
@@ -95,8 +95,9 @@ Experimental (Unstable and may change or be removed at any time, regardless of S
       --interface-qdisc <mode>
           The queueing discipline to use at the network interface [default: "fifo"]
 
-      --log-errors-to-stderr <bool>
-          When true, log error-level log messages to stderr in addition to stdout. [default: true]
+      --log-errors-to-tty <bool>
+          When true, log error-level messages to stderr in addition to stdout when stdout is not a
+          tty but stderr is. [default: true]
 
       --max-unapplied-cpu-latency <seconds>
           Max amount of execution-time latency allowed to accumulate before the clock is moved


### PR DESCRIPTION
In the common use-case of redirecting stdout to a log file, but viewing stderr on the console, it'd be nice to see errors on the console in addition to in the log file. I think this will be particularly helpful for errors that aren't at the very end of the log file. e.g. see the new user debugging experience here: https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/1229#note_2924406

Example:

After locally inserting garbage into `src/test/tor/minimal/conf/tgen.server.graphml.xml`, before this PR:

```
$ (cd build/src/test/tor/minimal/ && rm -rf tor-minimal-shadow.data       &&  /home/jnewsome/projects/shadow/dev/build/src/main/shadow       --data-directory=tor-minimal-shadow.data    --template-directory shadow.data.template  --progress=true     /home/jnewsome/projects/shadow/dev/src/test/tor/minimal/tor-minimal.yaml > shadow.log)
** Starting Shadow v3.0.0-372-g96285f2c9-dirty 2023-08-01--10:25:28 with GLib v2.72.4
** Shadow did not complete successfully: Failed to run the simulation
**   3 managed processes in unexpected final state
** See the log for details
```

And after:

```
$ (cd build/src/test/tor/minimal/ && rm -rf tor-minimal-shadow.data       &&  /home/jnewsome/projects/shadow/dev/build/src/main/shadow       --data-directory=tor-minimal-shadow.data    --template-directory shadow.data.template  --progress=true     /home/jnewsome/projects/shadow/dev/src/test/tor/minimal/tor-minimal.yaml > shadow.log)
** Starting Shadow v3.0.0-376-gc8c6761b5-dirty 2023-08-01--14:04:45 with GLib v2.72.4
00:00:00.302071 [276892:shadow-worker] 00:00:02.000000000 [ERROR] [fileserver:11.0.0.4] [process.rs:1228] [shadow_rs::host::process] process 'fileserver.tgen.1000' exited with status Normal(0); expected en
d state was running but was exited: 0
00:00:15.271654 [276895:shadow-worker] 00:30:00.000000000 [ERROR] [torclient:11.0.0.11] [process.rs:1228] [shadow_rs::host::process] process 'torclient.tgen.1001' exited with status StoppedByShadow; expect
ed end state was exited: 0 but was running
00:00:15.276291 [276896:shadow-worker] 00:30:00.000000000 [ERROR] [torbridgeclient:11.0.0.10] [process.rs:1228] [shadow_rs::host::process] process 'torbridgeclient.tgen.1001' exited with status StoppedBySh
adow; expected end state was exited: 0 but was running
00:00:16.003385 [276870:shadow] n/a [ERROR] [n/a] [main.rs:399] [shadow_rs::core::main::export] Failed to run the simulation
00:00:16.003505 [276870:shadow] n/a [ERROR] [n/a] [main.rs:399] [shadow_rs::core::main::export] 
00:00:16.003635 [276870:shadow] n/a [ERROR] [n/a] [main.rs:399] [shadow_rs::core::main::export] Caused by:
00:00:16.003830 [276870:shadow] n/a [ERROR] [n/a] [main.rs:399] [shadow_rs::core::main::export]     3 managed processes in unexpected final state
** Shadow did not complete successfully: Failed to run the simulation
**   3 managed processes in unexpected final state
** See the log for details
```