### PR TITLE
Use std::io::IsTerminal instead of nix::unistd::isatty

### DIFF
--- a/src/main/core/controller.rs
+++ b/src/main/core/controller.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -42,7 +43,7 @@ impl<'a> Controller<'a> {
         let status_logger = self.config.general.progress.unwrap().then(|| {
             let state = ShadowStatusBarState::new(self.end_time);
 
-            if nix::unistd::isatty(libc::STDERR_FILENO).unwrap() {
+            if std::io::stderr().lock().is_terminal() {
                 let redraw_interval = Duration::from_millis(1000);
                 StatusLogger::Bar(StatusBar::new(state, redraw_interval))
             } else {

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 use std::ffi::{CStr, OsStr};
-use std::os::fd::AsRawFd;
+use std::io::IsTerminal;
 use std::os::unix::ffi::OsStrExt;
 use std::thread;
 
@@ -143,8 +143,8 @@ pub fn run_shadow(build_info: &ShadowBuildInfo, args: Vec<&OsStr>) -> anyhow::Re
 
     // start up the logging subsystem to handle all future messages
     let log_errors_to_stderr = shadow_config.experimental.log_errors_to_tty.unwrap()
-        && !nix::unistd::isatty(std::io::stdout().as_raw_fd()).unwrap()
-        && nix::unistd::isatty(std::io::stderr().as_raw_fd()).unwrap();
+        && !std::io::stdout().lock().is_terminal()
+        && std::io::stderr().lock().is_terminal();
     shadow_logger::init(log_level.to_level_filter(), log_errors_to_stderr).unwrap();
 
     // disable log buffering during startup so that we see every message immediately in the terminal

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -347,6 +347,8 @@ mod tests {
 }
 
 mod export {
+    use std::io::IsTerminal;
+
     #[no_mangle]
     pub unsafe extern "C" fn utility_handleErrorInner(
         file_name: *const libc::c_char,
@@ -394,7 +396,8 @@ mod export {
             **ABORTING**"
         );
 
-        if !nix::unistd::isatty(libc::STDOUT_FILENO).unwrap_or(true) {
+        // TODO: Why do we only print this if stdout isn't a terminal?
+        if !std::io::stdout().lock().is_terminal() {
             println!("{error_msg}");
         }
 

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -396,12 +396,14 @@ mod export {
             **ABORTING**"
         );
 
-        // TODO: Why do we only print this if stdout isn't a terminal?
-        if !std::io::stdout().lock().is_terminal() {
+        eprintln!("{error_msg}");
+
+        // If stderr is a terminal, and stdout isn't, also print to stdout.
+        // This helps ensure the error is preserved in the case that stdout
+        // is recorded to a file but stderr is not.
+        if std::io::stderr().lock().is_terminal() && !std::io::stdout().lock().is_terminal() {
             println!("{error_msg}");
         }
-
-        eprintln!("{error_msg}");
 
         std::process::abort()
     }


### PR DESCRIPTION
`isatty` can return surprising errors on some file systems. `IsTerminal` interprets such errors as "not a terminal", which is generally the behavior we want. In particular this should fix a crash we're getting in our tor and tgen benchmarks.

Background:
* https://docs.kernel.org/driver-api/ioctl.html#return-code
* https://github.com/containers/podman/issues/120700

Crash example:
* https://github.com/shadow/benchmark/actions/runs/5746502577/job/15576071390

  ```
  thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: ENOSYS', main/core/main.rs:146:64
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  fatal runtime error: failed to initiate panic, error 5
  ```