### PR TITLE
Fix sending packets from sockets bound to 0.0.0.0

### DIFF
--- a/src/main/host/network/namespace.rs
+++ b/src/main/host/network/namespace.rs
@@ -145,9 +145,16 @@ impl NetworkNamespace {
         &self,
         addr: Ipv4Addr,
     ) -> Option<impl Deref<Target = NetworkInterface> + '_> {
+        // Notes:
+        // - The `is_loopback` matches all loopback addresses, but shadow will only work correctly
+        //   with 127.0.0.1. Using any other loopback address will lead to problems.
+        // - If the address is 0.0.0.0, we return the `internet` interface. This is not ideal if a
+        //   socket bound to 0.0.0.0 is trying to send a localhost packet and uses this method to
+        //   get the network interface, since the packet will be sent on the internet interface
+        //   instead of loopback. It's not clear if this will lead to bugs.
         if addr.is_loopback() {
             Some(self.localhost.borrow())
-        } else if addr == self.default_ip {
+        } else if addr == self.default_ip || addr.is_unspecified() {
             Some(self.internet.borrow())
         } else {
             None
@@ -160,9 +167,16 @@ impl NetworkNamespace {
         &self,
         addr: Ipv4Addr,
     ) -> Option<impl Deref<Target = NetworkInterface> + DerefMut + '_> {
+        // Notes:
+        // - The `is_loopback` matches all loopback addresses, but shadow will only work correctly
+        //   with 127.0.0.1. Using any other loopback address will lead to problems.
+        // - If the address is 0.0.0.0, we return the `internet` interface. This is not ideal if a
+        //   socket bound to 0.0.0.0 is trying to send a localhost packet and uses this method to
+        //   get the network interface, since the packet will be sent on the internet interface
+        //   instead of loopback. It's not clear if this will lead to bugs.
         if addr.is_loopback() {
             Some(self.localhost.borrow_mut())
-        } else if addr == self.default_ip {
+        } else if addr == self.default_ip || addr.is_unspecified() {
             Some(self.internet.borrow_mut())
         } else {
             None


### PR DESCRIPTION
I don't think this is a proper fix since it means that localhost packets from sockets bound to 0.0.0.0 will be sent over the internet interface rather than the loopback interface. But I don't think there's anything else we can do here. The C TCP code does [something](https://github.com/shadow/shadow/issues/3088#issuecomment-1668389960) slightly different, but I don't think it's better than using just the internet interface.

Closes #3088.