### PR TITLE
Add better support for recursive RootedRc

### DIFF
--- a/src/lib/shadow-shim-helper-rs/src/explicit_drop.rs
+++ b/src/lib/shadow-shim-helper-rs/src/explicit_drop.rs
@@ -1,0 +1,15 @@
+/// Trait for a type that provides an explicit method for dropping its value.
+///
+/// Unlike the `Drop` trait, this traits method:
+/// * Can take a parameter
+/// * Can return something
+/// * Consumes the value (instead of taking a `&mut`)
+///
+/// Unfortunately there is no built-in way to *ensure* a type is explicitly
+/// dropped. One workaround is for a type to also implement `Drop`, and have
+/// that implementation validate that `ExplicitDrop::explicit_drop` was called.
+pub trait ExplicitDrop {
+    type ExplicitDropParam;
+    type ExplicitDropResult;
+    fn explicit_drop(self, param: &Self::ExplicitDropParam) -> Self::ExplicitDropResult;
+}

--- a/src/lib/shadow-shim-helper-rs/src/lib.rs
+++ b/src/lib/shadow-shim-helper-rs/src/lib.rs
@@ -6,6 +6,7 @@
 use vasi::VirtualAddressSpaceIndependent;
 
 pub mod emulated_time;
+pub mod explicit_drop;
 pub mod ipc;
 pub mod notnull;
 pub mod option;

--- a/src/lib/shadow-shim-helper-rs/src/rootedcell/cell.rs
+++ b/src/lib/shadow-shim-helper-rs/src/rootedcell/cell.rs
@@ -80,6 +80,7 @@ mod test_rooted_cell {
     use std::thread;
 
     use super::*;
+    use crate::explicit_drop::ExplicitDrop;
     use crate::rootedcell::rc::RootedRc;
 
     #[test]
@@ -121,14 +122,14 @@ mod test_rooted_cell {
             let rc = { rc.clone(&root) };
             thread::spawn(move || {
                 rc.set(&root, 3);
-                rc.safely_drop(&root);
+                rc.explicit_drop(&root);
                 root
             })
             .join()
             .unwrap()
         };
         assert_eq!(rc.get(&root), 3);
-        rc.safely_drop(&root);
+        rc.explicit_drop(&root);
     }
 
     #[test]

--- a/src/lib/shadow-shim-helper-rs/src/rootedcell/refcell.rs
+++ b/src/lib/shadow-shim-helper-rs/src/rootedcell/refcell.rs
@@ -132,6 +132,7 @@ mod test_rooted_refcell {
     use std::thread;
 
     use super::*;
+    use crate::explicit_drop::ExplicitDrop;
     use crate::rootedcell::rc::RootedRc;
 
     #[test]
@@ -151,7 +152,7 @@ mod test_rooted_refcell {
                 *borrow = 3;
                 // Drop rc with lock still held.
                 drop(borrow);
-                rc.safely_drop(&root);
+                rc.explicit_drop(&root);
                 root
             })
             .join()
@@ -160,6 +161,6 @@ mod test_rooted_refcell {
         let borrow = rc.borrow(&root);
         assert_eq!(*borrow, 3);
         drop(borrow);
-        rc.safely_drop(&root);
+        rc.explicit_drop(&root);
     }
 }

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -7,6 +7,7 @@ use atomic_refcell::{AtomicRef, AtomicRefCell};
 use once_cell::sync::Lazy;
 use rand::Rng;
 use shadow_shim_helper_rs::emulated_time::EmulatedTime;
+use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
@@ -211,7 +212,7 @@ impl Worker {
     pub fn clear_active_process() {
         Worker::with(|w| {
             let old = w.active_process.borrow_mut().take().unwrap();
-            old.safely_drop(w.active_host.borrow().as_ref().unwrap().root());
+            old.explicit_drop(w.active_host.borrow().as_ref().unwrap().root());
         })
         .unwrap();
     }
@@ -230,7 +231,7 @@ impl Worker {
     pub fn clear_active_thread() {
         Worker::with(|w| {
             let old = w.active_thread.borrow_mut().take().unwrap();
-            old.safely_drop(w.active_host.borrow().as_ref().unwrap().root());
+            old.explicit_drop(w.active_host.borrow().as_ref().unwrap().root());
         })
         .unwrap()
     }

--- a/src/main/host/context.rs
+++ b/src/main/host/context.rs
@@ -32,6 +32,8 @@
 //! alternatively be implemented by providing methods that borrow some or all of
 //! their internal references simultaneously.
 
+use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
+
 use super::process::ProcessId;
 use super::thread::ThreadId;
 use super::{host::Host, process::Process, thread::Thread};
@@ -142,7 +144,7 @@ impl<'a> ThreadContextObjs<'a> {
             let mut ctx = ThreadContext::new(self.host, &process, &thread);
             f(&mut ctx)
         };
-        threadrc.safely_drop(self.host.root());
+        threadrc.explicit_drop(self.host.root());
         res
     }
 }

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -16,6 +16,7 @@ use once_cell::unsync::OnceCell;
 use rand::SeedableRng;
 use rand_xoshiro::Xoshiro256PlusPlus;
 use shadow_shim_helper_rs::emulated_time::EmulatedTime;
+use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::rootedcell::Root;
@@ -450,7 +451,7 @@ impl Host {
         if remove_process {
             trace!("Dropping orphan zombie process {pid:?}");
             let process = self.processes.borrow_mut().remove(&pid).unwrap();
-            RootedRc::safely_drop(process, self.root());
+            process.explicit_drop(self.root());
         }
     }
 
@@ -689,7 +690,7 @@ impl Host {
                 Worker::clear_active_process();
             }
 
-            processrc.safely_drop(self.root());
+            processrc.explicit_drop(self.root());
         }
         trace!("done freeing application for host '{}'", self.name());
     }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -19,6 +19,7 @@ use nix::fcntl::OFlag;
 use nix::sys::signal as nixsignal;
 use nix::sys::stat::Mode;
 use nix::unistd::Pid;
+use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::rootedcell::Root;
@@ -271,7 +272,7 @@ impl RunnableProcess {
         }
 
         drop(thread);
-        threadrc.safely_drop(host.root());
+        threadrc.explicit_drop(host.root());
     }
 
     /// This cleans up memory references left over from legacy C code; usually
@@ -878,7 +879,7 @@ impl Process {
         let ctx = ProcessContext::new(host, self);
         let res = thread.resume(&ctx);
         drop(thread);
-        threadrc.safely_drop(host.root());
+        threadrc.explicit_drop(host.root());
 
         #[cfg(feature = "perf_timers")]
         {


### PR DESCRIPTION
This is in preparation for moving the `DescriptorTable` into a `RootedRc`. Since the object containing the `DescriptorTable` (currently `Process`, but soon to be `Thread`) is also in a `RootedRc`, safely dropping becomes a bit complex.

In the past when we've run into this, we've solved it by having the `Drop` impl of the "outer" type get the `Root` from the thread-local `Worker`, but in general we're trying to move away from implicit thread-local accesses in favor of explicit parameter passing.

This first adds `RootedRc::into_inner`. This lets us extract the inner value when dropping the last strong reference of a `RootedRc`. The caller is then able to recursively safely destruct the inner value. This has the downside though of requiring any call site that wants to destruct a `RootedRc<T>` to also know the details about how to safely destruct `T`.

This next adds a trait `ExplicitDrop`, so that types can provide an explicit drop method through a uniform interface. This also lets us add `RootedRc<T>::explicit_drop_recursive`  where `T` implements `ExplicitDrop`, which takes care of safely destructing `T` when the last strong reference to it is dropped.