### PR TITLE
Support clone with CLONE_FILES unset

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1579,6 +1579,7 @@ name = "shadow-tests"
 version = "3.0.0"
 dependencies = [
  "anyhow",
+ "formatting-nostd",
  "libc",
  "linux-api",
  "nix",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,4 +1,11 @@
 [workspace]
+# We need version 2 of the resolver to avoid features enabled in build dependencies
+# causing that feature to also be enabled outside of build dependencies. In particular
+# we need this to avoid rustix's `std` feature from being enabled in the shim and in
+# tests via cbindgen via build dependencies.
+# https://github.com/bytecodealliance/rustix/issues/780
+# https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
+resolver = "2"
 
 members = [
     "main",

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -23,7 +23,7 @@ naked-function = "0.1.5"
 linux-raw-sys = "0.4.5"
 
 [dev-dependencies]
-rustix = { version = "0.38.4", features = ["thread", "process", "time"] }
+rustix = { version = "0.38.4", default-features=false, features = ["thread", "process", "time"] }
 
 [build-dependencies]
 shadow-build-common = { path = "../shadow-build-common" }

--- a/src/lib/shadow-shim-helper-rs/src/rootedcell/refcell.rs
+++ b/src/lib/shadow-shim-helper-rs/src/rootedcell/refcell.rs
@@ -2,6 +2,8 @@ use std::cell::{Cell, UnsafeCell};
 
 use vasi::VirtualAddressSpaceIndependent;
 
+use crate::explicit_drop::ExplicitDrop;
+
 use super::{Root, Tag};
 
 /// Analagous to [std::cell::RefCell]. In particular like [std::cell::RefCell]
@@ -77,6 +79,18 @@ impl<T> RootedRefCell<T> {
 
 unsafe impl<T: Send> Send for RootedRefCell<T> {}
 unsafe impl<T: Send> Sync for RootedRefCell<T> {}
+
+impl<T> ExplicitDrop for RootedRefCell<T>
+where
+    T: ExplicitDrop,
+{
+    type ExplicitDropParam = <T as ExplicitDrop>::ExplicitDropParam;
+    type ExplicitDropResult = <T as ExplicitDrop>::ExplicitDropResult;
+
+    fn explicit_drop(self, param: &Self::ExplicitDropParam) -> Self::ExplicitDropResult {
+        self.val.into_inner().explicit_drop(param)
+    }
+}
 
 pub struct RootedRefCellRef<'a, T> {
     guard: &'a RootedRefCell<T>,

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -231,9 +231,9 @@ impl Worker {
     pub fn clear_active_thread() {
         Worker::with(|w| {
             let host = w.active_host.borrow();
-            let root = host.as_ref().unwrap().root();
+            let host = host.as_ref().unwrap();
             let old = w.active_thread.borrow_mut().take().unwrap();
-            old.explicit_drop_recursive(root, root);
+            old.explicit_drop_recursive(host.root(), host);
         })
         .unwrap()
     }

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -156,7 +156,7 @@ impl Worker {
     ///
     /// Prefer to pass Thread explicitly where feasible. e.g. see `ThreadContext`.
     #[must_use]
-    fn with_active_thread<F, R>(f: F) -> Option<R>
+    pub fn with_active_thread<F, R>(f: F) -> Option<R>
     where
         F: FnOnce(&Thread) -> R,
     {
@@ -230,8 +230,10 @@ impl Worker {
     /// Clear the currently-active Thread.
     pub fn clear_active_thread() {
         Worker::with(|w| {
+            let host = w.active_host.borrow();
+            let root = host.as_ref().unwrap().root();
             let old = w.active_thread.borrow_mut().take().unwrap();
-            old.explicit_drop(w.active_host.borrow().as_ref().unwrap().root());
+            old.explicit_drop_recursive(root, root);
         })
         .unwrap()
     }

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeSet, HashMap};
 use log::*;
 
 use crate::host::descriptor::Descriptor;
+use crate::utility::ObjectCounter;
 
 /// POSIX requires fds to be assigned as `libc::c_int`, so we can't allow any fds larger than this.
 pub const FD_MAX: u32 = i32::MAX as u32;
@@ -18,6 +19,8 @@ pub struct DescriptorTable {
     // Lowest index not in `available_indices` that *might* be available. We still need to verify
     // availability in `descriptors`, though.
     next_index: u32,
+
+    _counter: ObjectCounter,
 }
 
 impl DescriptorTable {
@@ -26,6 +29,7 @@ impl DescriptorTable {
             descriptors: HashMap::new(),
             available_indices: BTreeSet::new(),
             next_index: 0,
+            _counter: ObjectCounter::new("DescriptorTable"),
         }
     }
 

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -888,11 +888,15 @@ impl LegacyTcpSocket {
         // should be fine since nothing should be relying on the socket having a specific/fixed fd
         // handle.
 
-        let new_descriptor = Worker::with_active_process(|proc| {
-            proc.descriptor_table_borrow_mut()
-                .deregister_descriptor(accepted_fd.try_into().unwrap())
-                .unwrap()
+        let new_descriptor = Worker::with_active_host(|host| {
+            Worker::with_active_thread(|thread| {
+                thread
+                    .descriptor_table_borrow_mut(host)
+                    .deregister_descriptor(accepted_fd.try_into().unwrap())
+                    .unwrap()
+            })
         })
+        .unwrap()
         .unwrap();
 
         let CompatFile::New(open_file) = new_descriptor.into_file() else {

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -269,7 +269,7 @@ impl RunnableProcess {
         }
 
         drop(thread);
-        threadrc.explicit_drop_recursive(host.root(), host.root());
+        threadrc.explicit_drop_recursive(host.root(), host);
     }
 
     /// This cleans up memory references left over from legacy C code; usually
@@ -867,7 +867,7 @@ impl Process {
         let ctx = ProcessContext::new(host, self);
         let res = thread.resume(&ctx);
         drop(thread);
-        threadrc.explicit_drop_recursive(host.root(), host.root());
+        threadrc.explicit_drop_recursive(host.root(), host);
 
         #[cfg(feature = "perf_timers")]
         {

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1167,18 +1167,6 @@ impl Process {
             runnable.total_run_time.get()
         );
 
-        {
-            let mut descriptor_table = runnable.desc_table.borrow_mut();
-            let descriptors = descriptor_table.remove_all();
-            crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
-                CallbackQueue::queue_and_run(|cb_queue| {
-                    for desc in descriptors {
-                        desc.close(host, cb_queue);
-                    }
-                })
-            });
-        }
-
         use nix::sys::wait::WaitStatus;
         let exit_status = match (
             killed_by_shadow,

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -19,7 +19,6 @@ use nix::fcntl::OFlag;
 use nix::sys::signal as nixsignal;
 use nix::sys::stat::Mode;
 use nix::unistd::Pid;
-use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::rootedcell::Root;
@@ -41,11 +40,10 @@ use crate::core::work::task::TaskRef;
 use crate::core::worker::Worker;
 use crate::cshadow;
 use crate::host::context::ProcessContext;
-use crate::host::descriptor::{CompatFile, Descriptor};
+use crate::host::descriptor::Descriptor;
 use crate::host::managed_thread::ManagedThread;
 use crate::host::syscall::formatter::FmtOptions;
 use crate::utility;
-use crate::utility::callback_queue::CallbackQueue;
 #[cfg(feature = "perf_timers")]
 use crate::utility::perf_timer::PerfTimer;
 
@@ -212,7 +210,6 @@ pub struct RunnableProcess {
     #[cfg(feature = "perf_timers")]
     total_run_time: Cell<Duration>,
 
-    desc_table: RefCell<DescriptorTable>,
     itimer_real: RefCell<Timer>,
 
     // The `RootedRc` lets us hold a reference to a thread without holding a
@@ -272,7 +269,7 @@ impl RunnableProcess {
         }
 
         drop(thread);
-        threadrc.explicit_drop(host.root());
+        threadrc.explicit_drop_recursive(host.root(), host.root());
     }
 
     /// This cleans up memory references left over from legacy C code; usually
@@ -326,18 +323,6 @@ impl RunnableProcess {
 
         let mut file = strace_logging.file.borrow_mut();
         Some(f(&mut file))
-    }
-
-    #[track_caller]
-    pub fn descriptor_table_borrow(&self) -> impl Deref<Target = DescriptorTable> + '_ {
-        self.desc_table.borrow()
-    }
-
-    #[track_caller]
-    pub fn descriptor_table_borrow_mut(
-        &self,
-    ) -> impl Deref<Target = DescriptorTable> + DerefMut + '_ {
-        self.desc_table.borrow_mut()
     }
 
     pub fn native_pid(&self) -> Pid {
@@ -646,7 +631,10 @@ impl Process {
         let main_thread_id = host.get_new_thread_id();
         let process_id = ProcessId::from(main_thread_id);
 
-        let desc_table = RefCell::new(DescriptorTable::new());
+        let desc_table = RootedRc::new(
+            host.root(),
+            RootedRefCell::new(host.root(), DescriptorTable::new()),
+        );
         let itimer_real = RefCell::new(Timer::new(move |host| {
             itimer_real_expiration(host, process_id)
         }));
@@ -704,7 +692,7 @@ impl Process {
         // and it shouldn't matter much.
 
         {
-            let mut descriptor_table = desc_table.borrow_mut();
+            let mut descriptor_table = desc_table.borrow_mut(host.root());
             Self::open_stdio_file_helper(
                 &mut descriptor_table,
                 libc::STDIN_FILENO.try_into().unwrap(),
@@ -745,7 +733,8 @@ impl Process {
             &shimlog_path,
         );
         let native_pid = mthread.native_pid();
-        let main_thread = Thread::wrap_mthread(host, mthread, process_id, main_thread_id).unwrap();
+        let main_thread =
+            Thread::wrap_mthread(host, mthread, desc_table, process_id, main_thread_id).unwrap();
 
         debug!("process '{:?}' started", plugin_name);
 
@@ -797,7 +786,6 @@ impl Process {
                         expected_final_state: Some(expected_final_state),
                         shim_shared_mem_block,
                         memory_manager: Box::new(RefCell::new(memory_manager)),
-                        desc_table,
                         itimer_real,
                         strace_logging,
                         dumpable: Cell::new(cshadow::SUID_DUMP_USER),
@@ -879,7 +867,7 @@ impl Process {
         let ctx = ProcessContext::new(host, self);
         let res = thread.resume(&ctx);
         drop(thread);
-        threadrc.explicit_drop(host.root());
+        threadrc.explicit_drop_recursive(host.root(), host.root());
 
         #[cfg(feature = "perf_timers")]
         {
@@ -1051,24 +1039,6 @@ impl Process {
     /// Deprecated wrapper for `RunnableProcess::with_strace_file`
     pub fn with_strace_file<T>(&self, f: impl FnOnce(&mut std::fs::File) -> T) -> Option<T> {
         self.runnable().unwrap().with_strace_file(f)
-    }
-
-    /// Deprecated wrapper for `RunnableProcess::descriptor_table_borrow`
-    #[track_caller]
-    pub fn descriptor_table_borrow(&self) -> impl Deref<Target = DescriptorTable> + '_ {
-        std_util::nested_ref::NestedRef::map(self.runnable().unwrap(), |runnable| {
-            runnable.desc_table.borrow()
-        })
-    }
-
-    /// Deprecated wrapper for `RunnableProcess::descriptor_table_borrow_mut`
-    #[track_caller]
-    pub fn descriptor_table_borrow_mut(
-        &self,
-    ) -> impl Deref<Target = DescriptorTable> + DerefMut + '_ {
-        std_util::nested_ref::NestedRefMut::map(self.runnable().unwrap(), |runnable| {
-            runnable.desc_table.borrow_mut()
-        })
     }
 
     /// Deprecated wrapper for `RunnableProcess::native_pid`
@@ -1459,105 +1429,8 @@ mod export {
     use super::*;
     use crate::core::worker::Worker;
     use crate::host::context::ThreadContext;
-    use crate::host::descriptor::socket::inet::InetSocket;
-    use crate::host::descriptor::socket::Socket;
-    use crate::host::descriptor::File;
     use crate::host::syscall_types::{ForeignArrayPtr, SyscallReturn};
     use crate::host::thread::Thread;
-
-    /// Register a `Descriptor`. This takes ownership of the descriptor and you must not access it
-    /// after.
-    #[no_mangle]
-    pub extern "C" fn process_registerDescriptor(
-        proc: *const Process,
-        desc: *mut Descriptor,
-    ) -> libc::c_int {
-        let proc = unsafe { proc.as_ref().unwrap() };
-        let desc = Descriptor::from_raw(desc).unwrap();
-
-        proc.descriptor_table_borrow_mut()
-            .register_descriptor(*desc)
-            .unwrap()
-            .into()
-    }
-
-    /// Get a temporary reference to a descriptor.
-    #[no_mangle]
-    pub extern "C" fn process_getRegisteredDescriptor(
-        proc: *const Process,
-        handle: libc::c_int,
-    ) -> *const Descriptor {
-        let proc = unsafe { proc.as_ref().unwrap() };
-
-        let handle = match handle.try_into() {
-            Ok(i) => i,
-            Err(_) => {
-                log::debug!("Attempted to get a descriptor with handle {}", handle);
-                return std::ptr::null();
-            }
-        };
-
-        match proc.descriptor_table_borrow().get(handle) {
-            Some(d) => d as *const Descriptor,
-            None => std::ptr::null(),
-        }
-    }
-
-    /// Get a temporary mutable reference to a descriptor.
-    #[no_mangle]
-    pub extern "C" fn process_getRegisteredDescriptorMut(
-        proc: *const Process,
-        handle: libc::c_int,
-    ) -> *mut Descriptor {
-        let proc = unsafe { proc.as_ref().unwrap() };
-
-        let handle = match handle.try_into() {
-            Ok(i) => i,
-            Err(_) => {
-                log::debug!("Attempted to get a descriptor with handle {}", handle);
-                return std::ptr::null_mut();
-            }
-        };
-
-        match proc.descriptor_table_borrow_mut().get_mut(handle) {
-            Some(d) => d as *mut Descriptor,
-            None => std::ptr::null_mut(),
-        }
-    }
-
-    /// Get a temporary reference to a legacy file.
-    #[no_mangle]
-    pub unsafe extern "C" fn process_getRegisteredLegacyFile(
-        proc: *const Process,
-        handle: libc::c_int,
-    ) -> *mut cshadow::LegacyFile {
-        let proc = unsafe { proc.as_ref().unwrap() };
-
-        let handle = match handle.try_into() {
-            Ok(i) => i,
-            Err(_) => {
-                log::debug!("Attempted to get a descriptor with handle {}", handle);
-                return std::ptr::null_mut();
-            }
-        };
-
-        match proc.descriptor_table_borrow().get(handle).map(|x| x.file()) {
-            Some(CompatFile::Legacy(file)) => file.ptr(),
-            Some(CompatFile::New(file)) => {
-                // we have a special case for the legacy C TCP objects
-                if let File::Socket(Socket::Inet(InetSocket::LegacyTcp(tcp))) = file.inner_file() {
-                    tcp.borrow().as_legacy_file()
-                } else {
-                    log::warn!(
-                        "A descriptor exists for fd={}, but it is not a legacy file. Returning NULL.",
-                        handle
-                    );
-                    std::ptr::null_mut()
-                }
-            }
-            None => std::ptr::null_mut(),
-        }
-    }
 
     /// Copy `n` bytes from `src` to `dst`. Returns 0 on success or -EFAULT if any of
     /// the specified range couldn't be accessed. Always succeeds with n==0.
@@ -1970,6 +1843,20 @@ mod export {
         Worker::with_active_host(|host| {
             let tid = ThreadId::try_from(tid).unwrap();
             let Some(thread) = proc.thread_borrow(tid) else {
+                return std::ptr::null();
+            };
+            let thread = thread.borrow(host.root());
+            &*thread
+        })
+        .unwrap()
+    }
+
+    /// Returns a pointer to an arbitrary live thread in the process.
+    #[no_mangle]
+    pub unsafe extern "C" fn process_firstLiveThread(proc: *const Process) -> *const Thread {
+        let proc = unsafe { proc.as_ref().unwrap() };
+        Worker::with_active_host(|host| {
+            let Some(thread) = proc.first_live_thread_borrow(host.root()) else {
                 return std::ptr::null();
             };
             let thread = thread.borrow(host.root());

--- a/src/main/host/syscall/epoll.c
+++ b/src/main/host/syscall/epoll.c
@@ -51,7 +51,7 @@ static SyscallReturn _syscallhandler_epollWaitHelper(SysCallHandler* sys, gint e
     }
 
     /* Get and check the epoll descriptor. */
-    LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), epfd);
+    LegacyFile* desc = thread_getRegisteredLegacyFile(_syscallhandler_getThread(sys), epfd);
     gint errorCode = _syscallhandler_validateLegacyFile(desc, DT_EPOLL);
 
     if (errorCode) {
@@ -138,7 +138,7 @@ static int _syscallhandler_createEpollHelper(SysCallHandler* sys, int64_t size,
 
     Epoll* epolld = epoll_new();
     Descriptor* desc = descriptor_fromLegacyFile((LegacyFile*)epolld, descFlags);
-    int handle = process_registerDescriptor(_syscallhandler_getProcess(sys), desc);
+    int handle = thread_registerDescriptor(_syscallhandler_getThread(sys), desc);
 
     return handle;
 }
@@ -184,7 +184,7 @@ SyscallReturn syscallhandler_epoll_ctl(SysCallHandler* sys, const SysCallArgs* a
 
     /* Get and check the epoll descriptor. */
     LegacyFile* epollDescriptor =
-        process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), epfd);
+        thread_getRegisteredLegacyFile(_syscallhandler_getThread(sys), epfd);
     gint errorCode = _syscallhandler_validateLegacyFile(epollDescriptor, DT_EPOLL);
 
     if (errorCode) {
@@ -198,7 +198,7 @@ SyscallReturn syscallhandler_epoll_ctl(SysCallHandler* sys, const SysCallArgs* a
 
     /* Find the child descriptor that the epoll is monitoring. */
     const Descriptor* descriptor =
-        process_getRegisteredDescriptor(_syscallhandler_getProcess(sys), fd);
+        thread_getRegisteredDescriptor(_syscallhandler_getThread(sys), fd);
 
     if (descriptor == NULL) {
         debug("Child %i is not a shadow descriptor", fd);

--- a/src/main/host/syscall/fcntl.c
+++ b/src/main/host/syscall/fcntl.c
@@ -177,7 +177,7 @@ SyscallReturn syscallhandler_fcntl(SysCallHandler* sys, const SysCallArgs* args)
 
     trace("fcntl called on fd %d for command %lu", fd, command);
 
-    LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), fd);
+    LegacyFile* desc = thread_getRegisteredLegacyFile(_syscallhandler_getThread(sys), fd);
     int errcode = _syscallhandler_validateLegacyFile(desc, DT_NONE);
     if (errcode < 0) {
         return syscallreturn_makeDoneErrno(-errcode);

--- a/src/main/host/syscall/file.c
+++ b/src/main/host/syscall/file.c
@@ -32,7 +32,7 @@ static int _syscallhandler_validateFileHelper(SysCallHandler* sys, int filefd,
     }
 
     /* Check if this is a virtual Shadow descriptor. */
-    LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), filefd);
+    LegacyFile* desc = thread_getRegisteredLegacyFile(_syscallhandler_getThread(sys), filefd);
     if (desc && file_desc_out) {
         *file_desc_out = (RegularFile*)desc;
     }
@@ -74,7 +74,7 @@ static SyscallReturn _syscallhandler_openHelper(SysCallHandler* sys, UntypedFore
 
     utility_debugAssert(errcode == 0);
     Descriptor* desc = descriptor_fromLegacyFile((LegacyFile*)filed, flags & O_CLOEXEC);
-    int handle = process_registerDescriptor(_syscallhandler_getProcess(sys), desc);
+    int handle = thread_registerDescriptor(_syscallhandler_getThread(sys), desc);
     return syscallreturn_makeDoneI64(handle);
 }
 

--- a/src/main/host/syscall/fileat.c
+++ b/src/main/host/syscall/fileat.c
@@ -41,7 +41,7 @@ static int _syscallhandler_validateDirHelper(SysCallHandler* sys, int dirfd,
     }
 
     /* Check if this is a virtual Shadow descriptor. */
-    LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), dirfd);
+    LegacyFile* desc = thread_getRegisteredLegacyFile(_syscallhandler_getThread(sys), dirfd);
     if (desc && dir_desc_out) {
         *dir_desc_out = (RegularFile*)desc;
     }
@@ -138,7 +138,7 @@ SyscallReturn syscallhandler_openat(SysCallHandler* sys, const SysCallArgs* args
 
     utility_debugAssert(errcode == 0);
     Descriptor* desc = descriptor_fromLegacyFile((LegacyFile*)file_desc, flags & O_CLOEXEC);
-    int handle = process_registerDescriptor(_syscallhandler_getProcess(sys), desc);
+    int handle = thread_registerDescriptor(_syscallhandler_getThread(sys), desc);
     return syscallreturn_makeDoneI64(handle);
 }
 

--- a/src/main/host/syscall/handler/eventfd.rs
+++ b/src/main/host/syscall/handler/eventfd.rs
@@ -74,8 +74,8 @@ impl SyscallHandler {
 
         let fd = ctx
             .objs
-            .process
-            .descriptor_table_borrow_mut()
+            .thread
+            .descriptor_table_borrow_mut(ctx.objs.host)
             .register_descriptor(desc)
             .or(Err(Errno::ENFILE))?;
 

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -25,7 +25,7 @@ impl SyscallHandler {
             |ctx: &mut SyscallContext| Self::legacy_syscall(cshadow::syscallhandler_fcntl, ctx);
 
         // get the descriptor, or return early if it doesn't exist
-        let mut desc_table = ctx.objs.process.descriptor_table_borrow_mut();
+        let mut desc_table = ctx.objs.thread.descriptor_table_borrow_mut(ctx.objs.host);
         let desc = Self::get_descriptor_mut(&mut desc_table, fd)?;
 
         let Ok(cmd) = FcntlCommand::try_from(cmd) else {

--- a/src/main/host/syscall/handler/ioctl.rs
+++ b/src/main/host/syscall/handler/ioctl.rs
@@ -34,7 +34,7 @@ impl SyscallHandler {
 
         // get the descriptor, or return early if it doesn't exist
         let file = {
-            let mut desc_table = ctx.objs.process.descriptor_table_borrow_mut();
+            let mut desc_table = ctx.objs.thread.descriptor_table_borrow_mut(ctx.objs.host);
             let desc = Self::get_descriptor_mut(&mut desc_table, fd)?;
 
             // add the CLOEXEC flag

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -102,8 +102,8 @@ impl SyscallHandler {
 
         let fd = ctx
             .objs
-            .process
-            .descriptor_table_borrow_mut()
+            .thread
+            .descriptor_table_borrow_mut(ctx.objs.host)
             .register_descriptor(desc)
             .or(Err(Errno::ENFILE))?;
 
@@ -122,7 +122,7 @@ impl SyscallHandler {
     ) -> SyscallResult {
         let file = {
             // get the descriptor, or return early if it doesn't exist
-            let desc_table = ctx.objs.process.descriptor_table_borrow();
+            let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
             let desc = Self::get_descriptor(&desc_table, fd)?;
 
             let CompatFile::New(file) = desc.file() else {
@@ -174,7 +174,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 let CompatFile::New(file) = Self::get_descriptor(&desc_table, fd)?.file() else {
                     // we don't have any C socket objects
                     return Err(Errno::ENOTSOCK.into());
@@ -247,7 +247,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 match Self::get_descriptor(&desc_table, fd)?.file() {
                     CompatFile::New(file) => file.clone(),
                     CompatFile::Legacy(_file) => {
@@ -319,7 +319,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 let CompatFile::New(file) = Self::get_descriptor(&desc_table, fd)?.file() else {
                     // we don't have any C socket objects
                     return Err(Errno::ENOTSOCK.into());
@@ -397,7 +397,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 match Self::get_descriptor(&desc_table, fd)?.file() {
                     CompatFile::New(file) => file.clone(),
                     CompatFile::Legacy(_file) => {
@@ -466,7 +466,7 @@ impl SyscallHandler {
     ) -> SyscallResult {
         let addr_to_write: Option<SockaddrStorage> = {
             // get the descriptor, or return early if it doesn't exist
-            let desc_table = ctx.objs.process.descriptor_table_borrow();
+            let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
             let desc = Self::get_descriptor(&desc_table, fd)?;
 
             let CompatFile::New(file) = desc.file() else {
@@ -508,7 +508,7 @@ impl SyscallHandler {
     ) -> SyscallResult {
         let addr_to_write = {
             // get the descriptor, or return early if it doesn't exist
-            let desc_table = ctx.objs.process.descriptor_table_borrow();
+            let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
             let desc = Self::get_descriptor(&desc_table, fd)?;
 
             let CompatFile::New(file) = desc.file() else {
@@ -549,7 +549,7 @@ impl SyscallHandler {
         backlog: std::ffi::c_int,
     ) -> SyscallResult {
         // get the descriptor, or return early if it doesn't exist
-        let desc_table = ctx.objs.process.descriptor_table_borrow();
+        let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
         let desc = Self::get_descriptor(&desc_table, fd)?;
 
         let CompatFile::New(file) = desc.file() else {
@@ -596,7 +596,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 let CompatFile::New(file) = Self::get_descriptor(&desc_table, fd)?.file() else {
                     // we don't have any C socket objects
                     return Err(Errno::ENOTSOCK.into());
@@ -640,7 +640,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 let CompatFile::New(file) = Self::get_descriptor(&desc_table, fd)?.file() else {
                     // we don't have any C socket objects
                     return Err(Errno::ENOTSOCK.into());
@@ -732,8 +732,8 @@ impl SyscallHandler {
 
         let new_fd = ctx
             .objs
-            .process
-            .descriptor_table_borrow_mut()
+            .thread
+            .descriptor_table_borrow_mut(ctx.objs.host)
             .register_descriptor(new_desc)
             .or(Err(Errno::ENFILE))?;
 
@@ -762,7 +762,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 let CompatFile::New(file) = Self::get_descriptor(&desc_table, fd)?.file() else {
                     // we don't have any C socket objects
                     return Err(Errno::ENOTSOCK.into());
@@ -806,7 +806,7 @@ impl SyscallHandler {
         how: std::ffi::c_int,
     ) -> SyscallResult {
         // get the descriptor, or return early if it doesn't exist
-        let desc_table = ctx.objs.process.descriptor_table_borrow();
+        let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
         let desc = Self::get_descriptor(&desc_table, fd)?;
 
         let CompatFile::New(file) = desc.file() else {
@@ -902,7 +902,7 @@ impl SyscallHandler {
         desc_2.set_flags(descriptor_flags);
 
         // register the file descriptors
-        let mut dt = ctx.objs.process.descriptor_table_borrow_mut();
+        let mut dt = ctx.objs.thread.descriptor_table_borrow_mut(ctx.objs.host);
         // unwrap here since the error handling would be messy (need to deregister) and we shouldn't
         // ever need to worry about this in practice
         let fd_1 = dt.register_descriptor(desc_1).unwrap();
@@ -942,7 +942,7 @@ impl SyscallHandler {
         optlen_ptr: ForeignPtr<libc::socklen_t>,
     ) -> SyscallResult {
         // get the descriptor, or return early if it doesn't exist
-        let desc_table = ctx.objs.process.descriptor_table_borrow();
+        let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
         let desc = Self::get_descriptor(&desc_table, fd)?;
 
         let CompatFile::New(file) = desc.file() else {
@@ -991,7 +991,7 @@ impl SyscallHandler {
         optlen: libc::socklen_t,
     ) -> SyscallResult {
         // get the descriptor, or return early if it doesn't exist
-        let desc_table = ctx.objs.process.descriptor_table_borrow();
+        let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
         let desc = Self::get_descriptor(&desc_table, fd)?;
 
         let CompatFile::New(file) = desc.file() else {

--- a/src/main/host/syscall/handler/timerfd.rs
+++ b/src/main/host/syscall/handler/timerfd.rs
@@ -57,8 +57,8 @@ impl SyscallHandler {
 
         let fd = ctx
             .objs
-            .process
-            .descriptor_table_borrow_mut()
+            .thread
+            .descriptor_table_borrow_mut(ctx.objs.host)
             .register_descriptor(desc)
             .or(Err(Errno::ENFILE))?;
 
@@ -209,7 +209,7 @@ fn check_clockid(clockid: ClockId) -> Result<(), Errno> {
 
 fn get_cloned_file(ctx: &mut SyscallContext, fd: std::ffi::c_int) -> Result<File, Errno> {
     // get the descriptor, or return error if it doesn't exist
-    let desc_table = ctx.objs.process.descriptor_table_borrow();
+    let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
     let desc = SyscallHandler::get_descriptor(&desc_table, fd)?;
 
     // Our TimerFd is a New Rust type, if we get a Legacy C type it must not be a TimerFd.

--- a/src/main/host/syscall/handler/uio.rs
+++ b/src/main/host/syscall/handler/uio.rs
@@ -33,7 +33,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 match Self::get_descriptor(&desc_table, fd)?.file() {
                     CompatFile::New(file) => file.clone(),
                     // if it's a legacy file, use the C syscall handler instead
@@ -94,7 +94,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 match Self::get_descriptor(&desc_table, fd)?.file() {
                     CompatFile::New(file) => file.clone(),
                     // if it's a legacy file, use the C syscall handler instead
@@ -162,7 +162,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 match Self::get_descriptor(&desc_table, fd)?.file() {
                     CompatFile::New(file) => file.clone(),
                     // if it's a legacy file, use the C syscall handler instead
@@ -296,7 +296,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 match Self::get_descriptor(&desc_table, fd)?.file() {
                     CompatFile::New(file) => file.clone(),
                     // if it's a legacy file, use the C syscall handler instead
@@ -357,7 +357,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 match Self::get_descriptor(&desc_table, fd)?.file() {
                     CompatFile::New(file) => file.clone(),
                     // if it's a legacy file, use the C syscall handler instead
@@ -426,7 +426,7 @@ impl SyscallHandler {
             Some(x) => x,
             // get the file from the descriptor table, or return early if it doesn't exist
             None => {
-                let desc_table = ctx.objs.process.descriptor_table_borrow();
+                let desc_table = ctx.objs.thread.descriptor_table_borrow(ctx.objs.host);
                 match Self::get_descriptor(&desc_table, fd)?.file() {
                     CompatFile::New(file) => file.clone(),
                     // if it's a legacy file, use the C syscall handler instead

--- a/src/main/host/syscall/ioctl.c
+++ b/src/main/host/syscall/ioctl.c
@@ -67,7 +67,7 @@ SyscallReturn syscallhandler_ioctl(SysCallHandler* sys, const SysCallArgs* args)
 
     trace("ioctl called on fd %d for request %ld", fd, request);
 
-    LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), fd);
+    LegacyFile* desc = thread_getRegisteredLegacyFile(_syscallhandler_getThread(sys), fd);
     int errcode = _syscallhandler_validateLegacyFile(desc, DT_NONE);
     if (errcode < 0) {
         return syscallreturn_makeDoneErrno(-errcode);

--- a/src/main/host/syscall/mman.c
+++ b/src/main/host/syscall/mman.c
@@ -47,7 +47,7 @@ static int _syscallhandler_validateMmapArgsHelper(SysCallHandler* sys, int fd, s
 
     /* We only need a file if it's not an anonymous mapping. */
     if (!(flags & MAP_ANONYMOUS)) {
-        LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), fd);
+        LegacyFile* desc = thread_getRegisteredLegacyFile(_syscallhandler_getThread(sys), fd);
         int errcode = _syscallhandler_validateLegacyFile(desc, DT_NONE);
         if (errcode) {
             debug("Invalid fd %i", fd);

--- a/src/main/host/syscall/poll.c
+++ b/src/main/host/syscall/poll.c
@@ -78,7 +78,7 @@ static int _syscallhandler_getPollEvents(SysCallHandler* sys, struct pollfd* fds
 
         /* Get the descriptor. */
         const Descriptor* desc =
-            process_getRegisteredDescriptor(_syscallhandler_getProcess(sys), pfd->fd);
+            thread_getRegisteredDescriptor(_syscallhandler_getThread(sys), pfd->fd);
         if (desc) {
             _syscallhandler_getPollEventsHelper(desc, pfd);
         } else {
@@ -104,7 +104,7 @@ static void _syscallhandler_registerPollFDs(SysCallHandler* sys, struct pollfd* 
         }
 
         const Descriptor* desc =
-            process_getRegisteredDescriptor(_syscallhandler_getProcess(sys), pfd->fd);
+            thread_getRegisteredDescriptor(_syscallhandler_getThread(sys), pfd->fd);
         utility_debugAssert(desc); // we would have returned POLLNVAL in getPollEvents
 
         struct epoll_event epev = {0};

--- a/src/main/host/syscall/uio.c
+++ b/src/main/host/syscall/uio.c
@@ -27,7 +27,7 @@ static int _syscallhandler_validateVecParams(SysCallHandler* sys, int fd, Untype
                                              unsigned long iovlen, off_t offset,
                                              LegacyFile** desc_out, struct iovec** iov_out) {
     /* Get the descriptor. */
-    LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), fd);
+    LegacyFile* desc = thread_getRegisteredLegacyFile(_syscallhandler_getThread(sys), fd);
     if (!desc) {
         return -EBADF;
     }

--- a/src/main/host/syscall/unistd.c
+++ b/src/main/host/syscall/unistd.c
@@ -33,7 +33,7 @@ SyscallReturn _syscallhandler_readHelper(SysCallHandler* sys, int fd, UntypedFor
         "trying to read %zu bytes on fd %i at offset %li", bufSize, fd, offset);
 
     /* Get the descriptor. */
-    LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), fd);
+    LegacyFile* desc = thread_getRegisteredLegacyFile(_syscallhandler_getThread(sys), fd);
     if (!desc) {
         return syscallreturn_makeDoneErrno(EBADF);
     }
@@ -122,7 +122,7 @@ SyscallReturn _syscallhandler_writeHelper(SysCallHandler* sys, int fd, UntypedFo
           offset);
 
     /* Get the descriptor. */
-    LegacyFile* desc = process_getRegisteredLegacyFile(_syscallhandler_getProcess(sys), fd);
+    LegacyFile* desc = thread_getRegisteredLegacyFile(_syscallhandler_getThread(sys), fd);
     if (!desc) {
         return syscallreturn_makeDoneErrno(EBADF);
     }

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -15,7 +15,7 @@ use super::managed_thread::{self, ManagedThread};
 use super::process::{Process, ProcessId};
 use crate::cshadow as c;
 use crate::host::syscall_condition::{SysCallConditionRef, SysCallConditionRefMut};
-use crate::utility::{syscall, IsSend};
+use crate::utility::{syscall, IsSend, ObjectCounter};
 
 /// The thread's state after having been allowed to execute some code.
 #[derive(Debug)]
@@ -45,6 +45,7 @@ pub struct Thread {
     cond: Cell<SendPointer<c::SysCallCondition>>,
     /// The native, managed thread
     mthread: RefCell<ManagedThread>,
+    _counter: ObjectCounter,
 }
 
 impl IsSend for Thread {}
@@ -315,6 +316,7 @@ impl Thread {
                 &host.shim_shmem_lock_borrow().unwrap(),
                 tid.into(),
             )),
+            _counter: ObjectCounter::new("Thread"),
         };
         Ok(child)
     }

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -6,7 +6,6 @@ use nix::unistd::Pid;
 use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
-use shadow_shim_helper_rs::rootedcell::Root;
 use shadow_shim_helper_rs::shim_shmem::{HostShmemProtected, ThreadShmem};
 use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SysCallReg};
 use shadow_shim_helper_rs::util::SendPointer;
@@ -451,12 +450,12 @@ impl Drop for Thread {
 }
 
 impl ExplicitDrop for Thread {
-    type ExplicitDropParam = Root;
+    type ExplicitDropParam = Host;
     type ExplicitDropResult = ();
 
-    fn explicit_drop(mut self, root: &Root) {
+    fn explicit_drop(mut self, host: &Host) {
         if let Some(table) = self.desc_table.take() {
-            table.explicit_drop(root);
+            table.explicit_drop_recursive(host.root(), host);
         }
     }
 }

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -194,7 +194,7 @@ libc = "0.2"
 linux-api = { path = "../lib/linux-api" }
 nix = "0.26.2"
 rand = { version="0.8.5", features=["small_rng"] }
-rustix = { version = "0.38.4", features=["mm", "time","thread"]}
+rustix = { version = "0.38.4", default-features=false, features=["mm", "time", "thread"]}
 signal-hook = "0.3.15"
 once_cell = "1.18.0"
 vasi-sync = { path = "../lib/vasi-sync" }

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -190,6 +190,7 @@ path = "time/nanosleep/test_nanosleep.rs"
 
 [dependencies]
 anyhow = { version = "1.0.71", features = ["backtrace"] }
+formatting-nostd = { path = "../lib/formatting-nostd" }
 libc = "0.2"
 linux-api = { path = "../lib/linux-api" }
 nix = "0.26.2"

--- a/src/test/clone/clone.yaml
+++ b/src/test/clone/clone.yaml
@@ -8,4 +8,5 @@ hosts:
     network_node_id: 0
     processes:
     - path: ../../target/debug/test_clone
+      args: --shadow-passing
       start_time: 1

--- a/src/test/clone/test_clone.rs
+++ b/src/test/clone/test_clone.rs
@@ -317,7 +317,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let summarize = std::env::args().any(|x| x == "--summarize");
 
     let all_envs = set![TestEnv::Libc, TestEnv::Shadow];
-    let libc_only = set![TestEnv::Libc];
 
     let mut tests: Vec<test_utils::ShadowTest<(), Box<dyn Error>>> = vec![
         ShadowTest::new("minimal", test_clone_minimal, all_envs.clone()),
@@ -330,7 +329,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         ShadowTest::new(
             "clone_files_unset_description_offset",
             || test_clone_files_description_offset(false),
-            libc_only.clone(),
+            all_envs.clone(),
         ),
         ShadowTest::new(
             "clone_files_set_dup2",
@@ -340,14 +339,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         ShadowTest::new(
             "clone_files_unset_dup2",
             || test_clone_files_dup(false),
-            libc_only.clone(),
+            all_envs.clone(),
         ),
     ];
 
     // Explicitly reference these to avoid clippy warning about unnecessary
     // clone at point of last usage above.
     drop(all_envs);
-    drop(libc_only);
 
     if filter_shadow_passing {
         tests.retain(|x| x.passing(TestEnv::Shadow));


### PR DESCRIPTION
`fork` and `fork`-like syscalls have the behavior of `clone` without the `CLONE_FILES` flag set: the child gets a copy of the parent's descriptor table.

While it's rare in the wild to use `clone` to create a new thread without setting `CLONE_FILES`, testing this use-case gets us closer to supporting `fork` etc.