### PR TITLE
Migrate most bare clone tests to Rust

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -766,9 +766,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "linux-syscall"
@@ -1315,7 +1315,7 @@ dependencies = [
  "bitflags 2.3.3",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.5",
  "windows-sys",
 ]
 
@@ -1521,7 +1521,7 @@ dependencies = [
  "formatting-nostd",
  "libc",
  "linux-api",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.5",
  "log",
  "log-c2rust",
  "logger",
@@ -1573,6 +1573,7 @@ dependencies = [
  "rand",
  "rustix 0.38.4",
  "signal-hook",
+ "vasi-sync",
 ]
 
 [[package]]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "bytemuck",
  "cbindgen",
  "linux-errno",
+ "linux-raw-sys 0.4.5",
  "linux-syscall",
  "log",
  "memoffset 0.9.0",

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -20,6 +20,7 @@ bytemuck = "1.13.1"
 linux-syscall = "1.0.0"
 linux-errno = "1.0.1"
 naked-function = "0.1.5"
+linux-raw-sys = "0.4.5"
 
 [dev-dependencies]
 rustix = { version = "0.38.4", features = ["thread", "process", "time"] }

--- a/src/lib/linux-api/src/ldt.rs
+++ b/src/lib/linux-api/src/ldt.rs
@@ -1,0 +1,12 @@
+/// Descriptor type, used e.g. as the `tls` parameter to the `clone` syscall.
+//
+// I initially tried using `bindgen` to get this type from the linux headers ourselves
+// as we do for most of our  types, but ran into trouble because *cbindgen* fails
+// to parse the bitfield definition created by *bindgen*. This causes cbindgen to fail
+// even if I added this type and the generated bitfield type to the ignore list.
+//
+// Once we're no longer re-exporting our generated kernel bindings out to C, we can
+// either generate this definition ourselves (as currently done for our other types),
+// or switch over to linux-raw-sys throughout.
+#[allow(non_camel_case_types)]
+pub type linux_user_desc = linux_raw_sys::general::user_desc;

--- a/src/lib/linux-api/src/lib.rs
+++ b/src/lib/linux-api/src/lib.rs
@@ -56,6 +56,7 @@ pub mod exit;
 pub mod fcntl;
 pub mod inet;
 pub mod ioctls;
+pub mod ldt;
 pub mod mman;
 pub mod posix_types;
 pub mod rseq;

--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -1477,8 +1477,8 @@ pub fn tgkill_raw(tgid: i32, tid: i32, signo: i32) -> Result<(), Errno> {
         .map_err(Errno::from)
 }
 
-pub fn tgkill(tgid: NonZeroI32, tid: NonZeroI32, signal: Signal) -> Result<(), Errno> {
-    tgkill_raw(tgid.get(), tid.get(), signal.as_i32())
+pub fn tgkill(tgid: NonZeroI32, tid: NonZeroI32, signal: Option<Signal>) -> Result<(), Errno> {
+    tgkill_raw(tgid.get(), tid.get(), signal.map(i32::from).unwrap_or(0))
 }
 
 mod export {

--- a/src/lib/shim/src/signals.rs
+++ b/src/lib/shim/src/signals.rs
@@ -286,8 +286,12 @@ pub unsafe fn process_signals(mut ucontext: Option<&mut ucontext>) -> bool {
 
         let pid = rustix::process::getpid();
         let tid = rustix::thread::gettid();
-        linux_api::signal::tgkill(pid.as_raw_nonzero(), tid.as_raw_nonzero(), Signal::SIGUSR1)
-            .unwrap();
+        linux_api::signal::tgkill(
+            pid.as_raw_nonzero(),
+            tid.as_raw_nonzero(),
+            Some(Signal::SIGUSR1),
+        )
+        .unwrap();
 
         // Reacquire locks and references.
         host = crate::global_host_shmem::get();

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -9,6 +9,10 @@ name = "test_utils"
 path = "test_utils.rs"
 
 [[bin]]
+name = "test_clone"
+path = "clone/test_clone.rs"
+
+[[bin]]
 name = "test_epoll"
 path = "epoll/test_epoll.rs"
 
@@ -190,6 +194,7 @@ libc = "0.2"
 linux-api = { path = "../lib/linux-api" }
 nix = "0.26.2"
 rand = { version="0.8.5", features=["small_rng"] }
-rustix = { version = "0.38.4", features=["time","thread"]}
+rustix = { version = "0.38.4", features=["mm", "time","thread"]}
 signal-hook = "0.3.15"
 once_cell = "1.18.0"
+vasi-sync = { path = "../lib/vasi-sync" }

--- a/src/test/clone/CMakeLists.txt
+++ b/src/test/clone/CMakeLists.txt
@@ -1,11 +1,11 @@
 include_directories(${GLIB_INCLUDE_DIRS})
-add_executable(test_clone test_clone.c ../test_common.c)
-target_compile_options(test_clone PUBLIC "-pthread")
-target_link_libraries(test_clone ${GLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-add_linux_tests(BASENAME clone COMMAND test_clone)
+add_executable(test_clone_leader_exits_early test_clone_leader_exits_early.c ../test_common.c)
+target_compile_options(test_clone_leader_exits_early PUBLIC "-pthread")
+target_link_libraries(test_clone_leader_exits_early ${GLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+add_linux_tests(BASENAME clone_leader_exits_early COMMAND test_clone_leader_exits_early)
 
 add_shadow_tests(
-    BASENAME clone
+    BASENAME clone_leader_exits_early
     # Shim-side strace-logging use libc functions that assume native
     # thread-local-storage is set up. It *usually* works in practice, but is a
     # potential source of hard-to-debug errors.
@@ -14,11 +14,22 @@ add_shadow_tests(
     ARGS --strace-logging-mode=off
 )
 
-# The clone test exercises some corner cases in memory management, particularly
-# when the thread leader exits before all the threads. Useful to test it without
-# the memory manager (really the MemoryMapper) enabled.
+# This test exercises some corner cases in memory management. Useful to test it
+# without the memory manager (really the MemoryMapper) enabled.
 add_shadow_tests(
-    BASENAME clone-nomm
+    BASENAME clone_leader_exits_early_nomm
+    SHADOW_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/clone_leader_exits_early.yaml"
+    # Shim-side strace-logging use libc functions that assume native
+    # thread-local-storage is set up. It *usually* works in practice, but is a
+    # potential source of hard-to-debug errors.
+    #
+    # See https://github.com/shadow/shadow/issues/2919
+    ARGS --strace-logging-mode=off --use-memory-manager=false
+)
+
+add_linux_tests(BASENAME clone COMMAND sh -c "../../target/debug/test_clone --libc-passing")
+add_shadow_tests(
+    BASENAME clone
     # Shim-side strace-logging use libc functions that assume native
     # thread-local-storage is set up. It *usually* works in practice, but is a
     # potential source of hard-to-debug errors.

--- a/src/test/clone/clone-nomm.yaml
+++ b/src/test/clone/clone-nomm.yaml
@@ -1,1 +1,0 @@
-clone.yaml

--- a/src/test/clone/clone_leader_exits_early.yaml
+++ b/src/test/clone/clone_leader_exits_early.yaml
@@ -7,5 +7,5 @@ hosts:
   testnode:
     network_node_id: 0
     processes:
-    - path: ../../target/debug/test_clone
+    - path: ./test_clone_leader_exits_early
       start_time: 1

--- a/src/test/clone/test_clone.rs
+++ b/src/test/clone/test_clone.rs
@@ -1,0 +1,189 @@
+use core::ffi::c_void;
+use std::error::Error;
+use std::num::NonZeroI32;
+use std::sync::atomic::{self, AtomicU32};
+
+use linux_api::errno::Errno;
+use linux_api::ldt::linux_user_desc;
+use linux_api::sched::CloneFlags;
+use linux_api::signal::tgkill;
+use rustix::mm::{MapFlags, MprotectFlags, ProtFlags};
+use rustix::time::Timespec;
+use test_utils::TestEnvironment as TestEnv;
+use test_utils::{running_in_shadow, set, ShadowTest};
+use vasi_sync::lazy_lock::LazyLock;
+use vasi_sync::scchannel::SelfContainedChannel;
+use vasi_sync::sync::futex_wait;
+
+const CLONE_TEST_STACK_NBYTES: usize = 4 * 4096;
+
+/// Make an "empty" descriptor, which we use to clear thread-local-storage in
+/// child threads.
+fn make_empty_tls() -> linux_user_desc {
+    let mut desc: linux_user_desc = unsafe { core::mem::zeroed() };
+    desc.set_seg_not_present(1);
+    desc.set_read_exec_only(1);
+    desc
+}
+
+fn wait_for_thread_exit(tid: NonZeroI32) {
+    let pid = rustix::process::getpid();
+    while tgkill(pid.as_raw_nonzero(), tid, None) != Err(Errno::ESRCH) {}
+}
+
+struct ThreadStack {
+    base: *mut c_void,
+    size: usize,
+}
+
+impl ThreadStack {
+    pub fn new(size: usize) -> Self {
+        let base = unsafe {
+            rustix::mm::mmap_anonymous(
+                core::ptr::null_mut(),
+                CLONE_TEST_STACK_NBYTES,
+                ProtFlags::READ | ProtFlags::WRITE,
+                MapFlags::PRIVATE | MapFlags::STACK,
+            )
+        }
+        .unwrap();
+
+        // Use first page as a guard page.
+        unsafe { rustix::mm::mprotect(base, 4096, MprotectFlags::empty()) }.unwrap();
+
+        Self { base, size }
+    }
+
+    pub fn top(&self) -> *mut c_void {
+        unsafe { self.base.add(self.size) }
+    }
+}
+
+impl Drop for ThreadStack {
+    fn drop(&mut self) {
+        unsafe { rustix::mm::munmap(self.base, self.size) }.unwrap()
+    }
+}
+
+fn test_clone_minimal() -> Result<(), Box<dyn Error>> {
+    static THREAD_DONE_CHANNEL: LazyLock<SelfContainedChannel<()>> =
+        LazyLock::const_new(SelfContainedChannel::new);
+    extern "C" fn thread_fn(_param: *mut c_void) -> i32 {
+        // thread-local storage is not set up; don't call libc functions here.
+
+        THREAD_DONE_CHANNEL.send(());
+        0
+    }
+    let mut tls = make_empty_tls();
+    let stack = ThreadStack::new(CLONE_TEST_STACK_NBYTES);
+    let flags = CloneFlags::CLONE_VM
+        | CloneFlags::CLONE_FS
+        | CloneFlags::CLONE_FILES
+        | CloneFlags::CLONE_SIGHAND
+        | CloneFlags::CLONE_THREAD
+        | CloneFlags::CLONE_SYSVSEM
+        | CloneFlags::CLONE_SETTLS;
+    let child = unsafe {
+        libc::clone(
+            thread_fn,
+            stack.top(),
+            flags.bits().try_into().unwrap(),
+            core::ptr::null_mut(),
+            core::ptr::null_mut::<i32>(),
+            &mut tls,
+        )
+    };
+    assert!(child > 0);
+    THREAD_DONE_CHANNEL.receive().unwrap();
+    // Wait until thread has exited before deallocating its stack.
+    wait_for_thread_exit(child.try_into().unwrap());
+    Ok(())
+}
+
+fn test_clone_clear_tid() -> Result<(), Box<dyn Error>> {
+    extern "C" fn thread_fn(_param: *mut c_void) -> i32 {
+        // thread-local storage is not set up; don't call libc functions here.
+
+        // Try to give parent a chance to sleep on the tid futex.
+        match rustix::thread::nanosleep(&Timespec {
+            tv_sec: 0,
+            tv_nsec: 1_000_000,
+        }) {
+            rustix::thread::NanosleepRelativeResult::Ok => (),
+            r @ rustix::thread::NanosleepRelativeResult::Interrupted(_)
+            | r @ rustix::thread::NanosleepRelativeResult::Err(_) => {
+                panic!("Unexpected result: {r:?}")
+            }
+        };
+        0
+    }
+    let mut tls = make_empty_tls();
+    let stack = ThreadStack::new(CLONE_TEST_STACK_NBYTES);
+    static CHILD_TID: AtomicU32 = AtomicU32::new(u32::MAX);
+    let flags = CloneFlags::CLONE_VM
+        | CloneFlags::CLONE_FS
+        | CloneFlags::CLONE_FILES
+        | CloneFlags::CLONE_SIGHAND
+        | CloneFlags::CLONE_THREAD
+        | CloneFlags::CLONE_SYSVSEM
+        | CloneFlags::CLONE_SETTLS
+        | CloneFlags::CLONE_CHILD_CLEARTID;
+    let child = unsafe {
+        libc::clone(
+            thread_fn,
+            stack.top(),
+            flags.bits().try_into().unwrap(),
+            core::ptr::null_mut(),
+            core::ptr::null_mut::<i32>(),
+            &mut tls,
+            CHILD_TID.as_ptr(),
+        )
+    };
+    assert!(child > 0);
+
+    // Wait to be notified of child exit via futex wake on `CHILD_TID`.
+    loop {
+        match futex_wait(&CHILD_TID, u32::MAX) {
+            Ok(0) | Err(rustix::io::Errno::AGAIN) | Err(rustix::io::Errno::INTR) => {
+                if CHILD_TID.load(atomic::Ordering::Relaxed) == 0 {
+                    // child thread has exited
+                    break;
+                } else {
+                    // spurious wakeup. Shouldn't happen under shadow.
+                    assert!(!running_in_shadow());
+                    // try again
+                }
+            }
+            other => panic!("Unexpected result: {other:?}"),
+        };
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // should we restrict the tests we run?
+    let filter_shadow_passing = std::env::args().any(|x| x == "--shadow-passing");
+    let filter_libc_passing = std::env::args().any(|x| x == "--libc-passing");
+    // should we summarize the results rather than exit on a failed test
+    let summarize = std::env::args().any(|x| x == "--summarize");
+
+    let all_envs = set![TestEnv::Libc, TestEnv::Shadow];
+
+    let mut tests: Vec<test_utils::ShadowTest<(), Box<dyn Error>>> = vec![
+        ShadowTest::new("minimal", test_clone_minimal, all_envs.clone()),
+        ShadowTest::new("clear_tid", test_clone_clear_tid, all_envs),
+    ];
+
+    if filter_shadow_passing {
+        tests.retain(|x| x.passing(TestEnv::Shadow));
+    }
+    if filter_libc_passing {
+        tests.retain(|x| x.passing(TestEnv::Libc));
+    }
+
+    test_utils::run_tests(&tests, summarize)?;
+
+    println!("Success.");
+    Ok(())
+}


### PR DESCRIPTION
This is in preparation to add additional clone tests as we extend clone functionality.
    
Since we're not setting up thread local storage in these tests, we can't safely call libc functions from the child threads. Using Rust lets use no_std alternatives that don't use thread local storage.