### PR TITLE
Impl tcp time traits for `SimulationTime` and `EmulatedTime`

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1569,6 +1569,7 @@ dependencies = [
  "shadow_shmem",
  "static_assertions",
  "system-deps",
+ "tcp",
  "vasi",
  "vasi-sync",
 ]

--- a/src/lib/shadow-shim-helper-rs/Cargo.toml
+++ b/src/lib/shadow-shim-helper-rs/Cargo.toml
@@ -21,6 +21,7 @@ static_assertions = "1.1.0"
 vasi = { path = "../vasi" }
 vasi-sync = { path = "../vasi-sync" }
 linux-api = { path = "../linux-api" }
+tcp = { path = "../tcp" }
 bytemuck = "1.13.1"
 
 [build-dependencies]

--- a/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
@@ -11,7 +11,9 @@ use crate::simulation_time::{self, CSimulationTime, SimulationTime};
 /// An instant in time (analagous to std::time::Instant) in the Shadow
 /// simulation.
 // Internally represented as Duration since the Unix Epoch.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, PartialOrd, Ord, VirtualAddressSpaceIndependent)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Debug, PartialOrd, Ord, Hash, VirtualAddressSpaceIndependent,
+)]
 #[repr(C)]
 pub struct EmulatedTime(CEmulatedTime);
 
@@ -142,6 +144,41 @@ impl std::ops::Sub<EmulatedTime> for EmulatedTime {
 
     fn sub(self, other: EmulatedTime) -> Self::Output {
         self.duration_since(&other)
+    }
+}
+
+impl std::ops::SubAssign<SimulationTime> for EmulatedTime {
+    fn sub_assign(&mut self, rhs: SimulationTime) {
+        *self = self.checked_sub(rhs).unwrap();
+    }
+}
+
+impl tcp::util::time::Instant for EmulatedTime {
+    type Duration = SimulationTime;
+
+    #[inline]
+    fn duration_since(&self, earlier: Self) -> Self::Duration {
+        self.duration_since(&earlier)
+    }
+
+    #[inline]
+    fn saturating_duration_since(&self, earlier: Self) -> Self::Duration {
+        self.saturating_duration_since(&earlier)
+    }
+
+    #[inline]
+    fn checked_duration_since(&self, earlier: Self) -> Option<Self::Duration> {
+        self.checked_duration_since(&earlier)
+    }
+
+    #[inline]
+    fn checked_add(&self, duration: Self::Duration) -> Option<Self> {
+        self.checked_add(duration)
+    }
+
+    #[inline]
+    fn checked_sub(&self, duration: Self::Duration) -> Option<Self> {
+        self.checked_sub(duration)
     }
 }
 

--- a/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
@@ -15,7 +15,9 @@ use vasi::VirtualAddressSpaceIndependent;
 
 use super::emulated_time;
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, PartialOrd, Ord, VirtualAddressSpaceIndependent)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Debug, PartialOrd, Ord, Hash, VirtualAddressSpaceIndependent,
+)]
 #[repr(C)]
 pub struct SimulationTime(CSimulationTime);
 
@@ -220,19 +222,31 @@ impl std::ops::SubAssign<SimulationTime> for SimulationTime {
     }
 }
 
-impl std::ops::Mul<u64> for SimulationTime {
+impl std::ops::Mul<u32> for SimulationTime {
     type Output = SimulationTime;
 
-    fn mul(self, other: u64) -> Self::Output {
-        self.checked_mul(other).unwrap()
+    fn mul(self, other: u32) -> Self::Output {
+        self.checked_mul(other.into()).unwrap()
     }
 }
 
-impl std::ops::Div<u64> for SimulationTime {
+impl std::ops::MulAssign<u32> for SimulationTime {
+    fn mul_assign(&mut self, rhs: u32) {
+        *self = self.checked_mul(rhs.into()).unwrap();
+    }
+}
+
+impl std::ops::Div<u32> for SimulationTime {
     type Output = SimulationTime;
 
-    fn div(self, other: u64) -> Self::Output {
-        self.checked_div(other).unwrap()
+    fn div(self, other: u32) -> Self::Output {
+        self.checked_div(other.into()).unwrap()
+    }
+}
+
+impl std::ops::DivAssign<u32> for SimulationTime {
+    fn div_assign(&mut self, rhs: u32) {
+        *self = self.checked_div(rhs.into()).unwrap();
     }
 }
 
@@ -364,6 +378,110 @@ impl std::convert::TryFrom<SimulationTime> for linux_api::time::timeval {
         let tv_sec = value.as_secs().try_into().map_err(|_| ())?;
         let tv_usec = value.subsec_micros().try_into().map_err(|_| ())?;
         Ok(linux_api::time::timeval { tv_sec, tv_usec })
+    }
+}
+
+impl tcp::util::time::Duration for SimulationTime {
+    const MAX: Self = Self::MAX;
+    const NANOSECOND: Self = Self::NANOSECOND;
+    const MICROSECOND: Self = Self::MICROSECOND;
+    const MILLISECOND: Self = Self::MILLISECOND;
+    const SECOND: Self = Self::SECOND;
+    const ZERO: Self = Self::ZERO;
+
+    #[inline]
+    fn as_micros(&self) -> u128 {
+        self.as_micros().into()
+    }
+
+    #[inline]
+    fn as_millis(&self) -> u128 {
+        self.as_millis().into()
+    }
+
+    #[inline]
+    fn as_nanos(&self) -> u128 {
+        self.as_nanos()
+    }
+
+    #[inline]
+    fn as_secs(&self) -> u64 {
+        self.as_secs()
+    }
+
+    #[inline]
+    fn checked_add(self, rhs: Self) -> Option<Self> {
+        self.checked_add(rhs)
+    }
+
+    #[inline]
+    fn checked_div(self, rhs: u32) -> Option<Self> {
+        self.checked_div(rhs.into())
+    }
+
+    #[inline]
+    fn checked_mul(self, rhs: u32) -> Option<Self> {
+        self.checked_mul(rhs.into())
+    }
+
+    #[inline]
+    fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.checked_sub(rhs)
+    }
+
+    #[inline]
+    fn from_micros(micros: u64) -> Self {
+        Self::from_micros(micros)
+    }
+
+    #[inline]
+    fn from_millis(millis: u64) -> Self {
+        Self::from_millis(millis)
+    }
+
+    #[inline]
+    fn from_nanos(nanos: u64) -> Self {
+        Self::from_nanos(nanos)
+    }
+
+    #[inline]
+    fn from_secs(secs: u64) -> Self {
+        Self::from_secs(secs)
+    }
+
+    #[inline]
+    fn is_zero(&self) -> bool {
+        self.is_zero()
+    }
+
+    #[inline]
+    fn saturating_add(self, rhs: Self) -> Self {
+        self.saturating_add(rhs)
+    }
+
+    #[inline]
+    fn saturating_mul(self, rhs: u32) -> Self {
+        self.saturating_mul(rhs.into())
+    }
+
+    #[inline]
+    fn saturating_sub(self, rhs: Self) -> Self {
+        self.saturating_sub(rhs)
+    }
+
+    #[inline]
+    fn subsec_micros(&self) -> u32 {
+        self.subsec_micros()
+    }
+
+    #[inline]
+    fn subsec_millis(&self) -> u32 {
+        self.subsec_millis()
+    }
+
+    #[inline]
+    fn subsec_nanos(&self) -> u32 {
+        self.subsec_nanos()
     }
 }
 

--- a/src/main/network/router/codel_queue.rs
+++ b/src/main/network/router/codel_queue.rs
@@ -421,16 +421,16 @@ mod tests {
         assert!(cdq.interval_end.is_some());
         assert_eq!(cdq.interval_end.unwrap(), start + TARGET + INTERVAL);
 
-        let now = start + TARGET + INTERVAL * 2u64;
+        let now = start + TARGET + INTERVAL * 2u32;
         assert_eq!(
-            cdq.process_standing_delay(&now, TARGET + INTERVAL * 2u64),
+            cdq.process_standing_delay(&now, TARGET + INTERVAL * 2u32),
             true
         );
         assert!(cdq.interval_end.is_some());
         assert_eq!(cdq.interval_end.unwrap(), start + TARGET + INTERVAL);
 
         // Delay back to low, interval resets, not ok to drop.
-        let now = start + TARGET + INTERVAL * 2u64;
+        let now = start + TARGET + INTERVAL * 2u32;
         assert_eq!(cdq.process_standing_delay(&now, one), false);
         assert!(cdq.interval_end.is_none());
     }
@@ -478,9 +478,9 @@ mod tests {
         // low-delay packets should put us back into store mode.
         for _ in 0..3 {
             // Add some low-delay packets
-            cdq.push(PacketRc::mock_new(), start + TARGET + INTERVAL * 2u64 - one);
+            cdq.push(PacketRc::mock_new(), start + TARGET + INTERVAL * 2u32 - one);
         }
-        cdq.pop(start + TARGET + INTERVAL * 2u64);
+        cdq.pop(start + TARGET + INTERVAL * 2u32);
         assert_eq!(cdq.mode, CoDelMode::Store);
     }
 


### PR DESCRIPTION
This will allow `SimulationTime` and `EmulatedTime` to be used with the tcp library.