### PR TITLE
Add a basic fork test

### DIFF
--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["rustix"]
 std = []
+rustix = ["dep:rustix"]
 
 [dependencies]
 bitflags = "2.3.1"
@@ -21,6 +23,7 @@ linux-syscall = "1.0.0"
 linux-errno = "1.0.1"
 naked-function = "0.1.5"
 linux-raw-sys = "0.4.5"
+rustix = { optional=true, version = "0.38.4", default-features=false, features = ["process"] }
 
 [dev-dependencies]
 rustix = { version = "0.38.4", default-features=false, features = ["thread", "process", "time"] }

--- a/src/lib/linux-api/src/exit.rs
+++ b/src/lib/linux-api/src/exit.rs
@@ -14,3 +14,16 @@ pub fn exit(val: i8) -> ! {
     exit_raw(val.into()).unwrap();
     unreachable!()
 }
+
+/// Exits the process, setting `val & 0xff` as the exit code.
+pub fn exit_group_raw(val: i32) -> Result<(), Errno> {
+    unsafe { linux_syscall::syscall!(linux_syscall::SYS_exit_group, val) }
+        .check()
+        .map_err(Errno::from)
+}
+
+/// Exits the current process, setting `val` as the exit code.
+pub fn exit_group(val: i8) -> ! {
+    exit_group_raw(val.into()).unwrap();
+    unreachable!()
+}

--- a/src/lib/linux-api/src/posix_types.rs
+++ b/src/lib/linux-api/src/posix_types.rs
@@ -41,3 +41,17 @@ impl Pid {
         self.0
     }
 }
+
+#[cfg(feature = "rustix")]
+impl From<rustix::process::Pid> for Pid {
+    fn from(value: rustix::process::Pid) -> Self {
+        Pid(value.as_raw_nonzero())
+    }
+}
+
+#[cfg(feature = "rustix")]
+impl From<Pid> for rustix::process::Pid {
+    fn from(value: Pid) -> Self {
+        rustix::process::Pid::from_raw(value.as_raw_nonzero().into()).unwrap()
+    }
+}

--- a/src/lib/linux-api/src/posix_types.rs
+++ b/src/lib/linux-api/src/posix_types.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroI32;
+
 use crate::bindings;
 
 pub use bindings::linux___kernel_pid_t;
@@ -15,3 +17,27 @@ pub type kernel_ulong_t = bindings::linux___kernel_ulong_t;
 pub use bindings::linux___kernel_off_t;
 #[allow(non_camel_case_types)]
 pub type kernel_off_t = linux___kernel_off_t;
+
+/// Type-safe wrapper around [`kernel_pid_t`]. Value is strictly positive.
+/// Interface inspired by `rustix::process::Pid`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Pid(NonZeroI32);
+
+impl Pid {
+    pub fn from_raw(pid: kernel_pid_t) -> Option<Self> {
+        if pid < 0 {
+            None
+        } else {
+            Some(Self(NonZeroI32::new(pid).unwrap()))
+        }
+    }
+
+    /// Returns a stricly positive integer for `Some`, or 0 for `None`.
+    pub fn as_raw(this: Option<Self>) -> kernel_pid_t {
+        this.map(|x| kernel_pid_t::from(x.0)).unwrap_or(0)
+    }
+
+    pub fn as_raw_nonzero(self) -> NonZeroI32 {
+        self.0
+    }
+}

--- a/src/lib/shim/src/signals.rs
+++ b/src/lib/shim/src/signals.rs
@@ -286,12 +286,7 @@ pub unsafe fn process_signals(mut ucontext: Option<&mut ucontext>) -> bool {
 
         let pid = rustix::process::getpid();
         let tid = rustix::thread::gettid();
-        linux_api::signal::tgkill(
-            pid.as_raw_nonzero(),
-            tid.as_raw_nonzero(),
-            Some(Signal::SIGUSR1),
-        )
-        .unwrap();
+        linux_api::signal::tgkill(pid.into(), tid.into(), Some(Signal::SIGUSR1)).unwrap();
 
         // Reacquire locks and references.
         host = crate::global_host_shmem::get();

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -195,7 +195,7 @@ libc = "0.2"
 linux-api = { path = "../lib/linux-api" }
 nix = "0.26.2"
 rand = { version="0.8.5", features=["small_rng"] }
-rustix = { version = "0.38.4", default-features=false, features=["mm", "time", "thread"]}
+rustix = { version = "0.38.4", default-features=false, features=["mm", "pipe", "time", "thread"]}
 signal-hook = "0.3.15"
 once_cell = "1.18.0"
 vasi-sync = { path = "../lib/vasi-sync" }

--- a/src/test/clone/test_clone.rs
+++ b/src/test/clone/test_clone.rs
@@ -8,7 +8,7 @@ use linux_api::errno::Errno;
 use linux_api::ldt::linux_user_desc;
 use linux_api::posix_types::Pid;
 use linux_api::sched::{CloneFlags, CloneResult};
-use linux_api::signal::{kill_process, tgkill, Signal};
+use linux_api::signal::{tgkill, Signal};
 use rustix::fd::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd};
 use rustix::fs::{OFlags, SeekFrom};
 use rustix::mm::{MapFlags, MprotectFlags, ProtFlags};
@@ -309,6 +309,37 @@ fn test_clone_files_dup(use_clone_files_flag: bool) -> Result<(), Box<dyn Error>
     Ok(())
 }
 
+fn test_fork() -> Result<(), Box<dyn Error>> {
+    let (reader, writer) = rustix::pipe::pipe().unwrap();
+
+    let flags = CloneFlags::empty();
+    let res = unsafe {
+        linux_api::sched::clone(
+            flags,
+            Some(Signal::SIGCHLD),
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+        )
+    }
+    .unwrap();
+
+    match res {
+        CloneResult::CallerIsChild => {
+            assert_eq!(rustix::io::write(&writer, &[42]), Ok(1));
+            linux_api::exit::exit_group(0);
+        }
+        CloneResult::CallerIsParent(_pid) => (),
+    };
+
+    let mut buf = [0];
+    assert_eq!(rustix::io::read(&reader, &mut buf), Ok(1));
+    assert_eq!(buf[0], 42);
+
+    Ok(())
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     // should we restrict the tests we run?
     let filter_shadow_passing = std::env::args().any(|x| x == "--shadow-passing");
@@ -317,6 +348,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let summarize = std::env::args().any(|x| x == "--summarize");
 
     let all_envs = set![TestEnv::Libc, TestEnv::Shadow];
+    let libc_only = set![TestEnv::Libc];
 
     let mut tests: Vec<test_utils::ShadowTest<(), Box<dyn Error>>> = vec![
         ShadowTest::new("minimal", test_clone_minimal, all_envs.clone()),
@@ -341,11 +373,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             || test_clone_files_dup(false),
             all_envs.clone(),
         ),
+        ShadowTest::new("fork_runs", test_fork, libc_only.clone()),
     ];
 
     // Explicitly reference these to avoid clippy warning about unnecessary
     // clone at point of last usage above.
     drop(all_envs);
+    drop(libc_only);
 
     if filter_shadow_passing {
         tests.retain(|x| x.passing(TestEnv::Shadow));


### PR DESCRIPTION
Doesn't pass in shadow yet.

This also includes some additions and tweaks to linux-api. Some of this ended up being unused for now; I intended to write an analogue of `wait_for_thread_exit` for a child process, but it appears that `kill(child_pid, 0)` "succeeds" (i.e. doesn't return `ESRCH`) if the child hasn't been reaped, even if no exit signal was specified. (I also don't want the first version of this test to use `waitpid`, since that implementation is a little further down the road)