### PR TITLE
Add new TCP socket implementation

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -89,6 +89,7 @@ hosts:
 - [`experimental.use_cpu_pinning`](#experimentaluse_cpu_pinning)
 - [`experimental.use_dynamic_runahead`](#experimentaluse_dynamic_runahead)
 - [`experimental.use_memory_manager`](#experimentaluse_memory_manager)
+- [`experimental.use_new_tcp`](#experimentaluse_new_tcp)
 - [`experimental.use_object_counters`](#experimentaluse_object_counters)
 - [`experimental.use_preload_libc`](#experimentaluse_preload_libc)
 - [`experimental.use_preload_openssl_crypto`](#experimentaluse_preload_openssl_crypto)
@@ -470,6 +471,13 @@ Type: Bool
 
 Use the MemoryManager. It can be useful to disable for debugging, but will hurt
 performance in most cases.
+
+#### `experimental.use_new_tcp`
+
+Default: false  
+Type: Bool
+
+Use the rust TCP implementation.
 
 #### `experimental.use_object_counters`
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1516,6 +1516,7 @@ dependencies = [
  "std-util",
  "syscall-logger",
  "system-deps",
+ "tcp",
  "tempfile",
  "vasi-sync",
  "vsprintf",

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -51,6 +51,7 @@ signal-hook = "0.3.15"
 static_assertions = "1.1.0"
 std-util = { path = "../lib/std-util" }
 syscall-logger = { path = "../lib/syscall-logger" }
+tcp = { path = "../lib/tcp" }
 tempfile = "3.7"
 vasi-sync = { path = "../lib/vasi-sync" }
 # TODO: switch to upstream crate if/when they merge and release

--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -163,6 +163,9 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         // Haven't decided how to handle glib struct types yet. Avoid using them
         // until we do.
         .blocklist_type("_?GQueue")
+        .allowlist_function("g_list_append")
+        .allowlist_function("g_list_free")
+        .allowlist_type("GList")
         // Needs GQueue
         .opaque_type("_?LegacySocket.*")
         .blocklist_type("_?Socket.*")
@@ -246,7 +249,6 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .opaque_type("DescriptorTable")
         .opaque_type("MemoryManager")
         .opaque_type("TaskRef")
-        .opaque_type("GList")
         .blocklist_type("Logger")
         .blocklist_type("Timer")
         .blocklist_type("Controller")

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -607,6 +607,7 @@ impl<'a> Manager<'a> {
                     .log_level
                     .unwrap_or_else(|| self.config.general.log_level.unwrap())
                     .to_c_loglevel(),
+                use_new_tcp: self.config.experimental.use_new_tcp.unwrap(),
             };
 
             Box::new(unsafe {

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -460,6 +460,12 @@ pub struct ExperimentalOptions {
     #[clap(long, value_name = "bool")]
     #[clap(help = EXP_HELP.get("log_errors_to_tty").unwrap().as_str())]
     pub log_errors_to_tty: Option<bool>,
+
+    /// Use the rust TCP implementation
+    #[clap(hide_short_help = true)]
+    #[clap(long, value_name = "bool")]
+    #[clap(help = EXP_HELP.get("use_new_tcp").unwrap().as_str())]
+    pub use_new_tcp: Option<bool>,
 }
 
 impl ExperimentalOptions {
@@ -509,6 +515,7 @@ impl Default for ExperimentalOptions {
             strace_logging_mode: Some(StraceLoggingMode::Off),
             scheduler: Some(Scheduler::ThreadPerCore),
             log_errors_to_tty: Some(true),
+            use_new_tcp: Some(false),
         }
     }
 }

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -845,7 +845,12 @@ impl LegacyTcpSocket {
         errcode.map_err(Into::into)
     }
 
-    pub fn accept(&mut self, _cb_queue: &mut CallbackQueue) -> Result<OpenFile, SyscallError> {
+    pub fn accept(
+        &mut self,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<OpenFile, SyscallError> {
         let is_valid_listener = unsafe { c::tcp_isValidListener(self.as_legacy_tcp()) } == 1;
 
         // we must be listening in order to accept

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -277,6 +277,7 @@ impl LegacyTcpSocket {
             InetSocket::LegacyTcp(Arc::clone(socket)),
             addr,
             peer_addr,
+            /* check_less_specific= */ true,
             net_ns,
             rng,
         )?;
@@ -660,6 +661,7 @@ impl LegacyTcpSocket {
                 super::InetSocket::LegacyTcp(socket.clone()),
                 local_addr,
                 peer_addr,
+                /* check_less_specific= */ true,
                 net_ns,
                 rng,
             )?;
@@ -763,6 +765,7 @@ impl LegacyTcpSocket {
                 super::InetSocket::LegacyTcp(socket.clone()),
                 local_addr,
                 peer_addr,
+                /* check_less_specific= */ true,
                 net_ns,
                 rng,
             )?;

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -339,11 +339,16 @@ impl InetSocketRefMut<'_> {
         -> Result<(), SyscallError>
     );
 
-    pub fn accept(&mut self, cb_queue: &mut CallbackQueue) -> Result<OpenFile, SyscallError> {
+    pub fn accept(
+        &mut self,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
+        cb_queue: &mut CallbackQueue,
+    ) -> Result<OpenFile, SyscallError> {
         match self {
-            Self::LegacyTcp(socket) => socket.accept(cb_queue),
-            Self::Tcp(socket) => socket.accept(cb_queue),
-            Self::Udp(socket) => socket.accept(cb_queue),
+            Self::LegacyTcp(socket) => socket.accept(net_ns, rng, cb_queue),
+            Self::Tcp(socket) => socket.accept(net_ns, rng, cb_queue),
+            Self::Udp(socket) => socket.accept(net_ns, rng, cb_queue),
         }
     }
 

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -22,14 +22,17 @@ use crate::utility::sockaddr::SockaddrStorage;
 use crate::utility::HostTreePointer;
 
 use self::legacy_tcp::LegacyTcpSocket;
+use self::tcp::TcpSocket;
 use self::udp::UdpSocket;
 
 pub mod legacy_tcp;
+pub mod tcp;
 pub mod udp;
 
 #[derive(Clone)]
 pub enum InetSocket {
     LegacyTcp(Arc<AtomicRefCell<LegacyTcpSocket>>),
+    Tcp(Arc<AtomicRefCell<TcpSocket>>),
     Udp(Arc<AtomicRefCell<UdpSocket>>),
 }
 
@@ -37,6 +40,7 @@ impl InetSocket {
     pub fn borrow(&self) -> InetSocketRef {
         match self {
             Self::LegacyTcp(ref f) => InetSocketRef::LegacyTcp(f.borrow()),
+            Self::Tcp(ref f) => InetSocketRef::Tcp(f.borrow()),
             Self::Udp(ref f) => InetSocketRef::Udp(f.borrow()),
         }
     }
@@ -44,6 +48,7 @@ impl InetSocket {
     pub fn try_borrow(&self) -> Result<InetSocketRef, atomic_refcell::BorrowError> {
         Ok(match self {
             Self::LegacyTcp(ref f) => InetSocketRef::LegacyTcp(f.try_borrow()?),
+            Self::Tcp(ref f) => InetSocketRef::Tcp(f.try_borrow()?),
             Self::Udp(ref f) => InetSocketRef::Udp(f.try_borrow()?),
         })
     }
@@ -51,6 +56,7 @@ impl InetSocket {
     pub fn borrow_mut(&self) -> InetSocketRefMut {
         match self {
             Self::LegacyTcp(ref f) => InetSocketRefMut::LegacyTcp(f.borrow_mut()),
+            Self::Tcp(ref f) => InetSocketRefMut::Tcp(f.borrow_mut()),
             Self::Udp(ref f) => InetSocketRefMut::Udp(f.borrow_mut()),
         }
     }
@@ -58,6 +64,7 @@ impl InetSocket {
     pub fn try_borrow_mut(&self) -> Result<InetSocketRefMut, atomic_refcell::BorrowMutError> {
         Ok(match self {
             Self::LegacyTcp(ref f) => InetSocketRefMut::LegacyTcp(f.try_borrow_mut()?),
+            Self::Tcp(ref f) => InetSocketRefMut::Tcp(f.try_borrow_mut()?),
             Self::Udp(ref f) => InetSocketRefMut::Udp(f.try_borrow_mut()?),
         })
     }
@@ -65,6 +72,7 @@ impl InetSocket {
     pub fn downgrade(&self) -> InetSocketWeak {
         match self {
             Self::LegacyTcp(x) => InetSocketWeak::LegacyTcp(Arc::downgrade(x)),
+            Self::Tcp(x) => InetSocketWeak::Tcp(Arc::downgrade(x)),
             Self::Udp(x) => InetSocketWeak::Udp(Arc::downgrade(x)),
         }
     }
@@ -74,6 +82,7 @@ impl InetSocket {
             // usually we'd use `Arc::as_ptr()`, but we want to use the handle for the C `TCP`
             // object for consistency with the handle for the `LegacySocket`
             Self::LegacyTcp(f) => f.borrow().canonical_handle(),
+            Self::Tcp(f) => Arc::as_ptr(f) as usize,
             Self::Udp(f) => Arc::as_ptr(f) as usize,
         }
     }
@@ -86,6 +95,7 @@ impl InetSocket {
     ) -> SyscallResult {
         match self {
             Self::LegacyTcp(socket) => LegacyTcpSocket::bind(socket, addr, net_ns, rng),
+            Self::Tcp(socket) => TcpSocket::bind(socket, addr, net_ns, rng),
             Self::Udp(socket) => UdpSocket::bind(socket, addr, net_ns, rng),
         }
     }
@@ -101,6 +111,7 @@ impl InetSocket {
             Self::LegacyTcp(socket) => {
                 LegacyTcpSocket::listen(socket, backlog, net_ns, rng, cb_queue)
             }
+            Self::Tcp(socket) => TcpSocket::listen(socket, backlog, net_ns, rng, cb_queue),
             Self::Udp(socket) => UdpSocket::listen(socket, backlog, net_ns, rng, cb_queue),
         }
     }
@@ -116,6 +127,7 @@ impl InetSocket {
             Self::LegacyTcp(socket) => {
                 LegacyTcpSocket::connect(socket, addr, net_ns, rng, cb_queue)
             }
+            Self::Tcp(socket) => TcpSocket::connect(socket, addr, net_ns, rng, cb_queue),
             Self::Udp(socket) => UdpSocket::connect(socket, addr, net_ns, rng, cb_queue),
         }
     }
@@ -131,6 +143,9 @@ impl InetSocket {
         match self {
             Self::LegacyTcp(socket) => {
                 LegacyTcpSocket::sendmsg(socket, args, memory_manager, net_ns, rng, cb_queue)
+            }
+            Self::Tcp(socket) => {
+                TcpSocket::sendmsg(socket, args, memory_manager, net_ns, rng, cb_queue)
             }
             Self::Udp(socket) => {
                 UdpSocket::sendmsg(socket, args, memory_manager, net_ns, rng, cb_queue)
@@ -148,6 +163,7 @@ impl InetSocket {
             Self::LegacyTcp(socket) => {
                 LegacyTcpSocket::recvmsg(socket, args, memory_manager, cb_queue)
             }
+            Self::Tcp(socket) => TcpSocket::recvmsg(socket, args, memory_manager, cb_queue),
             Self::Udp(socket) => UdpSocket::recvmsg(socket, args, memory_manager, cb_queue),
         }
     }
@@ -157,6 +173,7 @@ impl std::fmt::Debug for InetSocket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::LegacyTcp(_) => write!(f, "LegacyTcp")?,
+            Self::Tcp(_) => write!(f, "Tcp")?,
             Self::Udp(_) => write!(f, "Udp")?,
         }
 
@@ -175,29 +192,31 @@ impl std::fmt::Debug for InetSocket {
 
 pub enum InetSocketRef<'a> {
     LegacyTcp(atomic_refcell::AtomicRef<'a, LegacyTcpSocket>),
+    Tcp(atomic_refcell::AtomicRef<'a, TcpSocket>),
     Udp(atomic_refcell::AtomicRef<'a, UdpSocket>),
 }
 
 pub enum InetSocketRefMut<'a> {
     LegacyTcp(atomic_refcell::AtomicRefMut<'a, LegacyTcpSocket>),
+    Tcp(atomic_refcell::AtomicRefMut<'a, TcpSocket>),
     Udp(atomic_refcell::AtomicRefMut<'a, UdpSocket>),
 }
 
 // file functions
 impl InetSocketRef<'_> {
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn state(&self) -> FileState
     );
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn mode(&self) -> FileMode
     );
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn get_status(&self) -> FileStatus
     );
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn has_open_file(&self) -> bool
     );
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn supports_sa_restart(&self) -> bool
     );
 }
@@ -207,6 +226,7 @@ impl InetSocketRef<'_> {
     pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
             Self::LegacyTcp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
+            Self::Tcp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
             Self::Udp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
         }
     }
@@ -214,15 +234,16 @@ impl InetSocketRef<'_> {
     pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
             Self::LegacyTcp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
+            Self::Tcp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
             Self::Udp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
         }
     }
 
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn address_family(&self) -> nix::sys::socket::AddressFamily
     );
 
-    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp, Udp;
+    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp, Tcp, Udp;
         pub fn getsockopt(&self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
                           optlen: libc::socklen_t, memory_manager: &mut MemoryManager)
         -> Result<libc::socklen_t, SyscallError>
@@ -231,54 +252,54 @@ impl InetSocketRef<'_> {
 
 // inet socket-specific functions
 impl InetSocketRef<'_> {
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn peek_next_packet_priority(&self) -> Option<FifoPacketPriority>
     );
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn has_data_to_send(&self) -> bool
     );
 }
 
 // file functions
 impl InetSocketRefMut<'_> {
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn state(&self) -> FileState
     );
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn mode(&self) -> FileMode
     );
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn get_status(&self) -> FileStatus
     );
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn has_open_file(&self) -> bool
     );
-    enum_passthrough!(self, (val), LegacyTcp, Udp;
+    enum_passthrough!(self, (val), LegacyTcp, Tcp, Udp;
         pub fn set_has_open_file(&mut self, val: bool)
     );
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn supports_sa_restart(&self) -> bool
     );
-    enum_passthrough!(self, (cb_queue), LegacyTcp, Udp;
+    enum_passthrough!(self, (cb_queue), LegacyTcp, Tcp, Udp;
         pub fn close(&mut self, cb_queue: &mut CallbackQueue) -> Result<(), SyscallError>
     );
-    enum_passthrough!(self, (status), LegacyTcp, Udp;
+    enum_passthrough!(self, (status), LegacyTcp, Tcp, Udp;
         pub fn set_status(&mut self, status: FileStatus)
     );
-    enum_passthrough!(self, (request, arg_ptr, memory_manager), LegacyTcp, Udp;
+    enum_passthrough!(self, (request, arg_ptr, memory_manager), LegacyTcp, Tcp, Udp;
         pub fn ioctl(&mut self, request: IoctlRequest, arg_ptr: ForeignPtr<()>, memory_manager: &mut MemoryManager) -> SyscallResult
     );
-    enum_passthrough!(self, (ptr), LegacyTcp, Udp;
+    enum_passthrough!(self, (ptr), LegacyTcp, Tcp, Udp;
         pub fn add_legacy_listener(&mut self, ptr: HostTreePointer<c::StatusListener>)
     );
-    enum_passthrough!(self, (ptr), LegacyTcp, Udp;
+    enum_passthrough!(self, (ptr), LegacyTcp, Tcp, Udp;
         pub fn remove_legacy_listener(&mut self, ptr: *mut c::StatusListener)
     );
-    enum_passthrough!(self, (iovs, offset, flags, mem, cb_queue), LegacyTcp, Udp;
+    enum_passthrough!(self, (iovs, offset, flags, mem, cb_queue), LegacyTcp, Tcp, Udp;
         pub fn readv(&mut self, iovs: &[IoVec], offset: Option<libc::off_t>, flags: libc::c_int,
                      mem: &mut MemoryManager, cb_queue: &mut CallbackQueue) -> Result<libc::ssize_t, SyscallError>
     );
-    enum_passthrough!(self, (iovs, offset, flags, mem, cb_queue), LegacyTcp, Udp;
+    enum_passthrough!(self, (iovs, offset, flags, mem, cb_queue), LegacyTcp, Tcp, Udp;
         pub fn writev(&mut self, iovs: &[IoVec], offset: Option<libc::off_t>, flags: libc::c_int,
                       mem: &mut MemoryManager, cb_queue: &mut CallbackQueue) -> Result<libc::ssize_t, SyscallError>
     );
@@ -289,6 +310,7 @@ impl InetSocketRefMut<'_> {
     pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
             Self::LegacyTcp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
+            Self::Tcp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
             Self::Udp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
         }
     }
@@ -296,21 +318,22 @@ impl InetSocketRefMut<'_> {
     pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
         match self {
             Self::LegacyTcp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
+            Self::Tcp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
             Self::Udp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
         }
     }
 
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn address_family(&self) -> nix::sys::socket::AddressFamily
     );
 
-    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp, Udp;
+    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp, Tcp, Udp;
         pub fn getsockopt(&self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
                           optlen: libc::socklen_t, memory_manager: &mut MemoryManager)
         -> Result<libc::socklen_t, SyscallError>
     );
 
-    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp, Udp;
+    enum_passthrough!(self, (level, optname, optval_ptr, optlen, memory_manager), LegacyTcp, Tcp, Udp;
         pub fn setsockopt(&mut self, level: libc::c_int, optname: libc::c_int, optval_ptr: ForeignPtr<()>,
                           optlen: libc::socklen_t, memory_manager: &MemoryManager)
         -> Result<(), SyscallError>
@@ -319,27 +342,28 @@ impl InetSocketRefMut<'_> {
     pub fn accept(&mut self, cb_queue: &mut CallbackQueue) -> Result<OpenFile, SyscallError> {
         match self {
             Self::LegacyTcp(socket) => socket.accept(cb_queue),
+            Self::Tcp(socket) => socket.accept(cb_queue),
             Self::Udp(socket) => socket.accept(cb_queue),
         }
     }
 
-    enum_passthrough!(self, (how, cb_queue), LegacyTcp, Udp;
+    enum_passthrough!(self, (how, cb_queue), LegacyTcp, Tcp, Udp;
         pub fn shutdown(&mut self, how: Shutdown, cb_queue: &mut CallbackQueue) -> Result<(), SyscallError>
     );
 }
 
 // inet socket-specific functions
 impl InetSocketRefMut<'_> {
-    enum_passthrough!(self, (packet, cb_queue, recv_time), LegacyTcp, Udp;
+    enum_passthrough!(self, (packet, cb_queue, recv_time), LegacyTcp, Tcp, Udp;
         pub fn push_in_packet(&mut self, packet: PacketRc, cb_queue: &mut CallbackQueue, recv_time: EmulatedTime)
     );
-    enum_passthrough!(self, (cb_queue), LegacyTcp, Udp;
+    enum_passthrough!(self, (cb_queue), LegacyTcp, Tcp, Udp;
         pub fn pull_out_packet(&mut self, cb_queue: &mut CallbackQueue) -> Option<PacketRc>
     );
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn peek_next_packet_priority(&self) -> Option<FifoPacketPriority>
     );
-    enum_passthrough!(self, (), LegacyTcp, Udp;
+    enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn has_data_to_send(&self) -> bool
     );
 }
@@ -348,6 +372,7 @@ impl std::fmt::Debug for InetSocketRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::LegacyTcp(_) => write!(f, "LegacyTcp")?,
+            Self::Tcp(_) => write!(f, "Tcp")?,
             Self::Udp(_) => write!(f, "Udp")?,
         }
 
@@ -364,6 +389,7 @@ impl std::fmt::Debug for InetSocketRefMut<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::LegacyTcp(_) => write!(f, "LegacyTcp")?,
+            Self::Tcp(_) => write!(f, "Tcp")?,
             Self::Udp(_) => write!(f, "Udp")?,
         }
 
@@ -379,6 +405,7 @@ impl std::fmt::Debug for InetSocketRefMut<'_> {
 #[derive(Clone)]
 pub enum InetSocketWeak {
     LegacyTcp(Weak<AtomicRefCell<LegacyTcpSocket>>),
+    Tcp(Weak<AtomicRefCell<TcpSocket>>),
     Udp(Weak<AtomicRefCell<UdpSocket>>),
 }
 
@@ -386,6 +413,7 @@ impl InetSocketWeak {
     pub fn upgrade(&self) -> Option<InetSocket> {
         match self {
             Self::LegacyTcp(x) => x.upgrade().map(InetSocket::LegacyTcp),
+            Self::Tcp(x) => x.upgrade().map(InetSocket::Tcp),
             Self::Udp(x) => x.upgrade().map(InetSocket::Udp),
         }
     }
@@ -415,6 +443,7 @@ fn associate_socket(
 
     let protocol = match socket {
         InetSocket::LegacyTcp(_) => c::_ProtocolType_PTCP,
+        InetSocket::Tcp(_) => c::_ProtocolType_PTCP,
         InetSocket::Udp(_) => c::_ProtocolType_PUDP,
     };
 

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -429,10 +429,13 @@ impl InetSocketWeak {
 /// non-zero port will be chosen. The final local address will be returned. If the peer address is
 /// unspecified and has a port of 0, the socket will receive packets from every peer address. The
 /// socket will be automatically disassociated when the returned [`AssociationHandle`] is dropped.
+/// If `check_less_specific` is true, the association will also fail if there is already a socket
+/// associated with the local address `local_addr` and peer address 0.0.0.0.
 fn associate_socket(
     socket: InetSocket,
     local_addr: SocketAddrV4,
     peer_addr: SocketAddrV4,
+    check_less_specific: bool,
     net_ns: &NetworkNamespace,
     rng: impl rand::Rng,
 ) -> Result<(SocketAddrV4, AssociationHandle), SyscallError> {
@@ -468,7 +471,7 @@ fn associate_socket(
     };
 
     // make sure the port is available at this address for this protocol
-    if !net_ns.is_interface_available(protocol, local_addr, peer_addr) {
+    if !net_ns.is_interface_available(protocol, local_addr, peer_addr, check_less_specific) {
         log::debug!(
             "The provided addresses (local={local_addr}, peer={peer_addr}) are not available"
         );

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -1,0 +1,245 @@
+use std::sync::Arc;
+
+use atomic_refcell::AtomicRefCell;
+use linux_api::ioctls::IoctlRequest;
+use nix::sys::socket::{AddressFamily, Shutdown, SockaddrIn};
+use shadow_shim_helper_rs::emulated_time::EmulatedTime;
+use shadow_shim_helper_rs::syscall_types::ForeignPtr;
+
+use crate::cshadow as c;
+use crate::host::descriptor::socket::{RecvmsgArgs, RecvmsgReturn, SendmsgArgs};
+use crate::host::descriptor::{
+    FileMode, FileState, FileStatus, OpenFile, StateEventSource, StateListenerFilter, SyscallResult,
+};
+use crate::host::memory_manager::MemoryManager;
+use crate::host::network::interface::FifoPacketPriority;
+use crate::host::network::namespace::NetworkNamespace;
+use crate::host::syscall::io::IoVec;
+use crate::host::syscall_types::SyscallError;
+use crate::network::packet::PacketRc;
+use crate::utility::callback_queue::{CallbackQueue, Handle};
+use crate::utility::sockaddr::SockaddrStorage;
+use crate::utility::{HostTreePointer, ObjectCounter};
+
+pub struct TcpSocket {
+    event_source: StateEventSource,
+    status: FileStatus,
+    state: FileState,
+    // should only be used by `OpenFile` to make sure there is only ever one `OpenFile` instance for
+    // this file
+    has_open_file: bool,
+    _counter: ObjectCounter,
+}
+
+impl TcpSocket {
+    pub fn new(_status: FileStatus) -> Arc<AtomicRefCell<Self>> {
+        todo!();
+    }
+
+    pub fn get_status(&self) -> FileStatus {
+        self.status
+    }
+
+    pub fn set_status(&mut self, status: FileStatus) {
+        self.status = status;
+    }
+
+    pub fn mode(&self) -> FileMode {
+        FileMode::READ | FileMode::WRITE
+    }
+
+    pub fn has_open_file(&self) -> bool {
+        self.has_open_file
+    }
+
+    pub fn supports_sa_restart(&self) -> bool {
+        true
+    }
+
+    pub fn set_has_open_file(&mut self, val: bool) {
+        self.has_open_file = val;
+    }
+
+    pub fn push_in_packet(
+        &mut self,
+        mut _packet: PacketRc,
+        _cb_queue: &mut CallbackQueue,
+        _recv_time: EmulatedTime,
+    ) {
+        todo!();
+    }
+
+    pub fn pull_out_packet(&mut self, _cb_queue: &mut CallbackQueue) -> Option<PacketRc> {
+        todo!();
+    }
+
+    pub fn peek_next_packet_priority(&self) -> Option<FifoPacketPriority> {
+        todo!();
+    }
+
+    pub fn has_data_to_send(&self) -> bool {
+        todo!();
+    }
+
+    pub fn update_packet_header(&self, _packet: &mut PacketRc) {
+        todo!();
+    }
+
+    pub fn getsockname(&self) -> Result<Option<SockaddrIn>, SyscallError> {
+        todo!();
+    }
+
+    pub fn getpeername(&self) -> Result<Option<SockaddrIn>, SyscallError> {
+        todo!();
+    }
+
+    pub fn address_family(&self) -> AddressFamily {
+        AddressFamily::Inet
+    }
+
+    pub fn close(&mut self, _cb_queue: &mut CallbackQueue) -> Result<(), SyscallError> {
+        todo!();
+    }
+
+    pub fn bind(
+        _socket: &Arc<AtomicRefCell<Self>>,
+        _addr: Option<&SockaddrStorage>,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
+    ) -> SyscallResult {
+        todo!();
+    }
+
+    pub fn readv(
+        &mut self,
+        _iovs: &[IoVec],
+        _offset: Option<libc::off_t>,
+        _flags: libc::c_int,
+        _mem: &mut MemoryManager,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<libc::ssize_t, SyscallError> {
+        // we could call TcpSocket::recvmsg() here, but for now we expect that there are no code
+        // paths that would call TcpSocket::readv() since the readv() syscall handler should have
+        // called TcpSocket::recvmsg() instead
+        panic!("Called TcpSocket::readv() on a TCP socket");
+    }
+
+    pub fn writev(
+        &mut self,
+        _iovs: &[IoVec],
+        _offset: Option<libc::off_t>,
+        _flags: libc::c_int,
+        _mem: &mut MemoryManager,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<libc::ssize_t, SyscallError> {
+        // we could call TcpSocket::sendmsg() here, but for now we expect that there are no code
+        // paths that would call TcpSocket::writev() since the writev() syscall handler should have
+        // called TcpSocket::sendmsg() instead
+        panic!("Called TcpSocket::writev() on a TCP socket");
+    }
+
+    pub fn sendmsg(
+        _socket: &Arc<AtomicRefCell<Self>>,
+        _args: SendmsgArgs,
+        _mem: &mut MemoryManager,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<libc::ssize_t, SyscallError> {
+        todo!();
+    }
+
+    pub fn recvmsg(
+        _socket: &Arc<AtomicRefCell<Self>>,
+        _args: RecvmsgArgs,
+        _mem: &mut MemoryManager,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<RecvmsgReturn, SyscallError> {
+        todo!();
+    }
+
+    pub fn ioctl(
+        &mut self,
+        _request: IoctlRequest,
+        _arg_ptr: ForeignPtr<()>,
+        _mem: &mut MemoryManager,
+    ) -> SyscallResult {
+        todo!();
+    }
+
+    pub fn listen(
+        _socket: &Arc<AtomicRefCell<Self>>,
+        _backlog: i32,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<(), SyscallError> {
+        todo!();
+    }
+
+    pub fn connect(
+        _socket: &Arc<AtomicRefCell<Self>>,
+        _peer_addr: &SockaddrStorage,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<(), SyscallError> {
+        todo!();
+    }
+
+    pub fn accept(&mut self, _cb_queue: &mut CallbackQueue) -> Result<OpenFile, SyscallError> {
+        todo!();
+    }
+
+    pub fn shutdown(
+        &mut self,
+        _how: Shutdown,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<(), SyscallError> {
+        todo!();
+    }
+
+    pub fn getsockopt(
+        &self,
+        _level: libc::c_int,
+        _optname: libc::c_int,
+        _optval_ptr: ForeignPtr<()>,
+        _optlen: libc::socklen_t,
+        _mem: &mut MemoryManager,
+    ) -> Result<libc::socklen_t, SyscallError> {
+        todo!();
+    }
+
+    pub fn setsockopt(
+        &mut self,
+        _level: libc::c_int,
+        _optname: libc::c_int,
+        _optval_ptr: ForeignPtr<()>,
+        _optlen: libc::socklen_t,
+        _mem: &MemoryManager,
+    ) -> Result<(), SyscallError> {
+        todo!();
+    }
+
+    pub fn add_listener(
+        &mut self,
+        monitoring: FileState,
+        filter: StateListenerFilter,
+        notify_fn: impl Fn(FileState, FileState, &mut CallbackQueue) + Send + Sync + 'static,
+    ) -> Handle<(FileState, FileState)> {
+        self.event_source
+            .add_listener(monitoring, filter, notify_fn)
+    }
+
+    pub fn add_legacy_listener(&mut self, ptr: HostTreePointer<c::StatusListener>) {
+        self.event_source.add_legacy_listener(ptr);
+    }
+
+    pub fn remove_legacy_listener(&mut self, ptr: *mut c::StatusListener) {
+        self.event_source.remove_legacy_listener(ptr);
+    }
+
+    pub fn state(&self) -> FileState {
+        self.state
+    }
+}

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -1,30 +1,42 @@
-use std::sync::Arc;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::sync::{Arc, Weak};
 
 use atomic_refcell::AtomicRefCell;
+use bytes::BytesMut;
+use linux_api::errno::Errno;
 use linux_api::ioctls::IoctlRequest;
-use nix::sys::socket::{AddressFamily, Shutdown, SockaddrIn};
+use nix::sys::socket::{AddressFamily, MsgFlags, Shutdown, SockaddrIn};
 use shadow_shim_helper_rs::emulated_time::EmulatedTime;
+use shadow_shim_helper_rs::simulation_time::SimulationTime;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
+use crate::core::work::task::TaskRef;
+use crate::core::worker::Worker;
 use crate::cshadow as c;
-use crate::host::descriptor::socket::{RecvmsgArgs, RecvmsgReturn, SendmsgArgs};
+use crate::host::descriptor::socket::inet;
+use crate::host::descriptor::socket::{InetSocket, RecvmsgArgs, RecvmsgReturn, SendmsgArgs};
+use crate::host::descriptor::{File, Socket};
 use crate::host::descriptor::{
     FileMode, FileState, FileStatus, OpenFile, StateEventSource, StateListenerFilter, SyscallResult,
 };
 use crate::host::memory_manager::MemoryManager;
 use crate::host::network::interface::FifoPacketPriority;
-use crate::host::network::namespace::NetworkNamespace;
-use crate::host::syscall::io::IoVec;
+use crate::host::network::namespace::{AssociationHandle, NetworkNamespace};
+use crate::host::syscall::io::{write_partial, IoVec, IoVecReader, IoVecWriter};
 use crate::host::syscall_types::SyscallError;
-use crate::network::packet::PacketRc;
+use crate::network::packet::{PacketRc, PacketStatus};
 use crate::utility::callback_queue::{CallbackQueue, Handle};
 use crate::utility::sockaddr::SockaddrStorage;
 use crate::utility::{HostTreePointer, ObjectCounter};
 
 pub struct TcpSocket {
+    tcp_state: tcp::TcpState<TcpDeps>,
+    socket_weak: Weak<AtomicRefCell<Self>>,
     event_source: StateEventSource,
     status: FileStatus,
-    state: FileState,
+    file_state: FileState,
+    association: Option<AssociationHandle>,
+    connect_result_is_pending: bool,
     // should only be used by `OpenFile` to make sure there is only ever one `OpenFile` instance for
     // this file
     has_open_file: bool,
@@ -32,8 +44,37 @@ pub struct TcpSocket {
 }
 
 impl TcpSocket {
-    pub fn new(_status: FileStatus) -> Arc<AtomicRefCell<Self>> {
-        todo!();
+    pub fn new(status: FileStatus) -> Arc<AtomicRefCell<Self>> {
+        let rv = Arc::new_cyclic(|weak: &Weak<AtomicRefCell<Self>>| {
+            let tcp_dependencies = TcpDeps {
+                timer_state: Arc::new(AtomicRefCell::new(TcpDepsTimerState {
+                    socket: weak.clone(),
+                    registered_by: tcp::TimerRegisteredBy::Parent,
+                })),
+            };
+
+            AtomicRefCell::new(Self {
+                tcp_state: tcp::TcpState::new(tcp_dependencies),
+                socket_weak: weak.clone(),
+                event_source: StateEventSource::new(),
+                status,
+                // the readable/writable file state shouldn't matter here since we run
+                // `with_tcp_state` below to update it, but we need ACTIVE set so that epoll works
+                file_state: FileState::ACTIVE,
+                association: None,
+                connect_result_is_pending: false,
+                has_open_file: false,
+                _counter: ObjectCounter::new("TcpSocket"),
+            })
+        });
+
+        // run a no-op function on the state, which will force the socket to update its file state
+        // to match the tcp state
+        CallbackQueue::queue_and_run(|cb_queue| {
+            rv.borrow_mut().with_tcp_state(cb_queue, |_state| ())
+        });
+
+        rv
     }
 
     pub fn get_status(&self) -> FileStatus {
@@ -60,54 +101,228 @@ impl TcpSocket {
         self.has_open_file = val;
     }
 
-    pub fn push_in_packet(
+    /// Update the current tcp state. The tcp state should only ever be updated through this method.
+    fn with_tcp_state<T>(
         &mut self,
-        mut _packet: PacketRc,
-        _cb_queue: &mut CallbackQueue,
-        _recv_time: EmulatedTime,
-    ) {
-        todo!();
+        cb_queue: &mut CallbackQueue,
+        f: impl FnOnce(&mut tcp::TcpState<TcpDeps>) -> T,
+    ) -> T {
+        let rv = f(&mut self.tcp_state);
+
+        // we may have mutated the tcp state, so update the socket's file state and notify listeners
+
+        // if there are packets to send, notify the host
+        if self.tcp_state.wants_to_send() {
+            // The upgrade could fail if this was run during a drop, or if some outer code decided
+            // to take the `TcpSocket` out of the `Arc` for some reason. Might as well panic since
+            // it might indicate a bug somewhere else.
+            let socket = self.socket_weak.upgrade().unwrap();
+
+            // First try getting our IP address from the tcp state (if it's connected), then try
+            // from the association handle (if it's not connected but is bound). Assume that our IP
+            // address will match an interface's IP address.
+            let interface_ip = *self
+                .tcp_state
+                .local_remote_addrs()
+                .map(|x| x.0)
+                .or(self.association.as_ref().map(|x| x.local_addr()))
+                .unwrap()
+                .ip();
+
+            cb_queue.add(move |_cb_queue| {
+                Worker::with_active_host(|host| {
+                    let inet_socket = InetSocket::Tcp(socket);
+                    let compat_socket = unsafe { c::compatsocket_fromInetSocket(&inet_socket) };
+                    host.notify_socket_has_packets(interface_ip, &compat_socket);
+                })
+                .unwrap();
+            });
+        }
+
+        let mut read_write_flags = FileState::empty();
+        let poll_state = self.tcp_state.poll();
+
+        if poll_state.intersects(tcp::PollState::READABLE | tcp::PollState::RECV_CLOSED) {
+            read_write_flags.insert(FileState::READABLE);
+        }
+        if poll_state.intersects(tcp::PollState::WRITABLE) {
+            read_write_flags.insert(FileState::WRITABLE);
+        }
+        if poll_state.intersects(tcp::PollState::READY_TO_ACCEPT) {
+            read_write_flags.insert(FileState::READABLE);
+        }
+        if poll_state.intersects(tcp::PollState::ERROR) {
+            read_write_flags.insert(FileState::READABLE | FileState::WRITABLE);
+        }
+
+        // if the socket is closed, undo all of the flags set above (closed sockets aren't readable
+        // or writable)
+        if self.file_state.contains(FileState::CLOSED) {
+            read_write_flags = FileState::empty();
+        }
+
+        // overwrite readable/writable flags
+        self.copy_state(
+            FileState::READABLE | FileState::WRITABLE,
+            read_write_flags,
+            cb_queue,
+        );
+
+        // if the tcp state is in the closed state
+        if poll_state.contains(tcp::PollState::CLOSED) {
+            // drop the association handle so that we're removed from the network interface
+            self.association = None;
+            // we do not change to `FileState::CLOSED` here since that flag represents that the file
+            // has closed (with `close()`), not that the tcp state has closed
+        }
+
+        rv
     }
 
-    pub fn pull_out_packet(&mut self, _cb_queue: &mut CallbackQueue) -> Option<PacketRc> {
-        todo!();
+    pub fn push_in_packet(
+        &mut self,
+        mut packet: PacketRc,
+        cb_queue: &mut CallbackQueue,
+        _recv_time: EmulatedTime,
+    ) {
+        packet.add_status(PacketStatus::RcvSocketProcessed);
+
+        // TODO: don't bother copying the bytes if we know the push will fail
+
+        // TODO: we have no way of adding `PacketStatus::RcvSocketDropped` if the tcp state drops
+        // the packet
+
+        let header = packet
+            .get_tcp()
+            .expect("TCP socket received a non-tcp packet");
+
+        // in the future, the packet could contain the `Bytes` object itself and we could simply
+        // transfer the `Bytes` directly from the packet to the tcp state without copying the bytes
+
+        let mut payload = BytesMut::zeroed(packet.payload_size());
+        let num_bytes_copied = packet.get_payload(&mut payload);
+        assert_eq!(num_bytes_copied, packet.payload_size());
+
+        self.with_tcp_state(cb_queue, |s| s.push_packet(&header, payload.freeze()))
+            .unwrap();
+
+        packet.add_status(PacketStatus::RcvSocketBuffered);
+    }
+
+    pub fn pull_out_packet(&mut self, cb_queue: &mut CallbackQueue) -> Option<PacketRc> {
+        #[cfg(debug_assertions)]
+        let wants_to_send = self.tcp_state.wants_to_send();
+
+        // make sure that `self.has_data_to_send()` agrees with `tcp_state.wants_to_send()`
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(self.has_data_to_send(), wants_to_send);
+
+        // pop a packet from the socket
+        let rv = self.with_tcp_state(cb_queue, |s| s.pop_packet());
+
+        let (header, payload) = match rv {
+            Ok(x) => x,
+            Err(tcp::PopPacketError::NoPacket) => {
+                #[cfg(debug_assertions)]
+                debug_assert!(!wants_to_send);
+                return None;
+            }
+            Err(tcp::PopPacketError::InvalidState) => {
+                #[cfg(debug_assertions)]
+                debug_assert!(!wants_to_send);
+                return None;
+            }
+        };
+
+        #[cfg(debug_assertions)]
+        debug_assert!(wants_to_send);
+
+        let mut packet = PacketRc::new();
+
+        // in the future, the packet could contain the `Bytes` object itself and we could simply
+        // transfer the `Bytes` directly from the tcp state to the packet without copying the bytes
+
+        packet.set_tcp(&header);
+        // TODO: set packet priority?
+        packet.set_payload(&payload, /* priority= */ 0);
+        packet.add_status(PacketStatus::SndCreated);
+
+        Some(packet)
     }
 
     pub fn peek_next_packet_priority(&self) -> Option<FifoPacketPriority> {
-        todo!();
+        // TODO: support packet priorities?
+        self.has_data_to_send().then_some(0)
     }
 
     pub fn has_data_to_send(&self) -> bool {
-        todo!();
-    }
-
-    pub fn update_packet_header(&self, _packet: &mut PacketRc) {
-        todo!();
+        self.tcp_state.wants_to_send()
     }
 
     pub fn getsockname(&self) -> Result<Option<SockaddrIn>, SyscallError> {
-        todo!();
+        Ok(self.association.as_ref().map(|x| x.local_addr().into()))
     }
 
     pub fn getpeername(&self) -> Result<Option<SockaddrIn>, SyscallError> {
-        todo!();
+        Ok(self.association.as_ref().map(|x| x.remote_addr().into()))
     }
 
     pub fn address_family(&self) -> AddressFamily {
         AddressFamily::Inet
     }
 
-    pub fn close(&mut self, _cb_queue: &mut CallbackQueue) -> Result<(), SyscallError> {
-        todo!();
+    pub fn close(&mut self, cb_queue: &mut CallbackQueue) -> Result<(), SyscallError> {
+        // we don't expect close() to ever have an error
+        self.with_tcp_state(cb_queue, |state| state.close())
+            .unwrap();
+
+        // add the closed flag and remove all other flags
+        self.copy_state(FileState::all(), FileState::CLOSED, cb_queue);
+
+        Ok(())
     }
 
     pub fn bind(
-        _socket: &Arc<AtomicRefCell<Self>>,
-        _addr: Option<&SockaddrStorage>,
-        _net_ns: &NetworkNamespace,
-        _rng: impl rand::Rng,
+        socket: &Arc<AtomicRefCell<Self>>,
+        addr: Option<&SockaddrStorage>,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
     ) -> SyscallResult {
-        todo!();
+        // if the address pointer was NULL
+        let Some(addr) = addr else {
+            return Err(Errno::EFAULT.into());
+        };
+
+        // if not an inet socket address
+        let Some(addr) = addr.as_inet() else {
+            return Err(Errno::EINVAL.into());
+        };
+
+        let addr: SocketAddrV4 = (*addr).into();
+
+        let mut socket_ref = socket.borrow_mut();
+
+        // if the socket is already associated
+        if socket_ref.association.is_some() {
+            return Err(Errno::EINVAL.into());
+        }
+
+        // this will allow us to receive packets from any peer
+        let peer_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
+
+        // associate the socket
+        let (_addr, handle) = inet::associate_socket(
+            InetSocket::Tcp(Arc::clone(socket)),
+            addr,
+            peer_addr,
+            /* check_less_specific= */ true,
+            net_ns,
+            rng,
+        )?;
+
+        socket_ref.association = Some(handle);
+
+        Ok(0.into())
     }
 
     pub fn readv(
@@ -139,23 +354,110 @@ impl TcpSocket {
     }
 
     pub fn sendmsg(
-        _socket: &Arc<AtomicRefCell<Self>>,
-        _args: SendmsgArgs,
-        _mem: &mut MemoryManager,
+        socket: &Arc<AtomicRefCell<Self>>,
+        args: SendmsgArgs,
+        mem: &mut MemoryManager,
         _net_ns: &NetworkNamespace,
         _rng: impl rand::Rng,
-        _cb_queue: &mut CallbackQueue,
+        cb_queue: &mut CallbackQueue,
     ) -> Result<libc::ssize_t, SyscallError> {
-        todo!();
+        let mut socket_ref = socket.borrow_mut();
+
+        let Some(mut flags) = MsgFlags::from_bits(args.flags) else {
+            log::debug!("Unrecognized send flags: {:#b}", args.flags);
+            return Err(Errno::EINVAL.into());
+        };
+
+        if socket_ref.get_status().contains(FileStatus::NONBLOCK) {
+            flags.insert(MsgFlags::MSG_DONTWAIT);
+        }
+
+        let len: libc::size_t = args.iovs.iter().map(|x| x.len).sum();
+
+        // run in a closure so that an early return doesn't skip checking if we should block
+        let result = (|| {
+            let reader = IoVecReader::new(args.iovs, mem);
+
+            let rv = socket_ref.with_tcp_state(cb_queue, |state| state.send(reader, len));
+
+            let num_sent = match rv {
+                Ok(x) => x,
+                Err(tcp::SendError::Full) => return Err(Errno::EWOULDBLOCK),
+                Err(tcp::SendError::NotConnected) => return Err(Errno::EPIPE),
+                Err(tcp::SendError::StreamClosed) => return Err(Errno::EPIPE),
+                Err(tcp::SendError::Io(e)) => return Err(Errno::try_from(e).unwrap()),
+                Err(tcp::SendError::InvalidState) => return Err(Errno::EINVAL),
+            };
+
+            Ok(num_sent)
+        })();
+
+        // if the syscall would block and we don't have the MSG_DONTWAIT flag
+        if result == Err(Errno::EWOULDBLOCK) && !flags.contains(MsgFlags::MSG_DONTWAIT) {
+            return Err(SyscallError::new_blocked(
+                File::Socket(Socket::Inet(InetSocket::Tcp(socket.clone()))),
+                FileState::WRITABLE | FileState::CLOSED,
+                socket_ref.supports_sa_restart(),
+            ));
+        }
+
+        Ok(result?.try_into().unwrap())
     }
 
     pub fn recvmsg(
-        _socket: &Arc<AtomicRefCell<Self>>,
-        _args: RecvmsgArgs,
-        _mem: &mut MemoryManager,
-        _cb_queue: &mut CallbackQueue,
+        socket: &Arc<AtomicRefCell<Self>>,
+        args: RecvmsgArgs,
+        mem: &mut MemoryManager,
+        cb_queue: &mut CallbackQueue,
     ) -> Result<RecvmsgReturn, SyscallError> {
-        todo!();
+        let socket_ref = &mut *socket.borrow_mut();
+
+        let Some(mut flags) = MsgFlags::from_bits(args.flags) else {
+            log::debug!("Unrecognized recv flags: {:#b}", args.flags);
+            return Err(Errno::EINVAL.into());
+        };
+
+        if socket_ref.get_status().contains(FileStatus::NONBLOCK) {
+            flags.insert(MsgFlags::MSG_DONTWAIT);
+        }
+
+        let len: libc::size_t = args.iovs.iter().map(|x| x.len).sum();
+
+        // run in a closure so that an early return doesn't skip checking if we should block
+        let result = (|| {
+            let writer = IoVecWriter::new(args.iovs, mem);
+
+            let rv = socket_ref.with_tcp_state(cb_queue, |state| state.recv(writer, len));
+
+            let num_recv = match rv {
+                Ok(x) => x,
+                Err(tcp::RecvError::Empty) => return Err(Errno::EWOULDBLOCK),
+                Err(tcp::RecvError::NotConnected) => return Err(Errno::ENOTCONN),
+                Err(tcp::RecvError::StreamClosed) => 0,
+                Err(tcp::RecvError::Io(e)) => return Err(Errno::try_from(e).unwrap()),
+                Err(tcp::RecvError::InvalidState) => return Err(Errno::EINVAL),
+            };
+
+            Ok(RecvmsgReturn {
+                return_val: num_recv.try_into().unwrap(),
+                addr: None,
+                msg_flags: MsgFlags::empty().bits(),
+                control_len: 0,
+            })
+        })();
+
+        // if the syscall would block and we don't have the MSG_DONTWAIT flag
+        if result.as_ref().err() == Some(&Errno::EWOULDBLOCK)
+            && !flags.contains(MsgFlags::MSG_DONTWAIT)
+        {
+            return Err(SyscallError::new_blocked(
+                File::Socket(Socket::Inet(InetSocket::Tcp(socket.clone()))),
+                FileState::READABLE | FileState::CLOSED,
+                socket_ref.supports_sa_restart(),
+            ));
+        }
+
+        Ok(result?)
     }
 
     pub fn ioctl(
@@ -168,32 +470,262 @@ impl TcpSocket {
     }
 
     pub fn listen(
-        _socket: &Arc<AtomicRefCell<Self>>,
-        _backlog: i32,
-        _net_ns: &NetworkNamespace,
-        _rng: impl rand::Rng,
-        _cb_queue: &mut CallbackQueue,
+        socket: &Arc<AtomicRefCell<Self>>,
+        backlog: i32,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
+        cb_queue: &mut CallbackQueue,
     ) -> Result<(), SyscallError> {
-        todo!();
+        let socket_ref = &mut *socket.borrow_mut();
+
+        // linux also makes this cast, so negative backlogs wrap around to large positive backlogs
+        // https://elixir.free-electrons.com/linux/v5.11.22/source/net/ipv4/af_inet.c#L212
+        let backlog = backlog as u32;
+
+        let is_associated = socket_ref.association.is_some();
+
+        let rv = if is_associated {
+            // if already associated, do nothing
+            let associate_fn = || Ok(None);
+            socket_ref.with_tcp_state(cb_queue, |state| state.listen(backlog, associate_fn))
+        } else {
+            // if not associated, associate and return the handle
+            let associate_fn = || {
+                // implicitly bind to all interfaces
+                let local_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
+
+                // want to receive packets from any address
+                let peer_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
+                let socket = Arc::clone(socket);
+
+                // associate the socket
+                let (_addr, handle) = inet::associate_socket(
+                    InetSocket::Tcp(Arc::clone(&socket)),
+                    local_addr,
+                    peer_addr,
+                    /* check_less_specific= */ true,
+                    net_ns,
+                    rng,
+                )?;
+
+                Ok::<_, SyscallError>(Some(handle))
+            };
+            socket_ref.with_tcp_state(cb_queue, |state| state.listen(backlog, associate_fn))
+        };
+
+        let handle = match rv {
+            Ok(x) => x,
+            Err(tcp::ListenError::InvalidState) => return Err(Errno::EINVAL.into()),
+            Err(tcp::ListenError::FailedAssociation(e)) => return Err(e),
+        };
+
+        // the `associate_fn` may or may not have run, so `handle` may or may not be set
+        if let Some(handle) = handle {
+            assert!(socket_ref.association.is_none());
+            socket_ref.association = Some(handle);
+        }
+
+        Ok(())
     }
 
     pub fn connect(
-        _socket: &Arc<AtomicRefCell<Self>>,
-        _peer_addr: &SockaddrStorage,
-        _net_ns: &NetworkNamespace,
-        _rng: impl rand::Rng,
-        _cb_queue: &mut CallbackQueue,
+        socket: &Arc<AtomicRefCell<Self>>,
+        peer_addr: &SockaddrStorage,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
+        cb_queue: &mut CallbackQueue,
     ) -> Result<(), SyscallError> {
-        todo!();
+        let socket_ref = &mut *socket.borrow_mut();
+
+        // if there was an asynchronous error, return it
+        if let Some(error) = socket_ref.with_tcp_state(cb_queue, |state| state.clear_error()) {
+            // by returning this error, we're probably (but not necessarily) returning a previous
+            // connect() result
+            socket_ref.connect_result_is_pending = false;
+
+            return Err(match error {
+                // TODO: not sure what to return here
+                tcp::TcpError::ResetSent => Errno::EINVAL,
+                tcp::TcpError::ResetReceived => Errno::ECONNREFUSED,
+                tcp::TcpError::TimedOut => Errno::ETIMEDOUT,
+            }
+            .into());
+        }
+
+        // if connect() had previously been called (either blocking or non-blocking), we need to
+        // return the result
+        if socket_ref.connect_result_is_pending {
+            // ignore all connect arguments and just check if we've connected
+
+            // if the ESTABLISHED flag isn't set, then it's still connecting
+            if !socket_ref
+                .tcp_state
+                .poll()
+                .contains(tcp::PollState::ESTABLISHED)
+            {
+                return Err(Errno::EALREADY.into());
+            }
+
+            // the ESTABLISHED flag is set and there were no socket errors (checked above)
+            socket_ref.connect_result_is_pending = false;
+            return Ok(());
+        }
+
+        // if not an inet socket address
+        let Some(peer_addr) = peer_addr.as_inet() else {
+            return Err(Errno::EINVAL.into());
+        };
+
+        let mut peer_addr: std::net::SocketAddrV4 = (*peer_addr).into();
+
+        // On Linux a connection to 0.0.0.0 means a connection to localhost:
+        // https://stackoverflow.com/a/22425796
+        if peer_addr.ip().is_unspecified() {
+            peer_addr.set_ip(std::net::Ipv4Addr::LOCALHOST);
+        }
+
+        let local_addr = socket_ref.association.as_ref().map(|x| x.local_addr());
+
+        let rv = if let Some(mut local_addr) = local_addr {
+            // the local address needs to be a specific address (this is normally what a routing
+            // table would figure out for us)
+            if local_addr.ip().is_unspecified() {
+                if peer_addr.ip() == &std::net::Ipv4Addr::LOCALHOST {
+                    local_addr.set_ip(Ipv4Addr::LOCALHOST)
+                } else {
+                    local_addr.set_ip(net_ns.default_ip)
+                };
+            }
+
+            // it's already associated so use the existing address
+            let associate_fn = || Ok((local_addr, None));
+            socket_ref.with_tcp_state(cb_queue, |state| state.connect(peer_addr, associate_fn))
+        } else {
+            // if not associated, associate and return the handle
+            let associate_fn = || {
+                // the local address needs to be a specific address (this is normally what a routing
+                // table would figure out for us)
+                let local_addr = if peer_addr.ip() == &std::net::Ipv4Addr::LOCALHOST {
+                    Ipv4Addr::LOCALHOST
+                } else {
+                    net_ns.default_ip
+                };
+
+                // add a wildcard port number
+                let local_addr = SocketAddrV4::new(local_addr, 0);
+
+                let (local_addr, handle) = inet::associate_socket(
+                    InetSocket::Tcp(Arc::clone(socket)),
+                    local_addr,
+                    peer_addr,
+                    /* check_less_specific= */ true,
+                    net_ns,
+                    rng,
+                )?;
+
+                // use the actual local address that was assigned (will have port != 0)
+                Ok((local_addr, Some(handle)))
+            };
+            socket_ref.with_tcp_state(cb_queue, |state| state.connect(peer_addr, associate_fn))
+        };
+
+        let handle = match rv {
+            Ok(x) => x,
+            Err(tcp::ConnectError::InProgress) => return Err(Errno::EALREADY.into()),
+            Err(tcp::ConnectError::AlreadyConnected) => return Err(Errno::EISCONN.into()),
+            Err(tcp::ConnectError::InvalidState) => return Err(Errno::EINVAL.into()),
+            Err(tcp::ConnectError::FailedAssociation(e)) => return Err(e),
+        };
+
+        // the `associate_fn` may not have associated the socket, so `handle` may or may not be set
+        if let Some(handle) = handle {
+            assert!(socket_ref.association.is_none());
+            socket_ref.association = Some(handle);
+        }
+
+        // we're attempting to connect, so set a flag so that we know a future connect() call should
+        // return the result
+        socket_ref.connect_result_is_pending = true;
+
+        if socket_ref.status.contains(FileStatus::NONBLOCK) {
+            Err(Errno::EINPROGRESS.into())
+        } else {
+            let err = SyscallError::new_blocked(
+                File::Socket(Socket::Inet(InetSocket::Tcp(Arc::clone(socket)))),
+                FileState::WRITABLE | FileState::CLOSED,
+                socket_ref.supports_sa_restart(),
+            );
+
+            // block the current thread
+            Err(err)
+        }
     }
 
     pub fn accept(
         &mut self,
-        _net_ns: &NetworkNamespace,
-        _rng: impl rand::Rng,
-        _cb_queue: &mut CallbackQueue,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
+        cb_queue: &mut CallbackQueue,
     ) -> Result<OpenFile, SyscallError> {
-        todo!();
+        let rv = self.with_tcp_state(cb_queue, |state| state.accept());
+
+        let accepted_state = match rv {
+            Ok(x) => x,
+            Err(tcp::AcceptError::InvalidState) => return Err(Errno::EINVAL.into()),
+            Err(tcp::AcceptError::NothingToAccept) => return Err(Errno::EAGAIN.into()),
+        };
+
+        let local_addr = accepted_state.local_addr();
+        let remote_addr = accepted_state.remote_addr();
+
+        // convert the accepted tcp state to a full tcp socket
+        let new_socket = Arc::new_cyclic(|weak: &Weak<AtomicRefCell<Self>>| {
+            let accepted_state = accepted_state.finalize(|deps| {
+                // update the timer state for new and existing pending timers to use the new
+                // accepted socket rather than the parent listening socket
+                let timer_state = &mut *deps.timer_state.borrow_mut();
+                timer_state.socket = weak.clone();
+                timer_state.registered_by = tcp::TimerRegisteredBy::Parent;
+            });
+
+            AtomicRefCell::new(Self {
+                tcp_state: accepted_state,
+                socket_weak: weak.clone(),
+                event_source: StateEventSource::new(),
+                status: FileStatus::empty(),
+                // the readable/writable file state shouldn't matter here since we run
+                // `with_tcp_state` below to update it, but we need ACTIVE set so that epoll works
+                file_state: FileState::ACTIVE,
+                association: None,
+                connect_result_is_pending: false,
+                has_open_file: false,
+                _counter: ObjectCounter::new("TcpSocket"),
+            })
+        });
+
+        // run a no-op function on the state, which will force the socket to update its file state
+        // to match the tcp state
+        new_socket
+            .borrow_mut()
+            .with_tcp_state(cb_queue, |_state| ());
+
+        // TODO: if the association fails, we lose the child socket
+
+        // associate the socket
+        let (_addr, handle) = inet::associate_socket(
+            InetSocket::Tcp(Arc::clone(&new_socket)),
+            local_addr,
+            remote_addr,
+            /* check_less_specific= */ false,
+            net_ns,
+            rng,
+        )?;
+
+        new_socket.borrow_mut().association = Some(handle);
+
+        Ok(OpenFile::new(File::Socket(Socket::Inet(InetSocket::Tcp(
+            new_socket,
+        )))))
     }
 
     pub fn shutdown(
@@ -206,24 +738,76 @@ impl TcpSocket {
 
     pub fn getsockopt(
         &self,
-        _level: libc::c_int,
-        _optname: libc::c_int,
-        _optval_ptr: ForeignPtr<()>,
-        _optlen: libc::socklen_t,
-        _mem: &mut MemoryManager,
+        level: libc::c_int,
+        optname: libc::c_int,
+        optval_ptr: ForeignPtr<()>,
+        optlen: libc::socklen_t,
+        mem: &mut MemoryManager,
     ) -> Result<libc::socklen_t, SyscallError> {
-        todo!();
+        match (level, optname) {
+            (libc::SOL_SOCKET, libc::SO_DOMAIN) => {
+                let domain = libc::AF_INET;
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written = write_partial(mem, &domain, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
+            (libc::SOL_SOCKET, libc::SO_TYPE) => {
+                let sock_type = libc::SOCK_STREAM;
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written = write_partial(mem, &sock_type, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
+            (libc::SOL_SOCKET, libc::SO_PROTOCOL) => {
+                let protocol = libc::IPPROTO_TCP;
+
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written = write_partial(mem, &protocol, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
+            _ => {
+                log::warn!("getsockopt called with unsupported level {level} and opt {optname}");
+                Err(Errno::ENOPROTOOPT.into())
+            }
+        }
     }
 
     pub fn setsockopt(
         &mut self,
-        _level: libc::c_int,
-        _optname: libc::c_int,
+        level: libc::c_int,
+        optname: libc::c_int,
         _optval_ptr: ForeignPtr<()>,
         _optlen: libc::socklen_t,
         _mem: &MemoryManager,
     ) -> Result<(), SyscallError> {
-        todo!();
+        match (level, optname) {
+            (libc::SOL_SOCKET, libc::SO_REUSEADDR) => {
+                // TODO: implement this, tor and tgen use it
+                log::trace!("setsockopt SO_REUSEADDR not yet implemented");
+            }
+            (libc::SOL_SOCKET, libc::SO_REUSEPORT) => {
+                // TODO: implement this, tgen uses it
+                log::trace!("setsockopt SO_REUSEPORT not yet implemented");
+            }
+            (libc::SOL_SOCKET, libc::SO_KEEPALIVE) => {
+                // TODO: implement this, libevent uses it in evconnlistener_new_bind()
+                log::trace!("setsockopt SO_KEEPALIVE not yet implemented");
+            }
+            (libc::SOL_SOCKET, libc::SO_BROADCAST) => {
+                // TODO: implement this, pkg.go.dev/net uses it
+                log::trace!("setsockopt SO_BROADCAST not yet implemented");
+            }
+            _ => {
+                log::warn!("setsockopt called with unsupported level {level} and opt {optname}");
+                return Err(Errno::ENOPROTOOPT.into());
+            }
+        }
+
+        Ok(())
     }
 
     pub fn add_listener(
@@ -245,6 +829,109 @@ impl TcpSocket {
     }
 
     pub fn state(&self) -> FileState {
-        self.state
+        self.file_state
+    }
+
+    fn copy_state(&mut self, mask: FileState, state: FileState, cb_queue: &mut CallbackQueue) {
+        let old_state = self.file_state;
+
+        // remove the masked flags, then copy the masked flags
+        self.file_state.remove(mask);
+        self.file_state.insert(state & mask);
+
+        self.handle_state_change(old_state, cb_queue);
+    }
+
+    fn handle_state_change(&mut self, old_state: FileState, cb_queue: &mut CallbackQueue) {
+        let states_changed = self.file_state ^ old_state;
+
+        // if nothing changed
+        if states_changed.is_empty() {
+            return;
+        }
+
+        self.event_source
+            .notify_listeners(self.file_state, states_changed, cb_queue);
+    }
+}
+
+/// Shared state stored in timers. This allows us to update existing timers when a child `TcpState`
+/// is accept()ed and becomes owned by a new `TcpSocket` object.
+#[derive(Debug)]
+struct TcpDepsTimerState {
+    /// The socket that the timer callback will run on.
+    socket: Weak<AtomicRefCell<TcpSocket>>,
+    /// Whether the timer callback should modify the state of this socket
+    /// ([`TimerRegisteredBy::Parent`]), or one of its child sockets ([`TimerRegisteredBy::Child`]).
+    registered_by: tcp::TimerRegisteredBy,
+}
+
+/// The dependencies required by `TcpState::new()` so that the tcp code can interact with the
+/// simulator.
+#[derive(Debug)]
+struct TcpDeps {
+    /// State shared between all timers registered from this `TestEnvState`. This is needed since we
+    /// may need to update existing pending timers when we accept() a `TcpState` from a listening
+    /// state.
+    timer_state: Arc<AtomicRefCell<TcpDepsTimerState>>,
+}
+
+impl tcp::Dependencies for TcpDeps {
+    type Instant = EmulatedTime;
+    type Duration = SimulationTime;
+
+    fn register_timer(
+        &self,
+        time: Self::Instant,
+        f: impl FnOnce(&mut tcp::TcpState<Self>, tcp::TimerRegisteredBy) + Send + Sync + 'static,
+    ) {
+        // make sure the socket is kept alive in the closure while the timer is waiting to be run
+        // (don't store a weak reference), otherwise the socket may have already been dropped and
+        // the timer won't run
+        // TODO: is this the behaviour we want?
+        let timer_state = self.timer_state.borrow();
+        let socket = timer_state.socket.upgrade().unwrap();
+        let registered_by = timer_state.registered_by;
+
+        // This is needed because `TaskRef` takes a `Fn`, but we have a `FnOnce`. It would be nice
+        // if we could schedule a task that is guaranteed to run only once so we could avoid this
+        // extra allocation and atomic. Instead we'll panic if it does run more than once.
+        let f = Arc::new(AtomicRefCell::new(Some(f)));
+
+        // schedule a task with the host
+        Worker::with_active_host(|host| {
+            let task = TaskRef::new(move |_host| {
+                // take ownership of the task; will panic if the task is run more than once
+                let f = f.borrow_mut().take().unwrap();
+
+                // run the original closure on the tcp state
+                CallbackQueue::queue_and_run(|cb_queue| {
+                    socket.borrow_mut().with_tcp_state(cb_queue, |state| {
+                        f(state, registered_by);
+                    })
+                });
+            });
+
+            host.schedule_task_at_emulated_time(task, time);
+        })
+        .unwrap();
+    }
+
+    fn current_time(&self) -> Self::Instant {
+        Worker::current_time().unwrap()
+    }
+
+    fn fork(&self) -> Self {
+        let timer_state = self.timer_state.borrow();
+
+        // if a child is trying to fork(), something has gone wrong
+        assert_eq!(timer_state.registered_by, tcp::TimerRegisteredBy::Parent);
+
+        Self {
+            timer_state: Arc::new(AtomicRefCell::new(TcpDepsTimerState {
+                socket: timer_state.socket.clone(),
+                registered_by: tcp::TimerRegisteredBy::Child,
+            })),
+        }
     }
 }

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -187,7 +187,12 @@ impl TcpSocket {
         todo!();
     }
 
-    pub fn accept(&mut self, _cb_queue: &mut CallbackQueue) -> Result<OpenFile, SyscallError> {
+    pub fn accept(
+        &mut self,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<OpenFile, SyscallError> {
         todo!();
     }
 

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -749,7 +749,12 @@ impl UdpSocket {
         Ok(())
     }
 
-    pub fn accept(&mut self, _cb_queue: &mut CallbackQueue) -> Result<OpenFile, SyscallError> {
+    pub fn accept(
+        &mut self,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
+        _cb_queue: &mut CallbackQueue,
+    ) -> Result<OpenFile, SyscallError> {
         Err(Errno::EOPNOTSUPP.into())
     }
 

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -277,6 +277,7 @@ impl UdpSocket {
             InetSocket::Udp(Arc::clone(socket)),
             addr,
             unspecified_addr,
+            /* check_less_specific= */ true,
             net_ns,
             rng,
         )?;
@@ -388,6 +389,7 @@ impl UdpSocket {
                 InetSocket::Udp(Arc::clone(socket)),
                 local_addr,
                 unspecified_addr,
+                /* check_less_specific= */ true,
                 net_ns,
                 rng,
             )?;
@@ -735,6 +737,7 @@ impl UdpSocket {
                     InetSocket::Udp(Arc::clone(socket)),
                     local_addr,
                     unspecified_addr,
+                    /* check_less_specific= */ true,
                     net_ns,
                     rng,
                 )?;

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -295,10 +295,15 @@ impl SocketRefMut<'_> {
         -> Result<(), SyscallError>
     );
 
-    pub fn accept(&mut self, cb_queue: &mut CallbackQueue) -> Result<OpenFile, SyscallError> {
+    pub fn accept(
+        &mut self,
+        net_ns: &NetworkNamespace,
+        rng: impl rand::Rng,
+        cb_queue: &mut CallbackQueue,
+    ) -> Result<OpenFile, SyscallError> {
         match self {
-            Self::Unix(socket) => socket.accept(cb_queue),
-            Self::Inet(socket) => socket.accept(cb_queue),
+            Self::Unix(socket) => socket.accept(net_ns, rng, cb_queue),
+            Self::Inet(socket) => socket.accept(net_ns, rng, cb_queue),
         }
     }
 

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -239,7 +239,12 @@ impl UnixSocket {
             .connect(&mut socket_ref.common, socket, addr, cb_queue)
     }
 
-    pub fn accept(&mut self, cb_queue: &mut CallbackQueue) -> Result<OpenFile, SyscallError> {
+    pub fn accept(
+        &mut self,
+        _net_ns: &NetworkNamespace,
+        _rng: impl rand::Rng,
+        cb_queue: &mut CallbackQueue,
+    ) -> Result<OpenFile, SyscallError> {
         self.protocol_state.accept(&mut self.common, cb_queue)
     }
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -78,6 +78,7 @@ pub struct HostParameters {
     pub unblocked_vdso_latency: SimulationTime,
     pub strace_logging_options: Option<FmtOptions>,
     pub shim_log_level: LogLevel,
+    pub use_new_tcp: bool,
 }
 
 use super::cpu::Cpu;

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -1084,7 +1084,7 @@ mod export {
         );
         hostrc
             .net_ns
-            .is_interface_available(protocol_type, src, dst)
+            .is_interface_available(protocol_type, src, dst, true)
     }
 
     #[no_mangle]

--- a/src/main/host/network/interface.rs
+++ b/src/main/host/network/interface.rs
@@ -115,13 +115,26 @@ impl NetworkInterface {
         };
     }
 
-    pub fn is_associated(&self, protocol: c::ProtocolType, port: u16, peer: SocketAddrV4) -> bool {
+    pub fn is_associated(
+        &self,
+        protocol: c::ProtocolType,
+        port: u16,
+        peer: SocketAddrV4,
+        check_less_specific: bool,
+    ) -> bool {
         let port = port.to_be();
         let peer_ip = u32::from(*peer.ip()).to_be();
         let peer_port = peer.port().to_be();
 
         (unsafe {
-            c::networkinterface_isAssociated(self.c_ptr.ptr(), protocol, port, peer_ip, peer_port)
+            c::networkinterface_isAssociated(
+                self.c_ptr.ptr(),
+                protocol,
+                port,
+                peer_ip,
+                peer_port,
+                check_less_specific,
+            )
         }) != 0
     }
 

--- a/src/main/host/network/namespace.rs
+++ b/src/main/host/network/namespace.rs
@@ -352,6 +352,16 @@ pub struct AssociationHandle {
     remote_addr: SocketAddrV4,
 }
 
+impl AssociationHandle {
+    pub fn local_addr(&self) -> SocketAddrV4 {
+        self.local_addr
+    }
+
+    pub fn remote_addr(&self) -> SocketAddrV4 {
+        self.remote_addr
+    }
+}
+
 impl std::ops::Drop for AssociationHandle {
     fn drop(&mut self) {
         Worker::with_active_host(|host| {

--- a/src/main/host/network/namespace.rs
+++ b/src/main/host/network/namespace.rs
@@ -188,21 +188,25 @@ impl NetworkNamespace {
         protocol_type: cshadow::ProtocolType,
         src: SocketAddrV4,
         dst: SocketAddrV4,
+        check_less_specific: bool,
     ) -> bool {
         if src.ip().is_unspecified() {
             // Check that all interfaces are available.
-            !self
-                .localhost
-                .borrow()
-                .is_associated(protocol_type, src.port(), dst)
-                && !self
-                    .internet
-                    .borrow()
-                    .is_associated(protocol_type, src.port(), dst)
+            !self.localhost.borrow().is_associated(
+                protocol_type,
+                src.port(),
+                dst,
+                check_less_specific,
+            ) && !self.internet.borrow().is_associated(
+                protocol_type,
+                src.port(),
+                dst,
+                check_less_specific,
+            )
         } else {
             // The interface is not available if it does not exist.
             match self.interface_borrow(*src.ip()) {
-                Some(i) => !i.is_associated(protocol_type, src.port(), dst),
+                Some(i) => !i.is_associated(protocol_type, src.port(), dst, check_less_specific),
                 None => false,
             }
         }
@@ -231,6 +235,7 @@ impl NetworkNamespace {
                 protocol_type,
                 SocketAddrV4::new(interface_ip, random_port),
                 peer,
+                true,
             ) {
                 return Some(random_port);
             }
@@ -245,6 +250,7 @@ impl NetworkNamespace {
                 protocol_type,
                 SocketAddrV4::new(interface_ip, port),
                 peer,
+                true,
             ) {
                 return Some(port);
             }

--- a/src/main/host/network/network_interface.c
+++ b/src/main/host/network/network_interface.c
@@ -74,21 +74,25 @@ static gchar* _networkinterface_getAssociationKey(NetworkInterface* interface,
 
 /* The address and ports must be in network byte order. */
 gboolean networkinterface_isAssociated(NetworkInterface* interface, ProtocolType type,
-        in_port_t port, in_addr_t peerAddr, in_port_t peerPort) {
+                                       in_port_t port, in_addr_t peerAddr, in_port_t peerPort,
+                                       bool check_less_specific) {
     MAGIC_ASSERT(interface);
 
     gboolean isFound = FALSE;
 
-    /* we need to check the general key too (ie the ones listening sockets use) */
-    gchar* general = _networkinterface_getAssociationKey(interface, type, port, 0, 0);
-    if(g_hash_table_contains(interface->boundSockets, general)) {
-        isFound = TRUE;
+    if (check_less_specific) {
+        /* we need to check the general key too (ie the ones listening sockets use) */
+        gchar* general = _networkinterface_getAssociationKey(interface, type, port, 0, 0);
+        if (g_hash_table_contains(interface->boundSockets, general)) {
+            isFound = TRUE;
+        }
+        g_free(general);
     }
-    g_free(general);
 
-    if(!isFound) {
-        gchar* specific = _networkinterface_getAssociationKey(interface, type, port, peerAddr, peerPort);
-        if(g_hash_table_contains(interface->boundSockets, specific)) {
+    if (!isFound) {
+        gchar* specific =
+            _networkinterface_getAssociationKey(interface, type, port, peerAddr, peerPort);
+        if (g_hash_table_contains(interface->boundSockets, specific)) {
             isFound = TRUE;
         }
         g_free(specific);

--- a/src/main/host/network/network_interface.h
+++ b/src/main/host/network/network_interface.h
@@ -25,7 +25,8 @@ void networkinterface_free(NetworkInterface* interface);
 
 /* The address and ports must be in network byte order. */
 gboolean networkinterface_isAssociated(NetworkInterface* interface, ProtocolType type,
-        in_port_t port, in_addr_t peerAddr, in_port_t peerPort);
+                                       in_port_t port, in_addr_t peerAddr, in_port_t peerPort,
+                                       bool check_less_specific);
 
 void networkinterface_associate(NetworkInterface* interface, const CompatSocket* socket,
                                 ProtocolType type, in_port_t port, in_addr_t peerIP,

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -688,8 +688,13 @@ impl SyscallHandler {
             }
         };
 
+        let mut rng = ctx.objs.host.random_mut();
+        let net_ns = ctx.objs.host.network_namespace_borrow();
+
         let result = crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
-            CallbackQueue::queue_and_run(|cb_queue| socket.borrow_mut().accept(cb_queue))
+            CallbackQueue::queue_and_run(|cb_queue| {
+                socket.borrow_mut().accept(&net_ns, &mut *rng, cb_queue)
+            })
         });
 
         let file_status = socket.borrow().get_status();

--- a/src/main/routing/packet.c
+++ b/src/main/routing/packet.c
@@ -608,7 +608,7 @@ GList* packet_copyTCPSelectiveACKs(Packet* packet) {
 
 PacketTCPHeader* packet_getTCPHeader(const Packet* packet) {
     MAGIC_ASSERT(packet);
-    utility_debugAssert(packet->protocol == PTCP);
+    utility_alwaysAssert(packet->protocol == PTCP);
     return (PacketTCPHeader*)packet->header;
 }
 

--- a/src/test/cli/help-long-expected
+++ b/src/test/cli/help-long-expected
@@ -148,6 +148,9 @@ Experimental (Unstable and may change or be removed at any time, regardless of S
           Use the MemoryManager. It can be useful to disable for debugging, but will hurt
           performance in most cases [default: true]
 
+      --use-new-tcp <bool>
+          Use the rust TCP implementation [default: false]
+
       --use-object-counters <bool>
           Count object allocations and deallocations. If disabled, we will not be able to detect
           object memory leaks [default: true]

--- a/src/test/socket/accept/CMakeLists.txt
+++ b/src/test/socket/accept/CMakeLists.txt
@@ -1,2 +1,8 @@
 add_linux_tests(BASENAME accept COMMAND sh -c "../../../target/debug/test_accept --libc-passing")
+
 add_shadow_tests(BASENAME accept LOGLEVEL debug)
+add_shadow_tests(
+    BASENAME accept-new-tcp
+    SHADOW_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/accept.yaml"
+    LOGLEVEL debug
+    ARGS --use-new-tcp true)

--- a/src/test/socket/bind/CMakeLists.txt
+++ b/src/test/socket/bind/CMakeLists.txt
@@ -1,8 +1,18 @@
 add_linux_tests(BASENAME bind COMMAND sh -c "../../../target/debug/test_bind --libc-passing")
+
 add_shadow_tests(
     BASENAME bind
     LOGLEVEL debug
     ARGS --strace-logging-mode off
+    PROPERTIES
+      # This test can take a bit longer, especially on debug builds of shadow
+      TIMEOUT 30
+    )
+add_shadow_tests(
+    BASENAME bind-new-tcp
+    SHADOW_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/bind.yaml"
+    LOGLEVEL debug
+    ARGS --strace-logging-mode off --use-new-tcp true
     PROPERTIES
       # This test can take a bit longer, especially on debug builds of shadow
       TIMEOUT 30

--- a/src/test/socket/socket/CMakeLists.txt
+++ b/src/test/socket/socket/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_linux_tests(BASENAME socket COMMAND sh -c "../../../target/debug/test_socket --libc-passing")
+
 add_shadow_tests(BASENAME socket)
+add_shadow_tests(
+    BASENAME socket-new-tcp
+    SHADOW_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/socket.yaml"
+    ARGS --use-new-tcp true)

--- a/src/test/tcp/CMakeLists.txt
+++ b/src/test/tcp/CMakeLists.txt
@@ -16,6 +16,13 @@ foreach(BlockingMode blocking nonblocking-poll nonblocking-select nonblocking-ep
             # TODO: support lossy iov tests
             continue()
         endif()
+
         add_shadow_tests(BASENAME tcp-${BlockingMode}-${Network})
+
+        if(NOT "${Network}" STREQUAL lossy)
+            add_shadow_tests(BASENAME tcp-${BlockingMode}-${Network}-new-tcp
+                             SHADOW_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/tcp-${BlockingMode}-${Network}.yaml"
+                             ARGS --use-new-tcp true)
+        endif()
     endforeach()
 endforeach()


### PR DESCRIPTION
This adds a new TCP socket using the tcp library from #3098. This has the same current limitations of the tcp library (no retransmission, congestion control, etc). This also doesn't support ioctl(), shutdown(), most socket options, and some other things.

This TCP socket can be enabled with the experimental `--use-new-tcp true` flag. A few tests have been added that use this flag to test the new TCP socket. Some other tests are close to passing, but need retransimssion support before they can be enabled.

Current passing socket tests:

- socket-new-tcp-shadow
- bind-new-tcp-shadow
- accept-new-tcp-shadow
- tcp-nonblocking-epoll-lossless-new-tcp-shadow
- tcp-nonblocking-select-lossless-new-tcp-shadow
- tcp-blocking-loopback-new-tcp-shadow
- tcp-nonblocking-poll-lossless-new-tcp-shadow
- tcp-nonblocking-poll-loopback-new-tcp-shadow
- tcp-nonblocking-epoll-loopback-new-tcp-shadow
- tcp-nonblocking-select-loopback-new-tcp-shadow
- tcp-blocking-lossless-new-tcp-shadow
- tcp-iov-lossless-new-tcp-shadow
- tcp-iov-loopback-new-tcp-shadow