### PR TITLE
Reorganize `networkinterface_isAssociated`

### DIFF
--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -277,7 +277,7 @@ impl LegacyTcpSocket {
             InetSocket::LegacyTcp(Arc::clone(socket)),
             addr,
             peer_addr,
-            /* check_less_specific= */ true,
+            /* check_generic_peer= */ true,
             net_ns,
             rng,
         )?;
@@ -661,7 +661,7 @@ impl LegacyTcpSocket {
                 super::InetSocket::LegacyTcp(socket.clone()),
                 local_addr,
                 peer_addr,
-                /* check_less_specific= */ true,
+                /* check_generic_peer= */ true,
                 net_ns,
                 rng,
             )?;
@@ -765,7 +765,7 @@ impl LegacyTcpSocket {
                 super::InetSocket::LegacyTcp(socket.clone()),
                 local_addr,
                 peer_addr,
-                /* check_less_specific= */ true,
+                /* check_generic_peer= */ true,
                 net_ns,
                 rng,
             )?;

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddrV4;
+use std::net::{Ipv4Addr, SocketAddrV4};
 use std::sync::{Arc, Weak};
 
 use atomic_refcell::AtomicRefCell;
@@ -429,13 +429,13 @@ impl InetSocketWeak {
 /// non-zero port will be chosen. The final local address will be returned. If the peer address is
 /// unspecified and has a port of 0, the socket will receive packets from every peer address. The
 /// socket will be automatically disassociated when the returned [`AssociationHandle`] is dropped.
-/// If `check_less_specific` is true, the association will also fail if there is already a socket
-/// associated with the local address `local_addr` and peer address 0.0.0.0.
+/// If `check_generic_peer` is true, the association will also fail if there is already a socket
+/// associated with the local address `local_addr` and peer address 0.0.0.0:0.
 fn associate_socket(
     socket: InetSocket,
     local_addr: SocketAddrV4,
     peer_addr: SocketAddrV4,
-    check_less_specific: bool,
+    check_generic_peer: bool,
     net_ns: &NetworkNamespace,
     rng: impl rand::Rng,
 ) -> Result<(SocketAddrV4, AssociationHandle), SyscallError> {
@@ -471,11 +471,33 @@ fn associate_socket(
     };
 
     // make sure the port is available at this address for this protocol
-    if !net_ns.is_interface_available(protocol, local_addr, peer_addr, check_less_specific) {
-        log::debug!(
-            "The provided addresses (local={local_addr}, peer={peer_addr}) are not available"
-        );
-        return Err(Errno::EADDRINUSE.into());
+    match net_ns.is_addr_in_use(protocol, local_addr, peer_addr) {
+        Ok(true) => {
+            log::debug!(
+                "The provided addresses (local={local_addr}, peer={peer_addr}) are not available"
+            );
+            return Err(Errno::EADDRINUSE.into());
+        }
+        Err(_e) => return Err(Errno::EADDRNOTAVAIL.into()),
+        Ok(false) => {}
+    }
+
+    if check_generic_peer {
+        match net_ns.is_addr_in_use(
+            protocol,
+            local_addr,
+            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0),
+        ) {
+            Ok(true) => {
+                log::debug!(
+                    "The generic addresses (local={local_addr}, peer={}) are not available",
+                    SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)
+                );
+                return Err(Errno::EADDRINUSE.into());
+            }
+            Err(_e) => return Err(Errno::EADDRNOTAVAIL.into()),
+            Ok(false) => {}
+        }
     }
 
     let socket = unsafe { c::compatsocket_fromInetSocket(&socket) };

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -315,7 +315,7 @@ impl TcpSocket {
             InetSocket::Tcp(Arc::clone(socket)),
             addr,
             peer_addr,
-            /* check_less_specific= */ true,
+            /* check_generic_peer= */ true,
             net_ns,
             rng,
         )?;
@@ -503,7 +503,7 @@ impl TcpSocket {
                     InetSocket::Tcp(Arc::clone(&socket)),
                     local_addr,
                     peer_addr,
-                    /* check_less_specific= */ true,
+                    /* check_generic_peer= */ true,
                     net_ns,
                     rng,
                 )?;
@@ -618,7 +618,7 @@ impl TcpSocket {
                     InetSocket::Tcp(Arc::clone(socket)),
                     local_addr,
                     peer_addr,
-                    /* check_less_specific= */ true,
+                    /* check_generic_peer= */ true,
                     net_ns,
                     rng,
                 )?;
@@ -716,7 +716,7 @@ impl TcpSocket {
             InetSocket::Tcp(Arc::clone(&new_socket)),
             local_addr,
             remote_addr,
-            /* check_less_specific= */ false,
+            /* check_generic_peer= */ false,
             net_ns,
             rng,
         )?;

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -277,7 +277,7 @@ impl UdpSocket {
             InetSocket::Udp(Arc::clone(socket)),
             addr,
             unspecified_addr,
-            /* check_less_specific= */ true,
+            /* check_generic_peer= */ true,
             net_ns,
             rng,
         )?;
@@ -389,7 +389,7 @@ impl UdpSocket {
                 InetSocket::Udp(Arc::clone(socket)),
                 local_addr,
                 unspecified_addr,
-                /* check_less_specific= */ true,
+                /* check_generic_peer= */ true,
                 net_ns,
                 rng,
             )?;
@@ -737,7 +737,7 @@ impl UdpSocket {
                     InetSocket::Udp(Arc::clone(socket)),
                     local_addr,
                     unspecified_addr,
-                    /* check_less_specific= */ true,
+                    /* check_generic_peer= */ true,
                     net_ns,
                     rng,
                 )?;

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -1055,39 +1055,6 @@ mod export {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn host_doesInterfaceExist(
-        hostrc: *const Host,
-        interface_ip: in_addr_t,
-    ) -> bool {
-        let hostrc = unsafe { hostrc.as_ref().unwrap() };
-        let ipv4 = Ipv4Addr::from(u32::from_be(interface_ip));
-        ipv4.is_unspecified() || hostrc.interface_borrow(ipv4).is_some()
-    }
-
-    #[no_mangle]
-    pub unsafe extern "C" fn host_isInterfaceAvailable(
-        hostrc: *const Host,
-        protocol_type: cshadow::ProtocolType,
-        interface_addr: in_addr_t,
-        port: in_port_t,
-        peer_addr: in_addr_t,
-        peer_port: in_port_t,
-    ) -> bool {
-        let hostrc = unsafe { hostrc.as_ref().unwrap() };
-        let src = SocketAddrV4::new(
-            Ipv4Addr::from(u32::from_be(interface_addr)),
-            u16::from_be(port),
-        );
-        let dst = SocketAddrV4::new(
-            Ipv4Addr::from(u32::from_be(peer_addr)),
-            u16::from_be(peer_port),
-        );
-        hostrc
-            .net_ns
-            .is_interface_available(protocol_type, src, dst, true)
-    }
-
-    #[no_mangle]
     pub unsafe extern "C" fn host_disassociateInterface(
         hostrc: *const Host,
         protocol: cshadow::ProtocolType,

--- a/src/main/host/network/interface.rs
+++ b/src/main/host/network/interface.rs
@@ -115,26 +115,13 @@ impl NetworkInterface {
         };
     }
 
-    pub fn is_associated(
-        &self,
-        protocol: c::ProtocolType,
-        port: u16,
-        peer: SocketAddrV4,
-        check_less_specific: bool,
-    ) -> bool {
+    pub fn is_addr_in_use(&self, protocol: c::ProtocolType, port: u16, peer: SocketAddrV4) -> bool {
         let port = port.to_be();
         let peer_ip = u32::from(*peer.ip()).to_be();
         let peer_port = peer.port().to_be();
 
         (unsafe {
-            c::networkinterface_isAssociated(
-                self.c_ptr.ptr(),
-                protocol,
-                port,
-                peer_ip,
-                peer_port,
-                check_less_specific,
-            )
+            c::networkinterface_isAssociated(self.c_ptr.ptr(), protocol, port, peer_ip, peer_port)
         }) != 0
     }
 

--- a/src/main/host/network/network_interface.c
+++ b/src/main/host/network/network_interface.c
@@ -74,29 +74,14 @@ static gchar* _networkinterface_getAssociationKey(NetworkInterface* interface,
 
 /* The address and ports must be in network byte order. */
 gboolean networkinterface_isAssociated(NetworkInterface* interface, ProtocolType type,
-                                       in_port_t port, in_addr_t peerAddr, in_port_t peerPort,
-                                       bool check_less_specific) {
+                                       in_port_t port, in_addr_t peerAddr, in_port_t peerPort) {
     MAGIC_ASSERT(interface);
 
     gboolean isFound = FALSE;
 
-    if (check_less_specific) {
-        /* we need to check the general key too (ie the ones listening sockets use) */
-        gchar* general = _networkinterface_getAssociationKey(interface, type, port, 0, 0);
-        if (g_hash_table_contains(interface->boundSockets, general)) {
-            isFound = TRUE;
-        }
-        g_free(general);
-    }
-
-    if (!isFound) {
-        gchar* specific =
-            _networkinterface_getAssociationKey(interface, type, port, peerAddr, peerPort);
-        if (g_hash_table_contains(interface->boundSockets, specific)) {
-            isFound = TRUE;
-        }
-        g_free(specific);
-    }
+    gchar* key = _networkinterface_getAssociationKey(interface, type, port, peerAddr, peerPort);
+    isFound = g_hash_table_contains(interface->boundSockets, key);
+    g_free(key);
 
     return isFound;
 }

--- a/src/main/host/network/network_interface.h
+++ b/src/main/host/network/network_interface.h
@@ -25,8 +25,7 @@ void networkinterface_free(NetworkInterface* interface);
 
 /* The address and ports must be in network byte order. */
 gboolean networkinterface_isAssociated(NetworkInterface* interface, ProtocolType type,
-                                       in_port_t port, in_addr_t peerAddr, in_port_t peerPort,
-                                       bool check_less_specific);
+                                       in_port_t port, in_addr_t peerAddr, in_port_t peerPort);
 
 void networkinterface_associate(NetworkInterface* interface, const CompatSocket* socket,
                                 ProtocolType type, in_port_t port, in_addr_t peerIP,


### PR DESCRIPTION
I changed `networkinterface_isAssociated` to check only a single 4-tuple. This moves the complexity further up, and calling code can choose whether or not to also check the more-generic association (peer 0.0.0.0:0). This doesn't fix any bugs in the network interface code.

This is a follow up from https://github.com/shadow/shadow/pull/3105#discussion_r1293687008.