### PR TITLE
Add AtomicTlsMap::forget_all

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1988,6 +1988,7 @@ dependencies = [
  "criterion",
  "libc",
  "loom",
+ "nix",
  "num_enum",
  "rand",
  "rustc-hash",

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -16,6 +16,8 @@ rustc-hash = { version = "1.1.0", default-features=false }
 criterion = "0.5.1"
 rand = "0.8.5"
 rustix = { version = "0.38.4", default-features = false, features=["process"] }
+libc = "0.2"
+nix =  "0.26.2"
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.7", features = ["checkpoint"] }


### PR DESCRIPTION
Intended for use after fork; we can't safely drop values belonging to other threads, but can safely forget about and overwrite them.