### PR TITLE
cargo clippy --fix

### DIFF
--- a/src/lib/formatting-nostd/src/borrowed_fd_writer.rs
+++ b/src/lib/formatting-nostd/src/borrowed_fd_writer.rs
@@ -66,6 +66,6 @@ mod test {
 
         let mut buf = [0xff; 4];
         assert_eq!(rustix::io::read(reader.as_fd(), &mut buf), Ok(3));
-        assert_eq!(buf, ['1' as u8, '2' as u8, '3' as u8, 0xff]);
+        assert_eq!(buf, [b'1', b'2', b'3', 0xff]);
     }
 }

--- a/src/lib/formatting-nostd/src/utf8.rs
+++ b/src/lib/formatting-nostd/src/utf8.rs
@@ -29,18 +29,18 @@ pub fn split_at_first_char(buf: &[u8]) -> Option<(&str, &[u8])> {
 fn test_split_at_first_char() {
     // Valid first char; multiple lengths
     assert_eq!(
-        split_at_first_char(&['1' as u8, '2' as u8, '3' as u8][..]),
-        Some(("1", &['2' as u8, '3' as u8][..]))
+        split_at_first_char(&[b'1', b'2', b'3'][..]),
+        Some(("1", &[b'2', b'3'][..]))
     );
     assert_eq!(
-        split_at_first_char(&['1' as u8, '2' as u8][..]),
-        Some(("1", &['2' as u8][..]))
+        split_at_first_char(&[b'1', b'2'][..]),
+        Some(("1", &[b'2'][..]))
     );
-    assert_eq!(split_at_first_char(&['1' as u8][..]), Some(("1", &[][..])));
+    assert_eq!(split_at_first_char(&[b'1'][..]), Some(("1", &[][..])));
 
     // Invalid first char; multiple lengths
-    assert_eq!(split_at_first_char(&[0x80, '2' as u8, '3' as u8][..]), None);
-    assert_eq!(split_at_first_char(&[0x80, '2' as u8][..]), None);
+    assert_eq!(split_at_first_char(&[0x80, b'2', b'3'][..]), None);
+    assert_eq!(split_at_first_char(&[0x80, b'2'][..]), None);
     assert_eq!(split_at_first_char(&[0x80][..]), None);
 
     // > 1-byte first characters
@@ -106,7 +106,7 @@ fn test_split_at_first_char_lossy() {
     // Using the implementatin knowledge that this is implemented using `split_at_first_char`;
     // just focus on testing the cases that are different for this method.
     assert_eq!(
-        split_at_first_char_lossy(&['1' as u8, 2, 3][..]),
+        split_at_first_char_lossy(&[b'1', 2, 3][..]),
         ("1", &[2, 3][..])
     );
     assert_eq!(
@@ -148,7 +148,7 @@ fn test_lossy_decode_iterator() {
         vec!["1", "2", "3"]
     );
     assert_eq!(
-        decode_lossy(&[0x80, 0x80, 'x' as u8, 0x80]).collect::<Vec<_>>(),
+        decode_lossy(&[0x80, 0x80, b'x', 0x80]).collect::<Vec<_>>(),
         vec![
             UNICODE_REPLACEMENT_CHAR_STR,
             "x",

--- a/src/lib/shim/src/tls.rs
+++ b/src/lib/shim/src/tls.rs
@@ -815,7 +815,7 @@ mod test {
                         my_i16.get().store(i as i16, atomic::Ordering::Relaxed);
 
                         assert_eq!(my_i16.get().load(atomic::Ordering::Relaxed), i as i16);
-                        assert_eq!(my_i32.get().load(atomic::Ordering::Relaxed), { i });
+                        assert_eq!(my_i32.get().load(atomic::Ordering::Relaxed), i);
                         assert_eq!(my_i8.get().load(atomic::Ordering::Relaxed), i as i8);
                         unsafe { tls.unregister_current_thread() };
                     })

--- a/src/lib/shim/src/tls.rs
+++ b/src/lib/shim/src/tls.rs
@@ -810,12 +810,12 @@ mod test {
                         assert_eq!(my_i16.get().load(atomic::Ordering::Relaxed), 0);
 
                         // Order shouldn't matter here, but change it from above anyway.
-                        my_i32.get().store(i as i32, atomic::Ordering::Relaxed);
+                        my_i32.get().store(i, atomic::Ordering::Relaxed);
                         my_i8.get().store(i as i8, atomic::Ordering::Relaxed);
                         my_i16.get().store(i as i16, atomic::Ordering::Relaxed);
 
                         assert_eq!(my_i16.get().load(atomic::Ordering::Relaxed), i as i16);
-                        assert_eq!(my_i32.get().load(atomic::Ordering::Relaxed), i as i32);
+                        assert_eq!(my_i32.get().load(atomic::Ordering::Relaxed), { i });
                         assert_eq!(my_i8.get().load(atomic::Ordering::Relaxed), i as i8);
                         unsafe { tls.unregister_current_thread() };
                     })

--- a/src/lib/shmem/src/allocator.rs
+++ b/src/lib/shmem/src/allocator.rs
@@ -437,7 +437,7 @@ mod tests {
             execute_round();
         }
 
-        while marked_blocks.len() > 0 {
+        while !marked_blocks.is_empty() {
             let b = marked_blocks.pop().unwrap();
             shfree(b.1);
         }

--- a/src/lib/shmem/src/allocator.rs
+++ b/src/lib/shmem/src/allocator.rs
@@ -398,6 +398,8 @@ unsafe impl Sync for SharedMemDeserializer<'_> {}
 mod tests {
     use super::*;
     use rand::Rng;
+    use std::str::FromStr;
+    use std::string::ToString;
     use std::sync::atomic::{AtomicI32, Ordering};
 
     extern crate std;
@@ -450,8 +452,8 @@ mod tests {
         let original_block: ShMemBlock<T> = shmalloc(x);
         {
             let serialized_block = original_block.serialize();
-            let serialized_str = serialized_block.into();
-            let serialized_block = ShMemBlockSerialized::from(serialized_str);
+            let serialized_str = serialized_block.to_string();
+            let serialized_block = ShMemBlockSerialized::from_str(&serialized_str).unwrap();
             let block = unsafe { shdeserialize::<i32>(&serialized_block) };
             assert_eq!(*block, 42);
         }

--- a/src/lib/shmem/src/allocator.rs
+++ b/src/lib/shmem/src/allocator.rs
@@ -437,8 +437,7 @@ mod tests {
             execute_round();
         }
 
-        while !marked_blocks.is_empty() {
-            let b = marked_blocks.pop().unwrap();
+        while let Some(b) = marked_blocks.pop() {
             shfree(b.1);
         }
     }

--- a/src/lib/shmem/src/allocator.rs
+++ b/src/lib/shmem/src/allocator.rs
@@ -428,8 +428,8 @@ mod tests {
             }
 
             // Then check all blocks
-            for idx in 0..marked_blocks.len() {
-                assert_eq!(marked_blocks[idx].0, *marked_blocks[idx].1);
+            for block in &marked_blocks {
+                assert_eq!(block.0, *block.1);
             }
         };
 

--- a/src/lib/tcp/src/tests/mod.rs
+++ b/src/lib/tcp/src/tests/mod.rs
@@ -434,7 +434,7 @@ impl TcpSocket {
     }
 
     pub fn push_in_packet(&mut self, header: &TcpHeader, payload: Bytes) {
-        self.with_tcp_state(|s| s.push_packet(&header, payload))
+        self.with_tcp_state(|s| s.push_packet(header, payload))
             .unwrap();
     }
 
@@ -468,7 +468,7 @@ impl TcpSocket {
         }
 
         let peer_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
-        let tcp = Rc::clone(&tcp);
+        let tcp = Rc::clone(tcp);
         let handle = host.associate_socket(tcp, local_addr, peer_addr)?;
         tcp_ref.association_handle = Some(handle);
 
@@ -491,7 +491,7 @@ impl TcpSocket {
             let associate_fn = || {
                 let local_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
                 let peer_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
-                let tcp = Rc::clone(&tcp);
+                let tcp = Rc::clone(tcp);
                 host.associate_socket(tcp, local_addr, peer_addr).map(Some)
             };
             tcp_ref.with_tcp_state(|state| state.listen(backlog, associate_fn))
@@ -590,7 +590,7 @@ impl TcpSocket {
                     .unwrap();
                 let local_addr = SocketAddrV4::new(route, 0);
 
-                let socket = Rc::clone(&socket);
+                let socket = Rc::clone(socket);
                 let handle = host.associate_socket(socket, local_addr, peer_addr);
                 handle.map(|x| (x.local_addr(), Some(x)))
             };
@@ -700,7 +700,7 @@ impl Host {
             return Some(src);
         }
 
-        return None;
+        None
     }
 }
 
@@ -811,7 +811,7 @@ fn establish_helper(scheduler: &Scheduler, host: &mut Host) -> Rc<RefCell<TcpSoc
         Ref::map(tcp.borrow(), |x| x.tcp_state())
     }
 
-    let tcp = TcpSocket::new(&scheduler);
+    let tcp = TcpSocket::new(scheduler);
     assert!(s(&tcp).as_init().is_some());
 
     TcpSocket::bind(&tcp, SocketAddrV4::new(host.ip_addr, 10), host).unwrap();

--- a/src/lib/vasi-sync/benches/scchannel.rs
+++ b/src/lib/vasi-sync/benches/scchannel.rs
@@ -16,10 +16,7 @@ const PID_ZERO: Option<Pid> = unsafe { Pid::from_raw(0) };
 
 fn ping_pong(bencher: &mut Bencher, do_pinning: bool) {
     let initial_cpu_set = rustix::process::sched_getaffinity(PID_ZERO).unwrap();
-    let pinned_cpu_id = (0..)
-        .into_iter()
-        .find(|i| initial_cpu_set.is_set(*i))
-        .unwrap();
+    let pinned_cpu_id = (0..).find(|i| initial_cpu_set.is_set(*i)).unwrap();
     let pinned_cpu_set = {
         let mut s = CpuSet::new();
         s.set(pinned_cpu_id);

--- a/src/lib/vasi-sync/benches/scchannel.rs
+++ b/src/lib/vasi-sync/benches/scchannel.rs
@@ -12,7 +12,7 @@ use vasi_sync::scchannel::SelfContainedChannel;
 #[repr(align(128))]
 struct Ipc(SelfContainedChannel<()>, SelfContainedChannel<()>);
 
-const PID_ZERO: Option<Pid> = unsafe { Pid::from_raw(0) };
+const PID_ZERO: Option<Pid> = Pid::from_raw(0);
 
 fn ping_pong(bencher: &mut Bencher, do_pinning: bool) {
     let initial_cpu_set = rustix::process::sched_getaffinity(PID_ZERO).unwrap();

--- a/src/lib/vasi-sync/tests/atomic-tls-map-tests.rs
+++ b/src/lib/vasi-sync/tests/atomic-tls-map-tests.rs
@@ -84,14 +84,14 @@ mod atomic_tls_map_tests {
 
                 assert_eq!(
                     table
-                        .get(NonZeroUsize::try_from(NonZeroUsize::try_from(1).unwrap()).unwrap())
+                        .get(NonZeroUsize::try_from(1).unwrap())
                         .as_deref()
                         .copied(),
                     None
                 );
                 assert_eq!(
                     table
-                        .get(NonZeroUsize::try_from(NonZeroUsize::try_from(2).unwrap()).unwrap())
+                        .get(NonZeroUsize::try_from(2).unwrap())
                         .as_deref()
                         .copied(),
                     Some(12)

--- a/src/lib/vasi-sync/tests/scchannel-tests.rs
+++ b/src/lib/vasi-sync/tests/scchannel-tests.rs
@@ -32,7 +32,6 @@ mod scchannel_tests {
                 })
             };
             let reader = {
-                let channel = channel.clone();
                 sync::thread::spawn(move || channel.receive())
             };
             writer.join().unwrap();
@@ -100,7 +99,6 @@ mod scchannel_tests {
             // Simulate a separate watchdog thread that detects that the writer process
             // has exited, and closes the channel in parallel with the other operations.
             let watchdog = {
-                let channel = channel.clone();
                 sync::thread::spawn(move || channel.close_writer())
             };
             let res = reader.join().unwrap();

--- a/src/lib/vasi-sync/tests/scchannel-tests.rs
+++ b/src/lib/vasi-sync/tests/scchannel-tests.rs
@@ -31,7 +31,7 @@ mod scchannel_tests {
                     channel.send(42);
                 })
             };
-            let reader = { sync::thread::spawn(move || channel.receive()) };
+            let reader = sync::thread::spawn(move || channel.receive());
             writer.join().unwrap();
             assert_eq!(reader.join().unwrap(), Ok(42));
         })
@@ -96,7 +96,7 @@ mod scchannel_tests {
             };
             // Simulate a separate watchdog thread that detects that the writer process
             // has exited, and closes the channel in parallel with the other operations.
-            let watchdog = { sync::thread::spawn(move || channel.close_writer()) };
+            let watchdog = sync::thread::spawn(move || channel.close_writer());
             let res = reader.join().unwrap();
             // We should either get the written value, or an error, depending on
             // the execution order.

--- a/src/lib/vasi-sync/tests/scchannel-tests.rs
+++ b/src/lib/vasi-sync/tests/scchannel-tests.rs
@@ -31,9 +31,7 @@ mod scchannel_tests {
                     channel.send(42);
                 })
             };
-            let reader = {
-                sync::thread::spawn(move || channel.receive())
-            };
+            let reader = { sync::thread::spawn(move || channel.receive()) };
             writer.join().unwrap();
             assert_eq!(reader.join().unwrap(), Ok(42));
         })
@@ -98,9 +96,7 @@ mod scchannel_tests {
             };
             // Simulate a separate watchdog thread that detects that the writer process
             // has exited, and closes the channel in parallel with the other operations.
-            let watchdog = {
-                sync::thread::spawn(move || channel.close_writer())
-            };
+            let watchdog = { sync::thread::spawn(move || channel.close_writer()) };
             let res = reader.join().unwrap();
             // We should either get the written value, or an error, depending on
             // the execution order.
@@ -150,8 +146,8 @@ mod scchannel_tests {
                 })
             };
             let beta = {
-                let send_channel = beta_to_alpha.clone();
-                let recv_channel = alpha_to_beta.clone();
+                let send_channel = beta_to_alpha;
+                let recv_channel = alpha_to_beta;
                 sync::thread::spawn(move || {
                     let mut v = Vec::new();
                     v.push(recv_channel.receive());

--- a/src/main/host/syscall/formatter.rs
+++ b/src/main/host/syscall/formatter.rs
@@ -76,7 +76,7 @@ impl<'a, T> SyscallVal<'a, T> {
             args,
             options,
             mem,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 }
@@ -215,7 +215,7 @@ where
                 args,
                 options,
                 mem,
-                _phantom: PhantomData::default(),
+                _phantom: PhantomData,
             }),
             // the syscall was not completed and will be re-run again later
             SyscallResult::Err(SyscallError::Blocked(_)) => None,

--- a/src/main/host/syscall_condition.rs
+++ b/src/main/host/syscall_condition.rs
@@ -28,7 +28,7 @@ impl<'a> SysCallConditionRef<'a> {
         assert!(!ptr.is_null());
         Self {
             c_ptr: ptr,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 

--- a/src/main/network/relay/token_bucket.rs
+++ b/src/main/network/relay/token_bucket.rs
@@ -199,7 +199,7 @@ mod tests {
 
         for i in 1..=(capacity / increment) {
             // One more interval of time passes
-            let later = now + interval.saturating_mul(i.try_into().unwrap());
+            let later = now + interval.saturating_mul(i);
             // Should cause an increment to the balance
             let result = tb.conforming_remove_inner(0, &later);
             assert!(result.is_ok());

--- a/src/main/network/router/codel_queue.rs
+++ b/src/main/network/router/codel_queue.rs
@@ -406,32 +406,29 @@ mod tests {
         // Not above target so interval is not set.
         assert!(cdq.interval_end.is_none());
         let now = start + TARGET - one;
-        assert_eq!(cdq.process_standing_delay(&now, TARGET - one), false);
+        assert!(!cdq.process_standing_delay(&now, TARGET - one));
         assert!(cdq.interval_end.is_none());
 
         // Reached target, interval is set but still not ok to drop.
         let now = start + TARGET;
-        assert_eq!(cdq.process_standing_delay(&now, TARGET), false);
+        assert!(!cdq.process_standing_delay(&now, TARGET));
         assert!(cdq.interval_end.is_some());
         assert_eq!(cdq.interval_end.unwrap(), start + TARGET + INTERVAL);
 
         // Now we exceed target+interval, so ok to drop.
         let now = start + TARGET + INTERVAL;
-        assert_eq!(cdq.process_standing_delay(&now, TARGET + INTERVAL), true);
+        assert!(cdq.process_standing_delay(&now, TARGET + INTERVAL));
         assert!(cdq.interval_end.is_some());
         assert_eq!(cdq.interval_end.unwrap(), start + TARGET + INTERVAL);
 
         let now = start + TARGET + INTERVAL * 2u32;
-        assert_eq!(
-            cdq.process_standing_delay(&now, TARGET + INTERVAL * 2u32),
-            true
-        );
+        assert!(cdq.process_standing_delay(&now, TARGET + INTERVAL * 2u32));
         assert!(cdq.interval_end.is_some());
         assert_eq!(cdq.interval_end.unwrap(), start + TARGET + INTERVAL);
 
         // Delay back to low, interval resets, not ok to drop.
         let now = start + TARGET + INTERVAL * 2u32;
-        assert_eq!(cdq.process_standing_delay(&now, one), false);
+        assert!(!cdq.process_standing_delay(&now, one));
         assert!(cdq.interval_end.is_none());
     }
 
@@ -514,7 +511,7 @@ mod tests {
         assert_eq!(cdq.len(), N - 1);
         assert_eq!(cdq.current_drop_count, 0);
         assert_eq!(cdq.previous_drop_count, 0);
-        assert_eq!(cdq.was_dropping_recently(&(start + TARGET)), false);
+        assert!(!cdq.was_dropping_recently(&(start + TARGET)));
         assert_eq!(cdq.mode, CoDelMode::Store);
 
         // Enters Drop mode, drops 1 packet and sets drop_next
@@ -523,15 +520,12 @@ mod tests {
         assert_eq!(cdq.current_drop_count, 1);
         assert_eq!(cdq.previous_drop_count, 1);
         assert!(cdq.drop_next.is_some());
-        assert_eq!(
-            cdq.was_dropping_recently(&(start + TARGET + INTERVAL)),
-            true
-        );
+        assert!(cdq.was_dropping_recently(&(start + TARGET + INTERVAL)));
         assert_eq!(cdq.mode, CoDelMode::Drop);
 
         // In Drop mode, we have repeated drops, but then it leaves Drop mode
         // before the queue is empty.
-        assert_eq!(cdq.should_drop(&end), true);
+        assert!(cdq.should_drop(&end));
         cdq.pop(end);
         assert_eq!(cdq.len(), 1);
         assert_eq!(cdq.current_drop_count, N - 4);

--- a/src/main/utility/byte_queue.rs
+++ b/src/main/utility/byte_queue.rs
@@ -743,8 +743,8 @@ mod tests {
         const NUM_ITER: usize = 10;
 
         // pop more bytes and chunks than we push so that we generally stay near an empty queue
-        assert!(PROB_POP > PROB_PUSH);
-        assert!(MAX_POP > MAX_PUSH);
+        static_assertions::const_assert!(PROB_POP > PROB_PUSH);
+        static_assertions::const_assert!(MAX_POP > MAX_PUSH);
 
         let mut bq = ByteQueue::new(10);
 


### PR DESCRIPTION
`cargo clippy --fix` can be helpful for fixing clippy warnings. There are currently a lot of things in our code it changes though, making it awkward to use in a PR since it'll change code unrelated to the PR.

I'm not sure why, but `cargo clippy --fix` warns about and fixes things that just `cargo clippy` doesn't complain about. Maybe it has a different default policy set.

This PR includes some manual fixes as well for things that `clippy --fix` fixes suboptimally, or complains about without fixing.