### PR TITLE
Fix warning in rust 1.72 beta

### DIFF
--- a/src/main/core/work/task.rs
+++ b/src/main/core/work/task.rs
@@ -268,6 +268,6 @@ pub mod export {
     /// `task` must be legally dereferencable.
     #[no_mangle]
     pub unsafe extern "C" fn taskref_drop(task: *mut TaskRef) {
-        unsafe { Box::from_raw(notnull_mut(task)) };
+        drop(unsafe { Box::from_raw(notnull_mut(task)) });
     }
 }

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -910,7 +910,7 @@ mod export {
     pub extern "C" fn openfile_drop(file: *const OpenFile) {
         assert!(!file.is_null());
 
-        unsafe { Box::from_raw(file as *mut OpenFile) };
+        drop(unsafe { Box::from_raw(file as *mut OpenFile) });
     }
 
     /// Get the state of the `OpenFile` object.
@@ -989,7 +989,7 @@ mod export {
     pub extern "C" fn file_drop(file: *const File) {
         assert!(!file.is_null());
 
-        unsafe { Box::from_raw(file as *mut File) };
+        drop(unsafe { Box::from_raw(file as *mut File) });
     }
 
     /// Increment the ref count of the `File` object. The returned pointer will not be the same as
@@ -1059,7 +1059,7 @@ mod export {
     #[no_mangle]
     pub extern "C" fn eventsource_free(event_source: *mut RootedRefCell_StateEventSource) {
         assert!(!event_source.is_null());
-        unsafe { Box::from_raw(event_source) };
+        drop(unsafe { Box::from_raw(event_source) });
     }
 
     #[no_mangle]

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -518,7 +518,7 @@ mod export {
     #[no_mangle]
     pub extern "C" fn inetsocket_drop(socket: *const InetSocket) {
         assert!(!socket.is_null());
-        unsafe { Box::from_raw(socket.cast_mut()) };
+        drop(unsafe { Box::from_raw(socket.cast_mut()) });
     }
 
     /// Helper for GLib functions that take a `TaskObjectFreeFunc`. See [`inetsocket_drop`].
@@ -626,7 +626,7 @@ mod export {
     #[no_mangle]
     pub extern "C" fn inetsocketweak_drop(socket: *mut InetSocketWeak) {
         assert!(!socket.is_null());
-        unsafe { Box::from_raw(socket) };
+        drop(unsafe { Box::from_raw(socket) });
     }
 
     /// Upgrade the weak reference. May return `NULL` if the socket has no remaining strong

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -838,7 +838,7 @@ mod export {
 
     #[no_mangle]
     pub unsafe extern "C" fn memorymanager_freeRef(memory_ref: *mut ProcessMemoryRef<'_, u8>) {
-        unsafe { Box::from_raw(notnull_mut_debug(memory_ref)) };
+        drop(unsafe { Box::from_raw(notnull_mut_debug(memory_ref)) });
     }
 
     #[no_mangle]

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -297,7 +297,7 @@ mod export {
         if handler_ptr.is_null() {
             return;
         }
-        unsafe { Box::from_raw(handler_ptr) };
+        drop(unsafe { Box::from_raw(handler_ptr) });
     }
 
     #[no_mangle]

--- a/src/main/host/timer.rs
+++ b/src/main/host/timer.rs
@@ -229,7 +229,7 @@ pub mod export {
     /// `timer` must be safely dereferenceable. Consumes `timer`.
     #[no_mangle]
     pub unsafe extern "C" fn timer_drop(timer: *mut Timer) {
-        unsafe { Box::from_raw(timer) };
+        drop(unsafe { Box::from_raw(timer) });
     }
 
     /// # Safety

--- a/src/main/utility/counter.rs
+++ b/src/main/utility/counter.rs
@@ -218,7 +218,7 @@ mod export {
         if counter_ptr.is_null() {
             return;
         }
-        unsafe { Box::from_raw(counter_ptr) };
+        drop(unsafe { Box::from_raw(counter_ptr) });
     }
 
     #[no_mangle]
@@ -306,7 +306,7 @@ mod export {
         assert!(!counter.is_null());
         assert!(!ptr.is_null());
         // Free the previously alloc'd string
-        unsafe { CString::from_raw(ptr) };
+        drop(unsafe { CString::from_raw(ptr) });
     }
 }
 

--- a/src/main/utility/pcap_writer.rs
+++ b/src/main/utility/pcap_writer.rs
@@ -181,7 +181,7 @@ mod export {
         if pcap.is_null() {
             return;
         }
-        unsafe { Box::from_raw(pcap) };
+        drop(unsafe { Box::from_raw(pcap) });
     }
 
     /// If there's an error, returns 1. Otherwise returns 0. If there's an error, the pcap file is


### PR DESCRIPTION
I don't really think this should be a warning, but it's easy to work around anyways.

```
warning: unused return value of `Box::<T>::from_raw` that must be used
   --> main/utility/pcap_writer.rs:184:18
    |
184 |         unsafe { Box::from_raw(pcap) };
    |                  ^^^^^^^^^^^^^^^^^^^
    |
    = note: call `drop(Box::from_raw(ptr))` if you intend to drop the `Box`
help: use `let _ = ...` to ignore the resulting value
    |
184 |         unsafe { let _ = Box::from_raw(pcap); };
    |                  +++++++                    +
```