### PR TITLE
Improve process exit handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ currently be disabled via the (unstable) option `log-errors-to-tty`.
 * Added support for subprocess creation and management.
   * The `fork` syscall and `fork`-like invocations of the `clone` and `clone3` syscalls.
   * Process parent pid's, process group IDs, process session IDs, and related syscalls.
+  * Child exit signals (e.g. SIGCHLD)
 
 * Added Debian 12 (Bookworm) to our supported platforms.
 

--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -622,6 +622,7 @@ impl siginfo_t {
     }
 
     pub fn new_for_sigchld_exited(
+        exit_signal: Signal,
         child_pid: i32,
         child_uid: u32,
         child_exit_status: i32,
@@ -639,7 +640,7 @@ impl siginfo_t {
         // > waited-for  children  (unlike  getrusage(2) and times(2)).
         unsafe {
             Self::new(
-                Signal::SIGCHLD,
+                exit_signal,
                 0,
                 SigInfoCodeCld::CLD_EXITED.into(),
                 SigInfoDetailsFields {
@@ -666,6 +667,7 @@ impl siginfo_t {
     // > child process; these fields do not  include  the  times  used  by
     // > waited-for  children  (unlike  getrusage(2) and times(2)).
     fn new_for_sigchld_signaled(
+        exit_signal: Signal,
         code: SigInfoCodeCld,
         child_pid: i32,
         child_uid: u32,
@@ -675,7 +677,7 @@ impl siginfo_t {
     ) -> Self {
         unsafe {
             Self::new(
-                Signal::SIGCHLD,
+                exit_signal,
                 0,
                 code.into(),
                 SigInfoDetailsFields {
@@ -692,6 +694,7 @@ impl siginfo_t {
     }
 
     pub fn new_for_sigchld_killed(
+        exit_signal: Signal,
         child_pid: i32,
         child_uid: u32,
         fatal_signal: Signal,
@@ -699,6 +702,7 @@ impl siginfo_t {
         child_stime: i64,
     ) -> Self {
         Self::new_for_sigchld_signaled(
+            exit_signal,
             SigInfoCodeCld::CLD_KILLED,
             child_pid,
             child_uid,
@@ -708,6 +712,7 @@ impl siginfo_t {
         )
     }
     pub fn new_for_sigchld_dumped(
+        exit_signal: Signal,
         child_pid: i32,
         child_uid: u32,
         fatal_signal: Signal,
@@ -715,6 +720,7 @@ impl siginfo_t {
         child_stime: i64,
     ) -> Self {
         Self::new_for_sigchld_signaled(
+            exit_signal,
             SigInfoCodeCld::CLD_DUMPED,
             child_pid,
             child_uid,
@@ -724,12 +730,14 @@ impl siginfo_t {
         )
     }
     pub fn new_for_sigchld_trapped(
+        exit_signal: Signal,
         child_pid: i32,
         child_uid: u32,
         child_utime: i64,
         child_stime: i64,
     ) -> Self {
         Self::new_for_sigchld_signaled(
+            exit_signal,
             SigInfoCodeCld::CLD_TRAPPED,
             child_pid,
             child_uid,
@@ -739,12 +747,14 @@ impl siginfo_t {
         )
     }
     pub fn new_for_sigchld_stopped(
+        exit_signal: Signal,
         child_pid: i32,
         child_uid: u32,
         child_utime: i64,
         child_stime: i64,
     ) -> Self {
         Self::new_for_sigchld_signaled(
+            exit_signal,
             SigInfoCodeCld::CLD_STOPPED,
             child_pid,
             child_uid,
@@ -754,12 +764,14 @@ impl siginfo_t {
         )
     }
     pub fn new_for_sigchld_continued(
+        exit_signal: Signal,
         child_pid: i32,
         child_uid: u32,
         child_utime: i64,
         child_stime: i64,
     ) -> Self {
         Self::new_for_sigchld_signaled(
+            exit_signal,
             SigInfoCodeCld::CLD_CONTINUED,
             child_pid,
             child_uid,

--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -1121,7 +1121,7 @@ impl sigaction {
     /// safe to call iff the function pointer in the internal `lsa_handler` is,
     /// and is of the type specified in the internal `lsa_flags`.
     pub unsafe fn handler(&self) -> SignalHandler {
-        let as_usize = self.0.lsa_handler.map(|f| f as usize).unwrap_or(0);
+        let as_usize = self.as_usize();
         if as_usize == Self::SIG_IGN {
             SignalHandler::SigIgn
         } else if as_usize == Self::SIG_DFL {
@@ -1142,6 +1142,18 @@ impl sigaction {
         } else {
             SignalHandler::Handler(self.0.lsa_handler.unwrap())
         }
+    }
+
+    fn as_usize(&self) -> usize {
+        self.0.lsa_handler.map(|f| f as usize).unwrap_or(0)
+    }
+
+    pub fn is_ignore(&self) -> bool {
+        self.as_usize() == Self::SIG_IGN
+    }
+
+    pub fn is_default(&self) -> bool {
+        self.as_usize() == Self::SIG_DFL
     }
 }
 

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -154,6 +154,9 @@ struct Common {
     // Session id, as returned e.g. by `getsid`.
     session_id: Cell<ProcessId>,
 
+    // Signal to send to parent on death.
+    exit_signal: Option<Signal>,
+
     // unique id of the program that this process should run
     name: CString,
 
@@ -549,6 +552,7 @@ impl RunnableProcess {
         &self,
         host: &Host,
         flags: CloneFlags,
+        exit_signal: Option<Signal>,
         new_thread_group_leader: RootedRc<RootedRefCell<Thread>>,
     ) -> RootedRc<RootedRefCell<Process>> {
         let new_tgl_tid;
@@ -587,6 +591,7 @@ impl RunnableProcess {
             parent_pid: Cell::new(parent_pid),
             group_id: Cell::new(process_group_id),
             session_id: Cell::new(session_id),
+            exit_signal,
         };
 
         // The child will log to the same strace log file. Entries contain thread IDs,
@@ -891,6 +896,9 @@ impl Process {
             parent_pid: Cell::new(ProcessId::INIT),
             group_id: Cell::new(ProcessId::INIT),
             session_id: Cell::new(ProcessId::INIT),
+            // Exit signal is moot; since parent is INIT there will never
+            // be a valid target for it.
+            exit_signal: None,
         };
         RootedRc::new(
             host.root(),

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -111,7 +111,7 @@ impl From<ThreadId> for ProcessId {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ExitStatus {
     Normal(i32),
-    Signaled(nix::sys::signal::Signal),
+    Signaled(Signal),
     /// The process was killed by Shadow rather than exiting "naturally" as part
     /// of the simulation. Currently this only happens when the process is still
     /// running when the simulation stop_time is reached.
@@ -651,6 +651,79 @@ pub struct ZombieProcess {
 impl ZombieProcess {
     pub fn exit_status(&self) -> ExitStatus {
         self.exit_status
+    }
+
+    /// Process that can reap this zombie process, if any.
+    pub fn reaper<'host>(
+        &self,
+        host: &'host Host,
+    ) -> Option<impl Deref<Target = RootedRc<RootedRefCell<Process>>> + 'host> {
+        let Some(exit_signal) = self.common.exit_signal else {
+            return None;
+        };
+        let parent_pid = self.common.parent_pid.get();
+        if parent_pid == ProcessId::INIT {
+            return None;
+        }
+        let parentrc = host.process_borrow(parent_pid)?;
+
+        // If the parent has *explicitly* ignored the exit signal, then it
+        // doesn't reap.
+        //
+        // `waitpid(2)`:
+        // > POSIX.1-2001 specifies that if the disposition of SIGCHLD is set to SIG_IGN or the SA_NOCLDWAIT flag is set for SIGCHLD  (see
+        // > sigaction(2)),  then  children  that  terminate  do not become zombies and a call to wait() or waitpid() will block until all
+        // > children have terminated, and then fail with errno set to ECHILD.  (The original POSIX standard left the behavior of  setting
+        // > SIGCHLD to SIG_IGN unspecified.  Note that even though the default disposition of SIGCHLD is "ignore", explicitly setting the
+        // > disposition to SIG_IGN results in different treatment of zombie process children.)
+        //
+        // TODO: validate that this applies to whatever signal is configured as the exit
+        // signal, even if it's not SIGCHLD.
+        {
+            let parent = parentrc.borrow(host.root());
+            let parent_shmem = parent.shmem();
+            let host_shmem_lock = host.shim_shmem_lock_borrow().unwrap();
+            let parent_shmem_protected = parent_shmem.protected.borrow(&host_shmem_lock.root);
+            // SAFETY: We don't dereference function pointers.
+            let action = unsafe { parent_shmem_protected.signal_action(exit_signal) };
+            if action.is_ignore() {
+                return None;
+            }
+        }
+
+        Some(parentrc)
+    }
+
+    fn notify_parent_of_exit(&self, host: &Host) {
+        let Some(exit_signal) = self.common.exit_signal else {
+            trace!("Not notifying parent of exit: no signal specified");
+            return;
+        };
+        let parent_pid = self.common.parent_pid.get();
+        if parent_pid == ProcessId::INIT {
+            trace!("Not notifying parent of exit: parent is 'init'");
+            return;
+        }
+        let Some(parent_rc) = host.process_borrow(parent_pid) else {
+            trace!("Not notifying parent of exit: parent {parent_pid:?} not found");
+            return;
+        };
+        let parent = parent_rc.borrow(host.root());
+        // FIXME: Update to support signals other than SIGCHLD.
+        if exit_signal != Signal::SIGCHLD {
+            warn!("Exit signal other than SIGCHLD not supported")
+        }
+        let siginfo = match self.exit_status {
+            ExitStatus::Normal(exit_code) => {
+                siginfo_t::new_for_sigchld_exited(self.common.id.into(), 0, exit_code, 0, 0)
+            }
+            ExitStatus::Signaled(fatal_signal) => {
+                siginfo_t::new_for_sigchld_killed(self.common.id.into(), 0, fatal_signal, 0, 0)
+            }
+            ExitStatus::StoppedByShadow => unreachable!(),
+        };
+        parent.signal(host, None, &siginfo);
+        // TODO: also notify parent's syscallcondition if it's blocked in e.g. waitpid.
     }
 }
 
@@ -1299,6 +1372,7 @@ impl Process {
             }
             (false, Ok(WaitStatus::Exited(_pid, code))) => ExitStatus::Normal(code),
             (false, Ok(WaitStatus::Signaled(_pid, signal, _core_dump))) => {
+                let signal = Signal::try_from(signal as i32).unwrap();
                 ExitStatus::Signaled(signal)
             }
             (false, Ok(status)) => {
@@ -1338,10 +1412,13 @@ impl Process {
         };
         log::log!(log_level, "{}", main_result_string);
 
-        *opt_state = Some(ProcessState::Zombie(ZombieProcess {
+        let zombie = ZombieProcess {
             common: runnable.into_common(),
             exit_status,
-        }))
+        };
+        zombie.notify_parent_of_exit(host);
+
+        *opt_state = Some(ProcessState::Zombie(zombie));
     }
 
     /// Deprecated wrapper for `RunnableProcess::add_thread`
@@ -1369,10 +1446,6 @@ impl Drop for Process {
     fn drop(&mut self) {
         // Should only be dropped in the zombie state.
         debug_assert!(self.zombie().is_some());
-        // Shouldn't be dropped while a parent exists.
-        // Assuming for now that once we implement parent processes, we'll clear
-        // the parent id after the child has been reaped or the parent exits.
-        debug_assert_eq!(self.parent_id(), ProcessId::INIT);
     }
 }
 

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1317,7 +1317,12 @@ impl Process {
             if let Some(expected_final_state) = runnable.expected_final_state {
                 let actual_final_state = match exit_status {
                     ExitStatus::Normal(i) => ProcessFinalState::Exited { exited: i },
-                    ExitStatus::Signaled(s) => ProcessFinalState::Signaled { signaled: s.into() },
+                    ExitStatus::Signaled(s) => ProcessFinalState::Signaled {
+                        // This conversion will fail on realtime signals, but that
+                        // should currently be impossible since we don't support
+                        // sending realtime signals.
+                        signaled: s.try_into().unwrap(),
+                    },
                     ExitStatus::StoppedByShadow => ProcessFinalState::Running(RunningVal::Running),
                 };
                 if expected_final_state == actual_final_state {

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -709,17 +709,23 @@ impl ZombieProcess {
             return;
         };
         let parent = parent_rc.borrow(host.root());
-        // FIXME: Update to support signals other than SIGCHLD.
-        if exit_signal != Signal::SIGCHLD {
-            warn!("Exit signal other than SIGCHLD not supported")
-        }
         let siginfo = match self.exit_status {
-            ExitStatus::Normal(exit_code) => {
-                siginfo_t::new_for_sigchld_exited(self.common.id.into(), 0, exit_code, 0, 0)
-            }
-            ExitStatus::Signaled(fatal_signal) => {
-                siginfo_t::new_for_sigchld_killed(self.common.id.into(), 0, fatal_signal, 0, 0)
-            }
+            ExitStatus::Normal(exit_code) => siginfo_t::new_for_sigchld_exited(
+                exit_signal,
+                self.common.id.into(),
+                0,
+                exit_code,
+                0,
+                0,
+            ),
+            ExitStatus::Signaled(fatal_signal) => siginfo_t::new_for_sigchld_killed(
+                exit_signal,
+                self.common.id.into(),
+                0,
+                fatal_signal,
+                0,
+                0,
+            ),
             ExitStatus::StoppedByShadow => unreachable!(),
         };
         parent.signal(host, None, &siginfo);

--- a/src/main/host/syscall/handler/clone.rs
+++ b/src/main/host/syscall/handler/clone.rs
@@ -1,8 +1,8 @@
 use linux_api::errno::Errno;
 use linux_api::posix_types::kernel_pid_t;
 use linux_api::sched::CloneFlags;
+use linux_api::signal::Signal;
 use log::{debug, trace, warn};
-use nix::sys::signal::Signal;
 use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
@@ -203,7 +203,7 @@ impl SyscallHandler {
                 .process
                 .borrow_runnable()
                 .unwrap()
-                .new_forked_process(ctx.objs.host, flags, childrc);
+                .new_forked_process(ctx.objs.host, flags, exit_signal, childrc);
             child_process_rc = Some(process.clone(ctx.objs.host.root()));
             child_process_borrow = Some(
                 child_process_rc

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -199,7 +199,7 @@ libc = "0.2"
 linux-api = { path = "../lib/linux-api", features  = ["std"] }
 nix = "0.26.2"
 rand = { version="0.8.5", features=["small_rng"] }
-rustix = { version = "0.38.4", default-features=false, features=["mm", "pipe", "time", "thread"]}
+rustix = { version = "0.38.4", default-features=false, features=["fs", "mm", "pipe", "time", "thread"]}
 signal-hook = "0.3.15"
 once_cell = "1.18.0"
 vasi-sync = { path = "../lib/vasi-sync" }


### PR DESCRIPTION
Have child processes signal their parents on death.

Add additional checks for when a dead process should be kept around as a zombie (e.g. *not* when the parent process created the child with no exit signal, or has themselves blocked the child exit signal).