### PR TITLE
Format with rustfmt 1.6.0-stable (cargo 1.72)

### DIFF
--- a/src/lib/formatting-nostd/src/borrowed_fd_writer.rs
+++ b/src/lib/formatting-nostd/src/borrowed_fd_writer.rs
@@ -34,7 +34,8 @@ impl<'fd> core::fmt::Write for BorrowedFdWriter<'fd> {
     fn write_str(&mut self, s: &str) -> Result<(), core::fmt::Error> {
         let mut bytes_slice = s.as_bytes();
         while !bytes_slice.is_empty() {
-            let Ok(written) = rustix::io::retry_on_intr(|| rustix::io::write(self.fd, bytes_slice)) else {
+            let Ok(written) = rustix::io::retry_on_intr(|| rustix::io::write(self.fd, bytes_slice))
+            else {
                 return Err(core::fmt::Error);
             };
             if written == 0 {

--- a/src/lib/shim/src/signals.rs
+++ b/src/lib/shim/src/signals.rs
@@ -107,9 +107,11 @@ pub unsafe fn process_signals(mut ucontext: Option<&mut ucontext>) -> bool {
     let mut restartable = true;
 
     loop {
-        let Some((sig, siginfo)) = tls_process_shmem::with(|process| tls_thread_shmem::with(|thread| {
-            shim_shmem::take_pending_unblocked_signal(&host_lock, process, thread)
-        })) else {
+        let Some((sig, siginfo)) = tls_process_shmem::with(|process| {
+            tls_thread_shmem::with(|thread| {
+                shim_shmem::take_pending_unblocked_signal(&host_lock, process, thread)
+            })
+        }) else {
             break;
         };
 

--- a/src/lib/syscall-logger/src/lib.rs
+++ b/src/lib/syscall-logger/src/lib.rs
@@ -96,19 +96,27 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         // get the names of the function arguments
-        syscall_args = input_fn.sig.inputs.iter().map(|arg| {
-            let syn::FnArg::Typed(arg) = arg else {
-                panic!("Expected a typed arg. Does the function take `self`?");
-            };
+        syscall_args = input_fn
+            .sig
+            .inputs
+            .iter()
+            .map(|arg| {
+                let syn::FnArg::Typed(arg) = arg else {
+                    panic!("Expected a typed arg. Does the function take `self`?");
+                };
 
-            // rust functions can be complicated (for example struct destructured args), but syscall
-            // arguments will be simple
-            let syn::Pat::Ident(ident_pat) = &*arg.pat else {
-                panic!("Function arguments must be identities (ex: `name: Type`), not {:?}", arg.pat);
-            };
+                // rust functions can be complicated (for example struct destructured args), but syscall
+                // arguments will be simple
+                let syn::Pat::Ident(ident_pat) = &*arg.pat else {
+                    panic!(
+                        "Function arguments must be identities (ex: `name: Type`), not {:?}",
+                        arg.pat
+                    );
+                };
 
-            ident_pat.ident.clone()
-        }).collect();
+                ident_pat.ident.clone()
+            })
+            .collect();
 
         syscall_ret_type = input_fn.sig.output.clone();
 

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -914,7 +914,9 @@ impl LegacyTcpSocket {
         // sanity check: make sure new socket peer address matches address returned from
         // tcp_acceptServerPeer() above
         {
-            let File::Socket(Socket::Inet(InetSocket::LegacyTcp(new_socket))) = open_file.inner_file() else {
+            let File::Socket(Socket::Inet(InetSocket::LegacyTcp(new_socket))) =
+                open_file.inner_file()
+            else {
                 panic!("Expected this to be a LegacyTcpSocket");
             };
 

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -459,7 +459,9 @@ fn associate_socket(
     let local_addr = if local_addr.port() != 0 {
         local_addr
     } else {
-        let Some(new_port) = net_ns.get_random_free_port(protocol, *local_addr.ip(), peer_addr, rng) else {
+        let Some(new_port) =
+            net_ns.get_random_free_port(protocol, *local_addr.ip(), peer_addr, rng)
+        else {
             log::debug!("Association required an ephemeral port but none are available");
             return Err(Errno::EADDRINUSE.into());
         };
@@ -610,7 +612,8 @@ mod export {
         let socket = unsafe { socket.as_ref() }.unwrap();
 
         #[allow(irrefutable_let_patterns)]
-        let InetSocket::LegacyTcp(socket) = socket else {
+        let InetSocket::LegacyTcp(socket) = socket
+        else {
             panic!("Socket was not a legacy TCP socket: {socket:?}");
         };
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -454,7 +454,10 @@ impl Host {
     }
 
     pub fn resume(&self, pid: ProcessId, tid: ThreadId) {
-        let Some(processrc) = self.process_borrow(pid).map(|p| RootedRc::clone(&p, &self.root)) else {
+        let Some(processrc) = self
+            .process_borrow(pid)
+            .map(|p| RootedRc::clone(&p, &self.root))
+        else {
             trace!("{pid:?} doesn't exist");
             return;
         };

--- a/src/main/host/syscall/formatter.rs
+++ b/src/main/host/syscall/formatter.rs
@@ -294,7 +294,7 @@ mod export {
         let logging_mode = logging_mode.into();
         let Some(logging_mode) = logging_mode else {
             // logging was disabled
-            return result.into()
+            return result.into();
         };
 
         let proc = unsafe { proc.as_ref().unwrap() };

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -500,7 +500,7 @@ impl SyscallHandler {
         }
         let pid = ProcessId::try_from(pid).map_err(|_| Errno::EINVAL)?;
         let Some(process) = ctx.objs.host.process_borrow(pid) else {
-            return Err(Errno::ESRCH.into())
+            return Err(Errno::ESRCH.into());
         };
         let process = process.borrow(ctx.objs.host.root());
         Ok(process.group_id().into())
@@ -588,10 +588,10 @@ impl SyscallHandler {
             return Ok(ctx.objs.process.session_id().into());
         }
         let Ok(pid) = ProcessId::try_from(pid) else {
-            return Err(Errno::EINVAL.into())
+            return Err(Errno::EINVAL.into());
         };
         let Some(processrc) = ctx.objs.host.process_borrow(pid) else {
-            return Err(Errno::ESRCH.into())
+            return Err(Errno::ESRCH.into());
         };
         let process = processrc.borrow(ctx.objs.host.root());
         // No need to check that process is in the same session:

--- a/src/main/host/syscall_types.rs
+++ b/src/main/host/syscall_types.rs
@@ -352,7 +352,7 @@ mod export {
         scr: *mut SyscallReturn,
     ) -> *mut SyscallReturnBlocked {
         let scr = unsafe { scr.as_mut().unwrap() };
-        let SyscallReturn::Block(b)= scr else {
+        let SyscallReturn::Block(b) = scr else {
             panic!("Unexpected scr {:?}", scr);
         };
         b
@@ -361,7 +361,7 @@ mod export {
     #[no_mangle]
     pub unsafe extern "C" fn syscallreturn_done(scr: *mut SyscallReturn) -> *mut SyscallReturnDone {
         let scr = unsafe { scr.as_mut().unwrap() };
-        let SyscallReturn::Done(d)= scr else {
+        let SyscallReturn::Done(d) = scr else {
             panic!("Unexpected scr {:?}", scr);
         };
         d


### PR DESCRIPTION
The latest rustfmt version (the version bundled with cargo 1.72) now formats `let else` expressions, so there's some churn in our code. It makes some questionable formatting choices, but :shrug:.

```diff
@@ -610,7 +612,8 @@ mod export {
         let socket = unsafe { socket.as_ref() }.unwrap();

         #[allow(irrefutable_let_patterns)]
-        let InetSocket::LegacyTcp(socket) = socket else {
+        let InetSocket::LegacyTcp(socket) = socket
+        else {
             panic!("Socket was not a legacy TCP socket: {socket:?}");
         };
```

It also adds semicolons:

```diff
@@ -294,7 +294,7 @@ mod export {
         let logging_mode = logging_mode.into();
         let Some(logging_mode) = logging_mode else {
             // logging was disabled
-            return result.into()
+            return result.into();
         };
```