### PR TITLE
Add window scaling to rust tcp

### DIFF
--- a/src/lib/tcp/src/connection.rs
+++ b/src/lib/tcp/src/connection.rs
@@ -6,12 +6,14 @@ use crate::buffer::Segment;
 use crate::seq::{Seq, SeqRange};
 use crate::util::time::Instant;
 use crate::{
-    Ipv4Header, PopPacketError, PushPacketError, RecvError, SendError, TcpFlags, TcpHeader,
+    Ipv4Header, PopPacketError, PushPacketError, RecvError, SendError, TcpConfig, TcpFlags,
+    TcpHeader,
 };
 
 /// Information for a TCP connection. Equivalent to the Transmission Control Block (TCB).
 #[derive(Debug)]
 pub(crate) struct Connection<I: Instant> {
+    pub(crate) _config: TcpConfig,
     pub(crate) local_addr: SocketAddrV4,
     pub(crate) remote_addr: SocketAddrV4,
     pub(crate) send: ConnectionSend<I>,
@@ -25,8 +27,14 @@ impl<I: Instant> Connection<I> {
     /// temporarily until we implement a proper TCP queue.
     const SEND_BUF_MAX: usize = 100_000;
 
-    pub fn new(local_addr: SocketAddrV4, remote_addr: SocketAddrV4, send_initial_seq: Seq) -> Self {
+    pub fn new(
+        local_addr: SocketAddrV4,
+        remote_addr: SocketAddrV4,
+        send_initial_seq: Seq,
+        config: TcpConfig,
+    ) -> Self {
         Self {
+            _config: config,
             local_addr,
             remote_addr,
             send: ConnectionSend::new(send_initial_seq),

--- a/src/lib/tcp/src/connection.rs
+++ b/src/lib/tcp/src/connection.rs
@@ -365,11 +365,12 @@ impl<I: Instant> Connection<I> {
     /// Returns true if the recv buffer has data to read. Does not consider whether the connection
     /// is open/closed, either due to FIN packets or `shutdown()`.
     pub fn recv_buf_has_data(&self) -> bool {
-        !self
+        let is_empty = self
             .recv
             .as_ref()
             .map(|x| x.buffer.is_empty())
-            .unwrap_or(false)
+            .unwrap_or(true);
+        !is_empty
     }
 }
 

--- a/src/lib/tcp/src/lib.rs
+++ b/src/lib/tcp/src/lib.rs
@@ -90,6 +90,7 @@ mod buffer;
 mod connection;
 mod seq;
 mod states;
+mod window_scaling;
 
 #[cfg(test)]
 mod tests;

--- a/src/lib/tcp/src/lib.rs
+++ b/src/lib/tcp/src/lib.rs
@@ -45,7 +45,7 @@
 //!     let dependencies = TcpDependencies {
 //!         state: weak.clone(),
 //!     };
-//!     RefCell::new(tcp::TcpState::new(dependencies))
+//!     RefCell::new(tcp::TcpState::new(dependencies, tcp::TcpConfig::default()))
 //! });
 //!
 //! let mut tcp_state = tcp_state.borrow_mut();
@@ -227,8 +227,8 @@ pub struct TcpState<X: Dependencies>(Option<TcpStateEnum<X>>);
 // this exposes many of the methods from `TcpStateTrait`, but not necessarily all of them (for
 // example we don't expose `rst_close()`).
 impl<X: Dependencies> TcpState<X> {
-    pub fn new(deps: X) -> Self {
-        let new_state = InitState::new(deps);
+    pub fn new(deps: X, config: TcpConfig) -> Self {
+        let new_state = InitState::new(deps, config);
         Self(Some(new_state.into()))
     }
 
@@ -584,6 +584,25 @@ bitflags::bitflags! {
         /// and now is in the "fin-wait-1" state. This does not include the initial state (we don't
         /// consider a new TCP to be "closed").
         const CLOSED = 1 << 7;
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct TcpConfig {
+    pub(crate) window_scaling_enabled: bool,
+}
+
+impl TcpConfig {
+    pub fn window_scaling(&mut self, enable: bool) {
+        self.window_scaling_enabled = enable;
+    }
+}
+
+impl Default for TcpConfig {
+    fn default() -> Self {
+        Self {
+            window_scaling_enabled: true,
+        }
     }
 }
 

--- a/src/lib/tcp/src/lib.rs
+++ b/src/lib/tcp/src/lib.rs
@@ -76,6 +76,8 @@
 //   `TcpStateEnum` enum that encapsulates all individual states. Its methods usually take owned
 //   state objects and return owned `TcpStateEnum` objects.
 
+#![forbid(unsafe_code)]
+
 use std::fmt::Debug;
 use std::io::{Read, Write};
 use std::net::{Ipv4Addr, SocketAddrV4};

--- a/src/lib/tcp/src/tests/mod.rs
+++ b/src/lib/tcp/src/tests/mod.rs
@@ -7,6 +7,7 @@
 
 mod send_recv;
 mod transitions;
+mod window_scale;
 
 pub mod util;
 

--- a/src/lib/tcp/src/tests/mod.rs
+++ b/src/lib/tcp/src/tests/mod.rs
@@ -24,8 +24,8 @@ use crate::tests::util::time::{Duration, Instant};
 #[allow(unused_imports)]
 use crate::{
     AcceptError, CloseError, ConnectError, Dependencies, Ipv4Header, ListenError, PollState,
-    PopPacketError, PushPacketError, RecvError, RstCloseError, SendError, TcpFlags, TcpHeader,
-    TcpState, TimerRegisteredBy,
+    PopPacketError, PushPacketError, RecvError, RstCloseError, SendError, TcpConfig, TcpFlags,
+    TcpHeader, TcpState, TimerRegisteredBy,
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -311,7 +311,7 @@ struct TcpSocket {
 }
 
 impl TcpSocket {
-    pub fn new(scheduler: &Scheduler) -> Rc<RefCell<Self>> {
+    pub fn new(scheduler: &Scheduler, config: TcpConfig) -> Rc<RefCell<Self>> {
         // passed to the state machine so that it can scheduler tasks in the future
         let event_queue_rc = scheduler.event_queue_rc();
         // passed to the state machine so that it can get the current time
@@ -329,7 +329,7 @@ impl TcpSocket {
             };
 
             RefCell::new(Self {
-                tcp_state: TcpState::new(test_env_state),
+                tcp_state: TcpState::new(test_env_state, config),
                 socket_weak: weak.clone(),
                 // the file state shouldn't matter here since we run `with_tcp_state` below to
                 // update it
@@ -730,7 +730,7 @@ fn test_timer() {
         Ref::map(tcp.borrow(), |x| x.tcp_state())
     }
 
-    let tcp = TcpSocket::new(&scheduler);
+    let tcp = TcpSocket::new(&scheduler, TcpConfig::default());
     assert!(s(&tcp).as_init().is_some());
 
     TcpSocket::listen(&tcp, &mut host, 10).unwrap();
@@ -811,7 +811,7 @@ fn establish_helper(scheduler: &Scheduler, host: &mut Host) -> Rc<RefCell<TcpSoc
         Ref::map(tcp.borrow(), |x| x.tcp_state())
     }
 
-    let tcp = TcpSocket::new(scheduler);
+    let tcp = TcpSocket::new(scheduler, TcpConfig::default());
     assert!(s(&tcp).as_init().is_some());
 
     TcpSocket::bind(&tcp, SocketAddrV4::new(host.ip_addr, 10), host).unwrap();

--- a/src/lib/tcp/src/tests/send_recv.rs
+++ b/src/lib/tcp/src/tests/send_recv.rs
@@ -96,8 +96,7 @@ fn test_ack_with_empty_usable_send_window() {
         .as_established()
         .unwrap()
         .connection
-        .send
-        .window_range()
+        .send_window()
         .len();
 
     let mut buffered = 0;

--- a/src/lib/tcp/src/tests/transitions.rs
+++ b/src/lib/tcp/src/tests/transitions.rs
@@ -7,13 +7,13 @@ use bytes::Bytes;
 
 use crate::tests::util::time::Duration;
 use crate::tests::{establish_helper, Errno, Host, Scheduler, TcpSocket, TestEnvState};
-use crate::{Ipv4Header, TcpFlags, TcpHeader, TcpState};
+use crate::{Ipv4Header, TcpConfig, TcpFlags, TcpHeader, TcpState};
 
 #[test]
 fn test_close() {
     let scheduler = Scheduler::new();
 
-    let tcp = TcpSocket::new(&scheduler);
+    let tcp = TcpSocket::new(&scheduler, TcpConfig::default());
     let mut tcp_ref = tcp.borrow_mut();
     assert!(tcp_ref.tcp_state().as_init().is_some());
 
@@ -26,7 +26,7 @@ fn test_listen() {
     let scheduler = Scheduler::new();
     let mut host = Host::new();
 
-    let tcp = TcpSocket::new(&scheduler);
+    let tcp = TcpSocket::new(&scheduler, TcpConfig::default());
     assert!(tcp.borrow().tcp_state().as_init().is_some());
 
     TcpSocket::listen(&tcp, &mut host, 10).unwrap();
@@ -50,7 +50,7 @@ fn test_accept() {
         Ref::map(tcp.borrow(), |x| x.tcp_state())
     }
 
-    let tcp = TcpSocket::new(&scheduler);
+    let tcp = TcpSocket::new(&scheduler, TcpConfig::default());
     assert!(s(&tcp).as_init().is_some());
 
     TcpSocket::listen(&tcp, &mut host, 10).unwrap();
@@ -124,7 +124,7 @@ fn test_accept_close_wait() {
         Ref::map(tcp.borrow(), |x| x.tcp_state())
     }
 
-    let tcp = TcpSocket::new(&scheduler);
+    let tcp = TcpSocket::new(&scheduler, TcpConfig::default());
     assert!(s(&tcp).as_init().is_some());
 
     TcpSocket::listen(&tcp, &mut host, 10).unwrap();
@@ -215,7 +215,7 @@ fn test_connect_active_open() {
         Ref::map(tcp.borrow(), |x| x.tcp_state())
     }
 
-    let tcp = TcpSocket::new(&scheduler);
+    let tcp = TcpSocket::new(&scheduler, TcpConfig::default());
     assert!(s(&tcp).as_init().is_some());
 
     TcpSocket::connect(&tcp, "5.6.7.8:10".parse().unwrap(), &mut host).unwrap();
@@ -263,7 +263,7 @@ fn test_connect_simultaneous_open() {
         Ref::map(tcp.borrow(), |x| x.tcp_state())
     }
 
-    let tcp = TcpSocket::new(&scheduler);
+    let tcp = TcpSocket::new(&scheduler, TcpConfig::default());
     assert!(s(&tcp).as_init().is_some());
 
     TcpSocket::connect(&tcp, "5.6.7.8:10".parse().unwrap(), &mut host).unwrap();

--- a/src/lib/tcp/src/tests/window_scale.rs
+++ b/src/lib/tcp/src/tests/window_scale.rs
@@ -1,0 +1,561 @@
+//! Test different window scale configurations.
+
+use std::cell::{Ref, RefCell};
+use std::rc::Rc;
+
+use bytes::Bytes;
+
+use crate::tests::{Host, Scheduler, TcpSocket, TestEnvState};
+use crate::{Ipv4Header, TcpConfig, TcpFlags, TcpHeader, TcpState};
+
+#[test]
+fn test_peer_no_window_scaling() {
+    let scheduler = Scheduler::new();
+    let mut host = Host::new();
+
+    /// Helper to get the state from a socket.
+    fn s(tcp: &Rc<RefCell<TcpSocket>>) -> Ref<TcpState<TestEnvState>> {
+        Ref::map(tcp.borrow(), |x| x.tcp_state())
+    }
+
+    // make sure it has window scaling enabled
+    let mut config = TcpConfig::default();
+    config.window_scaling_enabled = true;
+
+    let tcp = TcpSocket::new(&scheduler, config);
+    assert!(s(&tcp).as_init().is_some());
+
+    TcpSocket::connect(&tcp, "5.6.7.8:10".parse().unwrap(), &mut host).unwrap();
+    assert!(s(&tcp).as_syn_sent().is_some());
+
+    // read the SYN and check that it sent a non-zero window scale option
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::SYN);
+    assert!(response_header.window_scale.unwrap() > 0);
+
+    // get the autobind address of the socket
+    let tcp_bind_addr = response_header.src();
+
+    // send the SYN+ACK without a window scale option
+    let header = TcpHeader {
+        ip: Ipv4Header {
+            src: "5.6.7.8".parse().unwrap(),
+            dst: *tcp_bind_addr.ip(),
+        },
+        flags: TcpFlags::SYN | TcpFlags::ACK,
+        src_port: 10,
+        dst_port: tcp_bind_addr.port(),
+        seq: 0,
+        ack: 1,
+        window_size: 10000,
+        selective_acks: None,
+        window_scale: None,
+        timestamp: None,
+        timestamp_echo: None,
+    };
+    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    assert!(s(&tcp).as_established().is_some());
+
+    // read the ACK
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::ACK);
+
+    let tcp_ref = s(&tcp);
+    let connection = &tcp_ref.as_established().unwrap().connection;
+
+    // make sure that it's not applying any window scaling
+    assert!(connection.window_scaling.is_configured());
+    assert_eq!(connection.window_scaling.recv_window_scale_shift(), 0);
+    assert_eq!(connection.window_scaling.send_window_scale_shift(), 0);
+}
+
+#[test]
+fn test_local_no_window_scaling() {
+    let scheduler = Scheduler::new();
+    let mut host = Host::new();
+
+    /// Helper to get the state from a socket.
+    fn s(tcp: &Rc<RefCell<TcpSocket>>) -> Ref<TcpState<TestEnvState>> {
+        Ref::map(tcp.borrow(), |x| x.tcp_state())
+    }
+
+    // make sure it has window scaling disabled
+    let mut config = TcpConfig::default();
+    config.window_scaling_enabled = false;
+
+    let tcp = TcpSocket::new(&scheduler, config);
+    assert!(s(&tcp).as_init().is_some());
+
+    TcpSocket::connect(&tcp, "5.6.7.8:10".parse().unwrap(), &mut host).unwrap();
+    assert!(s(&tcp).as_syn_sent().is_some());
+
+    // read the SYN and check that it sent a non-zero window scale option
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::SYN);
+    assert!(response_header.window_scale.is_none());
+
+    // get the autobind address of the socket
+    let tcp_bind_addr = response_header.src();
+
+    // send the SYN+ACK without a window scale option
+    let header = TcpHeader {
+        ip: Ipv4Header {
+            src: "5.6.7.8".parse().unwrap(),
+            dst: *tcp_bind_addr.ip(),
+        },
+        flags: TcpFlags::SYN | TcpFlags::ACK,
+        src_port: 10,
+        dst_port: tcp_bind_addr.port(),
+        seq: 0,
+        ack: 1,
+        window_size: 10000,
+        selective_acks: None,
+        window_scale: Some(3),
+        timestamp: None,
+        timestamp_echo: None,
+    };
+    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    assert!(s(&tcp).as_established().is_some());
+
+    // read the ACK
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::ACK);
+
+    let tcp_ref = s(&tcp);
+    let connection = &tcp_ref.as_established().unwrap().connection;
+
+    // make sure that it's not applying any window scaling
+    assert!(connection.window_scaling.is_configured());
+    assert_eq!(connection.window_scaling.recv_window_scale_shift(), 0);
+    assert_eq!(connection.window_scaling.send_window_scale_shift(), 0);
+}
+
+#[test]
+fn test_both_without_window_scaling() {
+    let scheduler = Scheduler::new();
+    let mut host = Host::new();
+
+    /// Helper to get the state from a socket.
+    fn s(tcp: &Rc<RefCell<TcpSocket>>) -> Ref<TcpState<TestEnvState>> {
+        Ref::map(tcp.borrow(), |x| x.tcp_state())
+    }
+
+    // make sure it has window scaling disabled
+    let mut config = TcpConfig::default();
+    config.window_scaling_enabled = false;
+
+    let tcp = TcpSocket::new(&scheduler, config);
+    assert!(s(&tcp).as_init().is_some());
+
+    TcpSocket::connect(&tcp, "5.6.7.8:10".parse().unwrap(), &mut host).unwrap();
+    assert!(s(&tcp).as_syn_sent().is_some());
+
+    // read the SYN and check that it sent a non-zero window scale option
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::SYN);
+    assert!(response_header.window_scale.is_none());
+
+    // get the autobind address of the socket
+    let tcp_bind_addr = response_header.src();
+
+    // send the SYN+ACK without a window scale option
+    let header = TcpHeader {
+        ip: Ipv4Header {
+            src: "5.6.7.8".parse().unwrap(),
+            dst: *tcp_bind_addr.ip(),
+        },
+        flags: TcpFlags::SYN | TcpFlags::ACK,
+        src_port: 10,
+        dst_port: tcp_bind_addr.port(),
+        seq: 0,
+        ack: 1,
+        window_size: 10000,
+        selective_acks: None,
+        window_scale: None,
+        timestamp: None,
+        timestamp_echo: None,
+    };
+    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    assert!(s(&tcp).as_established().is_some());
+
+    // read the ACK
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::ACK);
+
+    let tcp_ref = s(&tcp);
+    let connection = &tcp_ref.as_established().unwrap().connection;
+
+    // make sure that it's not applying any window scaling
+    assert!(connection.window_scaling.is_configured());
+    assert_eq!(connection.window_scaling.recv_window_scale_shift(), 0);
+    assert_eq!(connection.window_scaling.send_window_scale_shift(), 0);
+}
+
+#[test]
+fn test_both_with_window_scaling() {
+    let scheduler = Scheduler::new();
+    let mut host = Host::new();
+
+    /// Helper to get the state from a socket.
+    fn s(tcp: &Rc<RefCell<TcpSocket>>) -> Ref<TcpState<TestEnvState>> {
+        Ref::map(tcp.borrow(), |x| x.tcp_state())
+    }
+
+    // make sure it has window scaling enabled
+    let mut config = TcpConfig::default();
+    config.window_scaling_enabled = true;
+
+    let tcp = TcpSocket::new(&scheduler, config);
+    assert!(s(&tcp).as_init().is_some());
+
+    TcpSocket::connect(&tcp, "5.6.7.8:10".parse().unwrap(), &mut host).unwrap();
+    assert!(s(&tcp).as_syn_sent().is_some());
+
+    // read the SYN and check that it sent a non-zero window scale option
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    let response_window_scale = response_header.window_scale.unwrap();
+    assert_eq!(response_header.flags, TcpFlags::SYN);
+
+    // get the autobind address of the socket
+    let tcp_bind_addr = response_header.src();
+
+    // send the SYN+ACK without a window scale option
+    let header = TcpHeader {
+        ip: Ipv4Header {
+            src: "5.6.7.8".parse().unwrap(),
+            dst: *tcp_bind_addr.ip(),
+        },
+        flags: TcpFlags::SYN | TcpFlags::ACK,
+        src_port: 10,
+        dst_port: tcp_bind_addr.port(),
+        seq: 0,
+        ack: 1,
+        window_size: 10000,
+        selective_acks: None,
+        window_scale: Some(3),
+        timestamp: None,
+        timestamp_echo: None,
+    };
+    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    assert!(s(&tcp).as_established().is_some());
+
+    // read the ACK
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::ACK);
+
+    let tcp_ref = s(&tcp);
+    let connection = &tcp_ref.as_established().unwrap().connection;
+
+    // make sure that the window scaling is as expected
+    assert!(connection.window_scaling.is_configured());
+    assert_eq!(connection.window_scaling.send_window_scale_shift(), 3);
+    assert_eq!(
+        connection.window_scaling.recv_window_scale_shift(),
+        response_window_scale
+    );
+}
+
+#[test]
+fn test_large_window_scale() {
+    let scheduler = Scheduler::new();
+    let mut host = Host::new();
+
+    /// Helper to get the state from a socket.
+    fn s(tcp: &Rc<RefCell<TcpSocket>>) -> Ref<TcpState<TestEnvState>> {
+        Ref::map(tcp.borrow(), |x| x.tcp_state())
+    }
+
+    // make sure it has window scaling enabled
+    let mut config = TcpConfig::default();
+    config.window_scaling_enabled = true;
+
+    let tcp = TcpSocket::new(&scheduler, config);
+    assert!(s(&tcp).as_init().is_some());
+
+    TcpSocket::connect(&tcp, "5.6.7.8:10".parse().unwrap(), &mut host).unwrap();
+    assert!(s(&tcp).as_syn_sent().is_some());
+
+    // read the SYN and check that it sent a non-zero window scale option
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::SYN);
+    assert!(response_header.window_scale.is_some());
+
+    // get the autobind address of the socket
+    let tcp_bind_addr = response_header.src();
+
+    // send the SYN+ACK with a window scale option that's too large
+    let header = TcpHeader {
+        ip: Ipv4Header {
+            src: "5.6.7.8".parse().unwrap(),
+            dst: *tcp_bind_addr.ip(),
+        },
+        flags: TcpFlags::SYN | TcpFlags::ACK,
+        src_port: 10,
+        dst_port: tcp_bind_addr.port(),
+        seq: 0,
+        ack: 1,
+        window_size: 10000,
+        selective_acks: None,
+        window_scale: Some(15),
+        timestamp: None,
+        timestamp_echo: None,
+    };
+    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    assert!(s(&tcp).as_established().is_some());
+
+    // read the ACK
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::ACK);
+
+    let tcp_ref = s(&tcp);
+    let connection = &tcp_ref.as_established().unwrap().connection;
+
+    // make sure that the window scaling was lowered to 14
+    assert!(connection.window_scaling.is_configured());
+    assert_eq!(connection.window_scaling.send_window_scale_shift(), 14);
+}
+
+/// Test that the socket does not send a window scale option if the SYN packet it received did not
+/// have a window scale option set.
+#[test]
+fn test_window_scale_after_receiving_syn_without() {
+    let scheduler = Scheduler::new();
+    let mut host = Host::new();
+
+    /// Helper to get the state from a socket.
+    fn s(tcp: &Rc<RefCell<TcpSocket>>) -> Ref<TcpState<TestEnvState>> {
+        Ref::map(tcp.borrow(), |x| x.tcp_state())
+    }
+
+    // make sure it has window scaling enabled
+    let mut config = TcpConfig::default();
+    config.window_scaling_enabled = true;
+
+    let tcp = TcpSocket::new(&scheduler, config);
+    assert!(s(&tcp).as_init().is_some());
+
+    TcpSocket::listen(&tcp, &mut host, 10).unwrap();
+    assert!(s(&tcp).as_listen().is_some());
+
+    // send the SYN without a window scale option
+    let header = TcpHeader {
+        ip: Ipv4Header {
+            src: "5.6.7.8".parse().unwrap(),
+            dst: host.ip_addr,
+        },
+        flags: TcpFlags::SYN,
+        src_port: 10,
+        dst_port: 20,
+        seq: 0,
+        ack: 0,
+        window_size: 10000,
+        selective_acks: None,
+        window_scale: None,
+        timestamp: None,
+        timestamp_echo: None,
+    };
+    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
+
+    // read the SYN+ACK and make sure it didn't set the window scale option
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::SYN | TcpFlags::ACK);
+    assert!(response_header.window_scale.is_none());
+
+    // send the ACK to move the child to the "established" state
+    let header = TcpHeader {
+        ip: Ipv4Header {
+            src: "5.6.7.8".parse().unwrap(),
+            dst: host.ip_addr,
+        },
+        flags: TcpFlags::ACK,
+        src_port: 10,
+        dst_port: 20,
+        seq: 1,
+        ack: 1,
+        window_size: 10000,
+        selective_acks: None,
+        window_scale: None,
+        timestamp: None,
+        timestamp_echo: None,
+    };
+    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
+
+    // the connection is now established so can accept it
+    let accepted_socket = tcp.borrow_mut().accept(&mut host).unwrap();
+    assert!(s(&accepted_socket).as_established().is_some());
+    assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 0);
+
+    let accepted_socket_ref = s(&accepted_socket);
+    let connection = &accepted_socket_ref.as_established().unwrap().connection;
+
+    // make sure that it's not applying any window scaling
+    assert!(connection.window_scaling.is_configured());
+    assert_eq!(connection.window_scaling.recv_window_scale_shift(), 0);
+    assert_eq!(connection.window_scaling.send_window_scale_shift(), 0);
+}
+
+/// Test that the socket does send a window scale option if the SYN packet it received did have a
+/// window scale option set.
+#[test]
+fn test_window_scale_after_receiving_syn_with() {
+    let scheduler = Scheduler::new();
+    let mut host = Host::new();
+
+    /// Helper to get the state from a socket.
+    fn s(tcp: &Rc<RefCell<TcpSocket>>) -> Ref<TcpState<TestEnvState>> {
+        Ref::map(tcp.borrow(), |x| x.tcp_state())
+    }
+
+    // make sure it has window scaling enabled
+    let mut config = TcpConfig::default();
+    config.window_scaling_enabled = true;
+
+    let tcp = TcpSocket::new(&scheduler, config);
+    assert!(s(&tcp).as_init().is_some());
+
+    TcpSocket::listen(&tcp, &mut host, 10).unwrap();
+    assert!(s(&tcp).as_listen().is_some());
+
+    // send the SYN with a window scale option
+    let header = TcpHeader {
+        ip: Ipv4Header {
+            src: "5.6.7.8".parse().unwrap(),
+            dst: host.ip_addr,
+        },
+        flags: TcpFlags::SYN,
+        src_port: 10,
+        dst_port: 20,
+        seq: 0,
+        ack: 0,
+        window_size: 10000,
+        selective_acks: None,
+        window_scale: Some(3),
+        timestamp: None,
+        timestamp_echo: None,
+    };
+    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
+
+    // read the SYN+ACK and make sure it did set the window scale option
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    let response_window_scale = response_header.window_scale.unwrap();
+    assert_eq!(response_header.flags, TcpFlags::SYN | TcpFlags::ACK);
+
+    // send the ACK to move the child to the "established" state
+    let header = TcpHeader {
+        ip: Ipv4Header {
+            src: "5.6.7.8".parse().unwrap(),
+            dst: host.ip_addr,
+        },
+        flags: TcpFlags::ACK,
+        src_port: 10,
+        dst_port: 20,
+        seq: 1,
+        ack: 1,
+        window_size: 10000,
+        selective_acks: None,
+        window_scale: None,
+        timestamp: None,
+        timestamp_echo: None,
+    };
+    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
+
+    // the connection is now established so can accept it
+    let accepted_socket = tcp.borrow_mut().accept(&mut host).unwrap();
+    assert!(s(&accepted_socket).as_established().is_some());
+    assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 0);
+
+    let accepted_socket_ref = s(&accepted_socket);
+    let connection = &accepted_socket_ref.as_established().unwrap().connection;
+
+    // make sure that the window scaling is as expected
+    assert!(connection.window_scaling.is_configured());
+    assert_eq!(connection.window_scaling.send_window_scale_shift(), 3);
+    assert_eq!(
+        connection.window_scaling.recv_window_scale_shift(),
+        response_window_scale
+    );
+}
+
+#[test]
+fn test_duplicate_syn_with_different_window_scale() {
+    let scheduler = Scheduler::new();
+    let mut host = Host::new();
+
+    /// Helper to get the state from a socket.
+    fn s(tcp: &Rc<RefCell<TcpSocket>>) -> Ref<TcpState<TestEnvState>> {
+        Ref::map(tcp.borrow(), |x| x.tcp_state())
+    }
+
+    // make sure it has window scaling enabled
+    let mut config = TcpConfig::default();
+    config.window_scaling_enabled = true;
+
+    let tcp = TcpSocket::new(&scheduler, config);
+    assert!(s(&tcp).as_init().is_some());
+
+    TcpSocket::connect(&tcp, "5.6.7.8:10".parse().unwrap(), &mut host).unwrap();
+    assert!(s(&tcp).as_syn_sent().is_some());
+
+    // read the SYN and check that it sent a non-zero window scale option
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::SYN);
+    assert!(response_header.window_scale.is_some());
+
+    // get the autobind address of the socket
+    let tcp_bind_addr = response_header.src();
+
+    // send the SYN+ACK with a window scale option
+    let header = TcpHeader {
+        ip: Ipv4Header {
+            src: "5.6.7.8".parse().unwrap(),
+            dst: *tcp_bind_addr.ip(),
+        },
+        flags: TcpFlags::SYN | TcpFlags::ACK,
+        src_port: 10,
+        dst_port: tcp_bind_addr.port(),
+        seq: 0,
+        ack: 1,
+        window_size: 10000,
+        selective_acks: None,
+        window_scale: Some(3),
+        timestamp: None,
+        timestamp_echo: None,
+    };
+    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    assert!(s(&tcp).as_established().is_some());
+
+    // send the SYN+ACK again with a different window scale
+    let header = TcpHeader {
+        ip: Ipv4Header {
+            src: "5.6.7.8".parse().unwrap(),
+            dst: *tcp_bind_addr.ip(),
+        },
+        flags: TcpFlags::SYN | TcpFlags::ACK,
+        src_port: 10,
+        dst_port: tcp_bind_addr.port(),
+        seq: 0,
+        ack: 1,
+        window_size: 10000,
+        selective_acks: None,
+        window_scale: Some(5),
+        timestamp: None,
+        timestamp_echo: None,
+    };
+    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    assert!(s(&tcp).as_established().is_some());
+
+    // read the ACK
+    let (response_header, _) = scheduler.pop_packet().unwrap();
+    assert_eq!(response_header.flags, TcpFlags::ACK);
+
+    let tcp_ref = s(&tcp);
+    let connection = &tcp_ref.as_established().unwrap().connection;
+
+    // make sure that the window scaling was not changed by the duplicate SYN
+    assert!(connection.window_scaling.is_configured());
+    assert_eq!(connection.window_scaling.send_window_scale_shift(), 3);
+}

--- a/src/lib/tcp/src/window_scaling.rs
+++ b/src/lib/tcp/src/window_scaling.rs
@@ -1,0 +1,218 @@
+/// An object to encode the window scaling logic. It asserts that no operations have been taken
+/// out-of-order.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct WindowScaling {
+    sent_syn: bool,
+    received_syn: bool,
+    recv_window_scale_shift: Option<u8>,
+    send_window_scale_shift: Option<u8>,
+    disabled: bool,
+}
+
+impl WindowScaling {
+    /// Maximum value of the "Window Scale" TCP option as specified by RFC 7323.
+    const MAX_SCALE_SHIFT: u8 = 14;
+
+    pub fn new() -> Self {
+        Self {
+            sent_syn: false,
+            received_syn: false,
+            recv_window_scale_shift: None,
+            send_window_scale_shift: None,
+            disabled: false,
+        }
+    }
+
+    /// Given a maximum window size, this returns the window scale shift that should be used. As the
+    /// window size must be less than 2^30, the returned shift will be limited to 14. This does not
+    /// guarantee that `window >> shift` fits within a `u16`.
+    pub fn scale_shift_for_max_window(window: u32) -> u8 {
+        // the maximum possible window allowed by tcp
+        let max_window_size = (u16::MAX as u32) << Self::MAX_SCALE_SHIFT;
+
+        // calculation based on linux 6.5 `tcp_select_initial_window`:
+        // https://elixir.bootlin.com/linux/v6.5/source/net/ipv4/tcp_output.c#L206
+
+        let window = std::cmp::min(window, max_window_size);
+
+        if window == 0 {
+            return 0;
+        }
+
+        let shift = window
+            .ilog2()
+            .saturating_sub(Self::MAX_SCALE_SHIFT as u32 + 1);
+        let shift = std::cmp::min(shift, Self::MAX_SCALE_SHIFT as u32);
+
+        shift.try_into().unwrap()
+    }
+
+    /// Disable window scaling. This will ensure that a window scale is not sent in a SYN packet.
+    pub fn disable(&mut self) {
+        // tried to disable window scaling after sending the SYN
+        assert!(!self.sent_syn);
+        self.disabled = true;
+    }
+
+    /// A SYN packet was sent with the given window scale.
+    pub fn sent_syn(&mut self, window_scale: Option<u8>) {
+        // why did we send the SYN twice?
+        assert!(!self.sent_syn);
+
+        // if it was disabled, we shouldn't have sent a window scale in the SYN
+        if self.disabled {
+            assert!(window_scale.is_none());
+        }
+
+        if self.received_syn && self.send_window_scale_shift.is_none() {
+            // RFC 7323 1.3.:
+            // > Furthermore, the Window Scale option will be sent in a <SYN,ACK> segment only if
+            // > the corresponding option was received in the initial <SYN> segment.
+            assert!(window_scale.is_none());
+        }
+
+        if let Some(window_scale) = window_scale {
+            // RFC 7323 2.3.:
+            // > Since the max window is 2^S (where S is the scaling shift count) times at most 2^16
+            // > - 1 (the maximum unscaled window), the maximum window is guaranteed to be < 2^30 if
+            // > S <= 14.  Thus, the shift count MUST be limited to 14 (which allows windows of 2^30
+            // > = 1 GiB).
+            assert!(window_scale <= Self::MAX_SCALE_SHIFT);
+        }
+
+        self.sent_syn = true;
+        self.recv_window_scale_shift = window_scale;
+    }
+
+    /// A SYN packet was received with the given window scale.
+    pub fn received_syn(&mut self, mut window_scale: Option<u8>) {
+        // why did we receive the SYN twice?
+        assert!(!self.received_syn);
+
+        if let Some(ref mut window_scale) = window_scale {
+            // RFC 7323 2.3.:
+            // > If a Window Scale option is received with a shift.cnt value larger than 14, the TCP
+            // > SHOULD log the error but MUST use 14 instead of the specified value.
+            if *window_scale > Self::MAX_SCALE_SHIFT {
+                *window_scale = Self::MAX_SCALE_SHIFT;
+            }
+        }
+
+        self.received_syn = true;
+        self.send_window_scale_shift = window_scale;
+    }
+
+    /// Checks if it's valid for an outward SYN packet to contain a window scale option.
+    pub fn can_send_window_scale(&self) -> bool {
+        // can't send if window scaling has been disabled, or if we've already received a SYN packet
+        // that did not have window scaling enabled
+        !(self.disabled || (self.received_syn && self.send_window_scale_shift.is_none()))
+    }
+
+    /// Has window scaling been configured? This does *not* mean that it's enabled. If this returns
+    /// true, then `recv_window_scale_shift()` and `send_window_scale_shift()` should not panic.
+    pub fn is_configured(&self) -> bool {
+        self.disabled || (self.sent_syn && self.received_syn)
+    }
+
+    fn recv_shift(&self) -> u8 {
+        if self.disabled {
+            return 0;
+        }
+
+        if self.send_window_scale_shift.is_some() && self.recv_window_scale_shift.is_some() {
+            self.recv_window_scale_shift.unwrap()
+        } else {
+            0
+        }
+    }
+
+    fn send_shift(&self) -> u8 {
+        if self.disabled {
+            return 0;
+        }
+
+        if self.send_window_scale_shift.is_some() && self.recv_window_scale_shift.is_some() {
+            self.send_window_scale_shift.unwrap()
+        } else {
+            0
+        }
+    }
+
+    /// The right bit-shift to apply to the receive buffer's window size when sending a packet.
+    pub fn recv_window_scale_shift(&self) -> u8 {
+        // we shouldn't be trying to get the receive window scale before we've fully configured
+        // window scaling
+        assert!(self.is_configured());
+
+        self.recv_shift()
+    }
+
+    /// The left bit-shift to apply to the send buffer's window size when receiving a packet.
+    pub fn send_window_scale_shift(&self) -> u8 {
+        // we shouldn't be trying to get the send window scale before we've fully configured window
+        // scaling
+        assert!(self.is_configured());
+
+        self.send_shift()
+    }
+
+    pub fn recv_window_max(&self) -> u32 {
+        (u16::MAX as u32) << self.recv_shift()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scale_shift_for_max_window() {
+        // the maximum possible window allowed by tcp
+        const MAX_WINDOW_SIZE: u32 = (u16::MAX as u32) << 14;
+
+        fn test(window: u32, expected: u8) {
+            let rv = WindowScaling::scale_shift_for_max_window(window);
+
+            assert_eq!(rv, expected);
+
+            // Check that applying the window scale bit-shift does result in a value that fits
+            // within a u16. We can't check this if the provided window size is larger than
+            // `MAX_WINDOW_SIZE`, since we use a max bit shift value of 14.
+            if window <= MAX_WINDOW_SIZE {
+                assert!(window >> rv <= u16::MAX as u32);
+            }
+        }
+
+        const U16_MAX: u32 = u16::MAX as u32;
+
+        test(0, 0);
+        test(1, 0);
+
+        test(U16_MAX, 0);
+        test(U16_MAX + 1, 1);
+
+        test(2 * U16_MAX, 1);
+        test(2 * U16_MAX + 1, 1);
+        test(2 * (U16_MAX + 1), 2);
+
+        test(4 * U16_MAX, 2);
+        test(4 * U16_MAX + 1, 2);
+        test(4 * U16_MAX + 2, 2);
+        test(4 * (U16_MAX + 1), 3);
+
+        test(MAX_WINDOW_SIZE / 2, 13);
+        test(MAX_WINDOW_SIZE / 2 + 1, 13);
+        test(MAX_WINDOW_SIZE / 2 + 14, 13);
+        test(MAX_WINDOW_SIZE / 2 + 2_u32.pow(13) - 1, 13);
+        test(MAX_WINDOW_SIZE / 2 + 2_u32.pow(13), 14);
+
+        test(MAX_WINDOW_SIZE - 1, 14);
+        test(MAX_WINDOW_SIZE, 14);
+        test(MAX_WINDOW_SIZE + 1, 14);
+        test(MAX_WINDOW_SIZE + 2_u32.pow(14), 14);
+        test(MAX_WINDOW_SIZE + 2_u32.pow(14) + 1, 14);
+
+        test(u32::MAX, 14);
+    }
+}

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -54,7 +54,7 @@ impl TcpSocket {
             };
 
             AtomicRefCell::new(Self {
-                tcp_state: tcp::TcpState::new(tcp_dependencies),
+                tcp_state: tcp::TcpState::new(tcp_dependencies, tcp::TcpConfig::default()),
                 socket_weak: weak.clone(),
                 event_source: StateEventSource::new(),
                 status,

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -1237,7 +1237,8 @@ void tcp_networkInterfaceIsAboutToSendPacket(TCP* tcp, const Host* host, Packet*
     CSimulationTime now = worker_getCurrentSimulationTime();
 
     /* update TCP header to our current advertised window and acknowledgment and timestamps */
-    packet_updateTCP(packet, tcp->receive.next, tcp->send.selectiveACKs, tcp->receive.window, now, tcp->receive.lastTimestamp);
+    packet_updateTCP(packet, tcp->receive.next, tcp->send.selectiveACKs, tcp->receive.window, 0,
+                     false, now, tcp->receive.lastTimestamp);
 
     /* keep track of the last things we sent them */
     tcp->send.lastAcknowledgment = tcp->receive.next;

--- a/src/main/network/packet.rs
+++ b/src/main/network/packet.rs
@@ -123,6 +123,8 @@ impl PacketRc {
                 header.ack,
                 selective_acks_glist,
                 header.window_size.into(),
+                header.window_scale.unwrap_or(0),
+                header.window_scale.is_some(),
                 timestamp.into(),
                 timestamp_echo.into(),
             );
@@ -180,6 +182,8 @@ impl PacketRc {
             None
         };
 
+        let window_scale = header.windowScaleSet.then_some(header.windowScale);
+
         let src_ip = Ipv4Addr::from(u32::from_be(header.sourceIP));
         let src_port = u16::from_be(header.sourcePort);
 
@@ -198,8 +202,7 @@ impl PacketRc {
             ack: header.acknowledgment,
             window_size: header.window.try_into().unwrap(),
             selective_acks,
-            // TODO: add a window scale field to the C packet header
-            window_scale: None,
+            window_scale,
             timestamp: Some(timestamp.try_into().unwrap()),
             timestamp_echo: Some(timestamp_echo.try_into().unwrap()),
         })

--- a/src/main/routing/packet.h
+++ b/src/main/routing/packet.h
@@ -35,6 +35,8 @@ struct _PacketTCPHeader {
     guint acknowledgment;
     GList* selectiveACKs;
     guint window;
+    unsigned char windowScale;
+    bool windowScaleSet;
     CSimulationTime timestampValue;
     CSimulationTime timestampEcho;
 };
@@ -78,6 +80,7 @@ void packet_setTCP(Packet* packet, enum ProtocolTCPFlags flags,
         in_addr_t destinationIP, in_port_t destinationPort, guint sequence);
 
 void packet_updateTCP(Packet* packet, guint acknowledgement, GList* selectiveACKs, guint window,
+                      unsigned char windowScale, bool windowScaleSet,
                       CSimulationTime timestampValue, CSimulationTime timestampEcho);
 
 gsize packet_getTotalSize(const Packet* packet);


### PR DESCRIPTION
Window scaling is pretty simple: if each peer sends the window scale option in the syn packet then they both use window scaling, and window scaling is only used in non-syn packets. But handing the edge cases makes this a bit of a mess.