### PR TITLE
Coalesce chunks when sending packets in rust tcp

### DIFF
--- a/src/lib/tcp/src/connection.rs
+++ b/src/lib/tcp/src/connection.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Buf, Bytes};
 use std::io::{Read, Write};
 use std::net::SocketAddrV4;
 
@@ -65,7 +65,7 @@ impl<I: Instant> Connection<I> {
         self.send.is_closed = true;
     }
 
-    pub fn send(&mut self, mut reader: impl Read, len: usize) -> Result<usize, SendError> {
+    pub fn send(&mut self, reader: impl Read, len: usize) -> Result<usize, SendError> {
         // if the buffer is full
         if !self.send_buf_has_space() {
             return Err(SendError::Full);
@@ -75,23 +75,8 @@ impl<I: Instant> Connection<I> {
         let send_buffer_space = Self::SEND_BUF_MAX.saturating_sub(send_buffer_len);
 
         let len = std::cmp::min(len, send_buffer_space);
-        let mut remaining = len;
-
-        // The max number of payload bytes allowed per packet. This is an arbitrary number used
-        // temporarily until we add code that considers the MSS.
-        const MAX_PER_PACKET: usize = 1500;
-
-        while remaining > 0 {
-            let to_read = std::cmp::min(remaining, MAX_PER_PACKET);
-            let mut payload = BytesMut::from_iter(std::iter::repeat(0).take(to_read));
-            if let Err(e) = reader.read_exact(&mut payload[..]) {
-                return Err(SendError::Io(e));
-            }
-
-            let payload = payload.into();
-            self.send.buffer.add_data(payload);
-
-            remaining -= to_read;
+        if let Err(e) = self.send.buffer.add_data(reader, len) {
+            return Err(SendError::Io(e));
         }
 
         Ok(len)
@@ -101,9 +86,7 @@ impl<I: Instant> Connection<I> {
         let mut bytes_copied = 0;
         let recv = self.recv.as_mut().unwrap();
 
-        let has_data = !recv.buffer.is_empty();
-
-        if !has_data {
+        if recv.buffer.is_empty() {
             return Err(RecvError::Empty);
         }
 
@@ -112,6 +95,7 @@ impl<I: Instant> Connection<I> {
             let remaining_u32 = remaining.try_into().unwrap_or(u32::MAX);
 
             let Some((_seq, data)) = recv.buffer.pop(remaining_u32) else {
+                // no more data available
                 break;
             };
 
@@ -131,7 +115,7 @@ impl<I: Instant> Connection<I> {
     pub fn push_packet(
         &mut self,
         header: &TcpHeader,
-        payload: impl Into<Bytes>,
+        payload: Payload,
     ) -> Result<(), PushPacketError> {
         if self.recv.is_none() && header.flags.contains(TcpFlags::SYN) {
             // we needed to know the sender's initial sequence number before we could initialize the
@@ -153,8 +137,6 @@ impl<I: Instant> Connection<I> {
         //
         // TODO: be careful about this if we support a reassembly queue in the future
         let original_packet_had_syn = header.flags.contains(TcpFlags::SYN);
-
-        let payload = payload.into();
 
         let recv_window = self.recv_window().unwrap();
         let Some((header, payload)) = trim_segment(header, payload, &recv_window) else {
@@ -201,7 +183,7 @@ impl<I: Instant> Connection<I> {
                 0
             };
 
-            let payload_len: u32 = payload.len().try_into().unwrap();
+            let payload_len = payload.len();
             let payload_seq = (payload_len != 0).then_some(Seq::new(header.seq) + syn_len);
             let fin_seq = header
                 .flags
@@ -210,7 +192,9 @@ impl<I: Instant> Connection<I> {
 
             if let Some(payload_seq) = payload_seq {
                 if payload_seq == recv.buffer.next_seq() {
-                    recv.buffer.add(payload);
+                    for chunk in payload.0 {
+                        recv.buffer.add(chunk);
+                    }
                 } else {
                     // TODO: store (truncated?) out-of-order packet
                 }
@@ -261,7 +245,7 @@ impl<I: Instant> Connection<I> {
         Ok(())
     }
 
-    pub fn pop_packet(&mut self, now: I) -> Result<(TcpHeader, Bytes), PopPacketError> {
+    pub fn pop_packet(&mut self, now: I) -> Result<(TcpHeader, Payload), PopPacketError> {
         let (seq_range, mut flags, payload) =
             self.next_segment().ok_or(PopPacketError::NoPacket)?;
 
@@ -348,11 +332,16 @@ impl<I: Instant> Connection<I> {
         Ok((header, payload))
     }
 
-    fn next_segment(&self) -> Option<(SeqRange, TcpFlags, Bytes)> {
+    /// Returns a segment that is ready to send. This may be a data segment (a segment containing a
+    /// SYN/FIN flag and/or payload data) or an empty segment. Even if this returns an empty
+    /// segment, it must be sent with the correct acknowledgement number, window size, etc as it may
+    /// represent an acknowledgement or window update.
+    fn next_segment(&self) -> Option<(SeqRange, TcpFlags, Payload)> {
         // should be inlined
         self._next_segment()
     }
 
+    /// Returns true if ready to send a packet.
     pub fn wants_to_send(&self) -> bool {
         // should be inlined
         self._next_segment().is_some()
@@ -367,24 +356,11 @@ impl<I: Instant> Connection<I> {
     /// showing up in a profile/heatmap. Since the function is large and is `inline(always)` we only
     /// call it from two functions, `next_segment()` and `wants_to_send()`.
     #[inline(always)]
-    fn _next_segment(&self) -> Option<(SeqRange, TcpFlags, Bytes)> {
+    fn _next_segment(&self) -> Option<(SeqRange, TcpFlags, Payload)> {
         let (seq_range, syn_fin_flags, payload) = 'packet: {
-            // do we have a syn/fin/payload packet to send?
-            if let Some((seq, metadata)) = self.send.buffer.next_not_transmitted() {
-                let send_window = self.send_window();
-
-                // does the segment fit in the send window?
-                if send_window.contains(seq + metadata.segment().len()) {
-                    debug_assert!(send_window.contains(seq));
-                    let (syn_fin_flags, payload) = match metadata.segment() {
-                        Segment::Syn => (TcpFlags::SYN, Bytes::new()),
-                        Segment::Fin => (TcpFlags::FIN, Bytes::new()),
-                        Segment::Data(bytes) => (TcpFlags::empty(), bytes.clone()),
-                    };
-
-                    let seq_range = SeqRange::new(seq, seq + metadata.segment().len());
-                    break 'packet (seq_range, syn_fin_flags, payload);
-                }
+            // if we have syn/fin/payload data to send
+            if let Some((seq_range, syn_fin_flags, payload)) = self.next_data_segment() {
+                break 'packet (seq_range, syn_fin_flags, payload);
             }
 
             let mut send_empty_packet = false;
@@ -411,12 +387,12 @@ impl<I: Instant> Connection<I> {
                 let seq = self
                     .send
                     .buffer
-                    .next_not_transmitted()
+                    .next_not_transmitted(0)
                     .map(|x| x.0)
                     .unwrap_or(self.send.buffer.next_seq());
 
                 let seq_range = SeqRange::new(seq, seq);
-                break 'packet (seq_range, TcpFlags::empty(), Bytes::new());
+                break 'packet (seq_range, TcpFlags::empty(), Payload::default());
             }
 
             return None;
@@ -430,6 +406,76 @@ impl<I: Instant> Connection<I> {
         }
 
         Some((seq_range, syn_fin_flags, payload))
+    }
+
+    /// Returns a data segment that is ready to send. This is a segment containing a SYN/FIN flag
+    /// and/or payload data. Even if this returns `None`, we may still want to send some other
+    /// segment such as an acknowledgement or window update (see `Self::next_segment`).
+    fn next_data_segment(&self) -> Option<(SeqRange, TcpFlags, Payload)> {
+        let send_window = self.send_window();
+
+        let mut chunks = Vec::new();
+        let mut syn_fin_flags = TcpFlags::empty();
+        let mut seq_start = None;
+        let mut seq_len = 0;
+        let mut payload_bytes_len = 0;
+
+        // roughly represents the MSS
+        // TODO: handle the MSS properly
+        const MAX_BYTES_PER_PACKET: u32 = 1500;
+
+        // do we have syn/fin/payload data to send?
+        while let Some((seq, segment)) = self.send.buffer.next_not_transmitted(seq_len) {
+            // if no bytes of this segment fit within the send window
+            if !send_window.contains(seq) {
+                break;
+            }
+
+            // if we can't send any more payload bytes
+            if payload_bytes_len == MAX_BYTES_PER_PACKET {
+                break;
+            }
+
+            // if this is the first returned segment, keep track of the start
+            if seq_start.is_none() {
+                seq_start = Some(seq);
+            }
+
+            match segment {
+                Segment::Syn => {
+                    syn_fin_flags.insert(TcpFlags::SYN);
+                    seq_len += segment.len();
+                }
+                Segment::Fin => {
+                    syn_fin_flags.insert(TcpFlags::FIN);
+                    seq_len += segment.len();
+                }
+                Segment::Data(mut chunk) => {
+                    let allowed_len =
+                        MAX_BYTES_PER_PACKET.saturating_sub(payload_bytes_len) as usize;
+                    let allowed_len = std::cmp::min(allowed_len, send_window.len() as usize);
+
+                    chunk.truncate(std::cmp::min(chunk.len(), allowed_len));
+
+                    let chunk_len: u32 = chunk.len().try_into().unwrap();
+                    payload_bytes_len += chunk_len;
+                    seq_len += chunk_len;
+
+                    chunks.push(chunk);
+                }
+            };
+
+            // we shouldn't be sending more than allowed
+            debug_assert!(payload_bytes_len <= MAX_BYTES_PER_PACKET);
+        }
+
+        if !chunks.is_empty() || !syn_fin_flags.is_empty() {
+            let seq_start = seq_start.unwrap();
+            let seq_range = SeqRange::new(seq_start, seq_start + seq_len);
+            return Some((seq_range, syn_fin_flags, Payload(chunks)));
+        }
+
+        None
     }
 
     /// Returns true if we received a SYN packet from the peer.
@@ -543,11 +589,13 @@ impl ConnectionRecv {
     }
 }
 
+/// Trims the segment `header` and `payload` such that only bytes in the sequence `range` remain.
+/// This may modify the segment sequence number, SYN/FIN flags, or payload.
 fn trim_segment(
     header: &TcpHeader,
-    payload: Bytes,
+    payload: Payload,
     range: &SeqRange,
-) -> Option<(TcpHeader, Bytes)> {
+) -> Option<(TcpHeader, Payload)> {
     let seq = Seq::new(header.seq);
     let syn_len = if header.flags.contains(TcpFlags::SYN) {
         1
@@ -559,16 +607,22 @@ fn trim_segment(
     } else {
         0
     };
-    let payload_len = payload.len().try_into().unwrap();
+    let payload_len = payload.len();
+
     let header_range = SeqRange::new(seq, seq + syn_len + payload_len + fin_len);
+    let intersection = header_range.intersection(range)?;
+
+    if intersection == header_range {
+        // in the common case where the segment is completely contained within the range, return
+        // early without any modifications
+        return Some((*header, payload));
+    }
 
     let include_syn = syn_len == 1 && range.contains(header_range.start);
     let include_fin = fin_len == 1 && range.contains(header_range.end - 1);
 
-    let intersection = header_range.intersection(range)?;
-
     let payload_seq = seq + syn_len;
-    let new_payload = match trim_chunk(payload_seq, payload, range) {
+    let new_payload = match trim_payload(payload_seq, payload, range) {
         Some((new_seq, new_payload)) => {
             assert_eq!(
                 new_seq,
@@ -576,7 +630,7 @@ fn trim_segment(
             );
             new_payload
         }
-        None => Bytes::new(),
+        None => Payload::default(),
     };
 
     let mut new_flags = header.flags;
@@ -696,7 +750,7 @@ mod tests {
         fn test_trim(
             flags: TcpFlags,
             seq: Seq,
-            payload: impl Into<Bytes>,
+            payload: impl Into<Payload>,
             range: SeqRange,
         ) -> Option<(TcpFlags, Seq, Bytes)> {
             let header = TcpHeader {
@@ -717,6 +771,7 @@ mod tests {
             };
 
             let (header, payload) = trim_segment(&header, payload.into(), &range)?;
+            let payload = payload.concat();
 
             Some((header.flags, Seq::new(header.seq), payload))
         }

--- a/src/lib/tcp/src/lib.rs
+++ b/src/lib/tcp/src/lib.rs
@@ -204,12 +204,17 @@ where
     fn push_packet(
         self,
         _header: &TcpHeader,
-        _payload: impl Into<Bytes>,
+        _payload: Payload,
     ) -> (TcpStateEnum<X>, Result<(), PushPacketError>) {
         (self.into(), Err(PushPacketError::InvalidState))
     }
 
-    fn pop_packet(self) -> (TcpStateEnum<X>, Result<(TcpHeader, Bytes), PopPacketError>) {
+    fn pop_packet(
+        self,
+    ) -> (
+        TcpStateEnum<X>,
+        Result<(TcpHeader, Payload), PopPacketError>,
+    ) {
         (self.into(), Err(PopPacketError::InvalidState))
     }
 
@@ -286,13 +291,13 @@ impl<X: Dependencies> TcpState<X> {
     pub fn push_packet(
         &mut self,
         header: &TcpHeader,
-        payload: impl Into<Bytes>,
+        payload: Payload,
     ) -> Result<(), PushPacketError> {
         self.with_state(|state| state.push_packet(header, payload))
     }
 
     #[inline]
-    pub fn pop_packet(&mut self) -> Result<(TcpHeader, Bytes), PopPacketError> {
+    pub fn pop_packet(&mut self) -> Result<(TcpHeader, Payload), PopPacketError> {
         self.with_state(|state| state.pop_packet())
     }
 

--- a/src/lib/tcp/src/tests/mod.rs
+++ b/src/lib/tcp/src/tests/mod.rs
@@ -18,15 +18,13 @@ use std::io::{Read, Write};
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::rc::{Rc, Weak};
 
-use bytes::Bytes;
-
 use crate::tests::util::time::{Duration, Instant};
 
 #[allow(unused_imports)]
 use crate::{
-    AcceptError, CloseError, ConnectError, Dependencies, Ipv4Header, ListenError, PollState,
-    PopPacketError, PushPacketError, RecvError, RstCloseError, SendError, TcpConfig, TcpFlags,
-    TcpHeader, TcpState, TimerRegisteredBy,
+    AcceptError, CloseError, ConnectError, Dependencies, Ipv4Header, ListenError, Payload,
+    PollState, PopPacketError, PushPacketError, RecvError, RstCloseError, SendError, TcpConfig,
+    TcpFlags, TcpHeader, TcpState, TimerRegisteredBy,
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -152,7 +150,7 @@ struct Scheduler {
     /// The current simulation time.
     current_time: Rc<Cell<Instant>>,
     /// A queue of all outgoing packets sent by sockets.
-    outgoing_packet_queue: Rc<RefCell<VecDeque<(TcpHeader, Bytes)>>>,
+    outgoing_packet_queue: Rc<RefCell<VecDeque<(TcpHeader, Payload)>>>,
 }
 
 impl Scheduler {
@@ -184,7 +182,7 @@ impl Scheduler {
         self.advance_to(self.current_time.get() + duration);
     }
 
-    pub fn pop_packet(&self) -> Option<(TcpHeader, Bytes)> {
+    pub fn pop_packet(&self) -> Option<(TcpHeader, Payload)> {
         self.outgoing_packet_queue.borrow_mut().pop_front()
     }
 
@@ -196,7 +194,7 @@ impl Scheduler {
         Rc::clone(&self.current_time)
     }
 
-    pub fn outgoing_packet_queue_rc(&self) -> Rc<RefCell<VecDeque<(TcpHeader, Bytes)>>> {
+    pub fn outgoing_packet_queue_rc(&self) -> Rc<RefCell<VecDeque<(TcpHeader, Payload)>>> {
         Rc::clone(&self.outgoing_packet_queue)
     }
 }
@@ -306,7 +304,7 @@ struct TcpSocket {
     file_state: FileState,
     event_source: StateEventSource,
     /// A global queue of all outgoing packets shared with all sockets.
-    outgoing_packet_queue: Rc<RefCell<VecDeque<(TcpHeader, Bytes)>>>,
+    outgoing_packet_queue: Rc<RefCell<VecDeque<(TcpHeader, Payload)>>>,
     // a handle for the association of this socket with the host's network interface
     association_handle: Option<AssociationHandle>,
     collect_packets: bool,
@@ -318,7 +316,7 @@ impl TcpSocket {
         let event_queue_rc = scheduler.event_queue_rc();
         // passed to the state machine so that it can get the current time
         let current_time_rc = scheduler.current_time_rc();
-        let outgoint_packet_queue_rc = scheduler.outgoing_packet_queue_rc();
+        let outgoing_packet_queue_rc = scheduler.outgoing_packet_queue_rc();
 
         let rv = Rc::new_cyclic(|weak: &Weak<RefCell<Self>>| {
             let test_env_state = TestEnvState {
@@ -337,7 +335,7 @@ impl TcpSocket {
                 // update it
                 file_state: FileState::empty(),
                 event_source: StateEventSource::new(),
-                outgoing_packet_queue: outgoint_packet_queue_rc,
+                outgoing_packet_queue: outgoing_packet_queue_rc,
                 association_handle: None,
                 collect_packets: true,
             })
@@ -364,7 +362,7 @@ impl TcpSocket {
     ) -> T {
         let rv = f(&mut self.tcp_state);
 
-        // if packet collecting is enabled and the tcp state wants to send a packet
+        // if the tcp state wants to send a packet and we should collect packets
         if self.collect_packets {
             while self.tcp_state.wants_to_send() {
                 if let Some(_socket) = self.socket_weak.upgrade() {
@@ -448,7 +446,7 @@ impl TcpSocket {
         self.emit_file_state(file_state);
     }
 
-    pub fn push_in_packet(&mut self, header: &TcpHeader, payload: Bytes) {
+    pub fn push_in_packet(&mut self, header: &TcpHeader, payload: Payload) {
         self.with_tcp_state(|s| s.push_packet(header, payload))
             .unwrap();
     }
@@ -768,7 +766,7 @@ fn test_timer() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
 
     // the new child state set a timer event at 60 seconds to close if still in the "syn-received"
@@ -856,7 +854,7 @@ fn establish_helper(scheduler: &Scheduler, host: &mut Host) -> Rc<RefCell<TcpSoc
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_established().is_some());
 
     // read the ACK

--- a/src/lib/tcp/src/tests/transitions.rs
+++ b/src/lib/tcp/src/tests/transitions.rs
@@ -3,11 +3,9 @@
 use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
-use bytes::Bytes;
-
 use crate::tests::util::time::Duration;
 use crate::tests::{establish_helper, Errno, Host, Scheduler, TcpSocket, TestEnvState};
-use crate::{Ipv4Header, TcpConfig, TcpFlags, TcpHeader, TcpState};
+use crate::{Ipv4Header, Payload, TcpConfig, TcpFlags, TcpHeader, TcpState};
 
 #[test]
 fn test_close() {
@@ -74,7 +72,7 @@ fn test_accept() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
 
     // read the SYN+ACK
@@ -104,7 +102,7 @@ fn test_accept() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
 
     // the connection is now established
@@ -148,7 +146,7 @@ fn test_accept_close_wait() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
 
     // read the SYN+ACK
@@ -172,7 +170,7 @@ fn test_accept_close_wait() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
 
     // send a FIN to move the child to the "close-wait" state
@@ -192,7 +190,7 @@ fn test_accept_close_wait() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
 
     // read the ACK
@@ -245,7 +243,7 @@ fn test_connect_active_open() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_established().is_some());
 
     // read the ACK
@@ -293,7 +291,7 @@ fn test_connect_simultaneous_open() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_syn_received().is_some());
 
     // read the ACK
@@ -317,7 +315,7 @@ fn test_connect_simultaneous_open() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_established().is_some());
 }
 
@@ -351,7 +349,7 @@ fn test_passive_close() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_close_wait().is_some());
 
     // check the ACK packet sent by the socket
@@ -363,7 +361,7 @@ fn test_passive_close() {
 
     // check the data packet sent by the socket
     let (_, payload) = scheduler.pop_packet().unwrap();
-    assert_eq!(payload[..], b"hello"[..]);
+    assert_eq!(payload.concat()[..], b"hello"[..]);
 
     // close the socket (move tcp to the "last-ack" state)
     tcp.borrow_mut().close().unwrap();
@@ -390,7 +388,7 @@ fn test_passive_close() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_closed().is_some());
 }
 
@@ -432,7 +430,7 @@ fn test_active_close_1() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_fin_wait_two().is_some());
 
     // send a FIN (move tcp to the "time-wait" state)
@@ -452,7 +450,7 @@ fn test_active_close_1() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_time_wait().is_some());
 
     // check the ACK packet sent by the socket
@@ -506,7 +504,7 @@ fn test_active_close_2() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_time_wait().is_some());
 
     // check the ACK packet sent by the socket
@@ -560,7 +558,7 @@ fn test_active_close_3() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_closing().is_some());
 
     // check the ACK packet sent by the socket
@@ -584,7 +582,7 @@ fn test_active_close_3() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_time_wait().is_some());
 
     // at 59 seconds, the socket is still in time-wait

--- a/src/lib/tcp/src/tests/window_scale.rs
+++ b/src/lib/tcp/src/tests/window_scale.rs
@@ -3,10 +3,8 @@
 use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
-use bytes::Bytes;
-
 use crate::tests::{Host, Scheduler, TcpSocket, TestEnvState};
-use crate::{Ipv4Header, TcpConfig, TcpFlags, TcpHeader, TcpState};
+use crate::{Ipv4Header, Payload, TcpConfig, TcpFlags, TcpHeader, TcpState};
 
 #[test]
 fn test_peer_no_window_scaling() {
@@ -53,7 +51,7 @@ fn test_peer_no_window_scaling() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_established().is_some());
 
     // read the ACK
@@ -114,7 +112,7 @@ fn test_local_no_window_scaling() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_established().is_some());
 
     // read the ACK
@@ -175,7 +173,7 @@ fn test_both_without_window_scaling() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_established().is_some());
 
     // read the ACK
@@ -236,7 +234,7 @@ fn test_both_with_window_scaling() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_established().is_some());
 
     // read the ACK
@@ -300,7 +298,7 @@ fn test_large_window_scale() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_established().is_some());
 
     // read the ACK
@@ -354,7 +352,7 @@ fn test_window_scale_after_receiving_syn_without() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
 
     // read the SYN+ACK and make sure it didn't set the window scale option
@@ -379,7 +377,7 @@ fn test_window_scale_after_receiving_syn_without() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
 
     // the connection is now established so can accept it
@@ -435,7 +433,7 @@ fn test_window_scale_after_receiving_syn_with() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
 
     // read the SYN+ACK and make sure it did set the window scale option
@@ -460,7 +458,7 @@ fn test_window_scale_after_receiving_syn_with() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert_eq!(s(&tcp).as_listen().unwrap().children.len(), 1);
 
     // the connection is now established so can accept it
@@ -525,7 +523,7 @@ fn test_duplicate_syn_with_different_window_scale() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_established().is_some());
 
     // send the SYN+ACK again with a different window scale
@@ -545,7 +543,7 @@ fn test_duplicate_syn_with_different_window_scale() {
         timestamp: None,
         timestamp_echo: None,
     };
-    tcp.borrow_mut().push_in_packet(&header, Bytes::new());
+    tcp.borrow_mut().push_in_packet(&header, Payload::default());
     assert!(s(&tcp).as_established().is_some());
 
     // read the ACK


### PR DESCRIPTION
Since each `sendmsg` call by the application would add its own chunk to the send buffer, this meant that each chunk passed in the `sendmsg` call would be sent in its own packet even if the chunk was small. Now a packet can contain several chunks, so chunks passed in multiple `sendmsg` calls will be combined together into a single packet.

~A future PR will reduce the number of small chunks so that there generally will only be one or two chunks per packet.~