### PR TITLE
Partially upgrade nix to 1.27.1

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -948,16 +948,27 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
- "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.3.3",
+ "cfg-if",
+ "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -1493,7 +1504,7 @@ dependencies = [
  "lzma-rs",
  "memoffset 0.9.0",
  "merge",
- "nix",
+ "nix 0.27.1",
  "once_cell",
  "petgraph",
  "rand",
@@ -1563,7 +1574,7 @@ dependencies = [
  "linux-api",
  "log",
  "logger",
- "nix",
+ "nix 0.27.1",
  "once_cell",
  "rand",
  "shadow-build-common",
@@ -1583,7 +1594,7 @@ dependencies = [
  "formatting-nostd",
  "libc",
  "linux-api",
- "nix",
+ "nix 0.26.4",
  "once_cell",
  "rand",
  "rustix 0.38.4",
@@ -1603,7 +1614,7 @@ dependencies = [
  "linux-syscall",
  "log",
  "logger",
- "nix",
+ "nix 0.27.1",
  "once_cell",
  "rand",
  "shadow-pod",
@@ -1985,7 +1996,7 @@ dependencies = [
  "criterion",
  "libc",
  "loom",
- "nix",
+ "nix 0.27.1",
  "num_enum",
  "rand",
  "rustc-hash",

--- a/src/lib/shadow-shim-helper-rs/Cargo.toml
+++ b/src/lib/shadow-shim-helper-rs/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["rlib", "staticlib"]
 
 [dependencies]
 libc = "0.2"
-nix = "0.26.2"
+nix = { version = "0.26.2", features = ["event", "fs", "socket"] }
 # don't log debug or trace levels in release mode
 log = { version = "0.4", features = ["release_max_level_debug"] }
 logger = { path = "../logger" }

--- a/src/lib/shadow-shim-helper-rs/Cargo.toml
+++ b/src/lib/shadow-shim-helper-rs/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["rlib", "staticlib"]
 
 [dependencies]
 libc = "0.2"
-nix = { version = "0.26.2", features = ["event", "fs", "socket"] }
+nix = { version = "0.27.1", features = ["event", "fs", "socket"] }
 # don't log debug or trace levels in release mode
 log = { version = "0.4", features = ["release_max_level_debug"] }
 logger = { path = "../logger" }

--- a/src/lib/shmem/Cargo.toml
+++ b/src/lib/shmem/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 linux-api = { path = "../linux-api" }
 linux-syscall = "1.0.0"
 log = { version = "0.4", default-features = false }
-nix = "0.26.2"
+nix = "0.27.1"
 static_assertions = "1.1.0"
 
 [dev-dependencies]

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -21,6 +21,7 @@ nix =  "0.26.2"
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.7", features = ["checkpoint"] }
+nix = { version = "0.27.1", features = ["process"] }
 
 [target.'cfg(miri)'.dependencies]
 libc = { version ="0.2", default-features = false }

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -17,7 +17,7 @@ criterion = "0.5.1"
 rand = "0.8.5"
 rustix = { version = "0.38.4", default-features = false, features=["process"] }
 libc = "0.2"
-nix =  "0.26.2"
+nix =  "0.27.1"
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.7", features = ["checkpoint"] }

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -31,7 +31,7 @@ shadow-shim-helper-rs = { path = "../lib/shadow-shim-helper-rs" }
 lzma-rs = "0.3"
 memoffset = "0.9.0"
 merge = "0.1"
-nix = { version = "0.26.2", features = ["feature", "ioctl", "mman", "net", "personality", "resource", "sched", "signal", "socket", "time", "uio", "user"] }
+nix = { version = "0.27.1", features = ["feature", "ioctl", "mman", "net", "personality", "resource", "sched", "signal", "socket", "time", "uio", "user"] }
 shadow-pod = { path = "../lib/pod" }
 once_cell = "1.18"
 petgraph = "0.6"

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -31,7 +31,7 @@ shadow-shim-helper-rs = { path = "../lib/shadow-shim-helper-rs" }
 lzma-rs = "0.3"
 memoffset = "0.9.0"
 merge = "0.1"
-nix = "0.26.2"
+nix = { version = "0.26.2", features = ["feature", "ioctl", "mman", "net", "personality", "resource", "sched", "signal", "socket", "time", "uio", "user"] }
 shadow-pod = { path = "../lib/pod" }
 once_cell = "1.18"
 petgraph = "0.6"

--- a/src/main/utility/childpid_watcher.rs
+++ b/src/main/utility/childpid_watcher.rs
@@ -6,9 +6,7 @@ use std::sync::Mutex;
 use std::thread;
 
 use nix::errno::Errno;
-use nix::sys::epoll::{
-    epoll_create1, epoll_ctl, epoll_wait, EpollCreateFlags, EpollEvent, EpollFlags, EpollOp,
-};
+use nix::sys::epoll::{Epoll, EpollCreateFlags, EpollEvent, EpollFlags};
 use nix::unistd::Pid;
 
 // TODO: consider using std::os::linux::process::PidFd once it's stabilized.
@@ -24,7 +22,7 @@ fn pidfd_open(pid: Pid) -> nix::Result<File> {
 #[derive(Debug)]
 pub struct ChildPidWatcher {
     inner: Arc<Mutex<Inner>>,
-    epoll: Arc<File>,
+    epoll: Arc<Epoll>,
 }
 
 pub type WatchHandle = u64;
@@ -66,7 +64,7 @@ impl Inner {
         nix::unistd::write(self.command_notifier.as_raw_fd(), &1u64.to_ne_bytes()).unwrap();
     }
 
-    fn unwatch_pid(&mut self, epoll: &File, pid: Pid) {
+    fn unwatch_pid(&mut self, epoll: &Epoll, pid: Pid) {
         let Some(piddata) = self.pids.get_mut(&pid) else {
             // Already unregistered the pid
             return;
@@ -75,20 +73,14 @@ impl Inner {
             // Already unwatched the pid
             return;
         };
-        epoll_ctl(
-            epoll.as_raw_fd(),
-            EpollOp::EpollCtlDel,
-            fd.as_raw_fd(),
-            None,
-        )
-        .unwrap();
+        epoll.delete(fd).unwrap();
     }
 
     fn pid_has_exited(&self, pid: Pid) -> bool {
         self.pids.get(&pid).unwrap().pidfd.is_none()
     }
 
-    fn remove_pid(&mut self, epoll: &File, pid: Pid) {
+    fn remove_pid(&mut self, epoll: &Epoll, pid: Pid) {
         debug_assert!(self.should_remove_pid(pid));
         self.unwatch_pid(epoll, pid);
         self.pids.remove(&pid);
@@ -105,7 +97,7 @@ impl Inner {
         pid_data.callbacks.is_empty() && pid_data.unregistered
     }
 
-    fn maybe_remove_pid(&mut self, epoll: &File, pid: Pid) {
+    fn maybe_remove_pid(&mut self, epoll: &Epoll, pid: Pid) {
         if self.should_remove_pid(pid) {
             self.remove_pid(epoll, pid)
         }
@@ -116,23 +108,14 @@ impl ChildPidWatcher {
     /// Create a ChildPidWatcher. Spawns a background thread, which is joined
     /// when the object is dropped.
     pub fn new() -> Self {
-        let epoll = {
-            let raw = epoll_create1(EpollCreateFlags::empty()).unwrap();
-            Arc::new(unsafe { File::from_raw_fd(raw) })
-        };
+        let epoll = Arc::new(Epoll::new(EpollCreateFlags::empty()).unwrap());
         let command_notifier = {
             let raw =
                 nix::sys::eventfd::eventfd(0, nix::sys::eventfd::EfdFlags::EFD_NONBLOCK).unwrap();
             File::from(raw)
         };
-        let mut event = EpollEvent::new(EpollFlags::EPOLLIN, 0);
-        epoll_ctl(
-            epoll.as_raw_fd(),
-            EpollOp::EpollCtlAdd,
-            command_notifier.as_raw_fd(),
-            Some(&mut event),
-        )
-        .unwrap();
+        let event = EpollEvent::new(EpollFlags::EPOLLIN, 0);
+        epoll.add(&command_notifier, event).unwrap();
         let watcher = ChildPidWatcher {
             inner: Arc::new(Mutex::new(Inner {
                 next_handle: 1,
@@ -155,12 +138,12 @@ impl ChildPidWatcher {
         watcher
     }
 
-    fn thread_loop(inner: &Mutex<Inner>, epoll: &File) {
+    fn thread_loop(inner: &Mutex<Inner>, epoll: &Epoll) {
         let mut events = [EpollEvent::empty(); 10];
         let mut commands = Vec::new();
         let mut done = false;
         while !done {
-            let nevents = match epoll_wait(epoll.as_raw_fd(), &mut events, -1) {
+            let nevents = match epoll.wait(&mut events, -1) {
                 Ok(n) => n,
                 Err(Errno::EINTR) => {
                     // Just try again.
@@ -267,7 +250,10 @@ impl ChildPidWatcher {
     pub fn register_pid(&self, pid: Pid) {
         let mut inner = self.inner.lock().unwrap();
         let pidfd = pidfd_open(pid).unwrap();
-        let raw_pidfd = pidfd.as_raw_fd();
+
+        let event = EpollEvent::new(EpollFlags::EPOLLIN, pid.as_raw().try_into().unwrap());
+        self.epoll.add(&pidfd, event).unwrap();
+
         let prev = inner.pids.insert(
             pid,
             PidData {
@@ -277,14 +263,6 @@ impl ChildPidWatcher {
             },
         );
         assert!(prev.is_none());
-        let mut event = EpollEvent::new(EpollFlags::EPOLLIN, pid.as_raw().try_into().unwrap());
-        epoll_ctl(
-            self.epoll.as_raw_fd(),
-            EpollOp::EpollCtlAdd,
-            raw_pidfd,
-            Some(&mut event),
-        )
-        .unwrap();
     }
 
     // TODO: Re-enable when Rust supports vfork: https://github.com/rust-lang/rust/issues/58314

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -197,7 +197,7 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 formatting-nostd = { path = "../lib/formatting-nostd" }
 libc = "0.2"
 linux-api = { path = "../lib/linux-api", features  = ["std"] }
-nix = "0.26.2"
+nix = { version = "0.26.2", features = ["event", "feature", "fs", "poll", "process", "sched", "signal", "socket", "uio"] }
 rand = { version="0.8.5", features=["small_rng"] }
 rustix = { version = "0.38.4", default-features=false, features=["fs", "mm", "pipe", "time", "thread"]}
 signal-hook = "0.3.15"

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -197,7 +197,7 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 formatting-nostd = { path = "../lib/formatting-nostd" }
 libc = "0.2"
 linux-api = { path = "../lib/linux-api", features  = ["std"] }
-nix = { version = "0.26.2", features = ["event", "feature", "fs", "poll", "process", "sched", "signal", "socket", "uio"] }
+nix = { version = "0.26.4", features = ["event", "feature", "fs", "poll", "process", "sched", "signal", "socket", "uio"] }
 rand = { version="0.8.5", features=["small_rng"] }
 rustix = { version = "0.38.4", default-features=false, features=["fs", "mm", "pipe", "time", "thread"]}
 signal-hook = "0.3.15"


### PR DESCRIPTION
The latest nix version makes three main changes:
- no default cargo features
- old epoll api deprecated
- many (but not all) functions take `AsFd` types instead of `RawFd` (an integer)

This third point is particularly painful in tests where we use integer file handles everywhere. I've left the tests on nix 1.26 for now, but it seems worthwhile to get this upgrade out of the way for the actual shadow code. If we're going to need to update a lot of tests, it's probably worth changing them to rustix or linux-api instead.

Also I added nix cargo features to the `shadow-shim-helper`, `shadow-rs`, and `shadow-tests` crates. Ideally we should add all of the nix features to every crate that requires them, but this would probably quickly become out of date anyways so I haven't bothered with that. Instead we take advantage of the fact that features enabled in one crate enable it in all other crates for the current build.