### PR TITLE
Fix issue in verify.sh

### DIFF
--- a/src/test/tor/minimal/verify.sh
+++ b/src/test/tor/minimal/verify.sh
@@ -22,7 +22,7 @@ check_host () {
     # otherwise we miss errors from `grep` such as if the files don't exist.
     # https://unix.stackexchange.com/a/343259
     local stream_success_count
-    stream_success_count=$(grep -c stream-success hosts/"$NAME"/tgen.*.stdout)
+    stream_success_count=$(find ./shadow.data/hosts/"$NAME"/ -name "tgen.*.stdout" -exec grep -c stream-success {} +)
     echo "Successful $NAME stream count: ${stream_success_count}/$TOTAL_STREAMS (minimum $MINIMUM_STREAMS)"
     if [ "${stream_success_count}" -lt "$MINIMUM_STREAMS" ]; then
         printf "Verification %bfailed%b: Not enough $NAME streams were successful :(\n" "$RED" "$NC"


### PR DESCRIPTION
On Ubuntu 22.04.3 (6.2.0-32-generic), verification of Tor test fails:
```shell
user @ VirtualBox [11:07:05] [~/test/shadow/src/test/tor/minimal] [main *]
-> % ./verify.sh 
Bootstrapped count: 11/11
grep: hosts/client/tgen.*.stdout: No such file or directory
```

Edit line 25 of verify.sh to fix bug:
```shell
user @ VirtualBox [11:09:25] [~/test/shadow/src/test/tor/minimal] [main *]
-> % ./verify.sh
Bootstrapped count: 11/11
Successful client stream count: 10/10 (minimum 10)
Successful torclient stream count: 10/10 (minimum 10)
Successful torbridgeclient stream count: 10/10 (minimum 10)
Successful fileserver stream count: 30/30 (minimum 30)
Successful torhiddenclient stream count: 10/10 (minimum 5)
Successful hiddenserver stream count: 10/10 (minimum 5)
Verification succeeded: Yay :)
```