### PR TITLE
Make spawning processes fallible

### DIFF
--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -410,7 +410,8 @@ impl Host {
                 pause_for_debugging,
                 host.params.strace_logging_options,
                 expected_final_state,
-            );
+            )
+            .expect("Failed to initialize application {plugin_name:?}");
             let (process_id, thread_id) = {
                 let process = process.borrow(host.root());
                 (process.id(), process.thread_group_leader_id())

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -873,7 +873,7 @@ impl Process {
         pause_for_debugging: bool,
         strace_logging_options: Option<FmtOptions>,
         expected_final_state: ProcessFinalState,
-    ) -> RootedRc<RootedRefCell<Process>> {
+    ) -> nix::Result<RootedRc<RootedRefCell<Process>>> {
         debug!("starting process '{:?}'", plugin_name);
 
         let main_thread_id = host.get_new_thread_id();
@@ -972,7 +972,7 @@ impl Process {
             &working_dir,
             strace_logging.as_ref().map(|s| s.file.borrow().as_raw_fd()),
             &shimlog_path,
-        );
+        )?;
         let native_pid = mthread.native_pid();
         let main_thread =
             Thread::wrap_mthread(host, mthread, desc_table, process_id, main_thread_id).unwrap();
@@ -1023,7 +1023,7 @@ impl Process {
             // be a valid target for it.
             exit_signal: None,
         };
-        RootedRc::new(
+        Ok(RootedRc::new(
             host.root(),
             RootedRefCell::new(
                 host.root(),
@@ -1048,7 +1048,7 @@ impl Process {
                     }))),
                 },
             ),
-        )
+        ))
     }
 
     pub fn id(&self) -> ProcessId {

--- a/src/test/static-bin/CMakeLists.txt
+++ b/src/test/static-bin/CMakeLists.txt
@@ -4,4 +4,4 @@ set_property(TARGET nop PROPERTY EXCLUDE_FROM_ALL true)
 add_dependencies(extra_tests nop)
 
 # cmake will ignore the exit code and only search for the regex
-add_shadow_tests(BASENAME static-bin PROPERTIES PASS_REGULAR_EXPRESSION "path is not dynamically linked" CONFIGURATIONS extra)
+add_shadow_tests(BASENAME static-bin PROPERTIES PASS_REGULAR_EXPRESSION "not a dynamically linked ELF" CONFIGURATIONS extra)


### PR DESCRIPTION
Our implementation of `execve` will spawn a new `ManagedThread`. Unlike for processes that are spawned directly from shadow's config file, we'll want to gracefully return an error instead of panicking when this fails.

Progress on #2988 