### PR TITLE
Move preload injection to ManagedThread::spawn

### DIFF
--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -833,6 +833,12 @@ fn get_required_preload_path(libname: &str) -> anyhow::Result<PathBuf> {
 
     let libpath = libpath.ok_or_else(|| anyhow::anyhow!(format!("Could not library in rpath")))?;
 
+    let bytes = libpath.as_os_str().as_bytes();
+    if bytes.iter().any(|c| *c == b' ' || *c == b':') {
+        // These are unescapable separators in LD_PRELOAD.
+        anyhow::bail!("Preload path contains LD_PRELOAD-incompatible characters: {libpath:?}");
+    }
+
     log::debug!(
         "Found required preload library {} at path {}",
         libname,

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -224,6 +224,27 @@ impl<'a> Manager<'a> {
         })
     }
 
+    /// The list of paths to be added to LD_PRELOAD.
+    fn make_preload_paths(&self) -> Vec<PathBuf> {
+        let mut preload = vec![];
+
+        preload.push(self.preload_injector_path.clone());
+
+        if let Some(ref path) = self.preload_libc_path {
+            preload.push(path.clone());
+        }
+
+        if let Some(ref path) = self.preload_openssl_rng_path {
+            preload.push(path.clone());
+        }
+
+        if let Some(ref path) = self.preload_openssl_crypto_path {
+            preload.push(path.clone());
+        }
+
+        preload
+    }
+
     pub fn run(
         mut self,
         status_logger_state: Option<&Arc<Status<ShadowStatusBarState>>>,
@@ -677,21 +698,7 @@ impl<'a> Manager<'a> {
         //   - preload path of the openssl crypto lib
         //   - preload values from LD_PRELOAD entries in the environment process option
 
-        let mut preload = vec![];
-
-        preload.push(self.preload_injector_path.clone());
-
-        if let Some(ref path) = self.preload_libc_path {
-            preload.push(path.clone());
-        }
-
-        if let Some(ref path) = self.preload_openssl_rng_path {
-            preload.push(path.clone());
-        }
-
-        if let Some(ref path) = self.preload_openssl_crypto_path {
-            preload.push(path.clone());
-        }
+        let preload = self.make_preload_paths();
 
         for path in &preload {
             let path = path.as_os_str().as_bytes();

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -218,7 +218,7 @@ impl Host {
         raw_cpu_freq_khz: u64,
         dns: *mut cshadow::DNS,
         manager_shmem: &ShMemBlock<ManagerShmem>,
-        preload_paths: Vec<PathBuf>,
+        preload_paths: Arc<Vec<PathBuf>>,
     ) -> Self {
         #[cfg(feature = "perf_timers")]
         let execution_timer = RefCell::new(PerfTimer::new());
@@ -333,7 +333,7 @@ impl Host {
             #[cfg(feature = "perf_timers")]
             execution_timer,
             in_notify_socket_has_packets,
-            preload_paths: Arc::new(preload_paths),
+            preload_paths,
         };
 
         res.stop_execution_timer();

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -191,6 +191,9 @@ pub struct Host {
     shim_shmem: UnsafeCell<ShMemBlock<'static, HostShmem>>,
 
     in_notify_socket_has_packets: RootedCell<bool>,
+
+    /// Paths to be added to LD_PRELOAD of managed processes.
+    preload_paths: Arc<Vec<PathBuf>>,
 }
 
 /// Host must be `Send`.
@@ -215,6 +218,7 @@ impl Host {
         raw_cpu_freq_khz: u64,
         dns: *mut cshadow::DNS,
         manager_shmem: &ShMemBlock<ManagerShmem>,
+        preload_paths: Vec<PathBuf>,
     ) -> Self {
         #[cfg(feature = "perf_timers")]
         let execution_timer = RefCell::new(PerfTimer::new());
@@ -329,6 +333,7 @@ impl Host {
             #[cfg(feature = "perf_timers")]
             execution_timer,
             in_notify_socket_has_packets,
+            preload_paths: Arc::new(preload_paths),
         };
 
         res.stop_execution_timer();
@@ -1003,6 +1008,11 @@ impl Host {
             }
         }
         None
+    }
+
+    /// Paths of libraries that should be preloaded into managed processes.
+    pub fn preload_paths(&self) -> &[PathBuf] {
+        &self.preload_paths
     }
 }
 

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -971,6 +971,7 @@ impl Process {
             envv,
             strace_logging.as_ref().map(|s| s.file.borrow().as_raw_fd()),
             &shimlog_path,
+            host.preload_paths(),
         )?;
         let native_pid = mthread.native_pid();
         let main_thread =

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -433,6 +433,15 @@ pub fn inject_preloads(mut envv: Vec<CString>, injected_preloads: &[PathBuf]) ->
         .iter()
         .map(|path| path.as_os_str().as_bytes());
 
+    for p in injected_preloads_bytes.clone() {
+        // Should have been caught earlier in configuraton parsing,
+        // but verify here at point of use.
+        assert!(
+            !p.iter().any(|c| *c == b' ' || *c == b':'),
+            "Preload path contains LD_PRELOAD separator"
+        );
+    }
+
     // `ld.so(8)`: The items of the list can be separated by spaces or colons,
     // and there is no support for escaping either separator.
     let previous_preloads = previous_preloads_string.split(|c| *c == b':' || *c == b' ');


### PR DESCRIPTION
When using `ManagedThread::spawn` to help implement `execve`, we'll want to ensure that shadow's `LD_PRELOAD`'d libraries are injected into the new processes as well (in case the parent didn't pass through it's own `LD_PRELOAD` environment through to the child's environment).

Progress on #2988 