### PR TITLE
syscall-logger: log blocked syscalls

### DIFF
--- a/src/lib/syscall-logger/src/lib.rs
+++ b/src/lib/syscall-logger/src/lib.rs
@@ -196,18 +196,16 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
             // format the result (returns None if the syscall didn't complete)
             let syscall_rv = SyscallResultFmt::<#(#rv_type)*>::new(&rv, #context_arg_name.args.args, strace_fmt_options, &*memory);
 
-            if let Some(ref syscall_rv) = syscall_rv {
-                #context_arg_name.objs.process.with_strace_file(|file| {
-                    write_syscall(
-                        file,
-                        &Worker::current_time().unwrap(),
-                        #context_arg_name.objs.thread.id(),
-                        #syscall_name_str,
-                        &syscall_args,
-                        syscall_rv,
-                    ).unwrap();
-                });
-            }
+            #context_arg_name.objs.process.with_strace_file(|file| {
+                write_syscall(
+                    file,
+                    &Worker::current_time().unwrap(),
+                    #context_arg_name.objs.thread.id(),
+                    #syscall_name_str,
+                    &syscall_args,
+                    syscall_rv,
+                ).unwrap();
+            });
 
             // convert the `SyscallResult` back to the original `Result<T, SyscallError>`
             let rv = if let Some(rv_original_ok) = rv_original_ok {


### PR DESCRIPTION
Previously if a syscall blocked, it wasn't recorded in the strace file until if and when it ran again and completed. Recording blocked syscalls is slightly redundant since it logs the syscall and parameters multiple times, but makes it easier to see why control switched to another thread, and logs syscalls that blocking and never complete, e.g. because another thread in the process called `exit_group`, the simulation ended, or in the (unmerged) implementation of execve, which "blocks" and never returns.

e.g.

```
00:00:01.000000000 [tid 1000] clone(17, 0x0, 0x0, 0x0, 0x0) = 1001
00:00:01.000000000 [tid 1001] write(4, "*", 1) = 1
00:00:01.000000000 [tid 1001] exit_group(...) = <native>
00:00:01.000000000 [tid 1000] read(3, 0x7fffffffe707, 1) = 1
```

->

```
00:00:01.000000000 [tid 1000] clone(17, 0x0, 0x0, 0x0, 0x0) = 1001
00:00:01.000000000 [tid 1000] read(3, 0x7fffffffe707, 1) = <blocked>
00:00:01.000000000 [tid 1001] write(4, "*", 1) = 1
00:00:01.000000000 [tid 1001] exit_group(...) = <native>
00:00:01.000000000 [tid 1000] read(3, 0x7fffffffe707, 1) = 1
```