### PR TITLE
Don't report core dumps

### DIFF
--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -1184,7 +1184,7 @@ impl Default for sigaction {
 }
 
 // Corresponds to default actions documented in signal(7).
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Debug)]
 #[repr(C)]
 pub enum LinuxDefaultAction {
     TERM,

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -115,7 +115,7 @@ impl From<ThreadId> for ProcessId {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ExitStatus {
     Normal(i32),
-    Signaled(Signal, /* coredump */ bool),
+    Signaled(Signal),
     /// The process was killed by Shadow rather than exiting "naturally" as part
     /// of the simulation. Currently this only happens when the process is still
     /// running when the simulation stop_time is reached.
@@ -786,26 +786,19 @@ impl ZombieProcess {
                 0,
                 0,
             ),
-            ExitStatus::Signaled(fatal_signal, core_dump) => {
-                if core_dump {
-                    siginfo_t::new_for_sigchld_dumped(
-                        exit_signal,
-                        self.common.id.into(),
-                        0,
-                        fatal_signal,
-                        0,
-                        0,
-                    )
-                } else {
-                    siginfo_t::new_for_sigchld_killed(
-                        exit_signal,
-                        self.common.id.into(),
-                        0,
-                        fatal_signal,
-                        0,
-                        0,
-                    )
-                }
+            ExitStatus::Signaled(fatal_signal) => {
+                // This ought to be `siginfo_t::new_for_sigchld_dumped` if
+                // the child dumped core, but that depends on various other
+                // system variables outside of our control. We always report
+                // that no core was dropped for determinism.
+                siginfo_t::new_for_sigchld_killed(
+                    exit_signal,
+                    self.common.id.into(),
+                    0,
+                    fatal_signal,
+                    0,
+                    0,
+                )
             }
 
             ExitStatus::StoppedByShadow => unreachable!(),
@@ -1475,9 +1468,9 @@ impl Process {
                 ExitStatus::StoppedByShadow
             }
             (false, Ok(WaitStatus::Exited(_pid, code))) => ExitStatus::Normal(code),
-            (false, Ok(WaitStatus::Signaled(_pid, signal, core_dump))) => {
+            (false, Ok(WaitStatus::Signaled(_pid, signal, _core_dump))) => {
                 let signal = Signal::try_from(signal as i32).unwrap();
-                ExitStatus::Signaled(signal, core_dump)
+                ExitStatus::Signaled(signal)
             }
             (false, Ok(status)) => {
                 panic!("Unexpected status: {status:?}");
@@ -1495,7 +1488,7 @@ impl Process {
             if let Some(expected_final_state) = runnable.expected_final_state {
                 let actual_final_state = match exit_status {
                     ExitStatus::Normal(i) => ProcessFinalState::Exited { exited: i },
-                    ExitStatus::Signaled(s, _core_dump) => ProcessFinalState::Signaled {
+                    ExitStatus::Signaled(s) => ProcessFinalState::Signaled {
                         // This conversion will fail on realtime signals, but that
                         // should currently be impossible since we don't support
                         // sending realtime signals.

--- a/src/main/host/syscall/handler/wait.rs
+++ b/src/main/host/syscall/handler/wait.rs
@@ -153,12 +153,13 @@ impl SyscallHandler {
         let mut memory = ctx.objs.process.memory_borrow_mut();
 
         if !status_ptr.is_null() {
-            // From glib's waitstatus.h. Doesn't seem to be exposed in linux kernel headers.
-            const COREFLAG: i32 = 0x80;
             let status = match zombie.exit_status() {
                 ExitStatus::Normal(i) => i << 8,
-                ExitStatus::Signaled(s, false) => i32::from(s),
-                ExitStatus::Signaled(s, true) => i32::from(s) | COREFLAG,
+                ExitStatus::Signaled(s) => {
+                    // This should be `| 0x80` if the process dumped core, but since
+                    // this depends on the system config we never set this flag.
+                    i32::from(s)
+                }
                 ExitStatus::StoppedByShadow => unreachable!(),
             };
             memory.write(status_ptr, &status)?;


### PR DESCRIPTION
Whether a signaled process generates a core dump depends on platform conditions outside of our control (see `core(5)`). To avoid different simulation results depending on whether a core was actually dumped, which in turn depends on the system configuration, we should always report that it hasn't been.