### PR TITLE
Implement vfork

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -16,6 +16,25 @@ it will generally return `ENOSYS` and log at `warn` level or higher. In many
 such cases the application is able to recover, and this has little or no effect
 on the ultimate results of the simulation.
 
+There are some syscalls that shadow doesn't quite emulate faithfully, but has a
+"best effort" implementation. As with unimplemented sysalls, shadow logs at
+`warn` level when encountering such a syscall.
+
+### vfork
+
+A notable example of a not-quite faithfully implemented syscall is
+[`vfork`](https://www.man7.org/linux/man-pages/man2/vfork.2.html), which shadow
+effectively implements as a synonym for `fork`. Usage of `vfork` that is
+compliant with the POSIX.1 specification that "behavior is undefined if the
+process created by vfork() either modifies any data other than a variable of
+type pid_t used to store the return value...". However, usage that relies on
+specific Linux implementation details of `vfork` (e.g. that a write to a global
+variable from the child will be observed by the parent) won't work correctly.
+
+As in other such cases, shadow logs a warning when it encounters `vfork`, so
+that users can identify it as the potential source of problems if a simulation
+doesn't work as expected.
+
 ## IPv6
 
 Shadow does not yet implement IPv6. Most applications can be configured to use IPv4

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "rand",
  "rustix 0.38.4",
  "signal-hook",
+ "static_assertions",
  "vasi-sync",
 ]
 

--- a/src/lib/preload-libc/gen_syscall_wrappers_c.py
+++ b/src/lib/preload-libc/gen_syscall_wrappers_c.py
@@ -81,6 +81,7 @@ skip.update([
     'signalfd',
     'signalfd4',
     'timer_create',
+    'vfork',
     'wait4',
     'waitid',
 ])

--- a/src/lib/preload-libc/syscall_wrappers.c
+++ b/src/lib/preload-libc/syscall_wrappers.c
@@ -46,6 +46,9 @@ INTERPOSE(bind);
 INTERPOSE(bpf);
 #endif
 // Skipping SYS_brk
+#ifdef SYS_cachestat // kernel entry: num=451 func=sys_cachestat
+INTERPOSE(cachestat);
+#endif
 #ifdef SYS_capget // kernel entry: num=125 func=sys_capget
 INTERPOSE(capget);
 #endif
@@ -149,6 +152,9 @@ INTERPOSE(fchdir);
 #endif
 // Skipping SYS_fchmod
 // Skipping SYS_fchmodat
+#ifdef SYS_fchmodat2 // kernel entry: num=452 func=sys_fchmodat2
+INTERPOSE(fchmodat2);
+#endif
 #ifdef SYS_fchown // kernel entry: num=93 func=sys_fchown
 INTERPOSE(fchown);
 #endif
@@ -381,6 +387,9 @@ INTERPOSE(lstat);
 #endif
 #ifdef SYS_madvise // kernel entry: num=28 func=sys_madvise
 INTERPOSE(madvise);
+#endif
+#ifdef SYS_map_shadow_stack // kernel entry: num=453 func=sys_map_shadow_stack
+INTERPOSE(map_shadow_stack);
 #endif
 #ifdef SYS_mbind // kernel entry: num=237 func=sys_mbind
 INTERPOSE(mbind);
@@ -868,9 +877,7 @@ INTERPOSE(utimensat);
 #ifdef SYS_utimes // kernel entry: num=235 func=sys_utimes
 INTERPOSE(utimes);
 #endif
-#ifdef SYS_vfork // kernel entry: num=58 func=sys_vfork
-INTERPOSE(vfork);
-#endif
+// Skipping SYS_vfork
 #ifdef SYS_vhangup // kernel entry: num=153 func=sys_vhangup
 INTERPOSE(vhangup);
 #endif

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -203,3 +203,4 @@ rustix = { version = "0.38.4", default-features=false, features=["fs", "mm", "pi
 signal-hook = "0.3.15"
 once_cell = "1.18.0"
 vasi-sync = { path = "../lib/vasi-sync" }
+static_assertions = "1.1.0"


### PR DESCRIPTION
The implementation isn't strictly correct, because we effectively implement `vfork` as a synonym for `fork` (and likewise ignore `CLONE_VFORK|CLONE_VM` flags to `clone` and `clone3`).

In cases where `vfork` is treated as a "faster `fork`", this should work correctly. Confirmed with new tests that exercise `libc::posix_spawn` and `std::process::Command::spawn`.

It's possible though for a managed process to depend on implementation details of `vfork` that we don't honor. e.g. they could rely on the parent being paused until the child `exec`'s, or on having writes to memory by the child be visible to the parent. For this reason we log a warning when executing this code-path.

This seems preferable to the previous state of returning an error for `vfork`, since none of the uses I've found fall back to regular `fork` if `vfork` fails; they just bail out. i.e. better to at least try to keep running the simulation.

Progress on #3123 