### PR TITLE
Disable the MemoryManager by default

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -466,11 +466,12 @@ Update the minimum runahead dynamically throughout the simulation.
 
 #### `experimental.use_memory_manager`
 
-Default: true  
+Default: false  
 Type: Bool
 
-Use the MemoryManager. It can be useful to disable for debugging, but will hurt
-performance in most cases.
+Use the MemoryManager in memory-mapping mode. This can improve
+performance, but disables support for dynamically spawning processes
+inside the simulation (e.g. the `fork` syscall).
 
 #### `experimental.use_new_tcp`
 

--- a/src/main/core/support/configuration.rs
+++ b/src/main/core/support/configuration.rs
@@ -334,8 +334,9 @@ pub struct ExperimentalOptions {
     #[clap(help = EXP_HELP.get("use_preload_openssl_crypto").unwrap().as_str())]
     pub use_preload_openssl_crypto: Option<bool>,
 
-    /// Use the MemoryManager. It can be useful to disable for debugging, but will hurt performance in
-    /// most cases
+    /// Use the MemoryManager in memory-mapping mode. This can improve
+    /// performance, but disables support for dynamically spawning processes
+    /// inside the simulation (e.g. the `fork` syscall).
     #[clap(hide_short_help = true)]
     #[clap(long, value_name = "bool")]
     #[clap(help = EXP_HELP.get("use_memory_manager").unwrap().as_str())]
@@ -493,7 +494,7 @@ impl Default for ExperimentalOptions {
             // Actual latencies vary from ~40 to ~400 CPU cycles. https://stackoverflow.com/a/13096917
             // Default to the lower end to minimize effect in simualations without busy loops.
             unblocked_vdso_latency: Some(units::Time::new(10, units::TimePrefix::Nano)),
-            use_memory_manager: Some(true),
+            use_memory_manager: Some(false),
             use_cpu_pinning: Some(true),
             use_worker_spinning: Some(true),
             runahead: Some(NullableOption::Value(units::Time::new(

--- a/src/test/cli/help-long-expected
+++ b/src/test/cli/help-long-expected
@@ -145,8 +145,9 @@ Experimental (Unstable and may change or be removed at any time, regardless of S
           Update the minimum runahead dynamically throughout the simulation. [default: false]
 
       --use-memory-manager <bool>
-          Use the MemoryManager. It can be useful to disable for debugging, but will hurt
-          performance in most cases [default: true]
+          Use the MemoryManager in memory-mapping mode. This can improve performance, but disables
+          support for dynamically spawning processes inside the simulation (e.g. the `fork`
+          syscall). [default: false]
 
       --use-new-tcp <bool>
           Use the rust TCP implementation [default: false]


### PR DESCRIPTION
Progress on https://github.com/shadow/shadow/issues/2581

I'm still on the fence about ripping out entirely. I think we definitely want to disable by default so that `fork` works by default. I'd feel better waiting a release or two to give ourselves a chance to change our minds before removing it.