### PR TITLE
Clean up unnecessary lazy init

### DIFF
--- a/src/main/core/logger/shadow_logger.rs
+++ b/src/main/core/logger/shadow_logger.rs
@@ -99,9 +99,9 @@ pub struct ShadowLogger {
     log_errors_to_stderr: OnceCell<bool>,
 }
 
-thread_local!(static SENDER: RefCell<Option<Sender<LoggerCommand>>> = RefCell::new(None));
-thread_local!(static THREAD_NAME: Lazy<String> = Lazy::new(|| { get_thread_name() }));
-thread_local!(static THREAD_ID: Lazy<nix::unistd::Pid> = Lazy::new(|| { nix::unistd::gettid() }));
+thread_local!(static SENDER: RefCell<Option<Sender<LoggerCommand>>> = const{ RefCell::new(None)});
+thread_local!(static THREAD_NAME: String = get_thread_name());
+thread_local!(static THREAD_ID: nix::unistd::Pid = nix::unistd::gettid());
 
 fn get_thread_name() -> String {
     let mut thread_name = Vec::<i8>::with_capacity(16);
@@ -326,7 +326,7 @@ impl Log for ShadowLogger {
                 .try_with(|name| (*name).clone())
                 .unwrap_or_else(|_| get_thread_name()),
             thread_id: THREAD_ID
-                .try_with(|id| **id)
+                .try_with(|id| *id)
                 .unwrap_or_else(|_| nix::unistd::gettid()),
             host_info,
         };

--- a/src/main/core/scheduler/mod.rs
+++ b/src/main/core/scheduler/mod.rs
@@ -18,7 +18,7 @@ use crate::host::host::Host;
 
 std::thread_local! {
     /// The core affinity of the current thread, as set by the active scheduler.
-    static CORE_AFFINITY: RefCell<Option<u32>> = RefCell::new(None);
+    static CORE_AFFINITY: RefCell<Option<u32>> = const { RefCell::new(None) };
 }
 
 /// Get the core affinity of the current thread, as set by the active scheduler.

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -45,8 +45,7 @@ std::thread_local! {
 // shared global state
 // Must not mutably borrow when the simulation is running. Worker threads should access it through
 // `Worker::shared`.
-pub static WORKER_SHARED: Lazy<AtomicRefCell<Option<WorkerShared>>> =
-    Lazy::new(|| AtomicRefCell::new(None));
+pub static WORKER_SHARED: AtomicRefCell<Option<WorkerShared>> = AtomicRefCell::new(None);
 
 #[derive(Copy, Clone, Debug)]
 pub struct WorkerThreadID(pub u32);

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -39,7 +39,7 @@ static SIM_STATS: Lazy<SharedSimStats> = Lazy::new(SharedSimStats::new);
 std::thread_local! {
     // Initialized when the worker thread starts running. No shared ownership
     // or access from outside of the current thread.
-    static WORKER: once_cell::unsync::OnceCell<RefCell<Worker>> = once_cell::unsync::OnceCell::new();
+    static WORKER: once_cell::unsync::OnceCell<RefCell<Worker>> = const { once_cell::unsync::OnceCell::new() };
 }
 
 // shared global state

--- a/src/main/utility/legacy_callback_queue.rs
+++ b/src/main/utility/legacy_callback_queue.rs
@@ -12,7 +12,7 @@ use crate::utility::callback_queue::CallbackQueue;
 pub type RootedRefCell_StateEventSource = RootedRefCell<StateEventSource>;
 
 thread_local! {
-    static C_CALLBACK_QUEUE: RefCell<Option<CallbackQueue>> = RefCell::new(None);
+    static C_CALLBACK_QUEUE: RefCell<Option<CallbackQueue>> = const { RefCell::new(None) };
 }
 
 /// Helper function to initialize and run a global thread-local callback queue. This is a hack so


### PR DESCRIPTION
We had some extra layers of lazy initialization in some globals and thread-locals that are no longer needed with improvements to const-initialization support.

Theoretically this should save a little overhead on every access to these, but it probably won't make a measurable difference in most sims.