### PR TITLE
Fix return value for connect() with unix and tcp sockets

### DIFF
--- a/src/lib/tcp/src/lib.rs
+++ b/src/lib/tcp/src/lib.rs
@@ -539,6 +539,8 @@ pub enum ConnectError<E> {
     /// out, closing, half-closed, closed, etc. This does not include connection attempts that are
     /// in progress ("syn-sent" or "syn-received" states).
     AlreadyConnected,
+    /// Is already listening for new connections.
+    IsListening,
     FailedAssociation(E),
 }
 

--- a/src/lib/tcp/src/states.rs
+++ b/src/lib/tcp/src/states.rs
@@ -559,6 +559,14 @@ impl<X: Dependencies> TcpStateTrait<X> for ListenState<X> {
         (self.into(), Ok(rv))
     }
 
+    fn connect<T, E>(
+        self,
+        _remote_addr: SocketAddrV4,
+        _associate_fn: impl FnOnce() -> Result<(SocketAddrV4, T), E>,
+    ) -> (TcpStateEnum<X>, Result<T, ConnectError<E>>) {
+        (self.into(), Err(ConnectError::IsListening))
+    }
+
     fn accept(mut self) -> (TcpStateEnum<X>, Result<AcceptedTcpState<X>, AcceptError>) {
         let Some(child_key) = self.accept_queue.pop_front() else {
             return (self.into(), Err(AcceptError::NothingToAccept));

--- a/src/lib/tcp/src/tests/mod.rs
+++ b/src/lib/tcp/src/tests/mod.rs
@@ -626,6 +626,7 @@ impl TcpSocket {
             Ok(x) => x,
             Err(ConnectError::InProgress) => return Err(Errno::EALREADY),
             Err(ConnectError::AlreadyConnected) => return Err(Errno::EISCONN),
+            Err(ConnectError::IsListening) => return Err(Errno::EISCONN),
             Err(ConnectError::InvalidState) => return Err(Errno::EINVAL),
             Err(ConnectError::FailedAssociation(e)) => return Err(e),
         };

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -680,6 +680,7 @@ impl TcpSocket {
             Ok(x) => x,
             Err(tcp::ConnectError::InProgress) => return Err(Errno::EALREADY.into()),
             Err(tcp::ConnectError::AlreadyConnected) => return Err(Errno::EISCONN.into()),
+            Err(tcp::ConnectError::IsListening) => return Err(Errno::EISCONN.into()),
             Err(tcp::ConnectError::InvalidState) => return Err(Errno::EINVAL.into()),
             Err(tcp::ConnectError::FailedAssociation(e)) => return Err(e),
         };

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -1304,6 +1304,16 @@ impl Protocol for ConnOrientedListening {
         (self.into(), Ok(()))
     }
 
+    fn connect(
+        self,
+        _common: &mut UnixSocketCommon,
+        _socket: &Arc<AtomicRefCell<UnixSocket>>,
+        _addr: &SockaddrStorage,
+        _cb_queue: &mut CallbackQueue,
+    ) -> (ProtocolState, Result<(), SyscallError>) {
+        (self.into(), Err(Errno::EINVAL.into()))
+    }
+
     fn accept(
         &mut self,
         common: &mut UnixSocketCommon,

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -1664,6 +1664,11 @@ static gint _tcp_connectToPeer(LegacySocket* socket, const Host* host, in_addr_t
         return errorCode;
     }
 
+    /* listening sockets can't connect */
+    if (tcp_isValidListener(tcp)) {
+        return -EISCONN;
+    }
+
     /* send 1st part of 3-way handshake, state->syn_sent */
     _tcp_sendControlPacket(tcp, host, PTCP_SYN);
 


### PR DESCRIPTION
These sockets were returning the wrong value when connect() was called on a listening socket. The C TCP sockets were panicking due to a failed assert.