### PR TITLE
Rename `get_status()` to `status()`

### DIFF
--- a/src/main/host/descriptor/epoll/mod.rs
+++ b/src/main/host/descriptor/epoll/mod.rs
@@ -63,7 +63,7 @@ impl Epoll {
         Arc::new(AtomicRefCell::new(epoll))
     }
 
-    pub fn get_status(&self) -> FileStatus {
+    pub fn status(&self) -> FileStatus {
         self.status
     }
 

--- a/src/main/host/descriptor/eventfd.rs
+++ b/src/main/host/descriptor/eventfd.rs
@@ -37,7 +37,7 @@ impl EventFd {
         }
     }
 
-    pub fn get_status(&self) -> FileStatus {
+    pub fn status(&self) -> FileStatus {
         self.status
     }
 

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -377,7 +377,7 @@ impl std::fmt::Debug for File {
                 f,
                 "(state: {:?}, status: {:?})",
                 file.state(),
-                file.get_status()
+                file.status()
             )
         } else {
             write!(f, "(already borrowed)")
@@ -409,7 +409,7 @@ impl FileRef<'_> {
         pub fn mode(&self) -> FileMode
     );
     enum_passthrough!(self, (), Pipe, EventFd, Socket, TimerFd, Epoll;
-        pub fn get_status(&self) -> FileStatus
+        pub fn status(&self) -> FileStatus
     );
     enum_passthrough!(self, (), Pipe, EventFd, Socket, TimerFd, Epoll;
         pub fn has_open_file(&self) -> bool
@@ -427,7 +427,7 @@ impl FileRefMut<'_> {
         pub fn mode(&self) -> FileMode
     );
     enum_passthrough!(self, (), Pipe, EventFd, Socket, TimerFd, Epoll;
-        pub fn get_status(&self) -> FileStatus
+        pub fn status(&self) -> FileStatus
     );
     enum_passthrough!(self, (), Pipe, EventFd, Socket, TimerFd, Epoll;
         pub fn has_open_file(&self) -> bool
@@ -485,7 +485,7 @@ impl std::fmt::Debug for FileRef<'_> {
             f,
             "(state: {:?}, status: {:?})",
             self.state(),
-            self.get_status()
+            self.status()
         )
     }
 }
@@ -504,7 +504,7 @@ impl std::fmt::Debug for FileRefMut<'_> {
             f,
             "(state: {:?}, status: {:?})",
             self.state(),
-            self.get_status()
+            self.status()
         )
     }
 }

--- a/src/main/host/descriptor/pipe.rs
+++ b/src/main/host/descriptor/pipe.rs
@@ -51,7 +51,7 @@ impl Pipe {
         }
     }
 
-    pub fn get_status(&self) -> FileStatus {
+    pub fn status(&self) -> FileStatus {
         self.status
     }
 

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -96,7 +96,7 @@ impl LegacyTcpSocket {
         self.as_legacy_tcp() as *mut c::LegacyFile
     }
 
-    pub fn get_status(&self) -> FileStatus {
+    pub fn status(&self) -> FileStatus {
         let o_flags = unsafe { c::legacyfile_getFlags(self.as_legacy_file()) };
         let o_flags =
             linux_api::fcntl::OFlag::from_bits(o_flags).expect("Not a valid OFlag: {o_flags:?}");
@@ -354,7 +354,7 @@ impl LegacyTcpSocket {
             return Err(Errno::EINVAL.into());
         };
 
-        if socket_ref.get_status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 
@@ -465,7 +465,7 @@ impl LegacyTcpSocket {
             return Err(Errno::EINVAL.into());
         };
 
-        if socket_ref.get_status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 
@@ -811,7 +811,7 @@ impl LegacyTcpSocket {
             Ok(())
         };
 
-        if !socket_ref.get_status().contains(FileStatus::NONBLOCK) {
+        if !socket_ref.status().contains(FileStatus::NONBLOCK) {
             // this is a blocking connect call
             if errcode == Err(Errno::EINPROGRESS) {
                 // This is the first time we ever called connect, and so we need to wait for the

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -184,7 +184,7 @@ impl std::fmt::Debug for InetSocket {
                 f,
                 "(state: {:?}, status: {:?})",
                 file.state(),
-                file.get_status()
+                file.status()
             )
         } else {
             write!(f, "(already borrowed)")
@@ -213,7 +213,7 @@ impl InetSocketRef<'_> {
         pub fn mode(&self) -> FileMode
     );
     enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
-        pub fn get_status(&self) -> FileStatus
+        pub fn status(&self) -> FileStatus
     );
     enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn has_open_file(&self) -> bool
@@ -265,7 +265,7 @@ impl InetSocketRefMut<'_> {
         pub fn mode(&self) -> FileMode
     );
     enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
-        pub fn get_status(&self) -> FileStatus
+        pub fn status(&self) -> FileStatus
     );
     enum_passthrough!(self, (), LegacyTcp, Tcp, Udp;
         pub fn has_open_file(&self) -> bool
@@ -389,7 +389,7 @@ impl std::fmt::Debug for InetSocketRef<'_> {
             f,
             "(state: {:?}, status: {:?})",
             self.state(),
-            self.get_status()
+            self.status()
         )
     }
 }
@@ -406,7 +406,7 @@ impl std::fmt::Debug for InetSocketRefMut<'_> {
             f,
             "(state: {:?}, status: {:?})",
             self.state(),
-            self.get_status()
+            self.status()
         )
     }
 }

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -79,7 +79,7 @@ impl TcpSocket {
         rv
     }
 
-    pub fn get_status(&self) -> FileStatus {
+    pub fn status(&self) -> FileStatus {
         self.status
     }
 
@@ -403,7 +403,7 @@ impl TcpSocket {
             return Err(Errno::EINVAL.into());
         };
 
-        if socket_ref.get_status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 
@@ -461,7 +461,7 @@ impl TcpSocket {
             return Err(Errno::EINVAL.into());
         };
 
-        if socket_ref.get_status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -78,7 +78,7 @@ impl UdpSocket {
         Arc::new(AtomicRefCell::new(socket))
     }
 
-    pub fn get_status(&self) -> FileStatus {
+    pub fn status(&self) -> FileStatus {
         self.status
     }
 
@@ -354,7 +354,7 @@ impl UdpSocket {
             },
         };
 
-        if socket_ref.get_status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 
@@ -484,7 +484,7 @@ impl UdpSocket {
             return Err(Errno::EINVAL.into());
         };
 
-        if socket_ref.get_status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -156,7 +156,7 @@ impl std::fmt::Debug for Socket {
                 f,
                 "(state: {:?}, status: {:?})",
                 file.state(),
-                file.get_status()
+                file.status()
             )
         } else {
             write!(f, "(already borrowed)")
@@ -183,7 +183,7 @@ impl SocketRef<'_> {
         pub fn mode(&self) -> FileMode
     );
     enum_passthrough!(self, (), Unix, Inet;
-        pub fn get_status(&self) -> FileStatus
+        pub fn status(&self) -> FileStatus
     );
     enum_passthrough!(self, (), Unix, Inet;
         pub fn has_open_file(&self) -> bool
@@ -223,7 +223,7 @@ impl SocketRefMut<'_> {
         pub fn mode(&self) -> FileMode
     );
     enum_passthrough!(self, (), Unix, Inet;
-        pub fn get_status(&self) -> FileStatus
+        pub fn status(&self) -> FileStatus
     );
     enum_passthrough!(self, (), Unix, Inet;
         pub fn has_open_file(&self) -> bool
@@ -327,7 +327,7 @@ impl std::fmt::Debug for SocketRef<'_> {
             f,
             "(state: {:?}, status: {:?})",
             self.state(),
-            self.get_status()
+            self.status()
         )
     }
 }
@@ -343,7 +343,7 @@ impl std::fmt::Debug for SocketRefMut<'_> {
             f,
             "(state: {:?}, status: {:?})",
             self.state(),
-            self.get_status()
+            self.status()
         )
     }
 }

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -72,7 +72,7 @@ impl UnixSocket {
         })
     }
 
-    pub fn get_status(&self) -> FileStatus {
+    pub fn status(&self) -> FileStatus {
         self.common.status
     }
 

--- a/src/main/host/descriptor/timerfd.rs
+++ b/src/main/host/descriptor/timerfd.rs
@@ -107,7 +107,7 @@ impl TimerFd {
         self.update_state(cb_queue);
     }
 
-    pub fn get_status(&self) -> FileStatus {
+    pub fn status(&self) -> FileStatus {
         self.status
     }
 

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -66,7 +66,7 @@ impl SyscallHandler {
 
                 let file = file.inner_file().borrow();
                 // combine the file status and access mode flags
-                let flags = file.get_status().as_o_flags() | file.mode().as_o_flags();
+                let flags = file.status().as_o_flags() | file.mode().as_o_flags();
                 SysCallReg::from(flags.bits())
             }
             FcntlCommand::F_SETFL => {
@@ -96,7 +96,7 @@ impl SyscallHandler {
                 );
 
                 let mut file = file.inner_file().borrow_mut();
-                let old_flags = file.get_status().as_o_flags();
+                let old_flags = file.status().as_o_flags();
 
                 // fcntl(2): "On Linux, this command can change only the O_APPEND, O_ASYNC, O_DIRECT,
                 // O_NOATIME, and O_NONBLOCK flags"

--- a/src/main/host/syscall/handler/ioctl.rs
+++ b/src/main/host/syscall/handler/ioctl.rs
@@ -76,7 +76,7 @@ impl SyscallHandler {
             let arg_ptr = arg_ptr.cast::<std::ffi::c_int>();
             let arg = ctx.objs.process.memory_borrow_mut().read(arg_ptr)?;
 
-            let mut status = file.get_status();
+            let mut status = file.status();
             status.set(FileStatus::NONBLOCK, arg != 0);
             file.set_status(status);
 

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -697,7 +697,7 @@ impl SyscallHandler {
             })
         });
 
-        let file_status = socket.borrow().get_status();
+        let file_status = socket.borrow().status();
 
         // if the syscall would block and it's a blocking descriptor
         if result.as_ref().err() == Some(&Errno::EWOULDBLOCK.into())

--- a/src/main/host/syscall/handler/uio.rs
+++ b/src/main/host/syscall/handler/uio.rs
@@ -248,7 +248,7 @@ impl SyscallHandler {
             return Ok(return_val);
         }
 
-        let file_status = file.borrow().get_status();
+        let file_status = file.borrow().status();
 
         let result =
             // call the file's read(), and run any resulting events
@@ -507,7 +507,7 @@ impl SyscallHandler {
             return Ok(bytes_written);
         }
 
-        let file_status = file.borrow().get_status();
+        let file_status = file.borrow().status();
 
         let result =
             // call the file's write(), and run any resulting events


### PR DESCRIPTION
I've been holding off on this one until epoll was merged.