### PR TITLE
Upgrade rust in CI to 1.73.0

### DIFF
--- a/ci/rust-toolchain-nightly.toml
+++ b/ci/rust-toolchain-nightly.toml
@@ -9,6 +9,6 @@
 [toolchain]
 # Must be a version built with miri; check
 # https://rust-lang.github.io/rustup-components-history/
-channel = "nightly-2023-09-27"
+channel = "nightly-2023-10-05"
 # We don't add individual components here. CI individually
 # adds the ones they need (e.g. clippy, miri).

--- a/ci/rust-toolchain-stable.toml
+++ b/ci/rust-toolchain-stable.toml
@@ -7,4 +7,4 @@
 # See
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.72.1"
+channel = "1.73.0"

--- a/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
@@ -55,9 +55,8 @@ impl SimulationTime {
         }
     }
 
-    /// Convert a [`Duration`](std::time::Duration) to a [`SimulationTime`]. This function exists as
-    /// a `const` alternative to `SimulationTime::try_from(duration)`. May panic if the duration is
-    /// too large.
+    /// Convert a [`Duration`] to a [`SimulationTime`]. This function exists as a `const`
+    /// alternative to `SimulationTime::try_from(duration)`. May panic if the duration is too large.
     pub const fn from_duration(val: std::time::Duration) -> Self {
         if SIMTIME_ONE_NANOSECOND != 1 {
             unreachable!();

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -374,7 +374,6 @@ impl SyscallHandler {
         } = result?;
 
         if !addr_ptr.is_null() {
-            let addr_ptr = addr_ptr;
             io::write_sockaddr_and_len(&mut mem, from_addr.as_ref(), addr_ptr, addr_len_ptr)?;
         }
 

--- a/src/main/utility/byte_queue.rs
+++ b/src/main/utility/byte_queue.rs
@@ -228,7 +228,6 @@ impl ByteQueue {
                 break;
             }
 
-            let copied = copied;
             self.length -= copied;
             total_copied += copied;
 


### PR DESCRIPTION
Also fixes two minor clippy warnings and a documentation warning.