### PR TITLE
Remove the "(LOG_ONCE)" requirement from `warn_once_*` macros

### DIFF
--- a/src/main/host/descriptor/epoll/mod.rs
+++ b/src/main/host/descriptor/epoll/mod.rs
@@ -130,7 +130,7 @@ impl Epoll {
     ) -> SyscallResult {
         // After checking the epoll man pages and the Linux source for eventpoll.c, we don't think
         // epoll descriptors support any ioctl operations.
-        warn_once_then_trace!("(LOG_ONCE) Epoll does not support any ioctl requests.");
+        warn_once_then_trace!("Epoll does not support any ioctl requests.");
         // From ioctl(2): ENOTTY The specified request does not apply to the kind of object that the
         // file descriptor fd references. Verified that epoll descriptors return this on Linux.
         Err(Errno::ENOTTY.into())

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -613,7 +613,7 @@ impl LegacyTcpSocket {
             }
             request => {
                 warn_once_then_debug!(
-                    "(LOG_ONCE) We do not yet handle ioctl request {request:?} on tcp sockets"
+                    "We do not yet handle ioctl request {request:?} on tcp sockets"
                 );
                 Err(Errno::EINVAL.into())
             }

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -637,7 +637,7 @@ impl UdpSocket {
             }
             request => {
                 warn_once_then_debug!(
-                    "(LOG_ONCE) We do not yet handle ioctl request {request:?} on tcp sockets"
+                    "We do not yet handle ioctl request {request:?} on tcp sockets"
                 );
                 Err(Errno::EINVAL.into())
             }
@@ -922,28 +922,24 @@ impl UdpSocket {
             }
             (libc::SOL_SOCKET, libc::SO_REUSEADDR) => {
                 // TODO: implement this
-                warn_once_then_debug!(
-                    "(LOG_ONCE) setsockopt SO_REUSEADDR not yet implemented for udp"
-                );
+                warn_once_then_debug!("setsockopt SO_REUSEADDR not yet implemented for udp");
                 return Err(Errno::ENOPROTOOPT.into());
             }
             (libc::SOL_SOCKET, libc::SO_REUSEPORT) => {
                 // TODO: implement this
-                warn_once_then_debug!(
-                    "(LOG_ONCE) setsockopt SO_REUSEPORT not yet implemented for udp"
-                );
+                warn_once_then_debug!("setsockopt SO_REUSEPORT not yet implemented for udp");
                 return Err(Errno::ENOPROTOOPT.into());
             }
             (libc::SOL_SOCKET, libc::SO_KEEPALIVE) => {
                 // TODO: implement this
-                warn_once_then_debug!(
-                    "(LOG_ONCE) setsockopt SO_KEEPALIVE not yet implemented for udp"
-                );
+                warn_once_then_debug!("setsockopt SO_KEEPALIVE not yet implemented for udp");
                 return Err(Errno::ENOPROTOOPT.into());
             }
             (libc::SOL_SOCKET, libc::SO_BROADCAST) => {
                 // TODO: implement this, pkg.go.dev/net uses it
-                warn_once_then_debug!("(LOG_ONCE) setsockopt SO_BROADCAST not yet implemented for udp; ignoring and returning 0");
+                warn_once_then_debug!(
+                    "setsockopt SO_BROADCAST not yet implemented for udp; ignoring and returning 0"
+                );
             }
             _ => {
                 log::debug!("setsockopt called with unsupported level {level} and opt {optname}");

--- a/src/main/host/descriptor/timerfd.rs
+++ b/src/main/host/descriptor/timerfd.rs
@@ -206,9 +206,7 @@ impl TimerFd {
         // The only timerfd-specific ioctl request is for `TFD_IOC_SET_TICKS`, which is available
         // since Linux 3.17 but only if the kernel was configured with `CONFIG_CHECKPOINT_RESTORE`.
         // See timerfd_create(2) for more details.
-        warn_once_then_debug!(
-            "(LOG_ONCE) We do not yet handle ioctl request {request:?} on TimerFds"
-        );
+        warn_once_then_debug!("We do not yet handle ioctl request {request:?} on TimerFds");
         Err(Errno::EINVAL.into())
     }
 

--- a/src/main/host/syscall/handler/clone.rs
+++ b/src/main/host/syscall/handler/clone.rs
@@ -131,7 +131,8 @@ impl SyscallHandler {
             // "feature" and e.g. writes to non-scratch memory, expecting the
             // parent process to see those writes when it resumes.
             warn_once_then_debug!(
-                "(LOG_ONCE) Ignoring CLONE_VFORK (and CLONE_VM if set). In *typical* usage this won't result in incorrect behavior."
+                "Ignoring CLONE_VFORK (and CLONE_VM if set). In *typical* usage this won't \
+                result in incorrect behavior."
             );
             handled_flags.insert(CloneFlags::CLONE_VFORK);
         }

--- a/src/main/host/syscall/handler/epoll.rs
+++ b/src/main/host/syscall/handler/epoll.rs
@@ -124,8 +124,8 @@ impl SyscallHandler {
                         // Our implementation doesn't support other legacy types.
                         // We don't think we have such types remaining, but warn anyway.
                         warn_once_then_trace!(
-                            "(LOG_ONCE) Attempted to add a legacy file to an \
-                            epoll file, which shadow doesn't support"
+                            "Attempted to add a legacy file to an epoll file, which \
+                            shadow doesn't support"
                         );
                         return Err(Errno::EINVAL.into());
                     }

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -41,14 +41,14 @@ impl SyscallHandler {
             | FcntlCommand::F_OFD_GETLK => {
                 match desc.file() {
                     CompatFile::New(_) => {
-                        warn_once_then_debug!(
-                            "(LOG_ONCE) fcntl({cmd:?}) unimplemented for {:?}",
-                            desc.file()
-                        );
+                        warn_once_then_debug!("fcntl({cmd:?}) unimplemented for {:?}", desc.file());
                         return Err(Errno::ENOSYS.into());
                     }
                     CompatFile::Legacy(_) => {
-                        warn_once_then_debug!("(LOG_ONCE) Using fcntl({cmd:?}) implementation that assumes no lock contention. See https://github.com/shadow/shadow/issues/2258");
+                        warn_once_then_debug!(
+                            "Using fcntl({cmd:?}) implementation that assumes no lock contention. \
+                            See https://github.com/shadow/shadow/issues/2258"
+                        );
                         drop(desc_table);
                         return legacy_syscall_fn(ctx);
                     }
@@ -173,7 +173,7 @@ impl SyscallHandler {
                 }
             }
             cmd => {
-                warn_once_then_debug!("(LOG_ONCE) Unhandled fcntl command: {cmd:?}");
+                warn_once_then_debug!("Unhandled fcntl command: {cmd:?}");
                 return Err(Errno::EINVAL.into());
             }
         })

--- a/src/main/host/syscall/handler/futex.rs
+++ b/src/main/host/syscall/handler/futex.rs
@@ -30,7 +30,7 @@ impl SyscallHandler {
         _head_ptr: ForeignPtr<ForeignPtr<linux_api::futex::robust_list_head>>,
         _len_ptr: ForeignPtr<libc::size_t>,
     ) -> Result<(), SyscallError> {
-        warn_once_then_debug!("(LOG_ONCE) get_robust_list was called but we don't yet support it");
+        warn_once_then_debug!("get_robust_list was called but we don't yet support it");
         Err(Errno::ENOSYS.into())
     }
 
@@ -41,7 +41,7 @@ impl SyscallHandler {
         _head: ForeignPtr<linux_api::futex::robust_list_head>,
         _len: libc::size_t,
     ) -> Result<(), SyscallError> {
-        warn_once_then_debug!("(LOG_ONCE) set_robust_list was called but we don't yet support it");
+        warn_once_then_debug!("set_robust_list was called but we don't yet support it");
         Err(Errno::ENOSYS.into())
     }
 }

--- a/src/main/host/syscall/handler/mman.rs
+++ b/src/main/host/syscall/handler/mman.rs
@@ -49,7 +49,7 @@ impl SyscallHandler {
         // check for truncated flag bits (use u32 instead of i32 to prevent sign extension when
         // casting from signed to unsigned)
         if flags as u32 as u64 != flags {
-            warn_once_then_trace!("(LOG_ONCE) ignoring truncated flags from mremap: {flags}");
+            warn_once_then_trace!("Ignoring truncated flags from mremap: {flags}");
         }
 
         let flags = flags as i32;
@@ -98,7 +98,7 @@ impl SyscallHandler {
         // check for truncated flag bits (use u32 instead of i32 to prevent sign extension when
         // casting from signed to unsigned)
         if prot as u32 as u64 != prot {
-            warn_once_then_trace!("(LOG_ONCE) ignoring truncated prot flags from mprotect: {prot}");
+            warn_once_then_trace!("Ignoring truncated prot flags from mprotect: {prot}");
         }
 
         let prot = prot as i32;
@@ -139,7 +139,7 @@ impl SyscallHandler {
         // check for truncated flag bits (use u32 instead of i32 to prevent sign extension when
         // casting from signed to unsigned)
         if prot as u32 as u64 != prot {
-            warn_once_then_trace!("(LOG_ONCE) ignoring truncated prot flags from mmap: {prot}");
+            warn_once_then_trace!("Ignoring truncated prot flags from mmap: {prot}");
         }
 
         let prot = prot as i32;
@@ -147,7 +147,7 @@ impl SyscallHandler {
         let flags = match MapFlags::from_bits(flags) {
             Some(x) => x,
             None => {
-                warn_once_then_debug!("(LOG_ONCE) Invalid mmap flags: {flags}");
+                warn_once_then_debug!("Invalid mmap flags: {flags}");
                 MapFlags::from_bits_truncate(flags)
             }
         };
@@ -222,7 +222,7 @@ impl SyscallHandler {
         // check for truncated flag bits (use u32 instead of i32 to prevent sign extension when
         // casting from signed to unsigned)
         if flags as u32 as u64 != flags {
-            warn_once_then_trace!("(LOG_ONCE) ignoring truncated flags from mmap: {flags}");
+            warn_once_then_trace!("Ignoring truncated flags from mmap: {flags}");
         }
 
         let flags = flags as i32;
@@ -268,7 +268,7 @@ impl SyscallHandler {
         // make sure we don't open special files like /dev/urandom, /etc/localtime etc. in the
         // plugin via mmap
         if unsafe { c::regularfile_getType(file) } != c::_FileType_FILE_TYPE_REGULAR {
-            warn_once_then_debug!("(LOG_ONCE) Tried to mmap a non-regular-file");
+            warn_once_then_debug!("Tried to mmap a non-regular-file");
             return Err(());
         }
 

--- a/src/main/host/syscall/handler/time.rs
+++ b/src/main/host/syscall/handler/time.rs
@@ -39,7 +39,7 @@ impl SyscallHandler {
         };
 
         if which != ITimerId::ITIMER_REAL {
-            warn_once_then_debug!("(LOG_ONCE) Timer type {which:?} unsupported");
+            warn_once_then_debug!("Timer type {which:?} unsupported");
             return Err(Errno::EINVAL.into());
         }
 
@@ -66,7 +66,7 @@ impl SyscallHandler {
         };
 
         if which != ITimerId::ITIMER_REAL {
-            warn_once_then_debug!("(LOG_ONCE) Timer type {which:?} unsupported");
+            warn_once_then_debug!("Timer type {which:?} unsupported");
             return Err(Errno::EINVAL.into());
         }
 
@@ -166,7 +166,7 @@ impl SyscallHandler {
             Err(Errno::ENOTSUP.into())
         } else if [ClockId::CLOCK_PROCESS_CPUTIME_ID].contains(&clock_id) {
             // Supported in Linux, not in Shadow.
-            warn_once_then_debug!("(LOG_ONCE) Clock id {clock_id:?} unsupported in Shadow.",);
+            warn_once_then_debug!("Clock id {clock_id:?} unsupported in Shadow.",);
             Err(Errno::ENOTSUP.into())
         } else {
             log::debug!("Unknown clock id {clock_id:?}.");

--- a/src/main/host/syscall/handler/timerfd.rs
+++ b/src/main/host/syscall/handler/timerfd.rs
@@ -203,7 +203,7 @@ fn check_clockid(clockid: ClockId) -> Result<(), Errno> {
         return Ok(());
     }
 
-    warn_once_then_debug!("(LOG_ONCE) Unsupported clockid {clockid:?}");
+    warn_once_then_debug!("Unsupported clockid {clockid:?}");
     Err(Errno::EINVAL)
 }
 

--- a/src/main/utility/macros.rs
+++ b/src/main/utility/macros.rs
@@ -8,19 +8,18 @@ macro_rules! debug_panic {
 }
 
 /// Log a message once at level `lvl_once`, and any later log messages from this line at level
-/// `lvl_remaining`. A log target is not supported. It is recommended to also prepend "(LOG_ONCE)"
-/// to the log message to indicate that it will not be logged again at that level, but will be
-/// logged at a different level.
+/// `lvl_remaining`. A log target is not supported. The string "(LOG_ONCE)" will be prepended to the
+/// message to indicate that future messages won't be logged at `lvl_once`.
 ///
 /// ```
 /// # use log::Level;
 /// # use shadow_rs::log_once_at_level;
-/// log_once_at_level!(Level::Warn, Level::Debug, "(LOG_ONCE) Unexpected flag {}", 10);
+/// log_once_at_level!(Level::Warn, Level::Debug, "Unexpected flag {}", 10);
 /// ```
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! log_once_at_level {
-    ($lvl_once:expr, $lvl_remaining:expr, $($x:tt)+) => {
+    ($lvl_once:expr, $lvl_remaining:expr, $str:literal $($x:tt)*) => {
         // don't do atomic operations if this log statement isn't enabled
         if log::log_enabled!($lvl_once) || log::log_enabled!($lvl_remaining) {
             static HAS_LOGGED: std::sync::atomic::AtomicBool =
@@ -34,20 +33,19 @@ macro_rules! log_once_at_level {
                 std::sync::atomic::Ordering::Relaxed,
                 std::sync::atomic::Ordering::Relaxed,
             ) {
-                Ok(_) => log::log!($lvl_once, $($x)+),
-                Err(_) => log::log!($lvl_remaining, $($x)+),
+                Ok(_) => log::log!($lvl_once, "(LOG_ONCE) {}", format_args!($str $($x)*)),
+                Err(_) => log::log!($lvl_remaining, "(LOG_ONCE) {}", format_args!($str $($x)*)),
             }
         }
     };
 }
 
 /// Log a message once at warn level, and any later log messages from this line at debug level. A
-/// log target is not supported. It is recommended to also prepend "(LOG_ONCE)" to the log message
-/// to indicate that it will not be logged again at that level, but will be logged at a different
-/// level.
+/// log target is not supported. The string "(LOG_ONCE)" will be prepended to the message to
+/// indicate that future messages won't be logged at warn level.
 ///
 /// ```ignore
-/// warn_once_then_debug!("(LOG_ONCE) Unexpected flag {}", 10);
+/// warn_once_then_debug!("Unexpected flag {}", 10);
 /// ```
 #[allow(unused_macros)]
 macro_rules! warn_once_then_debug {
@@ -57,12 +55,11 @@ macro_rules! warn_once_then_debug {
 }
 
 /// Log a message once at warn level, and any later log messages from this line at trace level. A
-/// log target is not supported. It is recommended to also prepend "(LOG_ONCE)" to the log message
-/// to indicate that it will not be logged again at that level, but will be logged at a different
-/// level.
+/// log target is not supported. The string "(LOG_ONCE)" will be prepended to the message to
+/// indicate that future messages won't be logged at warn level.
 ///
 /// ```ignore
-/// warn_once_then_trace!("(LOG_ONCE) Unexpected flag {}", 10);
+/// warn_once_then_trace!("Unexpected flag {}", 10);
 /// ```
 #[allow(unused_macros)]
 macro_rules! warn_once_then_trace {


### PR DESCRIPTION
Now the "(LOG_ONCE)" will be prepended automatically. I think this is an improvement so that you don't need to remember to add it, and they will stay consistent.