### PR TITLE
Change a `warn` to `trace` in the mmap syscall handler

### DIFF
--- a/src/main/host/syscall/handler/mman.rs
+++ b/src/main/host/syscall/handler/mman.rs
@@ -213,7 +213,7 @@ impl SyscallHandler {
 
         // the file is None for an anonymous mapping, or a non-null Some otherwise
         let Ok(plugin_fd) = plugin_fd.transpose() else {
-            log::warn!("mmap on fd {fd} for {len} bytes failed");
+            log::trace!("mmap on fd {fd} for {len} bytes failed");
             return Err(Errno::EACCES.into());
         };
 


### PR DESCRIPTION
This reduces the huge number of log messages in tor simulations. See #3224.