### PR TITLE
Fix clippy warnings in rust 1.74 and rust 1.75-beta

### DIFF
--- a/ci/rust-toolchain-nightly.toml
+++ b/ci/rust-toolchain-nightly.toml
@@ -9,6 +9,6 @@
 [toolchain]
 # Must be a version built with miri; check
 # https://rust-lang.github.io/rustup-components-history/
-channel = "nightly-2023-10-05"
+channel = "nightly-2023-11-18"
 # We don't add individual components here. CI individually
 # adds the ones they need (e.g. clippy, miri).

--- a/ci/rust-toolchain-stable.toml
+++ b/ci/rust-toolchain-stable.toml
@@ -7,4 +7,4 @@
 # See
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.73.0"
+channel = "1.74.0"

--- a/src/lib/gml-parser/src/parser.rs
+++ b/src/lib/gml-parser/src/parser.rs
@@ -119,7 +119,7 @@ pub fn gml<'a, E: GmlParseError<'a>>(input: &'a str) -> IResult<&str, Gml, E> {
             ErrorKind::Fail,
         )?;
     }
-    let directed = match directed.get(0) {
+    let directed = match directed.first() {
         Some(GmlItem::Directed(x)) => *x,
         Some(_) => panic!(),
         // GML graphs are undirected by default

--- a/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
@@ -303,7 +303,7 @@ impl std::convert::TryFrom<SimulationTime> for libc::timespec {
     fn try_from(value: SimulationTime) -> Result<Self, Self::Error> {
         let value = Duration::from(value);
         let tv_sec = value.as_secs().try_into().map_err(|_| ())?;
-        let tv_nsec = value.subsec_nanos().try_into().map_err(|_| ())?;
+        let tv_nsec = value.subsec_nanos().into();
         Ok(libc::timespec { tv_sec, tv_nsec })
     }
 }
@@ -327,7 +327,7 @@ impl std::convert::TryFrom<SimulationTime> for linux_api::time::timespec {
     fn try_from(value: SimulationTime) -> Result<Self, Self::Error> {
         let value = Duration::from(value);
         let tv_sec = value.as_secs().try_into().map_err(|_| ())?;
-        let tv_nsec = value.subsec_nanos().try_into().map_err(|_| ())?;
+        let tv_nsec = value.subsec_nanos().into();
         Ok(linux_api::time::timespec { tv_sec, tv_nsec })
     }
 }
@@ -351,7 +351,7 @@ impl std::convert::TryFrom<SimulationTime> for libc::timeval {
     fn try_from(value: SimulationTime) -> Result<Self, Self::Error> {
         let value = Duration::from(value);
         let tv_sec = value.as_secs().try_into().map_err(|_| ())?;
-        let tv_usec = value.subsec_micros().try_into().map_err(|_| ())?;
+        let tv_usec = value.subsec_micros().into();
         Ok(libc::timeval { tv_sec, tv_usec })
     }
 }
@@ -375,7 +375,7 @@ impl std::convert::TryFrom<SimulationTime> for linux_api::time::timeval {
     fn try_from(value: SimulationTime) -> Result<Self, Self::Error> {
         let value = Duration::from(value);
         let tv_sec = value.as_secs().try_into().map_err(|_| ())?;
-        let tv_usec = value.subsec_micros().try_into().map_err(|_| ())?;
+        let tv_usec = value.subsec_micros().into();
         Ok(linux_api::time::timeval { tv_sec, tv_usec })
     }
 }

--- a/src/lib/shim/src/syscall.rs
+++ b/src/lib/shim/src/syscall.rs
@@ -23,11 +23,7 @@ unsafe fn native_syscall(args: &SysCallArgs) -> SysCallReg {
     if args.number == libc::SYS_clone {
         panic!("Shouldn't get here. Should have gone through ShimEventAddThreadReq");
     } else if args.number == libc::SYS_exit {
-        let exit_status = args.args[0];
-        let exit_status = i32::try_from(exit_status).unwrap_or_else(|_| {
-            log::debug!("Truncating thread exit status {exit_status:?}");
-            i64::from(exit_status) as i32
-        });
+        let exit_status = i32::from(args.args[0]);
         // This thread is exiting. Arrange for its thread-local-storage and
         // signal stack to be freed.
         unsafe { bindings::shim_freeSignalStack() };

--- a/src/lib/tcp/src/connection.rs
+++ b/src/lib/tcp/src/connection.rs
@@ -297,10 +297,10 @@ impl<I: Instant> Connection<I> {
         // update the send window, applying the window scale shift only if it wasn't a SYN packet
         // TODO: should we still update the window if the ACK was not in the valid range?
         if original_packet_had_syn {
-            self.send.window = u32::try_from(header.window_size).unwrap();
+            self.send.window = u32::from(header.window_size);
         } else {
-            self.send.window = u32::try_from(header.window_size).unwrap()
-                << self.window_scaling.send_window_scale_shift();
+            self.send.window =
+                u32::from(header.window_size) << self.window_scaling.send_window_scale_shift();
         }
 
         if header.flags.contains(TcpFlags::ACK) {

--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -120,8 +120,8 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
                 .export
                 .item_types
                 .iter()
+                .filter(|t| **t != cbindgen::ItemType::Functions)
                 .cloned()
-                .filter(|t| *t != cbindgen::ItemType::Functions)
                 .collect(),
             ..base_config.export.clone()
         };

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -361,8 +361,7 @@ impl Worker {
         // check if network reliability forces us to 'drop' the packet
         let reliability: f64 = Worker::with(|w| w.shared.reliability(src_ip, dst_ip).unwrap())
             .unwrap()
-            .try_into()
-            .unwrap();
+            .into();
         let chance: f64 = src_host.random_mut().gen();
 
         // don't drop control packets with length 0, otherwise congestion control has problems

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -146,7 +146,7 @@ impl SyscallHandler {
                 let new_fd = desc_table
                     .register_descriptor_with_min_fd(new_desc, min_fd)
                     .or(Err(Errno::EINVAL))?;
-                SysCallReg::from(i32::try_from(new_fd).unwrap())
+                SysCallReg::from(i32::from(new_fd))
             }
             FcntlCommand::F_DUPFD_CLOEXEC => {
                 let min_fd = arg.try_into().or(Err(Errno::EINVAL))?;
@@ -155,7 +155,7 @@ impl SyscallHandler {
                 let new_fd = desc_table
                     .register_descriptor_with_min_fd(new_desc, min_fd)
                     .or(Err(Errno::EINVAL))?;
-                SysCallReg::from(i32::try_from(new_fd).unwrap())
+                SysCallReg::from(i32::from(new_fd))
             }
             FcntlCommand::F_GETPIPE_SZ => {
                 let file = match desc.file() {

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -65,7 +65,7 @@ impl SyscallHandler {
             .or(Err(Errno::ENFILE))?;
 
         // return the new fd
-        Ok(std::ffi::c_int::try_from(new_fd).unwrap().into())
+        Ok(std::ffi::c_int::from(new_fd).into())
     }
 
     #[log_syscall(/* rv */ std::ffi::c_int, /* oldfd */ std::ffi::c_int, /* newfd */ std::ffi::c_int)]
@@ -153,7 +153,7 @@ impl SyscallHandler {
         }
 
         // return the new fd
-        Ok(std::ffi::c_int::try_from(new_fd).unwrap().into())
+        Ok(std::ffi::c_int::from(new_fd).into())
     }
 
     #[log_syscall(/* rv */ isize, /* fd */ std::ffi::c_int, /* buf */ *const std::ffi::c_void,
@@ -463,10 +463,7 @@ impl SyscallHandler {
         let write_fd = dt.register_descriptor(writer_desc).unwrap();
 
         // try to write them to the caller
-        let fds = [
-            i32::try_from(read_fd).unwrap(),
-            i32::try_from(write_fd).unwrap(),
-        ];
+        let fds = [i32::from(read_fd), i32::from(write_fd)];
         let write_res = ctx.objs.process.memory_borrow_mut().write(fd_ptr, &fds);
 
         // clean up in case of error

--- a/src/main/network/packet.rs
+++ b/src/main/network/packet.rs
@@ -433,7 +433,7 @@ impl PacketDisplay for *const c::Packet {
 
         if payload_len > 0 {
             // shadow's packet payloads are guarded by a mutex, so it's easiest to make a copy of them
-            let mut payload_buf = vec![0u8; payload_len.try_into().unwrap()];
+            let mut payload_buf = vec![0u8; payload_len.into()];
             let count = unsafe {
                 c::packet_copyPayloadShadow(
                     *self,

--- a/src/main/network/relay/mod.rs
+++ b/src/main/network/relay/mod.rs
@@ -314,5 +314,5 @@ fn create_token_bucket(bytes_per_second: u64) -> TokenBucket {
 /// average is maintained. But I don't think this would happen much in practice,
 /// and we are batching sends for performance reasons.
 fn get_burst_allowance() -> u64 {
-    c::CONFIG_MTU.try_into().unwrap()
+    c::CONFIG_MTU.into()
 }


### PR DESCRIPTION
Also upgrades to the latest rust stable/nightly versions in the CI.