### PR TITLE
Fix a bug in `_networkinterface_pop_next_packet_out`

### DIFF
--- a/src/main/host/network/network_interface.c
+++ b/src/main/host/network/network_interface.c
@@ -247,7 +247,13 @@ static Packet* _networkinterface_selectRoundRobin(NetworkInterface* interface, c
 
         if (compatsocket_hasDataToSend(&socket)) {
             /* socket has more packets, and is still reffed from before */
-            rrsocketqueue_push(&interface->rrQueue, &socket);
+            if (!rrsocketqueue_find(&interface->rrQueue, &socket)) {
+                rrsocketqueue_push(&interface->rrQueue, &socket);
+            } else {
+                /* socket is already in the rr queue (probably added by `compatsocket_pullOutPacket`
+                 * above); unref it from the sendable queue */
+                compatsocket_unref(&socket);
+            }
         } else {
             /* socket has no more packets, unref it from the sendable queue */
             compatsocket_unref(&socket);
@@ -288,7 +294,13 @@ static Packet* _networkinterface_selectFirstInFirstOut(NetworkInterface* interfa
 
         if (compatsocket_hasDataToSend(&socket)) {
             /* socket has more packets, and is still reffed from before */
-            fifosocketqueue_push(&interface->fifoQueue, &socket);
+            if (!fifosocketqueue_find(&interface->fifoQueue, &socket)) {
+                fifosocketqueue_push(&interface->fifoQueue, &socket);
+            } else {
+                /* socket is already in the fifo (probably added by `compatsocket_pullOutPacket`
+                 * above); unref it from the sendable queue */
+                compatsocket_unref(&socket);
+            }
         } else {
             /* socket has no more packets, unref it from the sendable queue */
             compatsocket_unref(&socket);

--- a/src/main/host/network/network_queuing_disciplines.c
+++ b/src/main/host/network/network_queuing_disciplines.c
@@ -159,7 +159,10 @@ void fifosocketqueue_push(FifoSocketQueue* self, const CompatSocket* socket) {
     utility_debugAssert(self != NULL);
     utility_debugAssert(self->queue != NULL);
     utility_debugAssert(socket->type != CST_NONE);
-    priorityqueue_push(self->queue, (void*)compatsocket_toTagged(socket));
+    gboolean successful = priorityqueue_push(self->queue, (void*)compatsocket_toTagged(socket));
+    // if this returned FALSE, it would mean that the socket was already in the queue and we would
+    // need to drop the socket to avoid a memory leak
+    utility_debugAssert(successful == TRUE);
 }
 
 bool fifosocketqueue_find(FifoSocketQueue* self, const CompatSocket* socket) {


### PR DESCRIPTION
The queue may change in between when we pop the socket and when we re-add the socket. This can lead to duplicate entries in the queue if we don't check before re-adding. I'm not exactly sure what the implication of this is. I think it can lead to some sockets being prioritized over others.

**Edit:** [No change](https://github.com/shadow/benchmark-results/blob/master/tor/2023-11-27-T05-35-50/README.md) in performance or simulation behaviour in a 10% network benchmark.

![run_time](https://github.com/shadow/shadow/assets/3708797/6318d1b6-354e-445e-8c9b-987df6bb6255)
![transfer_time_5242880 exit](https://github.com/shadow/shadow/assets/3708797/461fdd02-e35e-4986-8e45-77c172fd67c7)