### PR TITLE
Fix some rust nightly clippy lints

### DIFF
--- a/src/main/core/scheduler/logical_processor.rs
+++ b/src/main/core/scheduler/logical_processor.rs
@@ -70,9 +70,7 @@ impl LogicalProcessors {
     }
 
     /// Returns an iterator of logical processor indexes.
-    pub fn iter(
-        &self,
-    ) -> impl std::iter::Iterator<Item = usize> + Clone + std::iter::ExactSizeIterator {
+    pub fn iter(&self) -> impl std::iter::ExactSizeIterator<Item = usize> + Clone {
         0..self.lps.len()
     }
 }

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -572,7 +572,7 @@ impl Host {
         self.cpu.borrow()
     }
 
-    pub fn cpu_borrow_mut(&self) -> impl Deref<Target = Cpu> + DerefMut + '_ {
+    pub fn cpu_borrow_mut(&self) -> impl DerefMut<Target = Cpu> + '_ {
         self.cpu.borrow_mut()
     }
 
@@ -617,7 +617,7 @@ impl Host {
     }
 
     #[track_caller]
-    pub fn upstream_router_borrow_mut(&self) -> impl Deref<Target = Router> + DerefMut + '_ {
+    pub fn upstream_router_borrow_mut(&self) -> impl DerefMut<Target = Router> + '_ {
         self.router.borrow_mut()
     }
 
@@ -627,9 +627,7 @@ impl Host {
     }
 
     #[track_caller]
-    pub fn tracker_borrow_mut(
-        &self,
-    ) -> Option<impl Deref<Target = cshadow::Tracker> + DerefMut + '_> {
+    pub fn tracker_borrow_mut(&self) -> Option<impl DerefMut<Target = cshadow::Tracker> + '_> {
         let tracker = self.tracker.borrow_mut();
         if let Some(tracker) = &*tracker {
             debug_assert!(!tracker.ptr().is_null());
@@ -641,9 +639,7 @@ impl Host {
     }
 
     #[track_caller]
-    pub fn futextable_borrow_mut(
-        &self,
-    ) -> impl Deref<Target = cshadow::FutexTable> + DerefMut + '_ {
+    pub fn futextable_borrow_mut(&self) -> impl DerefMut<Target = cshadow::FutexTable> + '_ {
         let futex_table_ref = self.futex_table.borrow_mut();
         RefMut::map(futex_table_ref, |r| unsafe { &mut *r.ptr() })
     }
@@ -664,7 +660,7 @@ impl Host {
     pub fn interface_borrow_mut(
         &self,
         addr: Ipv4Addr,
-    ) -> Option<impl Deref<Target = NetworkInterface> + DerefMut + '_> {
+    ) -> Option<impl DerefMut<Target = NetworkInterface> + '_> {
         self.net_ns.interface_borrow_mut(addr)
     }
 
@@ -679,7 +675,7 @@ impl Host {
     }
 
     #[track_caller]
-    pub fn random_mut(&self) -> impl Deref<Target = Xoshiro256PlusPlus> + DerefMut + '_ {
+    pub fn random_mut(&self) -> impl DerefMut<Target = Xoshiro256PlusPlus> + '_ {
         self.random.borrow_mut()
     }
 

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -382,7 +382,7 @@ impl RunnableProcess {
     }
 
     #[track_caller]
-    pub fn memory_borrow_mut(&self) -> impl Deref<Target = MemoryManager> + DerefMut + '_ {
+    pub fn memory_borrow_mut(&self) -> impl DerefMut<Target = MemoryManager> + '_ {
         self.memory_manager.borrow_mut()
     }
 
@@ -1352,7 +1352,7 @@ impl Process {
 
     /// Deprecated wrapper for `RunnableProcess::memory_borrow_mut`
     #[track_caller]
-    pub fn memory_borrow_mut(&self) -> impl Deref<Target = MemoryManager> + DerefMut + '_ {
+    pub fn memory_borrow_mut(&self) -> impl DerefMut<Target = MemoryManager> + '_ {
         std_util::nested_ref::NestedRefMut::map(self.as_runnable().unwrap(), |runnable| {
             runnable.memory_manager.borrow_mut()
         })
@@ -1391,7 +1391,7 @@ impl Process {
 
     /// Deprecated wrapper for `RunnableProcess::realtime_timer_borrow_mut`
     #[track_caller]
-    pub fn realtime_timer_borrow_mut(&self) -> impl Deref<Target = Timer> + DerefMut + '_ {
+    pub fn realtime_timer_borrow_mut(&self) -> impl DerefMut<Target = Timer> + '_ {
         std_util::nested_ref::NestedRefMut::map(self.as_runnable().unwrap(), |runnable| {
             runnable.itimer_real.borrow_mut()
         })

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -267,7 +267,7 @@ impl Thread {
     pub fn descriptor_table_borrow_mut<'a>(
         &'a self,
         host: &'a Host,
-    ) -> impl Deref<Target = DescriptorTable> + DerefMut + 'a {
+    ) -> impl DerefMut<Target = DescriptorTable> + 'a {
         self.desc_table.as_ref().unwrap().borrow_mut(host.root())
     }
 


### PR DESCRIPTION
These are nightly lints, but I think they're an improvement. Example:

```text
warning: this bound is already specified as the supertrait of `std::iter::ExactSizeIterator`
  --> main/core/scheduler/logical_processor.rs:75:15
   |
75 |     ) -> impl std::iter::Iterator<Item = usize> + Clone + std::iter::ExactSizeIterator {
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#implied_bounds_in_impls
   = note: `#[warn(clippy::implied_bounds_in_impls)]` on by default
help: try removing this bound
   |
75 -     ) -> impl std::iter::Iterator<Item = usize> + Clone + std::iter::ExactSizeIterator {
75 +     ) -> impl Clone + std::iter::ExactSizeIterator<Item = usize> {
```