### PR TITLE
Move git and timestamp info to new crate

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1414,6 +1414,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadow-build-info"
+version = "0.1.0"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "shadow-pod"
 version = "0.1.0"
 dependencies = [
@@ -1458,6 +1465,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shadow-build-common",
+ "shadow-build-info",
  "shadow-pod",
  "shadow-shim-helper-rs",
  "shadow_shmem",
@@ -1469,7 +1477,6 @@ dependencies = [
  "system-deps",
  "tcp",
  "tempfile",
- "time",
  "vasi-sync",
  "vsprintf",
  "which 5.0.0",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "lib/logger",
     "lib/pod",
     "lib/shadow-build-common",
+    "lib/shadow-build-info",
     "lib/shadow-shim-helper-rs",
     "lib/shmem",
     "lib/shim",

--- a/src/lib/shadow-build-info/Cargo.toml
+++ b/src/lib/shadow-build-info/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "shadow-build-info"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+time = { version = "0.3.30", features = ["formatting"] }

--- a/src/lib/shadow-build-info/build.rs
+++ b/src/lib/shadow-build-info/build.rs
@@ -1,0 +1,99 @@
+// This crate and build script exists to reduce how often we need to run the expensive build script
+// in `src/main/`. Since we need to run some build script on every build to get the latest
+// timestamp and git details, we do that in this crate instead.
+//
+// We only get the timestamp and git details here, and not other information like compiler flags or
+// optimization levels. This is because crates can be built with different compiler options, so the
+// compiler options for this crate might be different than the `src/main/`crate.
+
+use std::process::Command;
+
+fn main() {
+    // Hack to make cargo always run the build script. We embed the timestamp and git details in
+    // shadow's build info, so we always need to re-run this build script to update them.
+    println!("cargo:rerun-if-changed=a-non-existent-path-sdafdmgidegegt3qyn5hw4oinqg");
+
+    if let Some(git_commit_info) = git_commit_info() {
+        println!("cargo:rustc-env=SHADOW_GIT_COMMIT_INFO={git_commit_info}");
+    }
+
+    if let Some(git_date) = git_date() {
+        println!("cargo:rustc-env=SHADOW_GIT_DATE={git_date}");
+    }
+
+    if let Some(git_branch) = git_branch() {
+        println!("cargo:rustc-env=SHADOW_GIT_BRANCH={git_branch}");
+    }
+
+    println!("cargo:rustc-env=SHADOW_TIMESTAMP={}", timestamp());
+}
+
+fn timestamp() -> String {
+    let date_format = "[year]-[month]-[day]--[hour]:[minute]:[second]";
+    let date_format = time::format_description::parse(date_format).unwrap();
+    time::OffsetDateTime::now_utc()
+        .format(&date_format)
+        .unwrap()
+}
+
+fn git_commit_info() -> Option<String> {
+    // current git commit version and hash
+    //
+    // `--always` allows us to still get the commit hash and dirty status when tags aren't
+    // available, as sometimes happens when building from a shallow clone
+    let Ok(git_describe) = Command::new("git")
+        .args(["describe", "--always", "--long", "--dirty"])
+        .output()
+    else {
+        return None;
+    };
+
+    if !git_describe.status.success() {
+        return None;
+    }
+
+    let git_describe = std::str::from_utf8(&git_describe.stdout).ok()?.trim();
+
+    Some(git_describe.into())
+}
+
+fn git_date() -> Option<String> {
+    // current git commit short date
+    let Ok(git_date) = Command::new("git")
+        .args([
+            "log",
+            "--pretty=format:%ad",
+            "--date=format:%Y-%m-%d--%H:%M:%S",
+            "-n",
+            "1",
+        ])
+        .output()
+    else {
+        return None;
+    };
+
+    if !git_date.status.success() {
+        return None;
+    }
+
+    let git_date = std::str::from_utf8(&git_date.stdout).ok()?.trim();
+
+    Some(git_date.into())
+}
+
+fn git_branch() -> Option<String> {
+    let Ok(git_rev_parse) = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+    else {
+        return None;
+    };
+
+    if !git_rev_parse.status.success() {
+        return None;
+    }
+
+    let git_rev_parse = std::str::from_utf8(&git_rev_parse.stdout).ok()?.trim();
+
+    Some(git_rev_parse.into())
+}

--- a/src/lib/shadow-build-info/src/lib.rs
+++ b/src/lib/shadow-build-info/src/lib.rs
@@ -1,0 +1,7 @@
+// this exposes information from the build script so that shadow can access it
+
+pub const BUILD_TIMESTAMP: &str = env!("SHADOW_TIMESTAMP");
+
+pub const GIT_COMMIT_INFO: Option<&str> = option_env!("SHADOW_GIT_COMMIT_INFO");
+pub const GIT_DATE: Option<&str> = option_env!("SHADOW_GIT_DATE");
+pub const GIT_BRANCH: Option<&str> = option_env!("SHADOW_GIT_BRANCH");

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -45,6 +45,7 @@ schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.107"
 serde_yaml = "0.9"
+shadow-build-info = { path = "../lib/shadow-build-info" }
 shadow_shmem = { path = "../lib/shmem" }
 shadow_tsc = { path = "../lib/tsc" }
 signal-hook = "0.3.17"
@@ -76,7 +77,6 @@ system-deps = "6.2"
 # Building the C code from this crate's build script requires
 # that these bindings have been generated.
 shadow-shim-helper-rs = { path = "../lib/shadow-shim-helper-rs" }
-time = { version = "0.3.30", features = ["formatting"] }
 
 [package.metadata.system-deps]
 # Keep consistent with the minimum version number in /CMakeLists.txt

--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -399,11 +399,15 @@ fn build_info() -> String {
     let profile = std::env::var("PROFILE").unwrap();
     let opt_level = std::env::var("OPT_LEVEL").unwrap();
     let debug = std::env::var("DEBUG").unwrap();
-    let rflags = std::env::var("CARGO_ENCODED_RUSTFLAGS").unwrap();
     let cflags = std::env::var("CFLAGS")
         .unwrap_or("<none>".to_string())
         .trim()
         .to_string();
+
+    // replace the unicode separator character with a space
+    let rflags = std::env::var("CARGO_ENCODED_RUSTFLAGS")
+        .unwrap()
+        .replace('\u{1f}', " ");
 
     // Note that the CFLAGS aren't necessarily the flags that the C code is built with. The `cc`
     // library is in charge of the flags. By default it's supposed to use CFLAGS (which I think we

--- a/src/main/core/main.rs
+++ b/src/main/core/main.rs
@@ -187,7 +187,7 @@ pub fn run_shadow(args: Vec<&OsStr>) -> anyhow::Result<()> {
     eprintln!("** Starting Shadow {}", env!("CARGO_PKG_VERSION"));
     let mut build_info = Vec::new();
     write_build_info(&mut build_info).unwrap();
-    for line in std::str::from_utf8(&build_info).unwrap().split('\n') {
+    for line in std::str::from_utf8(&build_info).unwrap().trim().split('\n') {
         log::info!("{line}");
     }
     log::info!("Logging current startup arguments and environment");


### PR DESCRIPTION
This improves the incremental build time if you're updating code that is *not* in `src/main/`. This improves incremental compilation in this case by about 8 seconds on my laptop since it skips the build script in `src/main/`. It still needs to (incrementally) rebuild `src/main/` though, which takes about 4 seconds.

This also makes small formatting changes to the `shadow --show-build-info` text.