### PR TITLE
Use 'opt-level = 3' for build scripts

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -41,4 +41,10 @@ members = [
 # In our test suite the main place we see failures without this is in the
 # `clone-shadow` test, but it could also affect golang or other environments
 # with "light" user-space threading.
-opt-level = 1 
+opt-level = 1
+
+[profile.dev.build-override]
+# Our build scripts are slow due to bindgen, cbindgen, and cc. Using optimizations for build scripts
+# significantly reduces the runtime of the build scripts, which is most impactful during incremental
+# builds.
+opt-level = 3


### PR DESCRIPTION
This noticeably reduces the runtime of build scripts during incremental builds, and does not seem to significantly increase the build time during clean builds. The shadow-rs build script run time reduces from 9 seconds to 4 seconds on my laptop.