### PR TITLE
Add missing changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ currently be disabled via the (unstable) option `log-errors-to-tty`.
 
 * Added support for the `SIOCGSTAMP` ioctl for TCP and UDP sockets.
 
+* Improved the simulation run time performance when there are a large number of
+  active sockets on a single host.
+  ([#3238](https://github.com/shadow/shadow/discussions/3238))
+
 PATCH changes (bugfixes):
 
 * Updated documentation and tests to reflect that shadow no longer requires
@@ -60,6 +64,10 @@ that use an inlined syscall instruction to make `sched_yield` syscalls.
 
 * Fixed the behaviour of the `read` and `recv` syscalls when called with
   0-length buffers.
+
+* Fixed incorrect behaviour (incorrect return value or panic) when `connect`
+  is called on a listening unix or tcp socket.
+  ([#3191](https://github.com/shadow/shadow/pull/3191))
 
 Full changelog since v3.0.0:
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ with hundreds of thousands of processes.
 Shadow implements **over 150 functions from the system call API**, but does not
 yet fully support all API features. Although applications that make _basic_ use
 of the supported system calls should work out of the box, those that use more
-_complex_ features or functions (e.g., `fork()`) may not yet function correctly
-when running in Shadow. Extending support for the API is a work-in-progress.
+_complex_ features or functions may not yet function correctly when running in
+Shadow. Extending support for the API is a work-in-progress.
 
 That being said, we are particularly motivated to run large-scale [Tor
 Network](https://www.torproject.org) simulations. This use-case is already


### PR DESCRIPTION
Also added a README change that removes a mention of `fork` as a non-working syscall.