### PR TITLE
Fix bug in linux-api rename script

### DIFF
--- a/src/lib/linux-api/rename.py
+++ b/src/lib/linux-api/rename.py
@@ -60,8 +60,8 @@ def get_consts(s):
     See module-level section "Caveats"
     """
 
-    # From "pub const FOO" extract "FOO"
-    return re.findall(r"pub const (\w+)", s)
+    # From "pub const FOO: " extract "FOO"
+    return re.findall(r"pub const (\w+): ", s)
     
 def prefix_consts(consts, s):
     """
@@ -112,7 +112,7 @@ def mangle(s):
     """
     Mangle the Rust source `s` to prefix identifiers.
 
-    See  module-level documentation for details.   
+    See module-level documentation for details.
     """
 
     types = get_types(s)


### PR DESCRIPTION
The previous version would accidentally rename `const` functions. For example:

```rust
pub const fn foo() {}
```

would be renamed to:

```rust
pub const LINUX_fn foo() {}
```

The updated version now requires a semicolon in the regex: `r"pub const (\w+): "`

I also regenerated the bindings to make sure this doesn't change any of the existing bindings.