### PR TITLE
syscallhandler: handle WARNED_SET race condition

### DIFF
--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -586,12 +586,14 @@ impl SyscallHandler {
                     .unwrap_or(false);
 
                 if !has_already_warned {
-                    // `insert()` returns `false` if the syscall num was already in the set
-                    assert!(WARNED_SET
+                    // `insert()` returns `false` if the syscall num was already in the set.
+                    // This can happen if another thread added the syscall after we released
+                    // the read-lock, above, and took the write lock, below.
+                    WARNED_SET
                         .write()
                         .unwrap()
                         .get_or_insert_with(HashSet::new)
-                        .insert(syscall));
+                        .insert(syscall);
                 }
 
                 let level = if has_already_warned {


### PR DESCRIPTION
The assertion that was here can (and did, once, for me) fail, and isn't needed.