### PR TITLE
More explicit_drop cleanup

### DIFF
--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -7,7 +7,6 @@ use atomic_refcell::{AtomicRef, AtomicRefCell};
 use once_cell::sync::Lazy;
 use rand::Rng;
 use shadow_shim_helper_rs::emulated_time::EmulatedTime;
-use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
@@ -206,7 +205,9 @@ impl Worker {
     pub fn clear_active_process() {
         Worker::with(|w| {
             let old = w.active_process.borrow_mut().take().unwrap();
-            old.explicit_drop(w.active_host.borrow().as_ref().unwrap().root());
+            let host = w.active_host.borrow();
+            let host = host.as_ref().unwrap();
+            old.explicit_drop_recursive(host.root(), host);
         })
         .unwrap();
     }

--- a/src/main/host/context.rs
+++ b/src/main/host/context.rs
@@ -34,8 +34,6 @@
 
 use std::ops::Deref;
 
-use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
-
 use super::managed_thread::ManagedThread;
 use super::process::ProcessId;
 use super::thread::ThreadId;
@@ -146,10 +144,10 @@ impl<'a> ThreadContextObjs<'a> {
                 let mut ctx = ThreadContext::new(self.host, &process, &thread);
                 f(&mut ctx)
             };
-            threadrc.explicit_drop(self.host.root());
+            threadrc.explicit_drop_recursive(self.host.root(), self.host);
             res
         };
-        processrc.explicit_drop(self.host.root());
+        processrc.explicit_drop_recursive(self.host.root(), self.host);
         res
     }
 }

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -18,7 +18,7 @@ use once_cell::unsync::OnceCell;
 use rand::SeedableRng;
 use rand_xoshiro::Xoshiro256PlusPlus;
 use shadow_shim_helper_rs::emulated_time::EmulatedTime;
-use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
+use shadow_shim_helper_rs::explicit_drop::{ExplicitDrop, ExplicitDropper};
 use shadow_shim_helper_rs::rootedcell::cell::RootedCell;
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
@@ -479,6 +479,7 @@ impl Host {
             trace!("{pid:?} doesn't exist");
             return;
         };
+        let processrc = ExplicitDropper::new(processrc, |p| p.explicit_drop(&self.root));
         let died;
         let is_orphan;
         {
@@ -495,7 +496,6 @@ impl Host {
                 is_orphan = false;
             }
         };
-        RootedRc::explicit_drop(processrc, &self.root);
 
         if !died {
             return;
@@ -791,17 +791,14 @@ impl Host {
         trace!("start freeing applications for host '{}'", self.name());
         let processes = std::mem::take(&mut *self.processes.borrow_mut());
         for (_id, processrc) in processes.into_iter() {
-            {
-                Worker::set_active_process(&processrc);
-                let process = processrc.borrow(self.root());
-                process.stop(self);
-                Worker::clear_active_process();
-                // Reparent to Shadow/INIT, since the original parent is or is
-                // about to be dead.
-                process.set_parent_id(ProcessId::INIT);
-            }
-
-            processrc.explicit_drop(self.root());
+            let processrc = ExplicitDropper::new(processrc, |p| p.explicit_drop(self.root()));
+            Worker::set_active_process(&processrc);
+            let process = processrc.borrow(self.root());
+            process.stop(self);
+            Worker::clear_active_process();
+            // Reparent to Shadow/INIT, since the original parent is or is
+            // about to be dead.
+            process.set_parent_id(ProcessId::INIT);
         }
         trace!("done freeing application for host '{}'", self.name());
     }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -24,7 +24,7 @@ use nix::fcntl::OFlag;
 use nix::sys::signal as nixsignal;
 use nix::sys::stat::Mode;
 use nix::unistd::Pid;
-use shadow_shim_helper_rs::explicit_drop::ExplicitDropper;
+use shadow_shim_helper_rs::explicit_drop::{ExplicitDrop, ExplicitDropper};
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::rootedcell::Root;
@@ -686,6 +686,18 @@ impl RunnableProcess {
     }
 }
 
+impl ExplicitDrop for RunnableProcess {
+    type ExplicitDropParam = Host;
+    type ExplicitDropResult = ();
+
+    fn explicit_drop(mut self, host: &Self::ExplicitDropParam) -> Self::ExplicitDropResult {
+        let threads = std::mem::take(self.threads.get_mut());
+        for thread in threads.into_values() {
+            thread.explicit_drop_recursive(host.root(), host);
+        }
+    }
+}
+
 /// A process that has exited.
 pub struct ZombieProcess {
     common: Common,
@@ -841,6 +853,18 @@ impl ProcessState {
         match self {
             ProcessState::Runnable(_) => None,
             ProcessState::Zombie(z) => Some(z),
+        }
+    }
+}
+
+impl ExplicitDrop for ProcessState {
+    type ExplicitDropParam = Host;
+    type ExplicitDropResult = ();
+
+    fn explicit_drop(self, host: &Self::ExplicitDropParam) -> Self::ExplicitDropResult {
+        match self {
+            ProcessState::Runnable(r) => r.explicit_drop(host),
+            ProcessState::Zombie(_) => (),
         }
     }
 }
@@ -1705,8 +1729,21 @@ impl Process {
 
 impl Drop for Process {
     fn drop(&mut self) {
-        // Should only be dropped in the zombie state.
-        debug_assert!(self.as_zombie().is_some());
+        // Should have been explicitly dropped.
+        debug_assert!(self.state.borrow().is_none());
+    }
+}
+
+impl ExplicitDrop for Process {
+    type ExplicitDropParam = Host;
+    type ExplicitDropResult = ();
+
+    fn explicit_drop(mut self, host: &Self::ExplicitDropParam) -> Self::ExplicitDropResult {
+        // Should normally only be dropped in the zombie state.
+        debug_assert!(self.as_zombie().is_some() || std::thread::panicking());
+
+        let state = self.state.get_mut().take().unwrap();
+        state.explicit_drop(host);
     }
 }
 

--- a/src/main/host/syscall/handler/wait.rs
+++ b/src/main/host/syscall/handler/wait.rs
@@ -6,7 +6,6 @@ use linux_api::posix_types::kernel_pid_t;
 use linux_api::resource::rusage;
 use linux_api::signal::{siginfo_t, Signal};
 use linux_api::wait::{WaitFlags, WaitId};
-use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use syscall_logger::log_syscall;
 
@@ -185,7 +184,7 @@ impl SyscallHandler {
                 .host
                 .process_remove(matching_child_zombie_pid)
                 .unwrap();
-            zombie_process.explicit_drop(ctx.objs.host.root());
+            zombie_process.explicit_drop_recursive(ctx.objs.host.root(), ctx.objs.host);
         }
 
         Ok(matching_child_zombie_pid.into())

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -126,7 +126,7 @@ impl Thread {
             // Descriptor table is unshared
             let desc_table_rc = self.desc_table.take().unwrap();
             let mut desc_table = DescriptorTable::clone(&desc_table_rc.borrow(host.root()));
-            desc_table_rc.explicit_drop(host.root());
+            desc_table_rc.explicit_drop_recursive(host.root(), host);
 
             // Any descriptors with CLOEXEC are closed.
             let to_close: Vec<DescriptorHandle> = desc_table


### PR DESCRIPTION
Audited calls to explicit_drop and:

* Used `ExplicitDropper` in cases where the code might otherwise return early or panic without explicitly dropping.
* Made `Process` `ExplicitDrop` to drop its internal `RootedRc`s. (Normally they would have already been dropped anyways, but possibly not e.g. in case of a panic)
* Changed various calls of `explicit_drop` to `RootedRc::explicit_drop_recursive` to ensure the inner value also gets explicitly dropped if that was the last reference.

I didn't see any "normal" early returns that these changes fix, but they may prevent some confusing "double panics" in case of panic, and makes the code more robust in case early returns get added at some point in the future.