### PR TITLE
Fix exponential slowdown in wait4 syscall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ PATCH changes (bugfixes):
 
 * On fork and fork-like invocations of `clone`, signal handlers are now correctly copied
 from the parent instead of reset to default (unless `CLONE_CLEAR_SIGHAND` is used).
+* Fix exponential slowdown after repeated usage of the `wait4` syscall.
 
 Full changelog since v3.1.0:
 

--- a/src/main/host/syscall/syscall_condition.c
+++ b/src/main/host/syscall/syscall_condition.c
@@ -122,18 +122,21 @@ static void _syscallcondition_cleanupListeners(SysCallCondition* cond) {
         cond->timeout = NULL;
     }
 
-    if (cond->trigger.object.as_pointer && cond->triggerListener) {
+    if (cond->triggerListener) {
         switch (cond->trigger.type) {
             case TRIGGER_DESCRIPTOR: {
+                utility_alwaysAssert(cond->trigger.object.as_pointer);
                 legacyfile_removeListener(
                     cond->trigger.object.as_legacy_file, cond->triggerListener);
                 break;
             }
             case TRIGGER_FILE: {
+                utility_alwaysAssert(cond->trigger.object.as_pointer);
                 file_removeListener(cond->trigger.object.as_file, cond->triggerListener);
                 break;
             }
             case TRIGGER_FUTEX: {
+                utility_alwaysAssert(cond->trigger.object.as_pointer);
                 futex_removeListener(cond->trigger.object.as_futex, cond->triggerListener);
                 break;
             }


### PR DESCRIPTION
The previous condition for clearing the trigger listener is no longer correct, since TRIGGER_CHILD doesn't take an object. As a result we were failing to clear the listener after `wait4` blocked when the thread ran again.

This resulted in duplicate child triggers, and then duplicate wakeup events, which would in turn schedule more duplicate triggers, resulting in an exponential slowdown after repeated `wait4` usage.