### PR TITLE
Use rust 1.76 features

### DIFF
--- a/ci/rust-toolchain-nightly.toml
+++ b/ci/rust-toolchain-nightly.toml
@@ -9,6 +9,6 @@
 [toolchain]
 # Must be a version built with miri; check
 # https://rust-lang.github.io/rustup-components-history/
-channel = "nightly-2023-12-29"
+channel = "nightly-2024-02-07"
 # We don't add individual components here. CI individually
 # adds the ones they need (e.g. clippy, miri).

--- a/ci/rust-toolchain-stable.toml
+++ b/ci/rust-toolchain-stable.toml
@@ -7,4 +7,4 @@
 # See
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"

--- a/src/lib/linux-api/src/futex.rs
+++ b/src/lib/linux-api/src/futex.rs
@@ -75,8 +75,7 @@ pub fn futex(
     val3: u32,
 ) -> Result<core::ffi::c_int, Errno> {
     let utime = utime
-        // TODO: in rust 1.76 use `core::ptr::from_ref`
-        .map(|x| x as *const _)
+        .map(core::ptr::from_ref)
         .unwrap_or(core::ptr::null_mut());
     let uaddr2 = uaddr2
         .map(AtomicU32::as_ptr)

--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -435,7 +435,7 @@ impl siginfo_t {
     ///
     /// See [`siginfo_t`] `Invariants`.
     pub unsafe fn wrap_ref_assume_initd(si: &linux_siginfo_t) -> &Self {
-        unsafe { &*(si as *const _ as *const Self) }
+        unsafe { &*(core::ptr::from_ref(si) as *const Self) }
     }
 
     /// Analogous to `bytemuck::TransparentWrapper::wrap_mut`, but `unsafe`.
@@ -444,7 +444,7 @@ impl siginfo_t {
     ///
     /// See [`siginfo_t`] `Invariants`.
     pub unsafe fn wrap_mut_assume_initd(si: &mut linux_siginfo_t) -> &mut Self {
-        unsafe { &mut *(si as *mut _ as *mut Self) }
+        unsafe { &mut *(core::ptr::from_mut(si) as *mut Self) }
     }
 
     /// # Safety
@@ -1108,11 +1108,11 @@ impl sigaction {
     }
 
     pub fn wrap_ref(si: &linux_sigaction) -> &Self {
-        unsafe { &*(si as *const _ as *const Self) }
+        unsafe { &*(core::ptr::from_ref(si) as *const Self) }
     }
 
     pub fn wrap_mut(si: &mut linux_sigaction) -> &mut Self {
-        unsafe { &mut *(si as *mut _ as *mut Self) }
+        unsafe { &mut *(core::ptr::from_mut(si) as *mut Self) }
     }
 
     /// # Safety
@@ -1315,7 +1315,7 @@ pub unsafe fn rt_sigaction(
             signal.as_i32(),
             new_action,
             old_action
-                .map(|o| o as *mut _)
+                .map(core::ptr::from_mut)
                 .unwrap_or(core::ptr::null_mut()),
             core::mem::size_of::<sigset_t>(),
         )
@@ -1368,7 +1368,7 @@ pub fn rt_sigprocmask(
             how.into(),
             sigset_in,
             sigset_out
-                .map(|s| s as *mut _)
+                .map(core::ptr::from_mut)
                 .unwrap_or(core::ptr::null_mut()),
             core::mem::size_of::<sigset_t>(),
         )
@@ -1509,10 +1509,10 @@ pub unsafe fn sigaltstack(
     unsafe {
         sigaltstack_raw(
             new_stack
-                .map(|p| p as *const _)
+                .map(core::ptr::from_ref)
                 .unwrap_or(core::ptr::null()),
             old_stack
-                .map(|p| p as *mut _)
+                .map(core::ptr::from_mut)
                 .unwrap_or(core::ptr::null_mut()),
         )
     }

--- a/src/lib/scheduler/src/sync/simple_latch.rs
+++ b/src/lib/scheduler/src/sync/simple_latch.rs
@@ -141,8 +141,7 @@ pub fn libc_futex(
 ) -> Result<core::ffi::c_int, Errno> {
     let uaddr: *mut u32 = uaddr.as_ptr();
     let utime: *const libc::timespec = utime
-        // TODO: in rust 1.76 use `core::ptr::from_ref`
-        .map(|x| x as *const _)
+        .map(std::ptr::from_ref)
         .unwrap_or(core::ptr::null_mut());
     let uaddr2: *mut u32 = uaddr2
         .map(AtomicU32::as_ptr)

--- a/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/emulated_time.rs
@@ -190,14 +190,10 @@ pub mod export {
         lhs: CEmulatedTime,
         rhs: CSimulationTime,
     ) -> CEmulatedTime {
-        let lhs = if let Some(e) = EmulatedTime::from_c_emutime(lhs) {
-            e
-        } else {
+        let Some(lhs) = EmulatedTime::from_c_emutime(lhs) else {
             return EmulatedTime::to_c_emutime(None);
         };
-        let rhs = if let Some(e) = SimulationTime::from_c_simtime(rhs) {
-            e
-        } else {
+        let Some(rhs) = SimulationTime::from_c_simtime(rhs) else {
             return EmulatedTime::to_c_emutime(None);
         };
         let sum = lhs.checked_add(rhs);
@@ -209,14 +205,10 @@ pub mod export {
         lhs: CEmulatedTime,
         rhs: CEmulatedTime,
     ) -> CSimulationTime {
-        let lhs = if let Some(e) = EmulatedTime::from_c_emutime(lhs) {
-            e
-        } else {
+        let Some(lhs) = EmulatedTime::from_c_emutime(lhs) else {
             return EmulatedTime::to_c_emutime(None);
         };
-        let rhs = if let Some(e) = EmulatedTime::from_c_emutime(rhs) {
-            e
-        } else {
+        let Some(rhs) = EmulatedTime::from_c_emutime(rhs) else {
             return EmulatedTime::to_c_emutime(None);
         };
         let diff = lhs.checked_duration_since(&rhs);

--- a/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
@@ -444,7 +444,7 @@ pub mod export {
     ) -> *mut ShimShmemHostLock {
         let host = unsafe { host.as_ref().unwrap() };
         let mut guard = host.protected().lock();
-        let lock = &mut *guard as *mut _;
+        let lock = std::ptr::from_mut(&mut *guard);
         guard.disconnect();
         lock
     }

--- a/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
@@ -443,8 +443,9 @@ pub mod export {
         host: *const ShimShmemHost,
     ) -> *mut ShimShmemHostLock {
         let host = unsafe { host.as_ref().unwrap() };
-        let mut guard = host.protected().lock();
-        let lock = std::ptr::from_mut(&mut *guard);
+        let mut guard: SelfContainedMutexGuard<ShimShmemHostLock> = host.protected().lock();
+        let lock: &mut ShimShmemHostLock = &mut guard;
+        let lock = std::ptr::from_mut(lock);
         guard.disconnect();
         lock
     }

--- a/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
@@ -48,11 +48,7 @@ impl SimulationTime {
     }
 
     pub fn to_c_simtime(val: Option<Self>) -> CSimulationTime {
-        if let Some(val) = val {
-            val.0
-        } else {
-            SIMTIME_INVALID
-        }
+        val.map_or(SIMTIME_INVALID, |val| val.0)
     }
 
     /// Convert a [`Duration`] to a [`SimulationTime`]. This function exists as a `const`
@@ -538,14 +534,10 @@ pub mod export {
         val: CSimulationTime,
         out: *mut libc::timeval,
     ) -> bool {
-        let simtime: SimulationTime = if let Some(s) = SimulationTime::from_c_simtime(val) {
-            s
-        } else {
+        let Some(simtime) = SimulationTime::from_c_simtime(val) else {
             return false;
         };
-        let tv: libc::timeval = if let Ok(tv) = libc::timeval::try_from(simtime) {
-            tv
-        } else {
+        let Ok(tv) = libc::timeval::try_from(simtime) else {
             return false;
         };
         unsafe { std::ptr::write(notnull_mut(out), tv) };
@@ -561,14 +553,10 @@ pub mod export {
         val: CSimulationTime,
         out: *mut libc::timespec,
     ) -> bool {
-        let simtime: SimulationTime = if let Some(s) = SimulationTime::from_c_simtime(val) {
-            s
-        } else {
+        let Some(simtime) = SimulationTime::from_c_simtime(val) else {
             return false;
         };
-        let ts: libc::timespec = if let Ok(ts) = libc::timespec::try_from(simtime) {
-            ts
-        } else {
+        let Ok(ts) = libc::timespec::try_from(simtime) else {
             return false;
         };
         unsafe { std::ptr::write(out, ts) };

--- a/src/lib/shim/src/clone.rs
+++ b/src/lib/shim/src/clone.rs
@@ -11,8 +11,8 @@ use crate::tls_allow_native_syscalls;
 /// TODO: replace with `core::ptr::offset_of` once stabilized.
 /// https://github.com/rust-lang/rust/issues/106655
 fn sigcontext_offset_of(base: &sigcontext, field: &u64) -> usize {
-    let base = base as *const _ as usize;
-    let field = field as *const _ as usize;
+    let base = core::ptr::from_ref(base) as usize;
+    let field = core::ptr::from_ref(field) as usize;
     field - base
 }
 
@@ -98,7 +98,7 @@ unsafe extern "C-unwind" fn set_context(ctx: &sigcontext) -> ! {
 
             // Ret to ctx's `rip`
             "ret",
-            in("rax") ctx as *const _,
+            in("rax") core::ptr::from_ref(ctx),
             options(noreturn)
         )
     };

--- a/src/lib/shim/src/lib.rs
+++ b/src/lib/shim/src/lib.rs
@@ -587,7 +587,7 @@ pub mod export {
     /// The returned pointer must not outlive the current thread.
     #[no_mangle]
     pub unsafe extern "C-unwind" fn shim_thisThreadEventIPC() -> *const IPCData {
-        tls_ipc::with(|ipc| ipc as *const _)
+        tls_ipc::with(core::ptr::from_ref)
     }
 
     /// This thread's IPC channel. Panics if it hasn't been initialized yet.
@@ -598,7 +598,7 @@ pub mod export {
     #[no_mangle]
     pub unsafe extern "C-unwind" fn shim_threadSharedMem(
     ) -> *const shadow_shim_helper_rs::shim_shmem::export::ShimShmemThread {
-        tls_thread_shmem::with(|thread| thread as *const _)
+        tls_thread_shmem::with(core::ptr::from_ref)
     }
 
     #[no_mangle]
@@ -627,7 +627,7 @@ pub mod export {
             // We know this pointer will be live for the lifetime of the
             // process, and that we never construct a mutable reference to the
             // underlying data.
-            rv as *const _
+            core::ptr::from_ref(rv)
         })
         .unwrap_or(core::ptr::null())
     }
@@ -641,7 +641,7 @@ pub mod export {
             // We know this pointer will be live for the lifetime of the
             // process, and that we never construct a mutable reference to the
             // underlying data.
-            rv as *const _
+            core::ptr::from_ref(rv)
         })
         .unwrap_or(core::ptr::null())
     }
@@ -653,7 +653,7 @@ pub mod export {
             // We know this pointer will be live for the lifetime of the
             // process, and that we never construct a mutable reference to the
             // underlying data.
-            process as *const _
+            core::ptr::from_ref(process)
         })
     }
 

--- a/src/lib/shim/src/signals.rs
+++ b/src/lib/shim/src/signals.rs
@@ -247,7 +247,7 @@ pub unsafe fn process_signals(mut ucontext: Option<&mut ucontext>) -> bool {
             action,
             ctx: ucontext
                 .as_mut()
-                .map(|c| *c as *mut ucontext)
+                .map(|c| core::ptr::from_mut(*c))
                 .unwrap_or(core::ptr::null_mut()),
         }));
         assert!(prev.is_none());

--- a/src/lib/shmem/src/shmalloc_impl.rs
+++ b/src/lib/shmem/src/shmalloc_impl.rs
@@ -222,7 +222,7 @@ impl Chunk {
     }
 
     fn get_data_start(&self) -> *const u8 {
-        let p = self as *const Self as *const u8;
+        let p = core::ptr::from_ref(self) as *const u8;
         unsafe { p.add(core::mem::size_of::<Self>()) }
     }
 }
@@ -317,7 +317,7 @@ impl Block {
 
         let data_offset = self.data_offset;
         let alloc_nbytes = self.alloc_nbytes;
-        let block = self as *const Block as *const u8;
+        let block = core::ptr::from_ref(self) as *const u8;
         assert!(!block.is_null());
 
         let data_begin = unsafe { block.add(data_offset as usize) };
@@ -467,7 +467,7 @@ impl FreelistAllocator {
         alloc_nbytes: usize,
         alloc_alignment: usize,
     ) -> *mut Block {
-        let chunk_start = chunk as *mut Chunk as *mut u8;
+        let chunk_start = core::ptr::from_mut(chunk) as *mut u8;
         let chunk_end = unsafe { chunk_start.add(chunk.chunk_nbytes) };
 
         let data_start = unsafe { chunk.get_mut_data_start().add(chunk.data_cur as usize) };

--- a/src/lib/shmem/src/shmalloc_impl.rs
+++ b/src/lib/shmem/src/shmalloc_impl.rs
@@ -218,7 +218,7 @@ struct Chunk {
 
 impl Chunk {
     fn get_mut_data_start(&mut self) -> *mut u8 {
-        self.get_data_start() as *mut u8
+        self.get_data_start().cast_mut()
     }
 
     fn get_data_start(&self) -> *const u8 {
@@ -338,7 +338,7 @@ impl Block {
         let x = self.get_ref();
         let nelems = x.len();
         let x_ptr: *const T = x.as_ptr();
-        unsafe { core::slice::from_raw_parts_mut(x_ptr as *mut T, nelems) }
+        unsafe { core::slice::from_raw_parts_mut(x_ptr.cast_mut(), nelems) }
     }
 }
 

--- a/src/lib/vasi-sync/src/sync.rs
+++ b/src/lib/vasi-sync/src/sync.rs
@@ -130,7 +130,7 @@ pub fn futex_wait(futex_word: &AtomicU32, val: u32) -> rustix::io::Result<usize>
             return Err(rustix::io::Errno::AGAIN);
         }
         let condvar = hashmap
-            .entry(futex_word as *const _ as usize)
+            .entry(std::ptr::from_ref(futex_word) as usize)
             .or_insert(Arc::new(Condvar::new()))
             .clone();
         // We could get a spurious wakeup here, but that's ok.
@@ -150,7 +150,7 @@ pub fn futex_wake_one(futex_word: &AtomicU32) -> rustix::io::Result<()> {
     #[cfg(loom)]
     {
         let hashmap = FUTEXES.lock().unwrap();
-        let Some(condvar) = hashmap.get(&(futex_word as *const _ as usize)) else {
+        let Some(condvar) = hashmap.get(&(std::ptr::from_ref(futex_word) as usize)) else {
             return Ok(());
         };
         condvar.notify_one();
@@ -177,7 +177,7 @@ pub fn futex_wake_all(futex_word: &AtomicU32) -> rustix::io::Result<()> {
     #[cfg(loom)]
     {
         let hashmap = FUTEXES.lock().unwrap();
-        let Some(condvar) = hashmap.get(&(futex_word as *const _ as usize)) else {
+        let Some(condvar) = hashmap.get(&(std::ptr::from_ref(futex_word) as usize)) else {
             return Ok(());
         };
         condvar.notify_all();

--- a/src/main/core/sim_config.rs
+++ b/src/main/core/sim_config.rs
@@ -221,7 +221,7 @@ fn build_host(
 
     // hostname hash is used as part of the host's seed
     let hostname_hash = {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        let mut hasher = std::hash::DefaultHasher::new();
         hostname.hash(&mut hasher);
         hasher.finish()
     };

--- a/src/main/core/work/task.rs
+++ b/src/main/core/work/task.rs
@@ -52,7 +52,6 @@ impl PartialEq for TaskRef {
     fn eq(&self, other: &Self) -> bool {
         self.magic.debug_check();
         other.magic.debug_check();
-        #[allow(clippy::vtable_address_comparisons)]
         Arc::ptr_eq(&self.inner, &other.inner)
     }
 }

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -493,7 +493,7 @@ impl Worker {
     pub fn resolve_name_to_ip(name: &std::ffi::CStr) -> Option<std::net::Ipv4Addr> {
         Worker::with_dns(|dns| {
             let addr = unsafe {
-                cshadow::dns_resolveNameToAddress(std::ptr::from_ref(dns) as *mut _, name.as_ptr())
+                cshadow::dns_resolveNameToAddress(std::ptr::from_ref(dns).cast_mut(), name.as_ptr())
             };
             if addr.is_null() {
                 return None;

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -493,7 +493,7 @@ impl Worker {
     pub fn resolve_name_to_ip(name: &std::ffi::CStr) -> Option<std::net::Ipv4Addr> {
         Worker::with_dns(|dns| {
             let addr = unsafe {
-                cshadow::dns_resolveNameToAddress(dns as *const _ as *mut _, name.as_ptr())
+                cshadow::dns_resolveNameToAddress(std::ptr::from_ref(dns) as *mut _, name.as_ptr())
             };
             if addr.is_null() {
                 return None;
@@ -663,7 +663,7 @@ mod export {
 
     #[no_mangle]
     pub extern "C-unwind" fn worker_getDNS() -> *mut cshadow::DNS {
-        Worker::with_dns(|dns| dns as *const cshadow::DNS).cast_mut()
+        Worker::with_dns(std::ptr::from_ref).cast_mut()
     }
 
     /// Addresses must be provided in network byte order.
@@ -705,7 +705,7 @@ mod export {
     /// SAFETY: The returned pointer must not be accessed after this worker thread has exited.
     #[no_mangle]
     pub unsafe extern "C-unwind" fn worker_getChildPidWatcher() -> *const ChildPidWatcher {
-        Worker::with(|w| w.shared.child_pid_watcher() as *const _).unwrap()
+        Worker::with(|w| std::ptr::from_ref(w.shared.child_pid_watcher())).unwrap()
     }
 
     /// Implementation for counting allocated objects. Do not use this function directly.
@@ -773,7 +773,7 @@ mod export {
     /// invalidated the next time the worker switches hosts.
     #[no_mangle]
     pub extern "C-unwind" fn worker_getCurrentHost() -> *const Host {
-        Worker::with_active_host(|h| h as *const _).unwrap()
+        Worker::with_active_host(std::ptr::from_ref).unwrap()
     }
 
     /// Returns a pointer to the current running process. The returned pointer is
@@ -782,14 +782,14 @@ mod export {
     pub extern "C-unwind" fn worker_getCurrentProcess() -> *const Process {
         // We can't use `with_active_process` here since that returns the &Process instead
         // of the enclosing &Process.
-        Worker::with_active_process(|process| process as *const _).unwrap()
+        Worker::with_active_process(std::ptr::from_ref).unwrap()
     }
 
     /// Returns a pointer to the current running thread. The returned pointer is
     /// invalidated the next time the worker switches threads.
     #[no_mangle]
     pub extern "C-unwind" fn worker_getCurrentThread() -> *const Thread {
-        Worker::with_active_thread(|thread| thread as *const _).unwrap()
+        Worker::with_active_thread(std::ptr::from_ref).unwrap()
     }
 
     /// Maximum time that the current event may run ahead to. Must only be called if we hold the

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -134,13 +134,15 @@ impl DescriptorTable {
         // *using* `self.available_indices` instead.
         self.available_indices.remove(&index.val());
 
-        if let Some(prev) = self.descriptors.insert(index, descriptor) {
+        let prev = self.descriptors.insert(index, descriptor);
+
+        if prev.is_some() {
             trace!("Overwriting index {}", index);
-            Some(prev)
         } else {
             trace!("Setting to unused index {}", index);
-            None
         }
+
+        prev
     }
 
     /// Register a descriptor and return its fd handle. Equivalent to

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -786,7 +786,7 @@ mod export {
     pub extern "C-unwind" fn openfile_drop(file: *const OpenFile) {
         assert!(!file.is_null());
 
-        drop(unsafe { Box::from_raw(file as *mut OpenFile) });
+        drop(unsafe { Box::from_raw(file.cast_mut()) });
     }
 
     /// Get the state of the `OpenFile` object.
@@ -865,7 +865,7 @@ mod export {
     pub extern "C-unwind" fn file_drop(file: *const File) {
         assert!(!file.is_null());
 
-        drop(unsafe { Box::from_raw(file as *mut File) });
+        drop(unsafe { Box::from_raw(file.cast_mut()) });
     }
 
     /// Increment the ref count of the `File` object. The returned pointer will not be the same as

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -619,7 +619,7 @@ mod export {
 
         let socket = unsafe { socket.as_ref() }.unwrap();
 
-        let mut s = std::collections::hash_map::DefaultHasher::new();
+        let mut s = std::hash::DefaultHasher::new();
         socket.hash(&mut s);
         s.finish()
     }

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -1256,7 +1256,7 @@ mod export {
         let host = unsafe { host.as_ref().unwrap() };
         let virtual_pid = ProcessId::try_from(virtual_pid).unwrap();
         host.process_borrow(virtual_pid)
-            .map(|x| &*x.borrow(host.root()) as *const _)
+            .map(|x| std::ptr::from_ref(&*x.borrow(host.root())))
             .unwrap_or(std::ptr::null_mut())
     }
 
@@ -1289,7 +1289,7 @@ mod export {
                 // explicitly here to ensure a compilation error if the type is
                 // changed again to one that would allow mutable references.
                 let thread = thread.borrow(host.root());
-                return &*thread as *const _;
+                return std::ptr::from_ref(&*thread);
             };
         }
         std::ptr::null_mut()

--- a/src/main/host/network/namespace.rs
+++ b/src/main/host/network/namespace.rs
@@ -126,7 +126,7 @@ impl NetworkNamespace {
     pub fn cleanup(&self, dns: &cshadow::DNS) {
         assert!(!self.has_run_cleanup.get());
 
-        let dns = dns as *const cshadow::DNS;
+        let dns = std::ptr::from_ref(dns);
         // deregistering localhost is a no-op, so we skip it
         unsafe {
             cshadow::dns_deregister(dns.cast_mut(), self.default_address.ptr());

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -2130,7 +2130,7 @@ mod export {
         proc: *const Process,
     ) -> *const ShimShmemProcess {
         let proc = unsafe { proc.as_ref().unwrap() };
-        proc.as_runnable().unwrap().shim_shared_mem_block.deref() as *const _
+        std::ptr::from_ref(proc.as_runnable().unwrap().shim_shared_mem_block.deref())
     }
 
     #[no_mangle]

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -680,7 +680,8 @@ impl SyscallHandler {
 
     /// Run a legacy C syscall handler.
     fn legacy_syscall(syscall: LegacySyscallFn, ctx: &mut SyscallContext) -> SyscallResult {
-        let rv: SyscallResult = unsafe { syscall(ctx.handler, ctx.args as *const _) }.into();
+        let rv: SyscallResult =
+            unsafe { syscall(ctx.handler, std::ptr::from_ref(ctx.args)) }.into();
 
         // we need to flush pointers here so that the syscall formatter can reliably borrow process
         // memory without an incompatible borrow
@@ -872,7 +873,7 @@ mod export {
         let sys = unsafe { sys.as_ref() }.unwrap();
         Worker::with_active_host(|h| {
             assert_eq!(h.id(), sys.host_id);
-            h as *const _
+            std::ptr::from_ref(h)
         })
         .unwrap()
     }
@@ -887,7 +888,7 @@ mod export {
         let sys = unsafe { sys.as_ref() }.unwrap();
         Worker::with_active_process(|p| {
             assert_eq!(p.id(), sys.process_id);
-            p as *const _
+            std::ptr::from_ref(p)
         })
         .unwrap()
     }
@@ -902,7 +903,7 @@ mod export {
         let sys = unsafe { sys.as_ref() }.unwrap();
         Worker::with_active_thread(|t| {
             assert_eq!(t.id(), sys.thread_id);
-            t as *const _
+            std::ptr::from_ref(t)
         })
         .unwrap()
     }

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -676,7 +676,7 @@ mod export {
         Worker::with_active_host(|host| {
             let process = host.process_borrow(thread.process_id).unwrap();
             let p: &Process = &process.borrow(host.root());
-            p as *const _
+            std::ptr::from_ref(p)
         })
         .unwrap()
     }
@@ -686,7 +686,7 @@ mod export {
         let thread = unsafe { thread.as_ref().unwrap() };
         Worker::with_active_host(|host| {
             assert_eq!(host.id(), thread.host_id());
-            host as *const _
+            std::ptr::from_ref(host)
         })
         .unwrap()
     }
@@ -761,7 +761,7 @@ mod export {
 
         Worker::with_active_host(
             |host| match thread.descriptor_table_borrow(host).get(handle) {
-                Some(d) => d as *const Descriptor,
+                Some(d) => std::ptr::from_ref(d),
                 None => std::ptr::null(),
             },
         )

--- a/src/main/host/timer.rs
+++ b/src/main/host/timer.rs
@@ -108,9 +108,7 @@ impl Timer {
         host: &Host,
         expire_id: u64,
     ) {
-        let internal = if let Some(internal) = Weak::upgrade(internal_weak) {
-            internal
-        } else {
+        let Some(internal) = Weak::upgrade(internal_weak) else {
             trace!("Expired Timer no longer exists.");
             return;
         };

--- a/src/main/shadow.rs
+++ b/src/main/shadow.rs
@@ -409,7 +409,7 @@ fn set_sched_fifo() -> anyhow::Result<()> {
     param.sched_priority = 1;
 
     let rv = nix::errno::Errno::result(unsafe {
-        libc::sched_setscheduler(0, libc::SCHED_FIFO, &param as *const _)
+        libc::sched_setscheduler(0, libc::SCHED_FIFO, std::ptr::from_ref(&param))
     })
     .context("Could not set kernel SCHED_FIFO")?;
 

--- a/src/main/utility/sockaddr.rs
+++ b/src/main/utility/sockaddr.rs
@@ -104,7 +104,9 @@ impl SockaddrStorage {
         assert_eq_size!(libc::sockaddr_in, nix::sys::socket::SockaddrIn);
         assert_eq_align!(libc::sockaddr_in, nix::sys::socket::SockaddrIn);
 
-        Some(unsafe { &*(&self.addr.inet as *const _ as *const nix::sys::socket::SockaddrIn) })
+        Some(unsafe {
+            &*(std::ptr::from_ref(&self.addr.inet) as *const nix::sys::socket::SockaddrIn)
+        })
     }
 
     /// Get a new `SockaddrStorage` with a copy of the ipv4 socket address.
@@ -132,7 +134,9 @@ impl SockaddrStorage {
         assert_eq_size!(libc::sockaddr_in6, nix::sys::socket::SockaddrIn6);
         assert_eq_align!(libc::sockaddr_in6, nix::sys::socket::SockaddrIn6);
 
-        Some(unsafe { &*(&self.addr.inet6 as *const _ as *const nix::sys::socket::SockaddrIn6) })
+        Some(unsafe {
+            &*(std::ptr::from_ref(&self.addr.inet6) as *const nix::sys::socket::SockaddrIn6)
+        })
     }
 
     /// Get a new `SockaddrStorage` with a copy of the ipv6 socket address.
@@ -520,7 +524,7 @@ mod tests {
             s_addr: libc::INADDR_LOOPBACK.to_be(),
         };
 
-        let ptr = &addr as *const _ as *const MaybeUninit<u8>;
+        let ptr = std::ptr::from_ref(&addr) as *const MaybeUninit<u8>;
         let len = std::mem::size_of_val(&addr).try_into().unwrap();
 
         let addr = unsafe { SockaddrStorage::from_ptr(ptr, len) }.unwrap();
@@ -540,7 +544,7 @@ mod tests {
         addr.sun_path = [1; 108];
         addr.sun_path[..4].copy_from_slice(&[1, 2, 3, 0]);
 
-        let ptr = &addr as *const _ as *const MaybeUninit<u8>;
+        let ptr = std::ptr::from_ref(&addr) as *const MaybeUninit<u8>;
         let len = std::mem::size_of_val(&addr).try_into().unwrap();
 
         let addr = unsafe { SockaddrStorage::from_ptr(ptr, len) }.unwrap();
@@ -561,7 +565,7 @@ mod tests {
             s_addr: libc::INADDR_LOOPBACK.to_be(),
         };
 
-        let ptr = &addr_in as *const _ as *const MaybeUninit<u8>;
+        let ptr = std::ptr::from_ref(&addr_in) as *const MaybeUninit<u8>;
         let len = std::mem::size_of_val(&addr_in).try_into().unwrap();
 
         let addr = unsafe { SockaddrStorage::from_ptr(ptr, len) }.unwrap();
@@ -600,7 +604,7 @@ mod tests {
         addr.sun_path = [1; 108];
         addr.sun_path[..pathname.len()].copy_from_slice(&pathname);
 
-        let ptr = &addr as *const _ as *const MaybeUninit<u8>;
+        let ptr = std::ptr::from_ref(&addr) as *const MaybeUninit<u8>;
         let len_useful_info = memoffset::offset_of!(libc::sockaddr_un, sun_path) + pathname.len();
         let len_useful_info = len_useful_info.try_into().unwrap();
         let len_struct = std::mem::size_of_val(&addr).try_into().unwrap();
@@ -662,7 +666,7 @@ mod tests {
         addr.sun_path[0] = 0;
         addr.sun_path[1..][..name.len()].copy_from_slice(u8_to_i8_slice(&name));
 
-        let ptr = &addr as *const _ as *const MaybeUninit<u8>;
+        let ptr = std::ptr::from_ref(&addr) as *const MaybeUninit<u8>;
 
         // the correct sockaddr length for this abstract unix socket address
         let len_real = memoffset::offset_of!(libc::sockaddr_un, sun_path) + 1 + name.len();
@@ -724,7 +728,7 @@ mod tests {
         addr.sun_family = libc::AF_UNIX as u16;
         addr.sun_path = [1; 108];
 
-        let ptr = &addr as *const _ as *const MaybeUninit<u8>;
+        let ptr = std::ptr::from_ref(&addr) as *const MaybeUninit<u8>;
 
         // the correct sockaddr length for this unnamed unix socket address
         let len_real = memoffset::offset_of!(libc::sockaddr_un, sun_path);

--- a/src/test/clone/test_clone.rs
+++ b/src/test/clone/test_clone.rs
@@ -128,7 +128,7 @@ fn test_bad_flags() -> Result<(), Box<dyn Error>> {
                 &clone_args {
                     stack: stack.top() as u64,
                     stack_size: CLONE_TEST_STACK_NBYTES as u64,
-                    tls: &mut tls as *mut _ as u64,
+                    tls: std::ptr::from_mut(&mut tls) as u64,
                     ..Default::default()
                 }
                 .with_flags(flags),
@@ -375,7 +375,7 @@ fn test_parent(use_clone_parent_flag: bool) -> Result<(), Box<dyn Error>> {
             thread_fn,
             stack.top(),
             flags.bits().try_into().unwrap(),
-            &ppid_channel as *const _ as *mut core::ffi::c_void,
+            std::ptr::from_ref(&ppid_channel) as *mut core::ffi::c_void,
             core::ptr::null_mut::<i32>(),
             &mut tls,
             child_tid.as_ptr(),

--- a/src/test/memory/test_unaligned.rs
+++ b/src/test/memory/test_unaligned.rs
@@ -24,13 +24,13 @@ fn test_unaligned_read() -> Result<(), Box<dyn Error>> {
 
     let src = unsafe {
         std::slice::from_raw_parts(
-            &t as *const libc::timespec as *const u8,
+            std::ptr::from_ref(&t) as *const u8,
             std::mem::size_of::<libc::timeval>(),
         )
     };
     let unaligned_t = unsafe {
         std::slice::from_raw_parts_mut(
-            (&mut buf as *mut libc::timespec as *mut u8).add(1),
+            (std::ptr::from_mut(&mut buf) as *mut u8).add(1),
             std::mem::size_of::<libc::timeval>(),
         )
     };

--- a/src/test/poll/test_poll.rs
+++ b/src/test/poll/test_poll.rs
@@ -58,7 +58,7 @@ fn test_pipe() -> Result<(), String> {
         };
 
         /* First make sure there's nothing there */
-        let mut ready = unsafe { libc::poll(&mut read_poll as *mut libc::pollfd, 1, 100) };
+        let mut ready = unsafe { libc::poll(std::ptr::from_mut(&mut read_poll), 1, 100) };
         match ready.cmp(&0) {
             Ordering::Less => {
                 return Err("error: poll failed".to_string());
@@ -79,7 +79,7 @@ fn test_pipe() -> Result<(), String> {
         read_poll.fd = pfd_read;
         read_poll.events = libc::POLLIN;
         read_poll.revents = 0;
-        ready = unsafe { libc::poll(&mut read_poll as *mut libc::pollfd, 1, 100) };
+        ready = unsafe { libc::poll(std::ptr::from_mut(&mut read_poll), 1, 100) };
         if ready != 1 {
             return Err(format!("error: poll returned {} instead of 1", ready));
         }
@@ -106,7 +106,7 @@ fn test_regular_file() -> Result<(), String> {
             events: libc::POLLIN,
             revents: 0,
         };
-        let ready = unsafe { libc::poll(&mut read_poll as *mut libc::pollfd, 1, 100) };
+        let ready = unsafe { libc::poll(std::ptr::from_mut(&mut read_poll), 1, 100) };
         match ready.cmp(&0) {
             Ordering::Less => {
                 return Err("error: poll on empty file failed".to_string());
@@ -143,7 +143,7 @@ fn test_regular_file() -> Result<(), String> {
             events: libc::POLLIN,
             revents: 0,
         };
-        let ready = unsafe { libc::poll(&mut read_poll as *mut libc::pollfd, 1, 100) };
+        let ready = unsafe { libc::poll(std::ptr::from_mut(&mut read_poll), 1, 100) };
         if ready != 1 {
             return Err(format!("error: poll returned {} instead of 1", ready));
         }
@@ -199,7 +199,7 @@ fn test_poll_args_common(
         let pfd_ptr = if pfd_null {
             std::ptr::null_mut()
         } else {
-            &mut pfd as *mut _
+            std::ptr::from_mut(&mut pfd)
         };
 
         // Our expected errno

--- a/src/test/select/test_select.rs
+++ b/src/test/select/test_select.rs
@@ -60,7 +60,7 @@ fn test_pipe() -> Result<(), String> {
         let mut ready = unsafe {
             libc::select(
                 pfd_read + 1,
-                &mut readfds as *mut libc::fd_set,
+                std::ptr::from_mut(&mut readfds),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
                 &mut libc::timeval {
@@ -94,7 +94,7 @@ fn test_pipe() -> Result<(), String> {
         ready = unsafe {
             libc::select(
                 pfd_read + 1,
-                &mut readfds as *mut libc::fd_set,
+                std::ptr::from_mut(&mut readfds),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
                 &mut libc::timeval {
@@ -140,7 +140,7 @@ fn test_regular_file() -> Result<(), String> {
         let ready = unsafe {
             libc::select(
                 fd + 1,
-                &mut readfds as *mut libc::fd_set,
+                std::ptr::from_mut(&mut readfds),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
                 &mut libc::timeval {
@@ -189,7 +189,7 @@ fn test_regular_file() -> Result<(), String> {
         let ready = unsafe {
             libc::select(
                 fd + 1,
-                &mut readfds as *mut libc::fd_set,
+                std::ptr::from_mut(&mut readfds),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
                 &mut libc::timeval {
@@ -282,17 +282,17 @@ fn test_select_args_common(
         let readfds_ptr = if readfds_null {
             std::ptr::null_mut()
         } else {
-            &mut readfds as *mut libc::fd_set
+            std::ptr::from_mut(&mut readfds)
         };
         let writefds_ptr = if writefds_null {
             std::ptr::null_mut()
         } else {
-            &mut writefds as *mut libc::fd_set
+            std::ptr::from_mut(&mut writefds)
         };
         let exceptfds_ptr = if exceptfds_null {
             std::ptr::null_mut()
         } else {
-            &mut exceptfds as *mut libc::fd_set
+            std::ptr::from_mut(&mut exceptfds)
         };
 
         // Our expected errno

--- a/src/test/socket/bind/test_bind_in_new_process.rs
+++ b/src/test/socket/bind/test_bind_in_new_process.rs
@@ -19,7 +19,7 @@ fn main() {
     let rv = unsafe {
         libc::bind(
             fd,
-            &addr as *const _ as *const libc::sockaddr,
+            std::ptr::from_ref(&addr) as *const libc::sockaddr,
             std::mem::size_of_val(&addr) as u32,
         )
     };

--- a/src/test/socket/connect/test_connect.rs
+++ b/src/test/socket/connect/test_connect.rs
@@ -529,7 +529,7 @@ fn test_two_sockets_same_port(sock_type: libc::c_int, flags: libc::c_int) -> Res
             let rv = unsafe {
                 libc::getsockname(
                     fd_client,
-                    &mut client_addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
+                    std::ptr::from_mut(&mut client_addr) as *mut libc::sockaddr,
                     &mut client_addr_len,
                 )
             };
@@ -543,7 +543,7 @@ fn test_two_sockets_same_port(sock_type: libc::c_int, flags: libc::c_int) -> Res
             let rv = Errno::result(unsafe {
                 libc::bind(
                     fd_other,
-                    &client_addr as *const libc::sockaddr_in as *const libc::sockaddr,
+                    std::ptr::from_ref(&client_addr) as *const libc::sockaddr,
                     client_addr_len,
                 )
             });
@@ -584,7 +584,7 @@ fn test_interface(
         let rv = unsafe {
             libc::bind(
                 fd_server,
-                &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
+                std::ptr::from_ref(&server_addr) as *const libc::sockaddr,
                 std::mem::size_of_val(&server_addr) as u32,
             )
         };
@@ -597,8 +597,8 @@ fn test_interface(
         let rv = unsafe {
             libc::getsockname(
                 fd_server,
-                &mut server_addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
-                &mut server_addr_size as *mut libc::socklen_t,
+                std::ptr::from_mut(&mut server_addr) as *mut libc::sockaddr,
+                std::ptr::from_mut(&mut server_addr_size),
             )
         };
         assert_eq!(rv, 0);
@@ -662,7 +662,7 @@ fn test_double_connect(
         let rv = unsafe {
             libc::bind(
                 fd_server,
-                &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
+                std::ptr::from_ref(&server_addr) as *const libc::sockaddr,
                 std::mem::size_of_val(&server_addr) as u32,
             )
         };
@@ -675,8 +675,8 @@ fn test_double_connect(
         let rv = unsafe {
             libc::getsockname(
                 fd_server,
-                &mut server_addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
-                &mut server_addr_size as *mut libc::socklen_t,
+                std::ptr::from_mut(&mut server_addr) as *mut libc::sockaddr,
+                std::ptr::from_mut(&mut server_addr_size),
             )
         };
         assert_eq!(rv, 0);

--- a/src/test/socket/getpeername/test_getpeername.rs
+++ b/src/test/socket/getpeername/test_getpeername.rs
@@ -915,8 +915,8 @@ fn compare_sockname_peername(
         let rv = unsafe {
             libc::getsockname(
                 fd_sockname,
-                &mut sockname_addr as *mut libc::sockaddr_storage as *mut libc::sockaddr,
-                &mut sockname_len as *mut libc::socklen_t,
+                std::ptr::from_mut(&mut sockname_addr) as *mut libc::sockaddr,
+                std::ptr::from_mut(&mut sockname_len),
             )
         };
         assert_eq!(rv, 0);
@@ -936,8 +936,8 @@ fn compare_sockname_peername(
         let rv = unsafe {
             libc::getpeername(
                 fd_peername,
-                &mut peername_addr as *mut libc::sockaddr_storage as *mut libc::sockaddr,
-                &mut peername_len as *mut libc::socklen_t,
+                std::ptr::from_mut(&mut peername_addr) as *mut libc::sockaddr,
+                std::ptr::from_mut(&mut peername_len),
             )
         };
         assert_eq!(rv, 0);

--- a/src/test/socket/send_recv/test_send_recv.rs
+++ b/src/test/socket/send_recv/test_send_recv.rs
@@ -1560,8 +1560,8 @@ fn test_recv_addr(
         unsafe {
             libc::getsockname(
                 fd_client,
-                &mut client_addr as *mut _ as *mut _,
-                &mut client_addr_len as *mut _ as *mut _,
+                std::ptr::from_mut(&mut client_addr) as *mut _,
+                std::ptr::from_mut(&mut client_addr_len) as *mut _,
             )
         },
         0
@@ -2065,7 +2065,7 @@ fn test_bound_to_inaddr_any(
         // bind on the autobind address
         {
             let server_addr_len = std::mem::size_of_val(&server_addr) as libc::socklen_t;
-            let server_addr = &mut server_addr as *mut _ as *mut libc::sockaddr;
+            let server_addr = std::ptr::from_mut(&mut server_addr) as *mut libc::sockaddr;
 
             let rv = unsafe { libc::bind(fd, server_addr, server_addr_len) };
             assert_eq!(rv, 0);
@@ -2074,7 +2074,7 @@ fn test_bound_to_inaddr_any(
         // get the assigned address
         {
             let mut server_addr_len = std::mem::size_of_val(&server_addr) as libc::socklen_t;
-            let server_addr = &mut server_addr as *mut _ as *mut libc::sockaddr;
+            let server_addr = std::ptr::from_mut(&mut server_addr) as *mut libc::sockaddr;
 
             let rv = unsafe { libc::getsockname(fd, server_addr, &mut server_addr_len) };
             assert_eq!(rv, 0);

--- a/src/test/socket/send_recv/test_send_recv.rs
+++ b/src/test/socket/send_recv/test_send_recv.rs
@@ -1150,8 +1150,8 @@ fn test_nonblocking_stream(
         assert!(!test_utils::is_readable(fd_peer, 0).unwrap());
         simple_recvfrom_helper(sys_method, fd_peer, &mut [0u8; 10], &[libc::EAGAIN], false)?;
 
-        let mut send_hash = std::collections::hash_map::DefaultHasher::new();
-        let mut recv_hash = std::collections::hash_map::DefaultHasher::new();
+        let mut send_hash = std::hash::DefaultHasher::new();
+        let mut recv_hash = std::hash::DefaultHasher::new();
 
         let mut send_rng = rand::rngs::SmallRng::seed_from_u64(0);
 

--- a/src/test/socket/shutdown/test_shutdown.rs
+++ b/src/test/socket/shutdown/test_shutdown.rs
@@ -228,7 +228,7 @@ fn setup_stream_sockets(domain: libc::c_int, flag: libc::c_int) -> (libc::c_int,
         let rv = unsafe {
             libc::getsockname(
                 fd_listener,
-                &mut addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
+                std::ptr::from_mut(&mut addr) as *mut libc::sockaddr,
                 &mut addr_len,
             )
         };
@@ -242,7 +242,7 @@ fn setup_stream_sockets(domain: libc::c_int, flag: libc::c_int) -> (libc::c_int,
         let rv = unsafe {
             libc::connect(
                 fd_client,
-                &addr as *const libc::sockaddr_in as *const libc::sockaddr,
+                std::ptr::from_ref(&addr) as *const libc::sockaddr,
                 std::mem::size_of_val(&addr) as u32,
             )
         };
@@ -283,7 +283,7 @@ fn setup_dgram_sockets(domain: libc::c_int, flag: libc::c_int) -> (libc::c_int, 
         let rv = unsafe {
             libc::bind(
                 fd_server,
-                &addr as *const libc::sockaddr_in as *const libc::sockaddr,
+                std::ptr::from_ref(&addr) as *const libc::sockaddr,
                 std::mem::size_of_val(&addr) as u32,
             )
         };
@@ -297,7 +297,7 @@ fn setup_dgram_sockets(domain: libc::c_int, flag: libc::c_int) -> (libc::c_int, 
         let rv = unsafe {
             libc::getsockname(
                 fd_server,
-                &mut addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
+                std::ptr::from_mut(&mut addr) as *mut libc::sockaddr,
                 &mut addr_len,
             )
         };
@@ -311,7 +311,7 @@ fn setup_dgram_sockets(domain: libc::c_int, flag: libc::c_int) -> (libc::c_int, 
         let rv = unsafe {
             libc::connect(
                 fd_client,
-                &server_addr as *const libc::sockaddr_in as *const libc::sockaddr,
+                std::ptr::from_ref(&server_addr) as *const libc::sockaddr,
                 std::mem::size_of_val(&server_addr) as u32,
             )
         };
@@ -325,7 +325,7 @@ fn setup_dgram_sockets(domain: libc::c_int, flag: libc::c_int) -> (libc::c_int, 
         let rv = unsafe {
             libc::getsockname(
                 fd_client,
-                &mut addr as *mut libc::sockaddr_in as *mut libc::sockaddr,
+                std::ptr::from_mut(&mut addr) as *mut libc::sockaddr,
                 &mut addr_len,
             )
         };
@@ -339,7 +339,7 @@ fn setup_dgram_sockets(domain: libc::c_int, flag: libc::c_int) -> (libc::c_int, 
         let rv = unsafe {
             libc::connect(
                 fd_server,
-                &client_addr as *const libc::sockaddr_in as *const libc::sockaddr,
+                std::ptr::from_ref(&client_addr) as *const libc::sockaddr,
                 std::mem::size_of_val(&client_addr) as u32,
             )
         };

--- a/src/test/socket/socketpair/test_socketpair.rs
+++ b/src/test/socket/socketpair/test_socketpair.rs
@@ -193,8 +193,8 @@ fn compare_sockname_peername(
         let rv = unsafe {
             libc::getsockname(
                 fd_sockname,
-                &mut sockname_addr as *mut libc::sockaddr_un as *mut libc::sockaddr,
-                &mut size as *mut libc::socklen_t,
+                std::ptr::from_mut(&mut sockname_addr) as *mut libc::sockaddr,
+                std::ptr::from_mut(&mut size),
             )
         };
         assert_eq!(rv, 0);
@@ -213,8 +213,8 @@ fn compare_sockname_peername(
         let rv = unsafe {
             libc::getpeername(
                 fd_peername,
-                &mut peername_addr as *mut libc::sockaddr_un as *mut libc::sockaddr,
-                &mut size as *mut libc::socklen_t,
+                std::ptr::from_mut(&mut peername_addr) as *mut libc::sockaddr,
+                std::ptr::from_mut(&mut size),
             )
         };
         assert_eq!(rv, 0);

--- a/src/test/threads/test_pthreads.rs
+++ b/src/test/threads/test_pthreads.rs
@@ -71,7 +71,7 @@ impl MuxSum {
     /// Get a raw mutable pointer to the inner pthread_mutex_t
     #[inline(always)]
     pub fn mux_ptr(&mut self) -> *mut libc::pthread_mutex_t {
-        &mut self.mux as *mut _
+        std::ptr::from_mut(&mut self.mux)
     }
 }
 
@@ -110,19 +110,19 @@ impl MuxTry {
     /// Returns a mutable pointer to first inner pthread_mutex_t
     #[inline(always)]
     pub fn mux1_ptr(&mut self) -> *mut libc::pthread_mutex_t {
-        &mut self.mux1 as *mut _
+        std::ptr::from_mut(&mut self.mux1)
     }
 
     /// Returns a mutable pointer to second inner pthread_mutex_t
     #[inline(always)]
     pub fn mux2_ptr(&mut self) -> *mut libc::pthread_mutex_t {
-        &mut self.mux2 as *mut _
+        std::ptr::from_mut(&mut self.mux2)
     }
 
     /// Returns a mutable pointer to second inner pthread_mutex_t
     #[inline(always)]
     pub fn cond_ptr(&mut self) -> *mut libc::pthread_cond_t {
-        &mut self.cond as *mut _
+        std::ptr::from_mut(&mut self.cond)
     }
 }
 
@@ -153,7 +153,7 @@ impl Attr {
     /// Returns a mutable pointer to the inner pthread_attr_t
     #[inline(always)]
     pub fn ptr(&mut self) -> *mut libc::pthread_attr_t {
-        &mut self.attr as *mut _
+        std::ptr::from_mut(&mut self.attr)
     }
 }
 
@@ -261,7 +261,7 @@ fn test_make_detached() -> Result<(), String> {
             &mut thread,
             attr.ptr(),
             make_detached,
-            &mut thread_counter as *mut _ as *mut libc::c_void,
+            std::ptr::from_mut(&mut thread_counter) as *mut libc::c_void,
         )
     };
     if rv != 0 {
@@ -301,7 +301,12 @@ fn test_make_joinable() -> Result<(), String> {
 
     /* try to join the threads, checking return value */
     for thread in threads.iter_mut() {
-        unsafe { libc::pthread_join(*thread, &mut rv as *mut _ as *mut *mut libc::c_void) };
+        unsafe {
+            libc::pthread_join(
+                *thread,
+                std::ptr::from_mut(&mut rv) as *mut *mut libc::c_void,
+            )
+        };
         if rv != 1 {
             return Err("pthread_join did not return one".into());
         }
@@ -355,7 +360,7 @@ fn test_mutex_lock() -> Result<(), String> {
                 thread,
                 std::ptr::null_mut(),
                 thread_mutex_lock,
-                &mut ms as *mut _ as *mut libc::c_void,
+                std::ptr::from_mut(&mut ms) as *mut libc::c_void,
             )
         };
         if error < 0 {
@@ -367,7 +372,13 @@ fn test_mutex_lock() -> Result<(), String> {
 
     /* join threads, check their exit values */
     for thread in threads.iter_mut() {
-        if unsafe { libc::pthread_join(*thread, &mut rv as *mut _ as *mut *mut libc::c_void) } < 0 {
+        if unsafe {
+            libc::pthread_join(
+                *thread,
+                std::ptr::from_mut(&mut rv) as *mut *mut libc::c_void,
+            )
+        } < 0
+        {
             return Err("pthread_join failed!".into());
         }
         check_pthread_error(ThreadRetVal::try_from(rv as u32)?)?;
@@ -452,7 +463,7 @@ fn test_mutex_trylock() -> Result<(), String> {
                 thread,
                 null_ptr,
                 thread_mutex_trylock,
-                &mut muxes as *mut _ as *mut libc::c_void,
+                std::ptr::from_mut(&mut muxes) as *mut libc::c_void,
             )
         };
         if error < 0 {
@@ -464,7 +475,13 @@ fn test_mutex_trylock() -> Result<(), String> {
 
     /* join threads, check their exit values */
     for thread in threads.iter_mut() {
-        if unsafe { libc::pthread_join(*thread, &mut rv as *mut _ as *mut *mut libc::c_void) } < 0 {
+        if unsafe {
+            libc::pthread_join(
+                *thread,
+                std::ptr::from_mut(&mut rv) as *mut *mut libc::c_void,
+            )
+        } < 0
+        {
             return Err("pthread_join failed".into());
         }
 

--- a/src/test/threads/test_pthreads.rs
+++ b/src/test/threads/test_pthreads.rs
@@ -319,7 +319,7 @@ fn test_make_joinable() -> Result<(), String> {
 extern "C" fn thread_mutex_lock(data: *mut libc::c_void) -> *mut libc::c_void {
     let mut rv = ThreadRetVal::Success;
 
-    let ms = data as *mut _ as *mut MuxSum;
+    let ms = data as *mut MuxSum;
 
     if ms.is_null() {
         rv = ThreadRetVal::NullThreadArg;
@@ -406,7 +406,7 @@ extern "C" fn thread_mutex_trylock(mx: *mut libc::c_void) -> *mut libc::c_void {
     }
 
     /* Track the number of threads that pass the lock. Should be < NUM_THREADS */
-    let muxes = mx as *mut _ as *mut MuxTry;
+    let muxes = mx as *mut MuxTry;
 
     /* Attempt to lock the mutex */
     if unsafe { libc::pthread_mutex_trylock((*muxes).mux1_ptr()) } == 0 {

--- a/src/test/time/clock_getres/test_clock_getres.rs
+++ b/src/test/time/clock_getres/test_clock_getres.rs
@@ -100,7 +100,7 @@ fn test_clock_getres(
         let resolution_ptr = resolution
             .value
             .as_mut()
-            .map_or(std::ptr::null_mut(), |v| v as *mut libc::timespec);
+            .map_or(std::ptr::null_mut(), std::ptr::from_mut);
         unsafe {
             (
                 libc::clock_getres(clockid.value, resolution_ptr),
@@ -127,7 +127,7 @@ fn test_syscall_clock_getres(
         let resolution_ptr = resolution
             .value
             .as_mut()
-            .map_or(std::ptr::null_mut(), |v| v as *mut libc::timespec);
+            .map_or(std::ptr::null_mut(), std::ptr::from_mut);
         unsafe {
             (
                 libc::syscall(libc::SYS_clock_getres, clockid.value, resolution_ptr),

--- a/src/test/time/clock_gettime/test_clock_gettime.rs
+++ b/src/test/time/clock_gettime/test_clock_gettime.rs
@@ -113,7 +113,7 @@ fn test_clock_gettime(
         let ts_ptr = ts
             .value
             .as_mut()
-            .map_or(std::ptr::null_mut(), |v| v as *mut libc::timespec);
+            .map_or(std::ptr::null_mut(), std::ptr::from_mut);
         unsafe {
             (
                 libc::clock_gettime(clockid.value, ts_ptr),
@@ -140,7 +140,7 @@ fn test_syscall_clock_gettime(
         let ts_ptr = ts
             .value
             .as_mut()
-            .map_or(std::ptr::null_mut(), |v| v as *mut libc::timespec);
+            .map_or(std::ptr::null_mut(), std::ptr::from_mut);
         unsafe {
             (
                 libc::syscall(libc::SYS_clock_gettime, clockid.value, ts_ptr),

--- a/src/test/time/clock_nanosleep/test_clock_nanosleep.rs
+++ b/src/test/time/clock_nanosleep/test_clock_nanosleep.rs
@@ -234,11 +234,11 @@ fn test_return_values(
         let request_ptr = request
             .value
             .as_ref()
-            .map_or(std::ptr::null(), |v| v as *const libc::timespec);
+            .map_or(std::ptr::null(), std::ptr::from_ref);
         let remain_ptr = remain
             .value
             .as_mut()
-            .map_or(std::ptr::null_mut(), |v| v as *mut libc::timespec);
+            .map_or(std::ptr::null_mut(), std::ptr::from_mut);
 
         unsafe {
             (

--- a/src/test/time/nanosleep/test_nanosleep.rs
+++ b/src/test/time/nanosleep/test_nanosleep.rs
@@ -133,12 +133,12 @@ fn test_return_values(
         let request_ptr = request
             .value
             .as_ref()
-            .map_or(std::ptr::null(), |v| v as *const libc::timespec);
+            .map_or(std::ptr::null(), std::ptr::from_ref);
 
         let remain_ptr = remain
             .value
             .as_mut()
-            .map_or(std::ptr::null_mut(), |v| v as *mut libc::timespec);
+            .map_or(std::ptr::null_mut(), std::ptr::from_mut);
 
         unsafe {
             (

--- a/src/test/unistd/test_unistd.rs
+++ b/src/test/unistd/test_unistd.rs
@@ -142,13 +142,8 @@ fn test_getpid_kill() {
         sa_mask: unsafe { std::mem::zeroed() },
         sa_restorer: None,
     };
-    let rv = unsafe {
-        libc::sigaction(
-            libc::SIGUSR1,
-            &x as *const libc::sigaction,
-            std::ptr::null_mut(),
-        )
-    };
+    let rv =
+        unsafe { libc::sigaction(libc::SIGUSR1, std::ptr::from_ref(&x), std::ptr::null_mut()) };
     assert_eq!(rv, 0);
 
     let rv = unsafe { libc::kill(pid as libc::pid_t, libc::SIGUSR1) };


### PR DESCRIPTION
Makes some changes for the [1.76](https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html) release.

The biggest change is from switching `&foo as *const _` and `&mut foo as *mut _` to `std::ptr::from_ref(&foo)` and `std::ptr::from_mut(&mut foo)`. I think the functions will help to avoid errors when casting references to pointers, and make it more clear about what the code is doing. I may have missed some of them, but this should be most. We use a lot of reference to pointer and pointer to pointer casts, so hopefully I got these all right (the tests pass at least).

This also makes some other small changes and upgrades the rust versions used in the CI.