### PR TITLE
Reduce the build time of the tests

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -85,9 +85,6 @@ name = "anyhow"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca87830a3e3fb156dc96cfbd31cb620265dd053be734723f22b760d6cc3c3051"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "atomic_refcell"

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -16,14 +16,14 @@ log = { version = "0.4.20", default-features = false }
 shadow-pod = { path = "../pod" }
 static_assertions = "1.1.0"
 vasi = { path = "../vasi" }
-num_enum = { version = "0.7.1", default-features=false }
+num_enum = { version = "0.7.1", default-features = false }
 memoffset = "0.9.0"
 bytemuck = "1.14.0"
 linux-syscall = "1.0.0"
 linux-errno = "1.0.1"
 naked-function = "0.1.5"
 linux-raw-sys = "0.6.3"
-rustix = { optional=true, version = "0.38.28", default-features=false, features = ["process"] }
+rustix = { optional = true, version = "0.38.28", default-features = false, features = ["process"] }
 
 [dev-dependencies]
 rustix = { version = "0.38.28", default-features=false, features = ["thread", "process", "time"] }

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [features]
 std = []
 rustix = ["dep:rustix"]
+c_bindings = ["dep:shadow-build-common", "dep:cbindgen"]
 
 [dependencies]
 bitflags = "2.4.1"
@@ -28,5 +29,5 @@ rustix = { optional=true, version = "0.38.28", default-features=false, features 
 rustix = { version = "0.38.28", default-features=false, features = ["thread", "process", "time"] }
 
 [build-dependencies]
-shadow-build-common = { path = "../shadow-build-common" }
-cbindgen = { version = "0.26.0", default_features = false }
+shadow-build-common = { optional = true, path = "../shadow-build-common" }
+cbindgen = { optional = true, version = "0.26.0", default_features = false }

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -29,5 +29,5 @@ rustix = { optional=true, version = "0.38.28", default-features=false, features 
 rustix = { version = "0.38.28", default-features=false, features = ["thread", "process", "time"] }
 
 [build-dependencies]
-shadow-build-common = { optional = true, path = "../shadow-build-common" }
+shadow-build-common = { optional = true, path = "../shadow-build-common", features = ["cbindgen"] }
 cbindgen = { optional = true, version = "0.26.0", default_features = false }

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["rustix"]
 std = []
 rustix = ["dep:rustix"]
 

--- a/src/lib/linux-api/build.rs
+++ b/src/lib/linux-api/build.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "c_bindings")]
 use shadow_build_common::ShadowBuildCommon;
 
+#[cfg(feature = "c_bindings")]
 fn run_cbindgen(build_common: &ShadowBuildCommon) {
     let base_config = build_common.cbindgen_base_config();
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -29,7 +31,10 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
 }
 
 fn main() {
-    let build_common =
-        shadow_build_common::ShadowBuildCommon::new(std::path::Path::new("../../.."), None);
-    run_cbindgen(&build_common);
+    #[cfg(feature = "c_bindings")]
+    {
+        let build_common =
+            shadow_build_common::ShadowBuildCommon::new(std::path::Path::new("../../.."), None);
+        run_cbindgen(&build_common);
+    }
 }

--- a/src/lib/log-c2rust/Cargo.toml
+++ b/src/lib/log-c2rust/Cargo.toml
@@ -15,5 +15,5 @@ va_list = { version = "0.1.4", default-features = false }
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
-shadow-build-common = { path = "../shadow-build-common" }
+shadow-build-common = { path = "../shadow-build-common", features = ["cbindgen"] }
 cbindgen = { version = "0.26.0", default_features = false }

--- a/src/lib/logger/Cargo.toml
+++ b/src/lib/logger/Cargo.toml
@@ -13,7 +13,7 @@ cc = { version = "1.0", features = ["parallel"] }
 bindgen = { version = "0.69.1" }
 # Needs to be a build-dependency as well for its generated header files
 # to be present, which our C build needs.
-linux-api = { path = "../linux-api" }
+linux-api = { path = "../linux-api", features = ["c_bindings"] }
 shadow-build-common = { path = "../shadow-build-common" }
 
 [lib]

--- a/src/lib/logger/Cargo.toml
+++ b/src/lib/logger/Cargo.toml
@@ -14,7 +14,7 @@ bindgen = { version = "0.69.1" }
 # Needs to be a build-dependency as well for its generated header files
 # to be present, which our C build needs.
 linux-api = { path = "../linux-api", features = ["c_bindings"] }
-shadow-build-common = { path = "../shadow-build-common" }
+shadow-build-common = { path = "../shadow-build-common", features = ["bindgen"] }
 
 [lib]
 path = "src/lib.rs"

--- a/src/lib/shadow-build-common/Cargo.toml
+++ b/src/lib/shadow-build-common/Cargo.toml
@@ -5,9 +5,14 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["bindgen", "cbindgen"]
+bindgen = ["dep:bindgen"]
+cbindgen = ["dep:cbindgen"]
+
 [dependencies]
-bindgen = { version = "0.69.1" }
-cbindgen = { version = "0.26.0", default_features = false }
+bindgen = { optional = true, version = "0.69.1" }
+cbindgen = { optional = true, version = "0.26.0", default_features = false }
 cc = { version = "1.0", features = ["parallel"] }
 system-deps = "6.2"
 

--- a/src/lib/shadow-build-common/Cargo.toml
+++ b/src/lib/shadow-build-common/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["bindgen", "cbindgen"]
 bindgen = ["dep:bindgen"]
 cbindgen = ["dep:cbindgen"]
 

--- a/src/lib/shadow-build-common/src/lib.rs
+++ b/src/lib/shadow-build-common/src/lib.rs
@@ -73,6 +73,7 @@ impl ShadowBuildCommon {
         b
     }
 
+    #[cfg(feature = "bindgen")]
     pub fn bindgen_builder(&self) -> bindgen::Builder {
         let mut builder = bindgen::Builder::default()
             // Tell cargo to invalidate the built crate whenever any of the
@@ -94,6 +95,7 @@ impl ShadowBuildCommon {
         builder
     }
 
+    #[cfg(feature = "cbindgen")]
     pub fn cbindgen_base_config(&self) -> cbindgen::Config {
         let header = "
 /*
@@ -143,6 +145,7 @@ impl ShadowBuildCommon {
     }
 }
 
+#[cfg(feature = "cbindgen")]
 pub trait CBindgenExt {
     fn get_mut(&mut self) -> &mut cbindgen::Config;
 
@@ -169,6 +172,7 @@ pub trait CBindgenExt {
     }
 }
 
+#[cfg(feature = "cbindgen")]
 impl CBindgenExt for cbindgen::Config {
     fn get_mut(&mut self) -> &mut cbindgen::Config {
         self

--- a/src/lib/shadow-shim-helper-rs/Cargo.toml
+++ b/src/lib/shadow-shim-helper-rs/Cargo.toml
@@ -27,7 +27,7 @@ bytemuck = "1.14.0"
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
-shadow-build-common = { path = "../shadow-build-common" }
+shadow-build-common = { path = "../shadow-build-common", features = ["cbindgen"] }
 system-deps = "6.2"
 cbindgen = { version = "0.26.0", default_features = false }
 

--- a/src/lib/shim/Cargo.toml
+++ b/src/lib/shim/Cargo.toml
@@ -37,7 +37,7 @@ test-log = "0.2.14"
 bindgen = { version = "0.69.1" }
 cbindgen = { version = "0.26.0", default_features = false }
 cc = { version = "1.0", features = ["parallel"] }
-shadow-build-common = { path = "../shadow-build-common" }
+shadow-build-common = { path = "../shadow-build-common", features = ["bindgen", "cbindgen"] }
 # Building the C code from this crate's build script requires
 # that these bindings have been generated.
 shadow-shim-helper-rs = { path = "../shadow-shim-helper-rs" }

--- a/src/lib/shim/Cargo.toml
+++ b/src/lib/shim/Cargo.toml
@@ -14,7 +14,7 @@ perf_timers = []
 [dependencies]
 formatting-nostd = { path = "../formatting-nostd" }
 libc = { version = "0.2", default-features = false }
-linux-api = { path = "../linux-api"}
+linux-api = { path = "../linux-api", features = ["rustix"] }
 num_enum = { version = "0.7.1", default-features=false }
 shadow-shim-helper-rs = { path = "../shadow-shim-helper-rs" }
 shadow_shmem = { path = "../shmem" }

--- a/src/lib/tsc/Cargo.toml
+++ b/src/lib/tsc/Cargo.toml
@@ -11,7 +11,7 @@ logger = { path = "../logger" }
 [build-dependencies]
 bindgen = { version = "0.69.1" }
 cc = { version = "1.0", features = ["parallel"] }
-shadow-build-common = { path = "../shadow-build-common" }
+shadow-build-common = { path = "../shadow-build-common", features = ["bindgen", "cbindgen"] }
 system-deps = "6.2"
 cbindgen = { version = "0.26.0", default_features = false }
 

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num_enum = { version = "0.7.1", default-features=false }
-rustix = { version = "0.38.28", default-features = false, features=["fs", "thread", "process"] }
+num_enum = { version = "0.7.1", default-features = false }
+rustix = { version = "0.38.28", default-features = false, features = ["fs", "thread", "process"] }
 static_assertions = "1.1.0"
 vasi = { path = "../vasi" }
-rustc-hash = { version = "1.1.0", default-features=false }
+rustc-hash = { version = "1.1.0", default-features = false }
 
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.5"
-rustix = { version = "0.38.28", default-features = false, features=["process"] }
+rustix = { version = "0.38.28", default-features = false, features = ["process"] }
 libc = "0.2"
-nix =  "0.27.1"
+nix = "0.27.1"
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.7", features = ["checkpoint"] }

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.5.0", features = ["derive", "wrap_help"] }
 crossbeam = "0.8.3"
 gml-parser = { path = "../lib/gml-parser" }
 libc = "0.2"
-linux-api = { path = "../lib/linux-api", features = ["std"] }
+linux-api = { path = "../lib/linux-api", features = ["c_bindings", "std"] }
 # don't log debug or trace levels in release mode
 log = { version = "0.4", features = ["release_max_level_debug"] }
 log-c2rust = { path = "../lib/log-c2rust" }

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 crate-type = ["rlib", "staticlib"]
 
 [dependencies]
-anyhow = { version = "1.0.78", features = ["backtrace"] }
+anyhow = "1.0.78"
 atomic_refcell = "0.1"
 backtrace = "0.3.69"
 bitflags = "2.4"

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -71,7 +71,7 @@ bytemuck = "1.14.0"
 perf_timers = []
 
 [build-dependencies]
-shadow-build-common = { path = "../lib/shadow-build-common" }
+shadow-build-common = { path = "../lib/shadow-build-common", features = ["bindgen", "cbindgen"] }
 bindgen = { version = "0.69.1" }
 cbindgen = { version = "0.26.0", default_features = false }
 cc = { version = "1.0", features = ["parallel"] }

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -223,8 +223,8 @@ libc = "0.2"
 linux-api = { path = "../lib/linux-api", features = ["rustix", "std"] }
 neli = "0.6.4"
 nix = { version = "0.26.4", features = ["event", "feature", "fs", "poll", "process", "sched", "signal", "socket", "uio"] }
-rand = { version="0.8.5", features=["small_rng"] }
-rustix = { version = "0.38.28", default-features=false, features=["fs", "mm", "pipe", "time", "thread"]}
+rand = { version = "0.8.5", features = ["small_rng"] }
+rustix = { version = "0.38.28", default-features = false, features = ["fs", "mm", "pipe", "time", "thread"] }
 signal-hook = "0.3.17"
 once_cell = "1.19.0"
 vasi-sync = { path = "../lib/vasi-sync" }

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -220,7 +220,7 @@ path = "prctl/test_prctl.rs"
 anyhow = { version = "1.0.78", features = ["backtrace"] }
 formatting-nostd = { path = "../lib/formatting-nostd" }
 libc = "0.2"
-linux-api = { path = "../lib/linux-api", features  = ["std"] }
+linux-api = { path = "../lib/linux-api", features = ["rustix", "std"] }
 neli = "0.6.4"
 nix = { version = "0.26.4", features = ["event", "feature", "fs", "poll", "process", "sched", "signal", "socket", "uio"] }
 rand = { version="0.8.5", features=["small_rng"] }

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -217,7 +217,7 @@ name = "test_prctl"
 path = "prctl/test_prctl.rs"
 
 [dependencies]
-anyhow = { version = "1.0.78", features = ["backtrace"] }
+anyhow = "1.0.78"
 formatting-nostd = { path = "../lib/formatting-nostd" }
 libc = "0.2"
 linux-api = { path = "../lib/linux-api", features = ["rustix", "std"] }


### PR DESCRIPTION
When building the tests we also build extra stuff that we don't need, for example the linux-api C bindings. This PR reduces the build time of the tests from 66 seconds to 42 seconds (207 compilation units to 150) when built with `./setup build --test`, as documented in the report from `cargo build --timings`. The next most problematic crates are the linux-api, vasi-sync, formatting-nostd/toml-edit, and neli crates due to their use of syn and related proc macros, but there's not much we can do about those.

Partial graph of the time taken by the test crates after this PR:

![1710128104_grim](https://github.com/shadow/shadow/assets/3708797/d457e80f-26ea-4f22-8eac-4acca11327b2)