### PR TITLE
Show warning if Go 1.21.x is installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,13 @@ include(FindPkgConfig)
 # Keep consistent with Cargo files that pull in glib: `git grep glib -- '*/Cargo.toml'`
 pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0>=2.58)
 
+## show a warning if Go is installed and is version 1.21.x
+execute_process(COMMAND bash -c "go version | { read _ _ v _; echo \${v#go}; }" OUTPUT_VARIABLE GO_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+if(GO_VERSION MATCHES "^1.21.")
+    # https://github.com/shadow/shadow/issues/3267
+    message(WARNING "Go version '${GO_VERSION}' is not supported. If running Shadow's extra tests, the Go-based extra tests will fail. See issue #3267.")
+endif()
+
 include(CheckSymbolExists)
 list(APPEND CMAKE_REQUIRED_INCLUDES ${GLIB_INCLUDE_DIRS})
 list(APPEND CMAKE_REQUIRED_LIBRARIES ${GLIB_LIBRARIES})


### PR DESCRIPTION
This adds a CMake warning if Go 1.21.x is installed when building Shadow. I don't see a nice way of enabling this check only when the `--extra` flag is used, so we need to always perform this check even if the `--extra` flag isn't used. For this reason I've made it a warning rather than an error. For example:

```text
$ ./setup build --test --extra
2024-03-12 23:39:35,595 [INFO] running 'cmake /shadow -DCMAKE_INSTALL_PREFIX=/root/.local -DCMAKE_BUILD_TYPE=Release -DSHADOW_TEST=ON -DCMAKE_PREFIX_PATH=' from '/shadow/build'
-- System name: Linux
-- System version: 5.15.0-91-generic
-- System processor: x86_64
-- CMAKE_MODULE_PATH = /shadow/cmake/
CMake Warning at CMakeLists.txt:82 (MESSAGE):
  Go version '1.21.7' is not supported.  Some extra tests will likely fail.
  See issue #3267.


-- SHADOW_VERSION_FULL=3.1.0
-- SHADOW_VERSION_MAJOR=3
-- SHADOW_VERSION_MINOR=1
-- SHADOW_VERSION_PATCH=0
```

This check is also fine if Go is not installed. In this case you won't see any message in the CMake output. For example:

```text
$  ./setup build --test --extra
2024-03-12 23:38:36,345 [INFO] running 'cmake /shadow -DCMAKE_INSTALL_PREFIX=/root/.local -DCMAKE_BUILD_TYPE=Release -DSHADOW_TEST=ON -DCMAKE_PREFIX_PATH=' from '/shadow/build'
-- System name: Linux
-- System version: 5.15.0-91-generic
-- System processor: x86_64
-- CMAKE_MODULE_PATH = /shadow/cmake/
-- SHADOW_VERSION_FULL=3.1.0
-- SHADOW_VERSION_MAJOR=3
-- SHADOW_VERSION_MINOR=1
-- SHADOW_VERSION_PATCH=0
```

Closes #3267.