### PR TITLE
Fix rust/clippy warnings

### DIFF
--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -39,8 +39,6 @@ impl From<Signal> for i32 {
     }
 }
 
-use core::iter::Iterator;
-
 impl Signal {
     pub const SIGHUP: Self = Self::std_from_u32_const(bindings::LINUX_SIGHUP);
     pub const SIGINT: Self = Self::std_from_u32_const(bindings::LINUX_SIGINT);

--- a/src/lib/linux-api/src/time.rs
+++ b/src/lib/linux-api/src/time.rs
@@ -1,4 +1,3 @@
-use core::result::Result;
 use linux_syscall::syscall;
 use linux_syscall::Result as LinuxSyscallResult;
 use num_enum::{IntoPrimitive, TryFromPrimitive};

--- a/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
@@ -419,9 +419,7 @@ pub mod export {
     use std::sync::atomic::Ordering;
 
     use bytemuck::TransparentWrapper;
-    use linux_api::signal::{
-        linux_sigaction, linux_siginfo_t, linux_sigset_t, linux_stack_t, siginfo_t,
-    };
+    use linux_api::signal::{linux_sigaction, linux_siginfo_t, linux_sigset_t, linux_stack_t};
     use vasi_sync::scmutex::SelfContainedMutexGuard;
 
     use super::*;

--- a/src/lib/shim/src/syscall.rs
+++ b/src/lib/shim/src/syscall.rs
@@ -175,8 +175,6 @@ unsafe fn emulated_syscall_event(
 
 pub mod export {
     use super::*;
-    use shadow_shim_helper_rs::shim_event::ShimEventSyscall;
-    use shadow_shim_helper_rs::syscall_types::{SysCallArgs, SysCallReg};
 
     /// # Safety
     ///

--- a/src/lib/shmem/src/raw_syscall.rs
+++ b/src/lib/shmem/src/raw_syscall.rs
@@ -11,8 +11,6 @@
 // constants. We may also use already-existing definitions for some of the syscalls implemented
 // here.
 
-use core::result::Result;
-
 use linux_api::errno::Errno;
 use linux_syscall::syscall;
 use linux_syscall::Result as LinuxSyscallResult;

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -308,6 +308,7 @@ impl<'a> Manager<'a> {
                 dns: unsafe { SyncSendPointer::new(dns) },
                 num_plugin_errors: AtomicU32::new(0),
                 // allow the status logger's state to be updated from anywhere
+                #[allow(clippy::map_clone)]
                 status_logger_state: status_logger_state.map(Arc::clone),
                 runahead: Runahead::new(
                     self.config.experimental.use_dynamic_runahead.unwrap(),

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{self, Context};
+use anyhow::Context;
 use atomic_refcell::AtomicRefCell;
 use log::warn;
 use rand::seq::SliceRandom;

--- a/src/main/core/work/task.rs
+++ b/src/main/core/work/task.rs
@@ -63,7 +63,7 @@ pub mod export {
     use shadow_shim_helper_rs::{notnull::notnull_mut, HostId};
 
     use super::*;
-    use crate::{host::host::Host, utility::HostTreePointer};
+    use crate::utility::HostTreePointer;
 
     pub type TaskCallbackFunc =
         extern "C-unwind" fn(*const Host, *mut libc::c_void, *mut libc::c_void);

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -659,7 +659,6 @@ mod export {
     use shadow_shim_helper_rs::simulation_time::CSimulationTime;
 
     use super::*;
-    use crate::host::process::Process;
 
     #[no_mangle]
     pub extern "C-unwind" fn worker_getDNS() -> *mut cshadow::DNS {

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -938,7 +938,7 @@ impl Host {
 
     pub fn shim_shmem_lock_borrow_mut(
         &self,
-    ) -> Option<impl Deref<Target = HostShmemProtected> + DerefMut + '_> {
+    ) -> Option<impl DerefMut<Target = HostShmemProtected> + '_> {
         RefMut::filter_map(self.shim_shmem_lock.borrow_mut(), |l| {
             l.as_ref().map(|l| {
                 // SAFETY: Returned object holds a checked borrow of the lock;

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -1034,7 +1034,7 @@ impl Drop for Host {
 }
 
 mod export {
-    use std::{ops::DerefMut, os::raw::c_char, time::Duration};
+    use std::{os::raw::c_char, time::Duration};
 
     use libc::{in_addr_t, in_port_t};
     use rand::{Rng, RngCore};
@@ -1043,8 +1043,7 @@ mod export {
     use super::*;
     use crate::{
         cshadow::{CEmulatedTime, CSimulationTime},
-        host::{process::Process, thread::Thread},
-        network::router::Router,
+        host::thread::Thread,
     };
 
     #[no_mangle]

--- a/src/main/host/managed_thread.rs
+++ b/src/main/host/managed_thread.rs
@@ -13,7 +13,6 @@ use std::sync::{atomic, Arc};
 use linux_api::sched::CloneFlags;
 use log::{debug, error, log_enabled, trace, Level};
 use nix::errno::Errno;
-use scheduler;
 use shadow_shim_helper_rs::ipc::IPCData;
 use shadow_shim_helper_rs::shim_event::{
     ShimEventAddThreadReq, ShimEventAddThreadRes, ShimEventSyscall, ShimEventSyscallComplete,

--- a/src/main/host/network/namespace.rs
+++ b/src/main/host/network/namespace.rs
@@ -167,7 +167,7 @@ impl NetworkNamespace {
     pub fn interface_borrow_mut(
         &self,
         addr: Ipv4Addr,
-    ) -> Option<impl Deref<Target = NetworkInterface> + DerefMut + '_> {
+    ) -> Option<impl DerefMut<Target = NetworkInterface> + '_> {
         // Notes:
         // - The `is_loopback` matches all loopback addresses, but shadow will only work correctly
         //   with 127.0.0.1. Using any other loopback address will lead to problems.

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1943,7 +1943,6 @@ fn make_name(host: &Host, exe_name: &str, id: ProcessId) -> CString {
 }
 
 mod export {
-    use std::ffi::c_char;
     use std::os::raw::c_void;
 
     use libc::size_t;
@@ -1954,9 +1953,6 @@ mod export {
     use shadow_shim_helper_rs::syscall_types::UntypedForeignPtr;
 
     use super::*;
-    use crate::core::worker::Worker;
-    use crate::host::syscall::types::ForeignArrayPtr;
-    use crate::host::thread::Thread;
     use crate::utility::HostTreePointer;
 
     /// Copy `n` bytes from `src` to `dst`. Returns 0 on success or -EFAULT if any of

--- a/src/main/host/syscall/handler/wait.rs
+++ b/src/main/host/syscall/handler/wait.rs
@@ -15,7 +15,7 @@ use crate::host::syscall::types::SyscallError;
 
 enum WaitTarget {
     Pid(ProcessId),
-    PidFd(c_int),
+    PidFd(#[allow(dead_code)] c_int),
     Pgid(ProcessId),
     Any,
 }

--- a/src/main/host/syscall/types.rs
+++ b/src/main/host/syscall/types.rs
@@ -1,6 +1,5 @@
 //! Types used in emulating syscalls.
 
-use std::convert::From;
 use std::marker::PhantomData;
 use std::mem::size_of;
 

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -603,8 +603,6 @@ mod export {
     use crate::host::descriptor::socket::inet::InetSocket;
     use crate::host::descriptor::socket::Socket;
     use crate::host::descriptor::{CompatFile, Descriptor, File};
-    use crate::host::host::Host;
-    use crate::host::process::Process;
 
     /// Make the requested syscall from within the plugin.
     ///

--- a/src/main/shadow.rs
+++ b/src/main/shadow.rs
@@ -9,7 +9,7 @@ use std::io::IsTerminal;
 use std::os::unix::ffi::OsStrExt;
 use std::thread;
 
-use anyhow::{self, Context};
+use anyhow::Context;
 use clap::Parser;
 use nix::sys::{personality, resource, signal};
 use signal_hook::{consts, iterator::Signals};

--- a/src/main/utility/counter.rs
+++ b/src/main/utility/counter.rs
@@ -75,7 +75,7 @@ impl Counter {
     /// Returns the counter value for the key given by id, or 0 if no operations have
     /// been performed on the key.
     pub fn get_value(&self, id: &str) -> i64 {
-        match self.items.get(&id.to_string()) {
+        match self.items.get(id) {
             Some(val) => *val,
             None => 0,
         }
@@ -127,7 +127,7 @@ impl Counter {
     fn sorted_for_display(
         &self,
     ) -> impl IntoIterator<
-        IntoIter = impl Iterator<Item = (&String, &i64)> + ExactSizeIterator,
+        IntoIter = impl ExactSizeIterator<Item = (&String, &i64)>,
         Item = (&String, &i64),
     > {
         // Get the items in a vector so we can sort them.

--- a/src/main/utility/shm_cleanup.rs
+++ b/src/main/utility/shm_cleanup.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use anyhow::{self, Context};
+use anyhow::Context;
 
 pub const SHM_DIR_PATH: &str = "/dev/shm/";
 const PROC_DIR_PATH: &str = "/proc/";

--- a/src/test/signal/test_signals.rs
+++ b/src/test/signal/test_signals.rs
@@ -1,6 +1,5 @@
 use std::arch::asm;
 use std::error::Error;
-use std::iter::Iterator;
 use std::os::unix::io::RawFd;
 use std::sync::mpsc::channel;
 use std::sync::Arc;

--- a/src/test/test_utils.rs
+++ b/src/test/test_utils.rs
@@ -66,10 +66,10 @@ impl<T, E> ShadowTest<T, E> {
 }
 
 /// Runs provided tests until failure and outputs results to stdout.
-pub fn run_tests<'a, I, T: 'a, E: 'a>(tests: I, summarize: bool) -> Result<Vec<T>, E>
+pub fn run_tests<'a, I, T: 'a, E>(tests: I, summarize: bool) -> Result<Vec<T>, E>
 where
     I: IntoIterator<Item = &'a ShadowTest<T, E>>,
-    E: std::fmt::Debug + std::fmt::Display,
+    E: 'a + std::fmt::Debug + std::fmt::Display,
 {
     let mut results = vec![];
 

--- a/src/test/time/mod.rs
+++ b/src/test/time/mod.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use super::*;
 
 /// When we go to sleep, this is the tolerance we allow when checking that we slept the correct


### PR DESCRIPTION
This fixes some rust and clippy warnings in the latest beta (the stable is to be released in a few days) and in rust nightly.