### PR TITLE
Remove Fedora 38 from the CI tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,8 +30,6 @@ jobs:
           - 'debian:11-slim'
           # EOL TBA https://wiki.debian.org/LTS
           - 'debian:12-slim'
-          # EOL May 18 2024 https://endoflife.date/fedora
-          - 'fedora:38'
         cc: ['gcc']
         buildtype: ['release']
         include:


### PR DESCRIPTION
See https://github.com/shadow/shadow/issues/3267#issuecomment-2007940284.

Fedora 38 is EOL on May 18, so our support policy lets us drop this from our supported platforms soon anyways. Since the non-extra tests don't require Go, I don't think we need to update anything in our documentation (for example golang isn't listed as a dependency). We do have a CMake warning at build-time if a broken Go version is installed.

This will also require removing Fedora 38 from the required GitHub tests.