### PR TITLE
Move the `kill` syscall handler to rust

### DIFF
--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -1629,16 +1629,6 @@ mod export {
     }
 
     #[no_mangle]
-    pub extern "C-unwind" fn linux_siginfo_new_for_kill(
-        lsi_signo: i32,
-        sender_pid: i32,
-        sender_uid: u32,
-    ) -> linux_siginfo_t {
-        let signal = Signal::try_from(lsi_signo).unwrap();
-        unsafe { siginfo_t::peel(siginfo_t::new_for_kill(signal, sender_pid, sender_uid)) }
-    }
-
-    #[no_mangle]
     pub unsafe extern "C-unwind" fn linux_kill(pid: i32, sig: i32) -> i32 {
         match kill_raw(pid, sig) {
             Ok(()) => 0,

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1946,7 +1946,6 @@ mod export {
     use std::os::raw::c_void;
 
     use libc::size_t;
-    use linux_api::signal::linux_siginfo_t;
     use log::trace;
     use shadow_shim_helper_rs::notnull::*;
     use shadow_shim_helper_rs::shim_shmem::export::ShimShmemProcess;
@@ -2226,26 +2225,6 @@ mod export {
     ) -> ManagedPhysicalMemoryAddr {
         let proc = unsafe { proc.as_ref().unwrap() };
         proc.physical_address(vptr)
-    }
-
-    /// Send the signal described in `siginfo` to `process`. `currentRunningThread`
-    /// should be set if there is one (e.g. if this is being called from a syscall
-    /// handler), and NULL otherwise (e.g. when called from a timer expiration event).
-    ///
-    /// # Safety
-    ///
-    /// Mandatory fields of `siginfo` must be initd.
-    #[no_mangle]
-    pub unsafe extern "C-unwind" fn process_signal(
-        target_proc: *const Process,
-        current_running_thread: *const Thread,
-        siginfo_t: *const linux_siginfo_t,
-    ) {
-        let target_proc = unsafe { target_proc.as_ref().unwrap() };
-        let current_running_thread = unsafe { current_running_thread.as_ref() };
-        let siginfo_t = unsafe { siginfo_t::wrap_ref_assume_initd(siginfo_t.as_ref().unwrap()) };
-        Worker::with_active_host(|host| target_proc.signal(host, current_running_thread, siginfo_t))
-            .unwrap()
     }
 
     #[no_mangle]

--- a/src/main/host/syscall/handler/signal.h
+++ b/src/main/host/syscall/handler/signal.h
@@ -8,7 +8,6 @@
 
 #include "main/host/syscall/protected.h"
 
-SYSCALL_HANDLER(kill);
 SYSCALL_HANDLER(tgkill);
 SYSCALL_HANDLER(tkill);
 SYSCALL_HANDLER(rt_sigaction);


### PR DESCRIPTION
I changed two `ENOSYS` return values to `ENOTSUP`. I've found it to be confusing when a shadow syscall handler returns `ENOSYS`, so I think `ENOTSUP` is more clear.