### PR TITLE
Rename "SysCall" to "Syscall"

### DIFF
--- a/src/lib/shadow-shim-helper-rs/build.rs
+++ b/src/lib/shadow-shim-helper-rs/build.rs
@@ -27,7 +27,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
             "shd_kernel_sigaction".into(),
             "HostId".into(),
             "SysCallArgs".into(),
-            "SysCallReg".into(),
+            "SyscallReg".into(),
             "ManagedPhysicalMemoryAddr".into(),
         ],
         // we provide our own definition for `UntypedForeignPtr` above

--- a/src/lib/shadow-shim-helper-rs/build.rs
+++ b/src/lib/shadow-shim-helper-rs/build.rs
@@ -26,7 +26,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
         include: vec![
             "shd_kernel_sigaction".into(),
             "HostId".into(),
-            "SysCallArgs".into(),
+            "SyscallArgs".into(),
             "SyscallReg".into(),
             "ManagedPhysicalMemoryAddr".into(),
         ],

--- a/src/lib/shadow-shim-helper-rs/src/shim_event.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_event.rs
@@ -1,13 +1,13 @@
 use shadow_shmem::allocator::ShMemBlockSerialized;
 use vasi::VirtualAddressSpaceIndependent;
 
-use crate::syscall_types::{ForeignPtr, SysCallArgs, SyscallReg, UntypedForeignPtr};
+use crate::syscall_types::{ForeignPtr, SyscallArgs, SyscallReg, UntypedForeignPtr};
 
 #[derive(Copy, Clone, Debug, VirtualAddressSpaceIndependent)]
 #[repr(C)]
 /// Data for [`ShimEventToShim::Syscall`] and [`ShimEventToShadow::Syscall`]
 pub struct ShimEventSyscall {
-    pub syscall_args: SysCallArgs,
+    pub syscall_args: SyscallArgs,
 }
 
 /// Data for [`ShimEventToShim::SyscallComplete`] and [`ShimEventToShadow::SyscallComplete`]

--- a/src/lib/shadow-shim-helper-rs/src/shim_event.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_event.rs
@@ -1,7 +1,7 @@
 use shadow_shmem::allocator::ShMemBlockSerialized;
 use vasi::VirtualAddressSpaceIndependent;
 
-use crate::syscall_types::{ForeignPtr, SysCallArgs, SysCallReg, UntypedForeignPtr};
+use crate::syscall_types::{ForeignPtr, SysCallArgs, SyscallReg, UntypedForeignPtr};
 
 #[derive(Copy, Clone, Debug, VirtualAddressSpaceIndependent)]
 #[repr(C)]
@@ -14,7 +14,7 @@ pub struct ShimEventSyscall {
 #[derive(Copy, Clone, Debug, VirtualAddressSpaceIndependent)]
 #[repr(C)]
 pub struct ShimEventSyscallComplete {
-    pub retval: SysCallReg,
+    pub retval: SyscallReg,
     /// Whether the syscall is eligible to be restarted. Only applicable
     /// when retval is -EINTR. See signal(7).
     pub restartable: bool,

--- a/src/lib/shadow-shim-helper-rs/src/syscall_types.rs
+++ b/src/lib/shadow-shim-helper-rs/src/syscall_types.rs
@@ -220,7 +220,7 @@ impl From<ManagedPhysicalMemoryAddr> for u64 {
 
 #[derive(Copy, Clone, Debug, VirtualAddressSpaceIndependent)]
 #[repr(C)]
-pub struct SysCallArgs {
+pub struct SyscallArgs {
     // SYS_* from sys/syscall.h.
     // (mostly included from
     // /usr/include/x86_64-linux-gnu/bits/syscall.h)
@@ -228,7 +228,7 @@ pub struct SysCallArgs {
     pub args: [SyscallReg; 6],
 }
 
-impl SysCallArgs {
+impl SyscallArgs {
     #[inline]
     pub fn get(&self, i: usize) -> SyscallReg {
         self.args[i]

--- a/src/lib/shadow-shim-helper-rs/src/syscall_types.rs
+++ b/src/lib/shadow-shim-helper-rs/src/syscall_types.rs
@@ -225,12 +225,12 @@ pub struct SysCallArgs {
     // (mostly included from
     // /usr/include/x86_64-linux-gnu/bits/syscall.h)
     pub number: libc::c_long,
-    pub args: [SysCallReg; 6],
+    pub args: [SyscallReg; 6],
 }
 
 impl SysCallArgs {
     #[inline]
-    pub fn get(&self, i: usize) -> SysCallReg {
+    pub fn get(&self, i: usize) -> SyscallReg {
         self.args[i]
     }
     #[inline]
@@ -242,146 +242,146 @@ impl SysCallArgs {
 /// A register used for input/output in a syscall.
 #[derive(Copy, Clone, Eq, VirtualAddressSpaceIndependent)]
 #[repr(C)]
-pub union SysCallReg {
+pub union SyscallReg {
     as_i64: i64,
     as_u64: u64,
     as_ptr: UntypedForeignPtr,
 }
-// SysCallReg and all of its fields must be transmutable with a 64 bit integer.
+// SyscallReg and all of its fields must be transmutable with a 64 bit integer.
 // TODO: Store as a single `u64` and explicitly transmute in the conversion
 // operations.  This requires getting rid of the direct field access in our C
 // code.
-static_assertions::assert_eq_align!(SysCallReg, u64);
-static_assertions::assert_eq_size!(SysCallReg, u64);
+static_assertions::assert_eq_align!(SyscallReg, u64);
+static_assertions::assert_eq_size!(SyscallReg, u64);
 
-impl PartialEq for SysCallReg {
+impl PartialEq for SyscallReg {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         unsafe { self.as_u64 == other.as_u64 }
     }
 }
 
-impl From<u64> for SysCallReg {
+impl From<u64> for SyscallReg {
     #[inline]
     fn from(v: u64) -> Self {
         Self { as_u64: v }
     }
 }
 
-impl From<SysCallReg> for u64 {
+impl From<SyscallReg> for u64 {
     #[inline]
-    fn from(v: SysCallReg) -> u64 {
+    fn from(v: SyscallReg) -> u64 {
         unsafe { v.as_u64 }
     }
 }
 
-impl From<u32> for SysCallReg {
+impl From<u32> for SyscallReg {
     #[inline]
     fn from(v: u32) -> Self {
         Self { as_u64: v as u64 }
     }
 }
 
-impl From<SysCallReg> for u32 {
+impl From<SyscallReg> for u32 {
     #[inline]
-    fn from(v: SysCallReg) -> u32 {
+    fn from(v: SyscallReg) -> u32 {
         (unsafe { v.as_u64 }) as u32
     }
 }
 
-impl From<usize> for SysCallReg {
+impl From<usize> for SyscallReg {
     #[inline]
     fn from(v: usize) -> Self {
         Self { as_u64: v as u64 }
     }
 }
 
-impl From<SysCallReg> for usize {
+impl From<SyscallReg> for usize {
     #[inline]
-    fn from(v: SysCallReg) -> usize {
+    fn from(v: SyscallReg) -> usize {
         unsafe { v.as_u64 as usize }
     }
 }
 
-impl From<isize> for SysCallReg {
+impl From<isize> for SyscallReg {
     #[inline]
     fn from(v: isize) -> Self {
         Self { as_i64: v as i64 }
     }
 }
 
-impl From<SysCallReg> for isize {
+impl From<SyscallReg> for isize {
     #[inline]
-    fn from(v: SysCallReg) -> isize {
+    fn from(v: SyscallReg) -> isize {
         unsafe { v.as_i64 as isize }
     }
 }
 
-impl From<i64> for SysCallReg {
+impl From<i64> for SyscallReg {
     #[inline]
     fn from(v: i64) -> Self {
         Self { as_i64: v }
     }
 }
 
-impl From<SysCallReg> for i64 {
+impl From<SyscallReg> for i64 {
     #[inline]
-    fn from(v: SysCallReg) -> i64 {
+    fn from(v: SyscallReg) -> i64 {
         unsafe { v.as_i64 }
     }
 }
 
-impl From<i32> for SysCallReg {
+impl From<i32> for SyscallReg {
     #[inline]
     fn from(v: i32) -> Self {
         Self { as_i64: v as i64 }
     }
 }
 
-impl From<SysCallReg> for i32 {
+impl From<SyscallReg> for i32 {
     #[inline]
-    fn from(v: SysCallReg) -> i32 {
+    fn from(v: SyscallReg) -> i32 {
         (unsafe { v.as_i64 }) as i32
     }
 }
 
-impl TryFrom<SysCallReg> for u8 {
+impl TryFrom<SyscallReg> for u8 {
     type Error = <u8 as TryFrom<u64>>::Error;
 
     #[inline]
-    fn try_from(v: SysCallReg) -> Result<u8, Self::Error> {
+    fn try_from(v: SyscallReg) -> Result<u8, Self::Error> {
         (unsafe { v.as_u64 }).try_into()
     }
 }
 
-impl TryFrom<SysCallReg> for u16 {
+impl TryFrom<SyscallReg> for u16 {
     type Error = <u16 as TryFrom<u64>>::Error;
 
     #[inline]
-    fn try_from(v: SysCallReg) -> Result<u16, Self::Error> {
+    fn try_from(v: SyscallReg) -> Result<u16, Self::Error> {
         (unsafe { v.as_u64 }).try_into()
     }
 }
 
-impl TryFrom<SysCallReg> for i8 {
+impl TryFrom<SyscallReg> for i8 {
     type Error = <i8 as TryFrom<i64>>::Error;
 
     #[inline]
-    fn try_from(v: SysCallReg) -> Result<i8, Self::Error> {
+    fn try_from(v: SyscallReg) -> Result<i8, Self::Error> {
         (unsafe { v.as_i64 }).try_into()
     }
 }
 
-impl TryFrom<SysCallReg> for i16 {
+impl TryFrom<SyscallReg> for i16 {
     type Error = <i16 as TryFrom<i64>>::Error;
 
     #[inline]
-    fn try_from(v: SysCallReg) -> Result<i16, Self::Error> {
+    fn try_from(v: SyscallReg) -> Result<i16, Self::Error> {
         (unsafe { v.as_i64 }).try_into()
     }
 }
 
-impl<T> From<ForeignPtr<T>> for SysCallReg {
+impl<T> From<ForeignPtr<T>> for SyscallReg {
     #[inline]
     fn from(v: ForeignPtr<T>) -> Self {
         Self {
@@ -390,32 +390,32 @@ impl<T> From<ForeignPtr<T>> for SysCallReg {
     }
 }
 
-impl<T> From<SysCallReg> for ForeignPtr<T> {
+impl<T> From<SyscallReg> for ForeignPtr<T> {
     #[inline]
-    fn from(v: SysCallReg) -> Self {
+    fn from(v: SyscallReg) -> Self {
         // This allows rust to infer the type for the cast. This isn't ideal since we generally want
         // to require that the user be explicit about casts (for example we use the
         // `NoTypeInference` trait on `ForeignPtr::cast`), but we need this type inference so that
-        // `SyscallHandlerFn` can convert the `SysCallReg` to the correct pointer type in syscall
+        // `SyscallHandlerFn` can convert the `SyscallReg` to the correct pointer type in syscall
         // handler arguments.
         (unsafe { v.as_ptr }).cast::<T>()
     }
 }
 
 // Useful for syscalls whose strongly-typed wrappers return some Result<(), ErrType>
-impl From<()> for SysCallReg {
+impl From<()> for SyscallReg {
     #[inline]
-    fn from(_: ()) -> SysCallReg {
-        SysCallReg { as_i64: 0 }
+    fn from(_: ()) -> SyscallReg {
+        SyscallReg { as_i64: 0 }
     }
 }
 
-impl std::fmt::Debug for SysCallReg {
+impl std::fmt::Debug for SyscallReg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // prepare the pointer for formatting
         let as_ptr = DebugFormatter(move |fmt| write!(fmt, "{:p}", unsafe { self.as_ptr }));
 
-        f.debug_struct("SysCallReg")
+        f.debug_struct("SyscallReg")
             .field("as_i64", unsafe { &self.as_i64 })
             .field("as_u64", unsafe { &self.as_u64 })
             .field("as_ptr", &as_ptr)
@@ -423,88 +423,88 @@ impl std::fmt::Debug for SysCallReg {
     }
 }
 
-// implement conversions from `SysCallReg`
+// implement conversions from `SyscallReg`
 
-impl From<SysCallReg> for linux_api::sched::CloneFlags {
-    fn from(value: SysCallReg) -> Self {
+impl From<SyscallReg> for linux_api::sched::CloneFlags {
+    fn from(value: SyscallReg) -> Self {
         Self::from_bits_retain(value.into())
     }
 }
 
-impl From<SysCallReg> for linux_api::fcntl::OFlag {
-    fn from(reg: SysCallReg) -> Self {
+impl From<SyscallReg> for linux_api::fcntl::OFlag {
+    fn from(reg: SyscallReg) -> Self {
         Self::from_bits_retain(reg.into())
     }
 }
 
-impl TryFrom<SysCallReg> for nix::sys::eventfd::EfdFlags {
+impl TryFrom<SyscallReg> for nix::sys::eventfd::EfdFlags {
     type Error = ();
-    fn try_from(reg: SysCallReg) -> Result<Self, Self::Error> {
+    fn try_from(reg: SyscallReg) -> Result<Self, Self::Error> {
         Self::from_bits(reg.into()).ok_or(())
     }
 }
 
-impl TryFrom<SysCallReg> for linux_api::socket::AddressFamily {
+impl TryFrom<SyscallReg> for linux_api::socket::AddressFamily {
     type Error = ();
-    fn try_from(reg: SysCallReg) -> Result<Self, Self::Error> {
+    fn try_from(reg: SyscallReg) -> Result<Self, Self::Error> {
         Ok(u16::try_from(reg).or(Err(()))?.into())
     }
 }
 
-impl TryFrom<SysCallReg> for nix::sys::socket::MsgFlags {
+impl TryFrom<SyscallReg> for nix::sys::socket::MsgFlags {
     type Error = ();
-    fn try_from(reg: SysCallReg) -> Result<Self, Self::Error> {
+    fn try_from(reg: SyscallReg) -> Result<Self, Self::Error> {
         Self::from_bits(reg.into()).ok_or(())
     }
 }
 
-impl TryFrom<SysCallReg> for nix::sys::stat::Mode {
+impl TryFrom<SyscallReg> for nix::sys::stat::Mode {
     type Error = ();
-    fn try_from(reg: SysCallReg) -> Result<Self, Self::Error> {
+    fn try_from(reg: SyscallReg) -> Result<Self, Self::Error> {
         Self::from_bits(reg.into()).ok_or(())
     }
 }
 
-impl From<SysCallReg> for linux_api::mman::ProtFlags {
-    fn from(reg: SysCallReg) -> Self {
+impl From<SyscallReg> for linux_api::mman::ProtFlags {
+    fn from(reg: SyscallReg) -> Self {
         Self::from_bits_retain(reg.into())
     }
 }
 
-impl From<SysCallReg> for linux_api::mman::MapFlags {
-    fn from(reg: SysCallReg) -> Self {
+impl From<SyscallReg> for linux_api::mman::MapFlags {
+    fn from(reg: SyscallReg) -> Self {
         Self::from_bits_retain(reg.into())
     }
 }
 
-impl From<SysCallReg> for linux_api::mman::MRemapFlags {
-    fn from(reg: SysCallReg) -> Self {
+impl From<SyscallReg> for linux_api::mman::MRemapFlags {
+    fn from(reg: SyscallReg) -> Self {
         Self::from_bits_retain(reg.into())
     }
 }
 
-impl TryFrom<SysCallReg> for linux_api::time::ClockId {
+impl TryFrom<SyscallReg> for linux_api::time::ClockId {
     type Error = ();
-    fn try_from(reg: SysCallReg) -> Result<Self, Self::Error> {
+    fn try_from(reg: SyscallReg) -> Result<Self, Self::Error> {
         Self::try_from(i32::from(reg)).map_err(|_| ())
     }
 }
 
-impl From<SysCallReg> for linux_api::time::ClockNanosleepFlags {
-    fn from(reg: SysCallReg) -> Self {
+impl From<SyscallReg> for linux_api::time::ClockNanosleepFlags {
+    fn from(reg: SyscallReg) -> Self {
         Self::from_bits_retain(reg.into())
     }
 }
 
-impl TryFrom<SysCallReg> for linux_api::time::ITimerId {
+impl TryFrom<SyscallReg> for linux_api::time::ITimerId {
     type Error = ();
-    fn try_from(reg: SysCallReg) -> Result<Self, Self::Error> {
+    fn try_from(reg: SyscallReg) -> Result<Self, Self::Error> {
         Self::try_from(i32::from(reg)).map_err(|_| ())
     }
 }
 
-impl From<SysCallReg> for linux_api::prctl::PrctlOp {
-    fn from(reg: SysCallReg) -> Self {
+impl From<SyscallReg> for linux_api::prctl::PrctlOp {
+    fn from(reg: SyscallReg) -> Self {
         Self::new(reg.into())
     }
 }

--- a/src/lib/shim/src/syscall.rs
+++ b/src/lib/shim/src/syscall.rs
@@ -11,7 +11,7 @@ use shadow_shim_helper_rs::shim_event::{
     ShimEventAddThreadRes, ShimEventSyscall, ShimEventSyscallComplete, ShimEventToShadow,
     ShimEventToShim,
 };
-use shadow_shim_helper_rs::syscall_types::{SysCallArgs, SysCallReg};
+use shadow_shim_helper_rs::syscall_types::{SysCallArgs, SyscallReg};
 use shadow_shim_helper_rs::util::time::TimeParts;
 
 use crate::{bindings, global_host_shmem, tls_ipc, tls_thread_shmem};
@@ -19,7 +19,7 @@ use crate::{bindings, global_host_shmem, tls_ipc, tls_thread_shmem};
 /// # Safety
 ///
 /// The specified syscall must be safe to make.
-unsafe fn native_syscall(args: &SysCallArgs) -> SysCallReg {
+unsafe fn native_syscall(args: &SysCallArgs) -> SyscallReg {
     if args.number == libc::SYS_clone {
         panic!("Shouldn't get here. Should have gone through ShimEventAddThreadReq");
     } else if args.number == libc::SYS_exit {
@@ -55,7 +55,7 @@ unsafe fn native_syscall(args: &SysCallArgs) -> SysCallReg {
 unsafe fn emulated_syscall_event(
     mut ctx: Option<&mut ucontext>,
     syscall_event: &ShimEventSyscall,
-) -> SysCallReg {
+) -> SyscallReg {
     log::trace!(
         "sending syscall {} event",
         syscall_event.syscall_args.number
@@ -194,7 +194,7 @@ pub mod export {
                 // than actually provided is sound because any bit pattern is a
                 // valid i64.
                 let arg = unsafe { args.get::<i64>() };
-                SysCallReg::from(arg)
+                SyscallReg::from(arg)
             }),
         };
 
@@ -224,7 +224,7 @@ pub mod export {
                 // than actually provided is sound because any bit pattern is a
                 // valid i64.
                 let arg = unsafe { args.get::<i64>() };
-                SysCallReg::from(arg)
+                SyscallReg::from(arg)
             }),
         };
         // SAFETY: Ensured by caller.

--- a/src/lib/shim/src/syscall.rs
+++ b/src/lib/shim/src/syscall.rs
@@ -11,7 +11,7 @@ use shadow_shim_helper_rs::shim_event::{
     ShimEventAddThreadRes, ShimEventSyscall, ShimEventSyscallComplete, ShimEventToShadow,
     ShimEventToShim,
 };
-use shadow_shim_helper_rs::syscall_types::{SysCallArgs, SyscallReg};
+use shadow_shim_helper_rs::syscall_types::{SyscallArgs, SyscallReg};
 use shadow_shim_helper_rs::util::time::TimeParts;
 
 use crate::{bindings, global_host_shmem, tls_ipc, tls_thread_shmem};
@@ -19,7 +19,7 @@ use crate::{bindings, global_host_shmem, tls_ipc, tls_thread_shmem};
 /// # Safety
 ///
 /// The specified syscall must be safe to make.
-unsafe fn native_syscall(args: &SysCallArgs) -> SyscallReg {
+unsafe fn native_syscall(args: &SyscallArgs) -> SyscallReg {
     if args.number == libc::SYS_clone {
         panic!("Shouldn't get here. Should have gone through ShimEventAddThreadReq");
     } else if args.number == libc::SYS_exit {
@@ -187,7 +187,7 @@ pub mod export {
     ) -> core::ffi::c_long {
         let old_native_syscall_flag = crate::tls_allow_native_syscalls::swap(true);
 
-        let syscall_args = SysCallArgs {
+        let syscall_args = SyscallArgs {
             number: n,
             args: core::array::from_fn(|_| {
                 // SAFETY: syscall args all "fit" in an i64. Reading more arguments
@@ -217,7 +217,7 @@ pub mod export {
         n: core::ffi::c_long,
         mut args: va_list::VaList,
     ) -> core::ffi::c_long {
-        let syscall_args = SysCallArgs {
+        let syscall_args = SyscallArgs {
             number: n,
             args: core::array::from_fn(|_| {
                 // SAFETY: syscall args all "fit" in an i64. Reading more arguments

--- a/src/lib/syscall-logger/src/lib.rs
+++ b/src/lib/syscall-logger/src/lib.rs
@@ -187,9 +187,9 @@ pub fn log_syscall(args: TokenStream, input: TokenStream) -> TokenStream {
             let memory = #context_arg_name.objs.process.memory_borrow();
 
             // Ugly hack to convert the `Result<T, SyscallError>` to a `SyscallResult` (so the `T`
-            // to a `SysCallReg`) without cloning the `SyscallError`. Since we need to convert back
+            // to a `SyscallReg`) without cloning the `SyscallError`. Since we need to convert back
             // to a `Result<T, SyscallError>` later, we keep a copy of the original `Result::Ok(T)`
-            // value. This assumes that `T: Into<SysCallReg> + Clone`.
+            // value. This assumes that `T: Into<SyscallReg> + Clone`.
             let rv_original_ok = rv.as_ref().ok().cloned();
             let rv = rv.map(|x| x.into());
 

--- a/src/lib/syscall-logger/src/lib.rs
+++ b/src/lib/syscall-logger/src/lib.rs
@@ -17,7 +17,7 @@ use quote::ToTokens;
 /// ```compile_fail
 /// # use syscall_logger::log_syscall;
 /// # use shadow_rs::host::syscall::handler::SyscallContext;
-/// # use shadow_rs::host::syscall_types::{SysCallArgs, SyscallError};
+/// # use shadow_rs::host::syscall_types::{SyscallArgs, SyscallError};
 /// struct MyHandler {}
 ///
 /// impl MyHandler {
@@ -31,7 +31,7 @@ use quote::ToTokens;
 /// ```compile_fail
 /// # use syscall_logger::log_syscall;
 /// # use shadow_rs::host::syscall::handler::SyscallContext;
-/// # use shadow_rs::host::syscall_types::{SysCallArgs, SyscallError};
+/// # use shadow_rs::host::syscall_types::{SyscallArgs, SyscallError};
 /// struct MyHandler {}
 ///
 /// impl MyHandler {

--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -283,7 +283,7 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         // Imported from libc crate below
         .blocklist_type("siginfo_t")
         .blocklist_type("SyscallReg")
-        .blocklist_type("SysCallArgs")
+        .blocklist_type("SyscallArgs")
         .blocklist_type("ForeignPtr")
         .blocklist_type("ManagedPhysicalMemoryAddr")
         // we typedef `UntypedForeignPtr` to `ForeignPtr<()>` in rust
@@ -303,7 +303,7 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .raw_line("use crate::utility::legacy_callback_queue::RootedRefCell_StateEventSource;")
         .raw_line("")
         .raw_line("use shadow_shim_helper_rs::HostId;")
-        .raw_line("use shadow_shim_helper_rs::syscall_types::{ManagedPhysicalMemoryAddr, SysCallArgs, UntypedForeignPtr};")
+        .raw_line("use shadow_shim_helper_rs::syscall_types::{ManagedPhysicalMemoryAddr, SyscallArgs, UntypedForeignPtr};")
         .raw_line("#[allow(unused)]")
         .raw_line("use shadow_shim_helper_rs::shim_shmem::{HostShmem, HostShmemProtected, ProcessShmem, ThreadShmem};")
         .raw_line("#[allow(unused)]")

--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -282,7 +282,7 @@ fn run_bindgen(build_common: &ShadowBuildCommon) {
         .blocklist_type("QDiscMode")
         // Imported from libc crate below
         .blocklist_type("siginfo_t")
-        .blocklist_type("SysCallReg")
+        .blocklist_type("SyscallReg")
         .blocklist_type("SysCallArgs")
         .blocklist_type("ForeignPtr")
         .blocklist_type("ManagedPhysicalMemoryAddr")

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -933,7 +933,7 @@ mod export {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::host::syscall::condition::SysCallCondition;
+    use crate::host::syscall::condition::SyscallCondition;
     use crate::host::syscall::types::{
         Blocked, Failed, SyscallError, SyscallReturn, SyscallReturnBlocked, SyscallReturnDone,
     };
@@ -955,7 +955,7 @@ mod tests {
                 restartable: false,
             })),
             Err(SyscallError::Blocked(Blocked {
-                condition: SysCallCondition::new(Trigger::from(c::Trigger {
+                condition: SyscallCondition::new(Trigger::from(c::Trigger {
                     type_: 1,
                     object: c::TriggerObject {
                         as_pointer: std::ptr::null_mut(),
@@ -981,7 +981,7 @@ mod tests {
     // can't call foreign function: syscallcondition_new
     #[cfg_attr(miri, ignore)]
     fn test_syscallreturn_roundtrip() {
-        let condition = SysCallCondition::new(Trigger::from(c::Trigger {
+        let condition = SyscallCondition::new(Trigger::from(c::Trigger {
             type_: 1,
             object: c::TriggerObject {
                 as_pointer: std::ptr::null_mut(),

--- a/src/main/host/managed_thread.rs
+++ b/src/main/host/managed_thread.rs
@@ -24,7 +24,7 @@ use vasi_sync::scchannel::SelfContainedChannelError;
 
 use super::context::ThreadContext;
 use super::host::Host;
-use super::syscall::condition::SysCallCondition;
+use super::syscall::condition::SyscallCondition;
 use crate::core::worker::{Worker, WORKER_SHARED};
 use crate::cshadow;
 use crate::host::syscall::handler::SyscallHandler;
@@ -35,8 +35,8 @@ use crate::utility::{inject_preloads, syscall, verify_plugin_path, VerifyPluginP
 #[derive(Debug)]
 #[must_use]
 pub enum ResumeResult {
-    /// Blocked on a SysCallCondition.
-    Blocked(SysCallCondition),
+    /// Blocked on a SyscallCondition.
+    Blocked(SyscallCondition),
     /// The native thread has exited with the given code.
     ExitedThread(i32),
     /// The thread's process has exited.
@@ -284,7 +284,7 @@ impl ManagedThread {
                     match scr {
                         SyscallReturn::Block(b) => {
                             return ResumeResult::Blocked(unsafe {
-                                SysCallCondition::consume_from_c(b.cond)
+                                SyscallCondition::consume_from_c(b.cond)
                             })
                         }
                         SyscallReturn::Done(d) => self.continue_plugin(

--- a/src/main/host/managed_thread.rs
+++ b/src/main/host/managed_thread.rs
@@ -18,7 +18,7 @@ use shadow_shim_helper_rs::shim_event::{
     ShimEventAddThreadReq, ShimEventAddThreadRes, ShimEventSyscall, ShimEventSyscallComplete,
     ShimEventToShadow, ShimEventToShim,
 };
-use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SysCallArgs, SyscallReg};
+use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SyscallArgs, SyscallReg};
 use shadow_shmem::allocator::ShMemBlock;
 use vasi_sync::scchannel::SelfContainedChannelError;
 
@@ -75,7 +75,7 @@ impl ManagedThread {
     /// Panics if the native thread is dead or dies during the syscall,
     /// including if the syscall itself is SYS_exit or SYS_exit_group.
     pub fn native_syscall(&self, ctx: &ThreadContext, n: i64, args: &[SyscallReg]) -> SyscallReg {
-        let mut syscall_args = SysCallArgs {
+        let mut syscall_args = SyscallArgs {
             number: n,
             args: [SyscallReg::from(0u64); 6],
         };

--- a/src/main/host/managed_thread.rs
+++ b/src/main/host/managed_thread.rs
@@ -18,7 +18,7 @@ use shadow_shim_helper_rs::shim_event::{
     ShimEventAddThreadReq, ShimEventAddThreadRes, ShimEventSyscall, ShimEventSyscallComplete,
     ShimEventToShadow, ShimEventToShim,
 };
-use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SysCallArgs, SysCallReg};
+use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SysCallArgs, SyscallReg};
 use shadow_shmem::allocator::ShMemBlock;
 use vasi_sync::scchannel::SelfContainedChannelError;
 
@@ -74,10 +74,10 @@ impl ManagedThread {
     ///
     /// Panics if the native thread is dead or dies during the syscall,
     /// including if the syscall itself is SYS_exit or SYS_exit_group.
-    pub fn native_syscall(&self, ctx: &ThreadContext, n: i64, args: &[SysCallReg]) -> SysCallReg {
+    pub fn native_syscall(&self, ctx: &ThreadContext, n: i64, args: &[SyscallReg]) -> SyscallReg {
         let mut syscall_args = SysCallArgs {
             number: n,
-            args: [SysCallReg::from(0u64); 6],
+            args: [SyscallReg::from(0u64); 6],
         };
         syscall_args.args[..args.len()].copy_from_slice(args);
         match self.continue_plugin(
@@ -371,7 +371,7 @@ impl ManagedThread {
             ShimEventToShadow::AddThreadRes(ShimEventAddThreadRes { clone_res }) => clone_res,
             r => panic!("Unexpected result: {r:?}"),
         };
-        let clone_res: SysCallReg = syscall::raw_return_value_to_result(clone_res)?;
+        let clone_res: SyscallReg = syscall::raw_return_value_to_result(clone_res)?;
         let child_native_tid = libc::pid_t::from(clone_res);
         trace!("native clone treated tid {child_native_tid}");
 

--- a/src/main/host/syscall/condition.rs
+++ b/src/main/host/syscall/condition.rs
@@ -101,11 +101,11 @@ impl<'a> std::ops::Deref for SyscallConditionRefMut<'a> {
 
 /// An owned syscall condition.
 #[derive(Debug, PartialEq, Eq)]
-pub struct SysCallCondition {
+pub struct SyscallCondition {
     condition: Option<SyscallConditionRefMut<'static>>,
 }
 
-impl SysCallCondition {
+impl SyscallCondition {
     /// "Steal" from a C pointer. i.e. doesn't increase ref count, but will decrease the ref count
     /// when dropped.
     ///
@@ -124,7 +124,7 @@ impl SysCallCondition {
     // TODO: Add support for taking a Timer, ideally after we have a Rust
     // implementation or wrapper.
     pub fn new(trigger: Trigger) -> Self {
-        SysCallCondition {
+        SyscallCondition {
             condition: Some(unsafe {
                 SyscallConditionRefMut::borrow_from_c(cshadow::syscallcondition_new(trigger.into()))
             }),
@@ -136,7 +136,7 @@ impl SysCallCondition {
     ///
     /// Panics if `abs_wakeup_time` is before the current emulated time.
     pub fn new_from_wakeup_time(abs_wakeup_time: EmulatedTime) -> Self {
-        SysCallCondition {
+        SyscallCondition {
             condition: Some(unsafe {
                 SyscallConditionRefMut::borrow_from_c(cshadow::syscallcondition_newWithAbsTimeout(
                     EmulatedTime::to_c_emutime(Some(abs_wakeup_time)),
@@ -152,7 +152,7 @@ impl SysCallCondition {
     }
 }
 
-impl Drop for SysCallCondition {
+impl Drop for SyscallCondition {
     fn drop(&mut self) {
         if let Some(condition) = &self.condition {
             if !condition.c_ptr.ptr().is_null() {
@@ -162,7 +162,7 @@ impl Drop for SysCallCondition {
     }
 }
 
-impl std::ops::Deref for SysCallCondition {
+impl std::ops::Deref for SyscallCondition {
     type Target = SyscallConditionRefMut<'static>;
 
     fn deref(&self) -> &Self::Target {
@@ -170,7 +170,7 @@ impl std::ops::Deref for SysCallCondition {
     }
 }
 
-impl std::ops::DerefMut for SysCallCondition {
+impl std::ops::DerefMut for SyscallCondition {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.condition.as_mut().unwrap()
     }

--- a/src/main/host/syscall/condition.rs
+++ b/src/main/host/syscall/condition.rs
@@ -11,13 +11,13 @@ use crate::host::syscall::Trigger;
 
 /// An immutable reference to a syscall condition.
 #[derive(Debug, PartialEq, Eq)]
-pub struct SysCallConditionRef<'a> {
+pub struct SyscallConditionRef<'a> {
     c_ptr: SendPointer<cshadow::SysCallCondition>,
     _phantom: PhantomData<&'a ()>,
 }
 
 // do not define any mutable methods for this type
-impl<'a> SysCallConditionRef<'a> {
+impl<'a> SyscallConditionRef<'a> {
     /// Borrows from a C pointer. i.e. doesn't increase the ref count, nor decrease the ref count
     /// when dropped.
     ///
@@ -50,12 +50,12 @@ impl<'a> SysCallConditionRef<'a> {
 
 /// A mutable reference to a syscall condition.
 #[derive(Debug, PartialEq, Eq)]
-pub struct SysCallConditionRefMut<'a> {
-    condition: SysCallConditionRef<'a>,
+pub struct SyscallConditionRefMut<'a> {
+    condition: SyscallConditionRef<'a>,
 }
 
-// any immutable methods should be implemented on SysCallConditionRef instead
-impl<'a> SysCallConditionRefMut<'a> {
+// any immutable methods should be implemented on SyscallConditionRef instead
+impl<'a> SyscallConditionRefMut<'a> {
     /// Borrows from a C pointer. i.e. doesn't increase the ref count, nor decrease the ref count
     /// when dropped.
     ///
@@ -66,7 +66,7 @@ impl<'a> SysCallConditionRefMut<'a> {
     pub unsafe fn borrow_from_c(ptr: *mut cshadow::SysCallCondition) -> Self {
         assert!(!ptr.is_null());
         Self {
-            condition: unsafe { SysCallConditionRef::borrow_from_c(ptr) },
+            condition: unsafe { SyscallConditionRef::borrow_from_c(ptr) },
         }
     }
 
@@ -91,8 +91,8 @@ impl<'a> SysCallConditionRefMut<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for SysCallConditionRefMut<'a> {
-    type Target = SysCallConditionRef<'a>;
+impl<'a> std::ops::Deref for SyscallConditionRefMut<'a> {
+    type Target = SyscallConditionRef<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.condition
@@ -102,7 +102,7 @@ impl<'a> std::ops::Deref for SysCallConditionRefMut<'a> {
 /// An owned syscall condition.
 #[derive(Debug, PartialEq, Eq)]
 pub struct SysCallCondition {
-    condition: Option<SysCallConditionRefMut<'static>>,
+    condition: Option<SyscallConditionRefMut<'static>>,
 }
 
 impl SysCallCondition {
@@ -116,7 +116,7 @@ impl SysCallCondition {
     pub unsafe fn consume_from_c(ptr: *mut cshadow::SysCallCondition) -> Self {
         assert!(!ptr.is_null());
         Self {
-            condition: Some(unsafe { SysCallConditionRefMut::borrow_from_c(ptr) }),
+            condition: Some(unsafe { SyscallConditionRefMut::borrow_from_c(ptr) }),
         }
     }
 
@@ -126,7 +126,7 @@ impl SysCallCondition {
     pub fn new(trigger: Trigger) -> Self {
         SysCallCondition {
             condition: Some(unsafe {
-                SysCallConditionRefMut::borrow_from_c(cshadow::syscallcondition_new(trigger.into()))
+                SyscallConditionRefMut::borrow_from_c(cshadow::syscallcondition_new(trigger.into()))
             }),
         }
     }
@@ -138,7 +138,7 @@ impl SysCallCondition {
     pub fn new_from_wakeup_time(abs_wakeup_time: EmulatedTime) -> Self {
         SysCallCondition {
             condition: Some(unsafe {
-                SysCallConditionRefMut::borrow_from_c(cshadow::syscallcondition_newWithAbsTimeout(
+                SyscallConditionRefMut::borrow_from_c(cshadow::syscallcondition_newWithAbsTimeout(
                     EmulatedTime::to_c_emutime(Some(abs_wakeup_time)),
                 ))
             }),
@@ -163,7 +163,7 @@ impl Drop for SysCallCondition {
 }
 
 impl std::ops::Deref for SysCallCondition {
-    type Target = SysCallConditionRefMut<'static>;
+    type Target = SyscallConditionRefMut<'static>;
 
     fn deref(&self) -> &Self::Target {
         self.condition.as_ref().unwrap()

--- a/src/main/host/syscall/formatter.rs
+++ b/src/main/host/syscall/formatter.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use std::marker::PhantomData;
 
 use shadow_shim_helper_rs::emulated_time::EmulatedTime;
-use shadow_shim_helper_rs::syscall_types::SysCallReg;
+use shadow_shim_helper_rs::syscall_types::SyscallReg;
 use shadow_shim_helper_rs::util::time::TimeParts;
 
 use crate::core::worker::Worker;
@@ -59,8 +59,8 @@ pub trait SyscallDisplay {
 /// A syscall argument or return value. It implements [`Display`], and only reads memory and
 /// converts types when being formatted.
 pub struct SyscallVal<'a, T> {
-    pub reg: SysCallReg,
-    pub args: [SysCallReg; 6],
+    pub reg: SyscallReg,
+    pub args: [SyscallReg; 6],
     options: FmtOptions,
     mem: &'a MemoryManager,
     _phantom: PhantomData<T>,
@@ -68,8 +68,8 @@ pub struct SyscallVal<'a, T> {
 
 impl<'a, T> SyscallVal<'a, T> {
     pub fn new(
-        reg: SysCallReg,
-        args: [SysCallReg; 6],
+        reg: SyscallReg,
+        args: [SyscallReg; 6],
         options: FmtOptions,
         mem: &'a MemoryManager,
     ) -> Self {
@@ -126,7 +126,7 @@ where
     SyscallVal<'a, E>: Display,
     SyscallVal<'a, F>: Display,
 {
-    pub fn new(args: [SysCallReg; 6], options: FmtOptions, mem: &'a MemoryManager) -> Self {
+    pub fn new(args: [SyscallReg; 6], options: FmtOptions, mem: &'a MemoryManager) -> Self {
         Self {
             a: SyscallVal::new(args[0], args, options, mem),
             b: SyscallVal::new(args[1], args, options, mem),
@@ -192,7 +192,7 @@ where
     RV: std::fmt::Debug,
 {
     rv: &'a SyscallResult,
-    args: [SysCallReg; 6],
+    args: [SyscallReg; 6],
     options: FmtOptions,
     mem: &'a MemoryManager,
     _phantom: PhantomData<RV>,
@@ -205,7 +205,7 @@ where
 {
     pub fn new(
         rv: &'a SyscallResult,
-        args: [SysCallReg; 6],
+        args: [SyscallReg; 6],
         options: FmtOptions,
         mem: &'a MemoryManager,
     ) -> Self {
@@ -232,7 +232,7 @@ where
             }
             SyscallResult::Err(SyscallError::Failed(failed)) => {
                 let errno = failed.errno;
-                let rv = SysCallReg::from(errno.to_negated_i64());
+                let rv = SyscallReg::from(errno.to_negated_i64());
                 let rv = SyscallVal::<'_, RV>::new(rv, self.args, self.options, self.mem);
                 write!(f, "{rv} ({errno})")
             }
@@ -276,7 +276,7 @@ pub fn log_syscall_simple(
         return Ok(());
     };
 
-    let args = [SysCallReg::from(0i64); 6];
+    let args = [SyscallReg::from(0i64); 6];
     let mem = proc.memory_borrow();
     let rv = SyscallResultFmt::<libc::c_long>::new(result, args, logging_mode, &mem);
 

--- a/src/main/host/syscall/formatter.rs
+++ b/src/main/host/syscall/formatter.rs
@@ -299,7 +299,7 @@ pub fn log_syscall_simple(
 mod test {
     use std::process::Command;
 
-    use shadow_shim_helper_rs::syscall_types::SysCallArgs;
+    use shadow_shim_helper_rs::syscall_types::SyscallArgs;
 
     use super::*;
 
@@ -307,7 +307,7 @@ mod test {
     // can't call foreign function: gnu_get_libc_version
     #[cfg_attr(miri, ignore)]
     fn test_no_args() {
-        let args = SysCallArgs {
+        let args = SyscallArgs {
             number: 100,
             args: [0u32.into(); 6],
         };

--- a/src/main/host/syscall/handler/fcntl.c
+++ b/src/main/host/syscall/handler/fcntl.c
@@ -170,7 +170,7 @@ static int _syscallhandler_fcntlHelper(SyscallHandler* sys, RegularFile* file, i
 // System Calls
 ///////////////////////////////////////////////////////////
 
-SyscallReturn syscallhandler_fcntl(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fcntl(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     unsigned long command = args->args[1].as_i64;
     SyscallReg argReg = args->args[2]; // type depends on command

--- a/src/main/host/syscall/handler/fcntl.c
+++ b/src/main/host/syscall/handler/fcntl.c
@@ -21,7 +21,7 @@
 ///////////////////////////////////////////////////////////
 
 static int _syscallhandler_fcntlHelper(SyscallHandler* sys, RegularFile* file, int fd,
-                                       unsigned long command, SysCallReg argReg) {
+                                       unsigned long command, SyscallReg argReg) {
     int result = 0;
 
     switch (command) {
@@ -173,7 +173,7 @@ static int _syscallhandler_fcntlHelper(SyscallHandler* sys, RegularFile* file, i
 SyscallReturn syscallhandler_fcntl(SyscallHandler* sys, const SysCallArgs* args) {
     int fd = args->args[0].as_i64;
     unsigned long command = args->args[1].as_i64;
-    SysCallReg argReg = args->args[2]; // type depends on command
+    SyscallReg argReg = args->args[2]; // type depends on command
 
     trace("fcntl called on fd %d for command %lu", fd, command);
 

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -1,7 +1,7 @@
 use linux_api::errno::Errno;
 use linux_api::fcntl::{DescriptorFlags, FcntlCommand, OFlag};
 use log::debug;
-use shadow_shim_helper_rs::syscall_types::SysCallReg;
+use shadow_shim_helper_rs::syscall_types::SyscallReg;
 use syscall_logger::log_syscall;
 
 use crate::cshadow;
@@ -67,7 +67,7 @@ impl SyscallHandler {
                 let file = file.inner_file().borrow();
                 // combine the file status and access mode flags
                 let flags = file.status().as_o_flags() | file.mode().as_o_flags();
-                SysCallReg::from(flags.bits())
+                SyscallReg::from(flags.bits())
             }
             FcntlCommand::F_SETFL => {
                 let file = match desc.file() {
@@ -130,14 +130,14 @@ impl SyscallHandler {
                 }
 
                 file.set_status(status);
-                SysCallReg::from(0)
+                SyscallReg::from(0)
             }
-            FcntlCommand::F_GETFD => SysCallReg::from(desc.flags().bits()),
+            FcntlCommand::F_GETFD => SyscallReg::from(desc.flags().bits()),
             FcntlCommand::F_SETFD => {
                 let flags = i32::try_from(arg).or(Err(Errno::EINVAL))?;
                 let flags = DescriptorFlags::from_bits(flags).ok_or(Errno::EINVAL)?;
                 desc.set_flags(flags);
-                SysCallReg::from(0)
+                SyscallReg::from(0)
             }
             FcntlCommand::F_DUPFD => {
                 let min_fd = arg.try_into().or(Err(Errno::EINVAL))?;
@@ -146,7 +146,7 @@ impl SyscallHandler {
                 let new_fd = desc_table
                     .register_descriptor_with_min_fd(new_desc, min_fd)
                     .or(Err(Errno::EINVAL))?;
-                SysCallReg::from(i32::from(new_fd))
+                SyscallReg::from(i32::from(new_fd))
             }
             FcntlCommand::F_DUPFD_CLOEXEC => {
                 let min_fd = arg.try_into().or(Err(Errno::EINVAL))?;
@@ -155,7 +155,7 @@ impl SyscallHandler {
                 let new_fd = desc_table
                     .register_descriptor_with_min_fd(new_desc, min_fd)
                     .or(Err(Errno::EINVAL))?;
-                SysCallReg::from(i32::from(new_fd))
+                SyscallReg::from(i32::from(new_fd))
             }
             FcntlCommand::F_GETPIPE_SZ => {
                 let file = match desc.file() {
@@ -167,7 +167,7 @@ impl SyscallHandler {
                 };
 
                 if let File::Pipe(pipe) = file.inner_file() {
-                    SysCallReg::from(i32::try_from(pipe.borrow().max_size()).unwrap())
+                    SyscallReg::from(i32::try_from(pipe.borrow().max_size()).unwrap())
                 } else {
                     return Err(Errno::EINVAL.into());
                 }

--- a/src/main/host/syscall/handler/file.c
+++ b/src/main/host/syscall/handler/file.c
@@ -93,18 +93,18 @@ static SyscallReturn _syscallhandler_fsyncHelper(SyscallHandler* sys, int fd) {
 // System Calls
 ///////////////////////////////////////////////////////////
 
-SyscallReturn syscallhandler_creat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_creat(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_openHelper(sys, args->args[0].as_ptr,
                                       O_CREAT | O_WRONLY | O_TRUNC,
                                       args->args[1].as_u64);
 }
 
-SyscallReturn syscallhandler_open(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_open(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_openHelper(
         sys, args->args[0].as_ptr, args->args[1].as_i64, args->args[2].as_u64);
 }
 
-SyscallReturn syscallhandler_fstat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fstat(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     UntypedForeignPtr bufPtr = args->args[1].as_ptr; // struct stat*
 
@@ -125,7 +125,7 @@ SyscallReturn syscallhandler_fstat(SyscallHandler* sys, const SysCallArgs* args)
     return syscallreturn_makeDoneI64(regularfile_fstat(file_desc, buf));
 }
 
-SyscallReturn syscallhandler_fstatfs(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fstatfs(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     UntypedForeignPtr bufPtr = args->args[1].as_ptr; // struct statfs*
 
@@ -146,19 +146,19 @@ SyscallReturn syscallhandler_fstatfs(SyscallHandler* sys, const SysCallArgs* arg
     return syscallreturn_makeDoneI64(regularfile_fstatfs(file_desc, buf));
 }
 
-SyscallReturn syscallhandler_fsync(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fsync(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_fsyncHelper(sys, args->args[0].as_i64);
 }
 
-SyscallReturn syscallhandler_fdatasync(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fdatasync(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_fsyncHelper(sys, args->args[0].as_i64);
 }
 
-SyscallReturn syscallhandler_syncfs(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_syncfs(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_fsyncHelper(sys, args->args[0].as_i64);
 }
 
-SyscallReturn syscallhandler_fchown(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fchown(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
 
     /* Get and validate the file descriptor. */
@@ -172,7 +172,7 @@ SyscallReturn syscallhandler_fchown(SyscallHandler* sys, const SysCallArgs* args
         regularfile_fchown(file_desc, args->args[1].as_u64, args->args[2].as_u64));
 }
 
-SyscallReturn syscallhandler_fchmod(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fchmod(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
 
     /* Get and validate the file descriptor. */
@@ -185,7 +185,7 @@ SyscallReturn syscallhandler_fchmod(SyscallHandler* sys, const SysCallArgs* args
     return syscallreturn_makeDoneI64(regularfile_fchmod(file_desc, args->args[1].as_u64));
 }
 
-SyscallReturn syscallhandler_fallocate(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fallocate(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
 
     /* Get and validate the file descriptor. */
@@ -199,7 +199,7 @@ SyscallReturn syscallhandler_fallocate(SyscallHandler* sys, const SysCallArgs* a
         file_desc, args->args[1].as_i64, args->args[2].as_u64, args->args[3].as_u64));
 }
 
-SyscallReturn syscallhandler_ftruncate(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_ftruncate(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
 
     /* Get and validate the file descriptor. */
@@ -212,7 +212,7 @@ SyscallReturn syscallhandler_ftruncate(SyscallHandler* sys, const SysCallArgs* a
     return syscallreturn_makeDoneI64(regularfile_ftruncate(file_desc, args->args[1].as_u64));
 }
 
-SyscallReturn syscallhandler_fadvise64(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fadvise64(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
 
     /* Get and validate the file descriptor. */
@@ -226,7 +226,7 @@ SyscallReturn syscallhandler_fadvise64(SyscallHandler* sys, const SysCallArgs* a
         file_desc, args->args[1].as_u64, args->args[2].as_u64, args->args[3].as_i64));
 }
 
-SyscallReturn syscallhandler_flock(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_flock(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
 
     /* Get and validate the file descriptor. */
@@ -239,7 +239,7 @@ SyscallReturn syscallhandler_flock(SyscallHandler* sys, const SysCallArgs* args)
     return syscallreturn_makeDoneI64(regularfile_flock(file_desc, args->args[1].as_i64));
 }
 
-SyscallReturn syscallhandler_fsetxattr(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fsetxattr(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     UntypedForeignPtr namePtr = args->args[1].as_ptr;  // const char*
     UntypedForeignPtr valuePtr = args->args[2].as_ptr; // const void*
@@ -269,7 +269,7 @@ SyscallReturn syscallhandler_fsetxattr(SyscallHandler* sys, const SysCallArgs* a
     return syscallreturn_makeDoneI64(regularfile_fsetxattr(file_desc, name, value, size, flags));
 }
 
-SyscallReturn syscallhandler_fgetxattr(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fgetxattr(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     UntypedForeignPtr namePtr = args->args[1].as_ptr;  // const char*
     UntypedForeignPtr valuePtr = args->args[2].as_ptr; // void*
@@ -297,7 +297,7 @@ SyscallReturn syscallhandler_fgetxattr(SyscallHandler* sys, const SysCallArgs* a
     return syscallreturn_makeDoneI64(regularfile_fgetxattr(file_desc, name, value, size));
 }
 
-SyscallReturn syscallhandler_flistxattr(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_flistxattr(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     UntypedForeignPtr listPtr = args->args[1].as_ptr; // char*
     size_t size = args->args[2].as_u64;
@@ -316,7 +316,7 @@ SyscallReturn syscallhandler_flistxattr(SyscallHandler* sys, const SysCallArgs* 
     return syscallreturn_makeDoneI64(regularfile_flistxattr(file_desc, list, size));
 }
 
-SyscallReturn syscallhandler_fremovexattr(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fremovexattr(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     UntypedForeignPtr namePtr = args->args[1].as_ptr; // const char*
 
@@ -338,7 +338,7 @@ SyscallReturn syscallhandler_fremovexattr(SyscallHandler* sys, const SysCallArgs
     return syscallreturn_makeDoneI64(regularfile_fremovexattr(file_desc, name));
 }
 
-SyscallReturn syscallhandler_sync_file_range(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_sync_file_range(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     off64_t offset = args->args[1].as_u64;
     off64_t nbytes = args->args[2].as_u64;
@@ -354,7 +354,7 @@ SyscallReturn syscallhandler_sync_file_range(SyscallHandler* sys, const SysCallA
     return syscallreturn_makeDoneI64(regularfile_sync_range(file_desc, offset, nbytes, flags));
 }
 
-SyscallReturn syscallhandler_readahead(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_readahead(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     off64_t offset = args->args[1].as_u64;
     size_t count = args->args[2].as_u64;
@@ -369,7 +369,7 @@ SyscallReturn syscallhandler_readahead(SyscallHandler* sys, const SysCallArgs* a
     return syscallreturn_makeDoneI64(regularfile_readahead(file_desc, offset, count));
 }
 
-SyscallReturn syscallhandler_lseek(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_lseek(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     off_t offset = args->args[1].as_u64;
     int whence = args->args[2].as_i64;
@@ -384,7 +384,7 @@ SyscallReturn syscallhandler_lseek(SyscallHandler* sys, const SysCallArgs* args)
     return syscallreturn_makeDoneI64(regularfile_lseek(file_desc, offset, whence));
 }
 
-SyscallReturn syscallhandler_getdents(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_getdents(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     UntypedForeignPtr dirpPtr = args->args[1].as_ptr; // struct linux_dirent*
     unsigned int count = args->args[2].as_u64;
@@ -406,7 +406,7 @@ SyscallReturn syscallhandler_getdents(SyscallHandler* sys, const SysCallArgs* ar
     return syscallreturn_makeDoneI64(regularfile_getdents(file_desc, dirp, count));
 }
 
-SyscallReturn syscallhandler_getdents64(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_getdents64(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     UntypedForeignPtr dirpPtr = args->args[1].as_ptr; // struct linux_dirent64*
     unsigned int count = args->args[2].as_u64;

--- a/src/main/host/syscall/handler/fileat.c
+++ b/src/main/host/syscall/handler/fileat.c
@@ -104,7 +104,7 @@ static SyscallReturn _syscallhandler_renameatHelper(SyscallHandler* sys, int old
 // System Calls
 ///////////////////////////////////////////////////////////
 
-SyscallReturn syscallhandler_openat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_openat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     int flags = args->args[2].as_i64;
@@ -141,7 +141,7 @@ SyscallReturn syscallhandler_openat(SyscallHandler* sys, const SysCallArgs* args
     return syscallreturn_makeDoneI64(handle);
 }
 
-SyscallReturn syscallhandler_newfstatat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_newfstatat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     UntypedForeignPtr bufPtr = args->args[2].as_ptr;      // struct stat*
@@ -177,7 +177,7 @@ SyscallReturn syscallhandler_newfstatat(SyscallHandler* sys, const SysCallArgs* 
         regularfile_fstatat(dir_desc, pathname, buf, flags, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_fchownat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fchownat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     uid_t owner = args->args[2].as_u64;
@@ -200,7 +200,7 @@ SyscallReturn syscallhandler_fchownat(SyscallHandler* sys, const SysCallArgs* ar
         regularfile_fchownat(dir_desc, pathname, owner, group, flags, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_fchmodat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_fchmodat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     uid_t mode = args->args[2].as_u64;
@@ -222,7 +222,7 @@ SyscallReturn syscallhandler_fchmodat(SyscallHandler* sys, const SysCallArgs* ar
         regularfile_fchmodat(dir_desc, pathname, mode, flags, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_futimesat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_futimesat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     UntypedForeignPtr timesPtr = args->args[2].as_ptr;    // const struct timeval [2]
@@ -248,7 +248,7 @@ SyscallReturn syscallhandler_futimesat(SyscallHandler* sys, const SysCallArgs* a
     return syscallreturn_makeDoneI64(regularfile_futimesat(dir_desc, pathname, times, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_utimensat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_utimensat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     UntypedForeignPtr timesPtr = args->args[2].as_ptr;    // const struct timespec [2]
@@ -276,7 +276,7 @@ SyscallReturn syscallhandler_utimensat(SyscallHandler* sys, const SysCallArgs* a
         regularfile_utimensat(dir_desc, pathname, times, flags, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_faccessat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_faccessat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     int mode = args->args[2].as_i64;
@@ -298,7 +298,7 @@ SyscallReturn syscallhandler_faccessat(SyscallHandler* sys, const SysCallArgs* a
         regularfile_faccessat(dir_desc, pathname, mode, flags, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_mkdirat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_mkdirat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     mode_t mode = args->args[2].as_u64;
@@ -318,7 +318,7 @@ SyscallReturn syscallhandler_mkdirat(SyscallHandler* sys, const SysCallArgs* arg
     return syscallreturn_makeDoneI64(regularfile_mkdirat(dir_desc, pathname, mode, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_mknodat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_mknodat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     mode_t mode = args->args[2].as_u64;
@@ -340,7 +340,7 @@ SyscallReturn syscallhandler_mknodat(SyscallHandler* sys, const SysCallArgs* arg
         regularfile_mknodat(dir_desc, pathname, mode, dev, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_linkat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_linkat(SyscallHandler* sys, const SyscallArgs* args) {
     int olddirfd = args->args[0].as_i64;
     UntypedForeignPtr oldpathPtr = args->args[1].as_ptr; // const char*
     int newdirfd = args->args[2].as_i64;
@@ -372,7 +372,7 @@ SyscallReturn syscallhandler_linkat(SyscallHandler* sys, const SysCallArgs* args
         regularfile_linkat(olddir_desc, oldpath, newdir_desc, newpath, flags, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_unlinkat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_unlinkat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     int flags = args->args[2].as_i64;
@@ -392,7 +392,7 @@ SyscallReturn syscallhandler_unlinkat(SyscallHandler* sys, const SysCallArgs* ar
     return syscallreturn_makeDoneI64(regularfile_unlinkat(dir_desc, pathname, flags, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_symlinkat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_symlinkat(SyscallHandler* sys, const SyscallArgs* args) {
     UntypedForeignPtr targetpathPtr = args->args[0].as_ptr; // const char*
     int dirfd = args->args[1].as_i64;
     UntypedForeignPtr linkpathPtr = args->args[2].as_ptr; // const char*
@@ -421,7 +421,7 @@ SyscallReturn syscallhandler_symlinkat(SyscallHandler* sys, const SysCallArgs* a
         regularfile_symlinkat(dir_desc, linkpath, targetpath, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_readlinkat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_readlinkat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     UntypedForeignPtr bufPtr = args->args[2].as_ptr;      // char*
@@ -456,20 +456,20 @@ SyscallReturn syscallhandler_readlinkat(SyscallHandler* sys, const SysCallArgs* 
         regularfile_readlinkat(dir_desc, pathname, buf, bufSize, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_renameat(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_renameat(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_renameatHelper(
         sys, args->args[0].as_i64, args->args[1].as_ptr, args->args[2].as_i64,
         args->args[3].as_ptr, 0);
 }
 
-SyscallReturn syscallhandler_renameat2(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_renameat2(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_renameatHelper(
         sys, args->args[0].as_i64, args->args[1].as_ptr, args->args[2].as_i64,
         args->args[3].as_ptr, args->args[4].as_u64);
 }
 
 #ifdef SYS_statx
-SyscallReturn syscallhandler_statx(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_statx(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     int flags = args->args[2].as_i64;

--- a/src/main/host/syscall/handler/futex.c
+++ b/src/main/host/syscall/handler/futex.c
@@ -157,7 +157,7 @@ static SyscallReturn _syscallhandler_futexWakeHelper(SyscallHandler* sys,
 // Support across different address spaces requires us to compute a unique id from the
 // hardware address (i.e., page table and offset). This is needed, e.g., when using
 // futexes across process boundaries.
-SyscallReturn syscallhandler_futex(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_futex(SyscallHandler* sys, const SyscallArgs* args) {
     utility_debugAssert(sys && args);
 
     UntypedForeignPtr uaddrptr = args->args[0].as_ptr; // int*

--- a/src/main/host/syscall/handler/ioctl.c
+++ b/src/main/host/syscall/handler/ioctl.c
@@ -60,7 +60,7 @@ static int _syscallhandler_ioctlFileHelper(SyscallHandler* sys, RegularFile* fil
 // System Calls
 ///////////////////////////////////////////////////////////
 
-SyscallReturn syscallhandler_ioctl(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_ioctl(SyscallHandler* sys, const SyscallArgs* args) {
     int fd = args->args[0].as_i64;
     unsigned long request = args->args[1].as_i64;
     UntypedForeignPtr argPtr = args->args[2].as_ptr; // type depends on request

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -9,7 +9,7 @@ use linux_api::errno::Errno;
 use linux_api::syscall::SyscallNum;
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
 use shadow_shim_helper_rs::syscall_types::SysCallArgs;
-use shadow_shim_helper_rs::syscall_types::SysCallReg;
+use shadow_shim_helper_rs::syscall_types::SyscallReg;
 use shadow_shim_helper_rs::util::SendPointer;
 use shadow_shim_helper_rs::HostId;
 
@@ -742,7 +742,7 @@ pub trait SyscallHandlerFn<T> {
 impl<F, T0> SyscallHandlerFn<()> for F
 where
     F: Fn(&mut SyscallContext) -> Result<T0, SyscallError>,
-    T0: Into<SysCallReg>,
+    T0: Into<SyscallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
         self(ctx).map(Into::into)
@@ -752,8 +752,8 @@ where
 impl<F, T0, T1> SyscallHandlerFn<(T1,)> for F
 where
     F: Fn(&mut SyscallContext, T1) -> Result<T0, SyscallError>,
-    T0: Into<SysCallReg>,
-    T1: From<SysCallReg>,
+    T0: Into<SyscallReg>,
+    T1: From<SyscallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
         self(ctx, ctx.args.get(0).into()).map(Into::into)
@@ -763,9 +763,9 @@ where
 impl<F, T0, T1, T2> SyscallHandlerFn<(T1, T2)> for F
 where
     F: Fn(&mut SyscallContext, T1, T2) -> Result<T0, SyscallError>,
-    T0: Into<SysCallReg>,
-    T1: From<SysCallReg>,
-    T2: From<SysCallReg>,
+    T0: Into<SyscallReg>,
+    T1: From<SyscallReg>,
+    T2: From<SyscallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
         self(ctx, ctx.args.get(0).into(), ctx.args.get(1).into()).map(Into::into)
@@ -775,10 +775,10 @@ where
 impl<F, T0, T1, T2, T3> SyscallHandlerFn<(T1, T2, T3)> for F
 where
     F: Fn(&mut SyscallContext, T1, T2, T3) -> Result<T0, SyscallError>,
-    T0: Into<SysCallReg>,
-    T1: From<SysCallReg>,
-    T2: From<SysCallReg>,
-    T3: From<SysCallReg>,
+    T0: Into<SyscallReg>,
+    T1: From<SyscallReg>,
+    T2: From<SyscallReg>,
+    T3: From<SyscallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
         self(
@@ -794,11 +794,11 @@ where
 impl<F, T0, T1, T2, T3, T4> SyscallHandlerFn<(T1, T2, T3, T4)> for F
 where
     F: Fn(&mut SyscallContext, T1, T2, T3, T4) -> Result<T0, SyscallError>,
-    T0: Into<SysCallReg>,
-    T1: From<SysCallReg>,
-    T2: From<SysCallReg>,
-    T3: From<SysCallReg>,
-    T4: From<SysCallReg>,
+    T0: Into<SyscallReg>,
+    T1: From<SyscallReg>,
+    T2: From<SyscallReg>,
+    T3: From<SyscallReg>,
+    T4: From<SyscallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
         self(
@@ -815,12 +815,12 @@ where
 impl<F, T0, T1, T2, T3, T4, T5> SyscallHandlerFn<(T1, T2, T3, T4, T5)> for F
 where
     F: Fn(&mut SyscallContext, T1, T2, T3, T4, T5) -> Result<T0, SyscallError>,
-    T0: Into<SysCallReg>,
-    T1: From<SysCallReg>,
-    T2: From<SysCallReg>,
-    T3: From<SysCallReg>,
-    T4: From<SysCallReg>,
-    T5: From<SysCallReg>,
+    T0: Into<SyscallReg>,
+    T1: From<SyscallReg>,
+    T2: From<SyscallReg>,
+    T3: From<SyscallReg>,
+    T4: From<SyscallReg>,
+    T5: From<SyscallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
         self(
@@ -838,13 +838,13 @@ where
 impl<F, T0, T1, T2, T3, T4, T5, T6> SyscallHandlerFn<(T1, T2, T3, T4, T5, T6)> for F
 where
     F: Fn(&mut SyscallContext, T1, T2, T3, T4, T5, T6) -> Result<T0, SyscallError>,
-    T0: Into<SysCallReg>,
-    T1: From<SysCallReg>,
-    T2: From<SysCallReg>,
-    T3: From<SysCallReg>,
-    T4: From<SysCallReg>,
-    T5: From<SysCallReg>,
-    T6: From<SysCallReg>,
+    T0: Into<SyscallReg>,
+    T1: From<SyscallReg>,
+    T2: From<SyscallReg>,
+    T3: From<SyscallReg>,
+    T4: From<SyscallReg>,
+    T5: From<SyscallReg>,
+    T6: From<SyscallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
         self(

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use linux_api::errno::Errno;
 use linux_api::syscall::SyscallNum;
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
-use shadow_shim_helper_rs::syscall_types::SysCallArgs;
+use shadow_shim_helper_rs::syscall_types::SyscallArgs;
 use shadow_shim_helper_rs::syscall_types::SyscallReg;
 use shadow_shim_helper_rs::util::SendPointer;
 use shadow_shim_helper_rs::HostId;
@@ -55,7 +55,7 @@ mod unistd;
 mod wait;
 
 type LegacySyscallFn =
-    unsafe extern "C-unwind" fn(*mut SyscallHandler, *const SysCallArgs) -> SyscallReturn;
+    unsafe extern "C-unwind" fn(*mut SyscallHandler, *const SyscallArgs) -> SyscallReturn;
 
 // Will eventually contain syscall handler state once migrated from the c handler
 pub struct SyscallHandler {
@@ -112,7 +112,7 @@ impl SyscallHandler {
         }
     }
 
-    pub fn syscall(&mut self, ctx: &ThreadContext, args: &SysCallArgs) -> SyscallResult {
+    pub fn syscall(&mut self, ctx: &ThreadContext, args: &SyscallArgs) -> SyscallResult {
         // it wouldn't make sense if we were given a different host, process, and thread
         assert_eq!(ctx.host.id(), self.host_id);
         assert_eq!(ctx.process.id(), self.process_id);
@@ -329,7 +329,7 @@ impl SyscallHandler {
     }
 
     #[allow(non_upper_case_globals)]
-    fn run_handler(&mut self, ctx: &ThreadContext, args: &SysCallArgs) -> SyscallResult {
+    fn run_handler(&mut self, ctx: &ThreadContext, args: &SyscallArgs) -> SyscallResult {
         const NR_shadow_yield: SyscallNum = SyscallNum::new(c::ShadowSyscallNum_SYS_shadow_yield);
         const NR_shadow_init_memory_manager: SyscallNum =
             SyscallNum::new(c::ShadowSyscallNum_SYS_shadow_init_memory_manager);
@@ -731,7 +731,7 @@ impl std::ops::Drop for SyscallHandler {
 
 pub struct SyscallContext<'a, 'b> {
     pub objs: &'a ThreadContext<'b>,
-    pub args: &'a SysCallArgs,
+    pub args: &'a SyscallArgs,
     pub handler: &'a mut SyscallHandler,
 }
 

--- a/src/main/host/syscall/handler/poll.c
+++ b/src/main/host/syscall/handler/poll.c
@@ -200,7 +200,7 @@ static int _syscallhandler_checkPollArgs(UntypedForeignPtr fds_ptr, nfds_t nfds)
 // System Calls
 ///////////////////////////////////////////////////////////
 
-SyscallReturn syscallhandler_poll(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_poll(SyscallHandler* sys, const SyscallArgs* args) {
     UntypedForeignPtr fds_ptr = args->args[0].as_ptr; // struct pollfd*
     nfds_t nfds = args->args[1].as_u64;
     int timeout_millis = args->args[2].as_i64;
@@ -218,7 +218,7 @@ SyscallReturn syscallhandler_poll(SyscallHandler* sys, const SysCallArgs* args) 
     }
 }
 
-SyscallReturn syscallhandler_ppoll(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_ppoll(SyscallHandler* sys, const SyscallArgs* args) {
     UntypedForeignPtr fds_ptr = args->args[0].as_ptr; // struct pollfd*
     nfds_t nfds = args->args[1].as_u64;
     UntypedForeignPtr ts_timeout_ptr = args->args[2].as_ptr; // const struct timespec*

--- a/src/main/host/syscall/handler/select.c
+++ b/src/main/host/syscall/handler/select.c
@@ -178,7 +178,7 @@ static int _syscallhandler_check_timeout(const struct timespec* timeout) {
 // System Calls
 ///////////////////////////////////////////////////////////
 
-SyscallReturn syscallhandler_select(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_select(SyscallHandler* sys, const SyscallArgs* args) {
     int nfds = args->args[0].as_i64;
     UntypedForeignPtr readfds_ptr = args->args[1].as_ptr;   // fd_set*
     UntypedForeignPtr writefds_ptr = args->args[2].as_ptr;  // fd_set*
@@ -222,7 +222,7 @@ SyscallReturn syscallhandler_select(SyscallHandler* sys, const SysCallArgs* args
                                          timeout_ptr.val ? &ts_timeout_val : NULL);
 }
 
-SyscallReturn syscallhandler_pselect6(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_pselect6(SyscallHandler* sys, const SyscallArgs* args) {
     int nfds = args->args[0].as_i64;
     UntypedForeignPtr readfds_ptr = args->args[1].as_ptr;   // fd_set*
     UntypedForeignPtr writefds_ptr = args->args[2].as_ptr;  // fd_set*

--- a/src/main/host/syscall/handler/signal.c
+++ b/src/main/host/syscall/handler/signal.c
@@ -72,7 +72,7 @@ static SyscallReturn _rt_sigaction(SyscallHandler* sys, int signum, UntypedForei
     return syscallreturn_makeDoneI64(0);
 }
 
-SyscallReturn syscallhandler_rt_sigaction(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_rt_sigaction(SyscallHandler* sys, const SyscallArgs* args) {
     utility_debugAssert(sys && args);
     SyscallReturn ret =
         _rt_sigaction(sys, /*signum=*/(int)args->args[0].as_i64,
@@ -81,7 +81,7 @@ SyscallReturn syscallhandler_rt_sigaction(SyscallHandler* sys, const SysCallArgs
     return ret;
 }
 
-SyscallReturn syscallhandler_sigaltstack(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_sigaltstack(SyscallHandler* sys, const SyscallArgs* args) {
     utility_debugAssert(sys && args);
     UntypedForeignPtr ss_ptr = args->args[0].as_ptr;
     UntypedForeignPtr old_ss_ptr = args->args[1].as_ptr;
@@ -186,7 +186,7 @@ static SyscallReturn _rt_sigprocmask(SyscallHandler* sys, int how, UntypedForeig
     return syscallreturn_makeDoneI64(0);
 }
 
-SyscallReturn syscallhandler_rt_sigprocmask(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_rt_sigprocmask(SyscallHandler* sys, const SyscallArgs* args) {
     utility_debugAssert(sys && args);
 
     SyscallReturn ret =

--- a/src/main/host/syscall/handler/uio.c
+++ b/src/main/host/syscall/handler/uio.c
@@ -344,35 +344,35 @@ static SyscallReturn _syscallhandler_writevHelper(SyscallHandler* sys, int fd,
 // System Calls
 ///////////////////////////////////////////////////////////
 
-SyscallReturn syscallhandler_readv(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_readv(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_readvHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                        args->args[2].as_u64, 0, 0, 0, false, false);
 }
 
-SyscallReturn syscallhandler_preadv(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_preadv(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_readvHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                        args->args[2].as_u64, args->args[3].as_u64,
                                        args->args[4].as_u64, 0, true, false);
 }
 
-SyscallReturn syscallhandler_preadv2(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_preadv2(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_readvHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                        args->args[2].as_u64, args->args[3].as_u64,
                                        args->args[4].as_u64, args->args[5].as_i64, true, true);
 }
 
-SyscallReturn syscallhandler_writev(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_writev(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_writevHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                         args->args[2].as_u64, 0, 0, 0, false, false);
 }
 
-SyscallReturn syscallhandler_pwritev(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_pwritev(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_writevHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                         args->args[2].as_u64, args->args[3].as_u64,
                                         args->args[4].as_u64, 0, true, false);
 }
 
-SyscallReturn syscallhandler_pwritev2(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_pwritev2(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_writevHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                         args->args[2].as_u64, args->args[3].as_u64,
                                         args->args[4].as_u64, args->args[5].as_i64, true, true);

--- a/src/main/host/syscall/handler/unistd.c
+++ b/src/main/host/syscall/handler/unistd.c
@@ -188,22 +188,22 @@ SyscallReturn _syscallhandler_writeHelper(SyscallHandler* sys, int fd, UntypedFo
 // System Calls
 ///////////////////////////////////////////////////////////
 
-SyscallReturn syscallhandler_read(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_read(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_readHelper(
         sys, args->args[0].as_i64, args->args[1].as_ptr, args->args[2].as_u64, 0, false);
 }
 
-SyscallReturn syscallhandler_pread64(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_pread64(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_readHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                       args->args[2].as_u64, args->args[3].as_i64, true);
 }
 
-SyscallReturn syscallhandler_write(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_write(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_writeHelper(
         sys, args->args[0].as_i64, args->args[1].as_ptr, args->args[2].as_u64, 0, false);
 }
 
-SyscallReturn syscallhandler_pwrite64(SyscallHandler* sys, const SysCallArgs* args) {
+SyscallReturn syscallhandler_pwrite64(SyscallHandler* sys, const SyscallArgs* args) {
     return _syscallhandler_writeHelper(sys, args->args[0].as_i64, args->args[1].as_ptr,
                                        args->args[2].as_u64, args->args[3].as_i64, true);
 }

--- a/src/main/host/syscall/handler/wait.rs
+++ b/src/main/host/syscall/handler/wait.rs
@@ -138,7 +138,7 @@ impl SyscallHandler {
             return if options.contains(WaitFlags::WNOHANG) {
                 Ok(0)
             } else {
-                // FIXME: save `target` in SysCallCondition and reuse, in case
+                // FIXME: save `target` in SyscallCondition and reuse, in case
                 // the target was specified as 0 => "current process group id"
                 // and the process group changes in the meantime.
                 Err(SyscallError::new_blocked_on_child(

--- a/src/main/host/syscall/protected.h
+++ b/src/main/host/syscall/protected.h
@@ -36,7 +36,7 @@ typedef enum {
  * The functions defined with this macro should never be called outside
  * of syscall_handler.c. */
 #define SYSCALL_HANDLER(s)                                                                         \
-    SyscallReturn syscallhandler_##s(SyscallHandler* sys, const SysCallArgs* args);
+    SyscallReturn syscallhandler_##s(SyscallHandler* sys, const SyscallArgs* args);
 
 int _syscallhandler_validateLegacyFile(LegacyFile* descriptor, LegacyFileType expectedType);
 

--- a/src/main/host/syscall/types.rs
+++ b/src/main/host/syscall/types.rs
@@ -7,7 +7,7 @@ use linux_api::errno::Errno;
 use log::Level::Debug;
 use log::*;
 use shadow_shim_helper_rs::emulated_time::EmulatedTime;
-use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SysCallReg};
+use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SyscallReg};
 
 use crate::cshadow as c;
 use crate::host::descriptor::{File, FileState};
@@ -141,7 +141,7 @@ pub struct Failed {
     pub restartable: bool,
 }
 
-pub type SyscallResult = Result<SysCallReg, SyscallError>;
+pub type SyscallResult = Result<SyscallReg, SyscallError>;
 
 impl From<SyscallReturn> for SyscallResult {
     fn from(r: SyscallReturn) -> Self {
@@ -258,7 +258,7 @@ impl SyscallError {
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SyscallReturnDone {
-    pub retval: SysCallReg,
+    pub retval: SyscallReg,
     // Only meaningful when `retval` is -EINTR.
     //
     // Whether the interrupted syscall is restartable.
@@ -292,7 +292,7 @@ mod export {
     use super::*;
 
     #[no_mangle]
-    pub unsafe extern "C-unwind" fn syscallreturn_makeDone(retval: SysCallReg) -> SyscallReturn {
+    pub unsafe extern "C-unwind" fn syscallreturn_makeDone(retval: SyscallReg) -> SyscallReturn {
         SyscallReturn::Done(SyscallReturnDone {
             retval,
             restartable: false,

--- a/src/main/host/syscall/types.rs
+++ b/src/main/host/syscall/types.rs
@@ -11,7 +11,7 @@ use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SyscallReg};
 
 use crate::cshadow as c;
 use crate::host::descriptor::{File, FileState};
-use crate::host::syscall::condition::SysCallCondition;
+use crate::host::syscall::condition::SyscallCondition;
 use crate::host::syscall::Trigger;
 
 /// Wrapper around a [`ForeignPtr`] that encapsulates its size and current position.
@@ -131,7 +131,7 @@ pub enum SyscallError {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Blocked {
-    pub condition: SysCallCondition,
+    pub condition: SyscallCondition,
     pub restartable: bool,
 }
 
@@ -157,7 +157,7 @@ impl From<SyscallReturn> for SyscallResult {
             }
             // SAFETY: XXX: We're assuming this points to a valid SysCallCondition.
             SyscallReturn::Block(blocked) => Err(SyscallError::Blocked(Blocked {
-                condition: unsafe { SysCallCondition::consume_from_c(blocked.cond) },
+                condition: unsafe { SyscallCondition::consume_from_c(blocked.cond) },
                 restartable: blocked.restartable,
             })),
             SyscallReturn::Native => Err(SyscallError::Native),
@@ -216,21 +216,21 @@ impl From<std::io::Error> for SyscallError {
 impl SyscallError {
     pub fn new_blocked_on_file(file: File, state: FileState, restartable: bool) -> Self {
         Self::Blocked(Blocked {
-            condition: SysCallCondition::new(Trigger::from_file(file, state)),
+            condition: SyscallCondition::new(Trigger::from_file(file, state)),
             restartable,
         })
     }
 
     pub fn new_blocked_on_child(restartable: bool) -> Self {
         Self::Blocked(Blocked {
-            condition: SysCallCondition::new(Trigger::child()),
+            condition: SyscallCondition::new(Trigger::child()),
             restartable,
         })
     }
 
     pub fn new_blocked_until(unblock_time: EmulatedTime, restartable: bool) -> Self {
         Self::Blocked(Blocked {
-            condition: SysCallCondition::new_from_wakeup_time(unblock_time),
+            condition: SyscallCondition::new_from_wakeup_time(unblock_time),
             restartable,
         })
     }
@@ -242,8 +242,8 @@ impl SyscallError {
         })
     }
 
-    /// Returns the [condition](SysCallCondition) that the syscall is blocked on.
-    pub fn blocked_condition(&mut self) -> Option<&mut SysCallCondition> {
+    /// Returns the [condition](SyscallCondition) that the syscall is blocked on.
+    pub fn blocked_condition(&mut self) -> Option<&mut SyscallCondition> {
         if let Self::Blocked(Blocked {
             ref mut condition, ..
         }) = self

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -11,7 +11,7 @@ use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::shim_shmem::{HostShmemProtected, ThreadShmem};
-use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SysCallReg};
+use shadow_shim_helper_rs::syscall_types::{ForeignPtr, SyscallReg};
 use shadow_shim_helper_rs::util::SendPointer;
 use shadow_shim_helper_rs::HostId;
 use shadow_shmem::allocator::{shmalloc, ShMemBlock};
@@ -173,7 +173,7 @@ impl Thread {
         &self,
         ctx: &ProcessContext,
         n: i64,
-        args: &[SysCallReg],
+        args: &[SyscallReg],
     ) -> libc::c_long {
         self.mthread
             .borrow()
@@ -186,8 +186,8 @@ impl Thread {
         &self,
         ctx: &ProcessContext,
         n: i64,
-        args: &[SysCallReg],
-    ) -> Result<SysCallReg, Errno> {
+        args: &[SyscallReg],
+    ) -> Result<SyscallReg, Errno> {
         syscall::raw_return_value_to_result(self.native_syscall_raw(ctx, n, args))
     }
 
@@ -300,12 +300,12 @@ impl Thread {
                 ctx,
                 libc::SYS_mmap,
                 &[
-                    SysCallReg::from(addr),
-                    SysCallReg::from(len),
-                    SysCallReg::from(prot),
-                    SysCallReg::from(flags),
-                    SysCallReg::from(fd),
-                    SysCallReg::from(offset),
+                    SyscallReg::from(addr),
+                    SyscallReg::from(len),
+                    SyscallReg::from(prot),
+                    SyscallReg::from(flags),
+                    SyscallReg::from(fd),
+                    SyscallReg::from(offset),
                 ],
             )?
             .into())
@@ -326,11 +326,11 @@ impl Thread {
                 ctx,
                 libc::SYS_mremap,
                 &[
-                    SysCallReg::from(old_addr),
-                    SysCallReg::from(old_len),
-                    SysCallReg::from(new_len),
-                    SysCallReg::from(flags),
-                    SysCallReg::from(new_addr),
+                    SyscallReg::from(old_addr),
+                    SyscallReg::from(old_len),
+                    SyscallReg::from(new_len),
+                    SyscallReg::from(flags),
+                    SyscallReg::from(new_addr),
                 ],
             )?
             .into())
@@ -348,9 +348,9 @@ impl Thread {
             ctx,
             libc::SYS_mprotect,
             &[
-                SysCallReg::from(addr),
-                SysCallReg::from(len),
-                SysCallReg::from(prot),
+                SyscallReg::from(addr),
+                SyscallReg::from(len),
+                SyscallReg::from(prot),
             ],
         )?;
         Ok(())
@@ -368,9 +368,9 @@ impl Thread {
             ctx,
             libc::SYS_open,
             &[
-                SysCallReg::from(pathname),
-                SysCallReg::from(flags),
-                SysCallReg::from(mode),
+                SyscallReg::from(pathname),
+                SyscallReg::from(flags),
+                SyscallReg::from(mode),
             ],
         );
         Ok(i32::from(res?))
@@ -378,7 +378,7 @@ impl Thread {
 
     /// Natively execute close(2) on the given thread.
     pub fn native_close(&self, ctx: &ProcessContext, fd: i32) -> Result<(), Errno> {
-        self.native_syscall(ctx, libc::SYS_close, &[SysCallReg::from(fd)])?;
+        self.native_syscall(ctx, libc::SYS_close, &[SyscallReg::from(fd)])?;
         Ok(())
     }
 
@@ -388,7 +388,7 @@ impl Thread {
         ctx: &ProcessContext,
         addr: ForeignPtr<u8>,
     ) -> Result<ForeignPtr<u8>, Errno> {
-        let res = self.native_syscall(ctx, libc::SYS_brk, &[SysCallReg::from(addr)])?;
+        let res = self.native_syscall(ctx, libc::SYS_brk, &[SyscallReg::from(addr)])?;
         Ok(ForeignPtr::from(res))
     }
 
@@ -622,12 +622,12 @@ mod export {
     unsafe extern "C-unwind" fn thread_nativeSyscall(
         thread: *const Thread,
         n: libc::c_long,
-        arg1: SysCallReg,
-        arg2: SysCallReg,
-        arg3: SysCallReg,
-        arg4: SysCallReg,
-        arg5: SysCallReg,
-        arg6: SysCallReg,
+        arg1: SyscallReg,
+        arg2: SyscallReg,
+        arg3: SyscallReg,
+        arg4: SyscallReg,
+        arg5: SyscallReg,
+        arg6: SyscallReg,
     ) -> libc::c_long {
         let thread = unsafe { thread.as_ref().unwrap() };
         Worker::with_active_host(|host| {

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -57,8 +57,8 @@ pub struct Thread {
     // any RootedRc members we could get rid of the requirement to explicitly
     // drop Thread.
     desc_table: Option<RootedRc<RootedRefCell<DescriptorTable>>>,
-    // TODO: convert to SysCallCondition (Rust wrapper for c::SysCallCondition).
-    // Non-trivial because SysCallCondition is currently not `Send`.
+    // TODO: convert to SyscallCondition (Rust wrapper for c::SysCallCondition).
+    // Non-trivial because SyscallCondition is currently not `Send`.
     cond: Cell<SendPointer<c::SysCallCondition>>,
     /// The native, managed thread
     mthread: RefCell<ManagedThread>,

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -22,7 +22,7 @@ use super::host::Host;
 use super::managed_thread::{self, ManagedThread};
 use super::process::{Process, ProcessId};
 use crate::cshadow as c;
-use crate::host::syscall::condition::{SysCallConditionRef, SysCallConditionRefMut};
+use crate::host::syscall::condition::{SyscallConditionRef, SyscallConditionRefMut};
 use crate::host::syscall::handler::SyscallHandler;
 use crate::utility::callback_queue::CallbackQueue;
 use crate::utility::{syscall, IsSend, ObjectCounter};
@@ -217,7 +217,7 @@ impl Thread {
         self.id == self.process_id.into()
     }
 
-    pub fn syscall_condition(&self) -> Option<SysCallConditionRef> {
+    pub fn syscall_condition(&self) -> Option<SyscallConditionRef> {
         // We check the for null explicitly here instead of using `as_mut` to
         // construct and match an `Option<&mut c::SysCallCondition>`, since it's
         // difficult to ensure we're not breaking any Rust aliasing rules when
@@ -226,18 +226,18 @@ impl Thread {
         if c.is_null() {
             None
         } else {
-            Some(unsafe { SysCallConditionRef::borrow_from_c(c) })
+            Some(unsafe { SyscallConditionRef::borrow_from_c(c) })
         }
     }
 
-    pub fn syscall_condition_mut(&self) -> Option<SysCallConditionRefMut> {
+    pub fn syscall_condition_mut(&self) -> Option<SyscallConditionRefMut> {
         // We can't safely use `as_mut` here, since that would construct a mutable reference,
         // and we can't prove no other reference exists.
         let c = self.cond.get().ptr();
         if c.is_null() {
             None
         } else {
-            Some(unsafe { SysCallConditionRefMut::borrow_from_c(c) })
+            Some(unsafe { SyscallConditionRefMut::borrow_from_c(c) })
         }
     }
 

--- a/src/main/utility/syscall.rs
+++ b/src/main/utility/syscall.rs
@@ -1,17 +1,17 @@
-use shadow_shim_helper_rs::syscall_types::SysCallReg;
+use shadow_shim_helper_rs::syscall_types::SyscallReg;
 
 // Linux reserves -1 through -4095 for errors. See
 // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86_64/sysdep.h;h=24d8b8ec20a55824a4806f8821ecba2622d0fe8e;hb=HEAD#l41
 const MAX_ERRNO: i64 = 4095;
 
-pub fn raw_return_value_to_errno(rv: i64) -> Result<SysCallReg, i32> {
+pub fn raw_return_value_to_errno(rv: i64) -> Result<SyscallReg, i32> {
     if (-MAX_ERRNO..=-1).contains(&rv) {
         return Err(-rv as i32);
     }
     Ok(rv.into())
 }
 
-pub fn raw_return_value_to_result(rv: i64) -> Result<SysCallReg, linux_api::errno::Errno> {
+pub fn raw_return_value_to_result(rv: i64) -> Result<SyscallReg, linux_api::errno::Errno> {
     if let Ok(rv) = u16::try_from(-rv) {
         if let Ok(errno) = linux_api::errno::Errno::try_from(rv) {
             return Err(errno);


### PR DESCRIPTION
We had decided a long time ago to standardize on the prefix "Syscall" rather than "SysCall", so this just renames some types.