### PR TITLE
alarm syscall: return 1 instead of 0 if timer was scheduled to fire now

### DIFF
--- a/src/main/host/timer.rs
+++ b/src/main/host/timer.rs
@@ -141,6 +141,12 @@ impl Timer {
             debug_assert!(interval.is_positive());
             internal_brw.next_expire_time = Some(next_expire_time + interval);
             Self::schedule_new_expire_event(&mut internal_brw, internal_weak.clone(), host);
+        } else {
+            // Reset next expire time to None, so that `remaining_time`
+            // correctly returns `None`, instead of `Some(0)`. (i.e. `Some(0)`
+            // should mean that the timer is scheduled to fire now, but the
+            // event hasn't executed yet).
+            internal_brw.next_expire_time = None;
         }
 
         // Re-borrow as an immutable reference while executing the callback.

--- a/src/test/time/itimer/test_itimer.rs
+++ b/src/test/time/itimer/test_itimer.rs
@@ -371,6 +371,40 @@ fn test_alarm_fired() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn test_alarm_with_zero_remaining() -> anyhow::Result<()> {
+    reset()?;
+
+    // Set to expire in exactly 1s
+    assert_eq!(linux_api::time::alarm(1), Ok(0));
+
+    // Sleep exactly 1s
+    std::thread::sleep(std::time::Duration::from_secs(1));
+
+    // Cancel, and get remaining time
+    let rem = linux_api::time::alarm(0).unwrap();
+
+    // We can't guarantee whether or not the timer fired before we canceled it.
+    // e.g. under shadow, there should have been both the `sleep` timer
+    // and the alarm timer set to expire at exactly the same time, but which
+    // one fired first is an implementation detail.
+    match SIGNAL_CTR.load(Ordering::Relaxed) {
+        0 => {
+            // The alarm hadn't fired yet. Even though there was exactly 0 time
+            // remaining, the syscall should return 1.
+            println!("Hadn't fired");
+            ensure_ord!(rem, ==, 1);
+        }
+        1 => {
+            // The alarm had already fired.
+            println!("Already fired");
+            ensure_ord!(rem, ==, 0);
+        }
+        x => anyhow::bail!("Unexpected val {x}"),
+    };
+
+    Ok(())
+}
+
 fn main() -> anyhow::Result<()> {
     // Install a SIGALRM handler that counts how many times it's been received.
     unsafe {
@@ -414,6 +448,11 @@ fn main() -> anyhow::Result<()> {
         ShadowTest::new("set_interval_zero", test_interval_zero, all_envs.clone()),
         ShadowTest::new("alarm", test_alarm, all_envs.clone()),
         ShadowTest::new("alarm_fired", test_alarm_fired, all_envs.clone()),
+        ShadowTest::new(
+            "alarm_with_zero_remaining",
+            test_alarm_with_zero_remaining,
+            all_envs.clone(),
+        ),
         // Must be last.
         // Validate proper cleanup for a timer that's still running when the
         // process exits.


### PR DESCRIPTION
* If `alarm` has already fired, calling it again should return 0
* If `alarm` is called at exactly the time when the timer was going to fire, but before it has fired, we should return 1 instead of 0.