### PR TITLE
Add support for Ubuntu 24.04 and Fedora 40, and drop Fedora 38

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,12 +24,16 @@ jobs:
           - 'ubuntu:20.04'
           # End of standard support: April 2027 https://wiki.ubuntu.com/Releases
           - 'ubuntu:22.04'
+          # End of standard support: June 2029 https://wiki.ubuntu.com/Releases
+          - 'ubuntu:24.04'
           # EOL ~August 2024 https://wiki.debian.org/LTS
           - 'debian:10-slim'
           # EOL ~June 2026 https://wiki.debian.org/LTS
           - 'debian:11-slim'
-          # EOL TBA https://wiki.debian.org/LTS
+          # EOL June 2028 https://wiki.debian.org/LTS
           - 'debian:12-slim'
+          # EOL May 2025 https://endoflife.date/fedora
+          - 'fedora:40'
         cc: ['gcc']
         buildtype: ['release']
         include:

--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -25,9 +25,6 @@ case "$CONTAINER" in
   # We need to force a newer-than-default version of libclang
   # on some platforms. Some older versions have trouble finding
   # compiler header files in bindgen, when compiling with gcc.
-  ubuntu:18*)
-    APT_PACKAGES+=(libclang-9-dev)
-    ;;
   debian:10*)
     APT_PACKAGES+=(libclang-13-dev)
     ;;

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -10,7 +10,7 @@ PUSH=0
 NOCACHE=
 REPO=shadowsim/shadow-ci
 
-CONTAINER=ubuntu:20.04
+CONTAINER=ubuntu:24.04
 CC=gcc
 BUILDTYPE=debug
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -28,7 +28,7 @@ For example, to perform an incremental build and test on ubuntu 24.04,
 with the gcc compiler in debug mode:
 
 ```{.bash}
-ci/run.sh -c ubuntu:24.04 -C gcc -b debug"
+ci/run.sh -c ubuntu:24.04 -C gcc -b debug
 ```
 
 If the tests fail, shadow's build directory, including test outputs, will be copied

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -24,11 +24,11 @@ from the [shadowsim/shadow-ci](https://hub.docker.com/r/shadowsim/shadow-ci) on
 dockerhub. You can override this repo with `-r` or force the script to build a
 new image locally with `-i`.
 
-For example, to perform an incremental build and test on ubuntu 18.04,
+For example, to perform an incremental build and test on ubuntu 24.04,
 with the gcc compiler in debug mode:
 
 ```{.bash}
-ci/run.sh -c ubuntu:18.04 -C gcc -b debug"
+ci/run.sh -c ubuntu:24.04 -C gcc -b debug"
 ```
 
 If the tests fail, shadow's build directory, including test outputs, will be copied
@@ -47,7 +47,7 @@ run an interactive shell in a container built from that image.
 e.g.:
 
 ```{.bash}
-docker run --shm-size=1024g --security-opt=seccomp=unconfined -it shadowsim/shadow-ci:ubuntu-22.04-gcc-debug /bin/bash
+docker run --shm-size=1024g --security-opt=seccomp=unconfined -it shadowsim/shadow-ci:ubuntu-24.04-gcc-debug /bin/bash
 ```
 
 If the failure happened in the middle of building the Docker image, you can do
@@ -55,7 +55,7 @@ the same with the last intermediate layer that was built successfully. e.g.
 given the output:
 
 ```{.bash}
-$ ci/run.sh -i -c ubuntu:22.04 -C gcc -b debug
+$ ci/run.sh -i -c ubuntu:24.04 -C gcc -b debug
 <snip>
 Step 13/13 : RUN . ci/container_scripts/build_and_install.sh
  ---> Running in a11c4a554ef8

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -4,8 +4,9 @@
 
 We support the following Linux x86-64 distributions:
 
-- Ubuntu 20.04, 22.04
+- Ubuntu 20.04, 22.04, 24.04
 - Debian 10, 11, and 12
+- Fedora 40
 
 We do not provide official support for other platforms. This means that we do
 not ensure that Shadow successfully builds and passes tests on other platforms.

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -40,7 +40,7 @@ profile. You can do this by passing additional flags to `docker run`.
 Example:
 
 ```bash
-docker run -it --shm-size=1024g --security-opt seccomp=unconfined ubuntu:22.04
+docker run -it --shm-size=1024g --security-opt seccomp=unconfined ubuntu:24.04
 ```
 
 If you are having difficulty installing Shadow on any supported platforms, you

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -6,7 +6,6 @@ We support the following Linux x86-64 distributions:
 
 - Ubuntu 20.04, 22.04
 - Debian 10, 11, and 12
-- Fedora 38
 
 We do not provide official support for other platforms. This means that we do
 not ensure that Shadow successfully builds and passes tests on other platforms.


### PR DESCRIPTION
Fedora 38 becomes EOL in two weeks (14 May 2024). We already dropped CI testing for this version.

Ubuntu 24.04 and Fedora 40 were just released. I also tested Shadow in an Ubuntu 24.04 VM and the standard tests passed, so the updated kernel (6.8.0-31-generic) should be fine.

The required CI tests will need to be updated before merging.