### PR TITLE
Add experimental `stub_syscalls` config option

### DIFF
--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -85,6 +85,7 @@ hosts:
 - [`experimental.socket_send_autotune`](#experimentalsocket_send_autotune)
 - [`experimental.socket_send_buffer`](#experimentalsocket_send_buffer)
 - [`experimental.strace_logging_mode`](#experimentalstrace_logging_mode)
+- [`experimental.stub_syscalls`](#experimentalstub_syscalls)
 - [`experimental.unblocked_syscall_latency`](#experimentalunblocked_syscall_latency)
 - [`experimental.unblocked_vdso_latency`](#experimentalunblocked_vdso_latency)
 - [`experimental.use_cpu_pinning`](#experimentaluse_cpu_pinning)
@@ -424,6 +425,17 @@ Limitations:
   example, the log may show `syscall(...) = -1 (EINTR)`, but the managed
   process may not actually see this return value. Instead the syscall may be
   restarted.
+
+#### `experimental.stub_syscalls`
+
+Default: []  
+Type: Array of Integer
+
+List of syscall numbers to add "return 0" stubs for.
+
+If any of the listed syscalls are called by the managed application, *and* Shadow does not provide
+its own implementation of that syscall, Shadow will simply return 0 from the syscall instead of
+`ENOSYS`.
 
 #### `experimental.unblocked_syscall_latency`
 

--- a/src/main/core/configuration.rs
+++ b/src/main/core/configuration.rs
@@ -483,6 +483,13 @@ pub struct ExperimentalOptions {
     #[clap(long, value_name = "bool")]
     #[clap(help = EXP_HELP.get("use_new_tcp").unwrap().as_str())]
     pub use_new_tcp: Option<bool>,
+
+    /// List of syscall numbers to add "return 0" stubs for.
+    #[clap(hide_short_help = true)]
+    #[clap(value_parser = parse_set_u32)]
+    #[clap(long, value_name = "syscalls")]
+    #[clap(help = EXP_HELP.get("stub_syscalls").unwrap().as_str())]
+    pub stub_syscalls: Option<HashSet<u32>>,
 }
 
 impl ExperimentalOptions {
@@ -533,6 +540,7 @@ impl Default for ExperimentalOptions {
             scheduler: Some(Scheduler::ThreadPerCore),
             log_errors_to_tty: Some(true),
             use_new_tcp: Some(false),
+            stub_syscalls: Some(HashSet::new()),
         }
     }
 }
@@ -952,6 +960,11 @@ fn parse_set_log_info_flags(
 
 /// Parse a string as a comma-delimited set of `String` values.
 fn parse_set_str(s: &str) -> Result<HashSet<String>, <String as FromStr>::Err> {
+    parse_set(s)
+}
+
+/// Parse a string as a comma-delimited set of `u32` values.
+fn parse_set_u32(s: &str) -> Result<HashSet<u32>, <u32 as FromStr>::Err> {
     parse_set(s)
 }
 

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use atomic_refcell::AtomicRefCell;
+use linux_api::syscall::SyscallNum;
 use log::warn;
 use rand::seq::SliceRandom;
 use rand_xoshiro::Xoshiro256PlusPlus;
@@ -611,6 +612,15 @@ impl<'a> Manager<'a> {
                 use_new_tcp: self.config.experimental.use_new_tcp.unwrap(),
                 use_mem_mapper: self.config.experimental.use_memory_manager.unwrap(),
                 use_syscall_counters: self.config.experimental.use_syscall_counters.unwrap(),
+                stub_syscalls: self
+                    .config
+                    .experimental
+                    .stub_syscalls
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .map(|x| SyscallNum::new(*x))
+                    .collect(),
             };
 
             Box::new(unsafe {

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -1,7 +1,7 @@
 //! An emulated Linux system.
 
 use std::cell::{Cell, Ref, RefCell, RefMut, UnsafeCell};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::{CStr, CString, OsString};
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::num::NonZeroU8;
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex};
 
 use atomic_refcell::AtomicRefCell;
 use linux_api::signal::{siginfo_t, Signal};
+use linux_api::syscall::SyscallNum;
 use log::{debug, trace};
 use logger::LogLevel;
 use once_cell::unsync::OnceCell;
@@ -86,6 +87,7 @@ pub struct HostParameters {
     pub use_new_tcp: bool,
     pub use_mem_mapper: bool,
     pub use_syscall_counters: bool,
+    pub stub_syscalls: HashSet<SyscallNum>,
 }
 
 use super::cpu::Cpu;

--- a/src/test/cli/help-long-expected
+++ b/src/test/cli/help-long-expected
@@ -129,6 +129,9 @@ Experimental (Unstable and may change or be removed at any time, regardless of S
       --strace-logging-mode <mode>
           Log the syscalls for each process to individual "strace" files [default: "off"]
 
+      --stub-syscalls <syscalls>
+          List of syscall numbers to add "return 0" stubs for. [default: []]
+
       --unblocked-syscall-latency <seconds>
           Simulated latency of an unblocked syscall. For efficiency Shadow only actually adds this
           latency if and when `max_unapplied_cpu_latency` is reached. [default: "1 μs"]


### PR DESCRIPTION
In #3280 we discussed allowing users to add stubs for features that Shadow is missing. There are a lot of different features that users may want to add stubs for (ex: syscalls, socket options, ioctl commands, misc syscall flags, etc).

This PR adds an experimental `stub_syscalls` (or `--stub-syscalls`) configuration option that allows you to list syscall numbers that you wish to add stubs for. This only covers a small part of #3280. I'm thinking that we could cover the rest of #3280 with a second `stub_features` option or something. But it might make sense to handle syscalls separately with their own `stub_syscalls` option.

This new option takes syscall numbers instead of names so that users can specify syscalls that shadow doesn't know about. For example if a new Linux version introduces a new syscall and we haven't added it to linux-api yet. It also helps prevent mistakes from misspellings or differences between linux syscall names and libc function names.

> #### `experimental.stub_syscalls`
>
> Default: []  
> Type: Array of Integer
>
> List of syscall numbers to add "return 0" stubs for.
>
> If any of the listed syscalls are called by the managed application, *and* Shadow does not provide
> its own implementation of that syscall, Shadow will simply return 0 from the syscall instead of
> `ENOSYS`.

@robgjansen Wdyt? I'm open to alternative designs.