### PR TITLE
Set Cargo edition/publish in workspace, and change non-main crates to 0.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -17,5 +17,3 @@ values =
 [bumpversion:file:CMakeLists.txt]
 
 [bumpversion:file:src/main/Cargo.toml]
-
-[bumpversion:file:src/test/Cargo.toml]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -516,7 +516,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "formatting-nostd"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "cc",
  "libc",
@@ -564,7 +564,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gml-parser"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "nom",
 ]
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "linux-api"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bitflags 2.5.0",
  "bytemuck",
@@ -793,7 +793,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "log-c2rust"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "cbindgen",
  "cc",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "logger"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "scheduler"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "atomic_refcell",
  "crossbeam",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-build-common"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bindgen",
  "cbindgen",
@@ -1455,14 +1455,14 @@ dependencies = [
 
 [[package]]
 name = "shadow-build-info"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "time",
 ]
 
 [[package]]
 name = "shadow-pod"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "libc",
 ]
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-shim"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bindgen",
  "cbindgen",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-shim-helper-rs"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bytemuck",
  "cbindgen",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-tests"
-version = "3.2.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "formatting-nostd",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "shadow_shmem"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "formatting-nostd",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "shadow_tsc"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bindgen",
  "cbindgen",
@@ -1691,7 +1691,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "std-util"
-version = "0.1.0"
+version = "0.0.0"
 
 [[package]]
 name = "strsim"
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "syscall-logger"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1751,7 +1751,7 @@ checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "tcp"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bitflags 2.5.0",
  "bytes",
@@ -1979,7 +1979,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vasi"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "static_assertions",
  "vasi-macro",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "vasi-macro"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "vasi-sync"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "criterion",
  "libc",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -31,6 +31,10 @@ members = [
     "lib/vasi-sync",
 ]
 
+[workspace.package]
+edition = "2021"
+publish = false
+
 [profile.dev]
 # Without this, the shim requires a relatively large stack, especially during
 # initialization.  Rust makes it difficult to avoid putting objects temporarily

--- a/src/lib/formatting-nostd/Cargo.toml
+++ b/src/lib/formatting-nostd/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "formatting-nostd"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/formatting-nostd/Cargo.toml
+++ b/src/lib/formatting-nostd/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "formatting-nostd"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/gml-parser/Cargo.toml
+++ b/src/lib/gml-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gml-parser"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/gml-parser/Cargo.toml
+++ b/src/lib/gml-parser/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "gml-parser"
-version = "0.1.0"
 edition = "2021"
 publish = false
 

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "linux-api"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "linux-api"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/log-c2rust/Cargo.toml
+++ b/src/lib/log-c2rust/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "log-c2rust"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/log-c2rust/Cargo.toml
+++ b/src/lib/log-c2rust/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "log-c2rust"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/logger/Cargo.toml
+++ b/src/lib/logger/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "logger"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/logger/Cargo.toml
+++ b/src/lib/logger/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "logger"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/pod/Cargo.toml
+++ b/src/lib/pod/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "shadow-pod"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/pod/Cargo.toml
+++ b/src/lib/pod/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "shadow-pod"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/scheduler/Cargo.toml
+++ b/src/lib/scheduler/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "scheduler"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 atomic_refcell = "0.1"

--- a/src/lib/scheduler/Cargo.toml
+++ b/src/lib/scheduler/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "scheduler"
-version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/src/lib/shadow-build-common/Cargo.toml
+++ b/src/lib/shadow-build-common/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "shadow-build-common"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/shadow-build-common/Cargo.toml
+++ b/src/lib/shadow-build-common/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "shadow-build-common"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/shadow-build-info/Cargo.toml
+++ b/src/lib/shadow-build-info/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "shadow-build-info"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 [build-dependencies]
 time = { version = "0.3.31", features = ["formatting"] }

--- a/src/lib/shadow-build-info/Cargo.toml
+++ b/src/lib/shadow-build-info/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "shadow-build-info"
-version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]

--- a/src/lib/shadow-shim-helper-rs/Cargo.toml
+++ b/src/lib/shadow-shim-helper-rs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "shadow-shim-helper-rs"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/shadow-shim-helper-rs/Cargo.toml
+++ b/src/lib/shadow-shim-helper-rs/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "shadow-shim-helper-rs"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/shim/Cargo.toml
+++ b/src/lib/shim/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "shadow-shim"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/shim/Cargo.toml
+++ b/src/lib/shim/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "shadow-shim"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/shmem/Cargo.toml
+++ b/src/lib/shmem/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "shadow_shmem"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/shmem/Cargo.toml
+++ b/src/lib/shmem/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "shadow_shmem"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/std-util/Cargo.toml
+++ b/src/lib/std-util/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "std-util"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/std-util/Cargo.toml
+++ b/src/lib/std-util/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "std-util"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/syscall-logger/Cargo.toml
+++ b/src/lib/syscall-logger/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "syscall-logger"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 [lib]
 proc-macro = true

--- a/src/lib/syscall-logger/Cargo.toml
+++ b/src/lib/syscall-logger/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "syscall-logger"
-version = "0.1.0"
 edition = "2021"
 
 [lib]

--- a/src/lib/tcp/Cargo.toml
+++ b/src/lib/tcp/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "tcp"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 bitflags = "2.5.0"

--- a/src/lib/tcp/Cargo.toml
+++ b/src/lib/tcp/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "tcp"
-version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/src/lib/tsc/Cargo.toml
+++ b/src/lib/tsc/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "shadow_tsc"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/tsc/Cargo.toml
+++ b/src/lib/tsc/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "shadow_tsc"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/vasi-macro/Cargo.toml
+++ b/src/lib/vasi-macro/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "vasi-macro"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/vasi-macro/Cargo.toml
+++ b/src/lib/vasi-macro/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "vasi-macro"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "vasi-sync"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "vasi-sync"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/vasi/Cargo.toml
+++ b/src/lib/vasi/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "vasi"
-edition = "2021"
+edition.workspace = true
+publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib/vasi/Cargo.toml
+++ b/src/lib/vasi/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "vasi"
-version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "shadow-rs"
 version = "3.2.0"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "shadow-tests"
-version = "3.2.0"
 edition = "2021"
 publish = false
 

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shadow-tests"
-edition = "2021"
-publish = false
+edition.workspace = true
+publish.workspace = true
 
 [features]
 extra_tests = []


### PR DESCRIPTION
This means we only need to update the edition and publish options in a single place (the workspace Cargo.toml file). It's a little unfortunate that we need to specify `foo.workspace = true` in all crates, but it's not too bad.

Documentation for this feature: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table

Previously most of our libraries were version 0.1.0, and now they are changed to 0.0.0 to indicate that we don't actually update their version numbers. This shouldn't have any user-facing changes.