### PR TITLE
Upgrade actions/github-script to v7

### DIFF
--- a/.github/workflows/ci_maintenance.yml
+++ b/.github/workflows/ci_maintenance.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@v7
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |

--- a/.github/workflows/ci_maintenance.yml
+++ b/.github/workflows/ci_maintenance.yml
@@ -33,8 +33,8 @@ jobs:
           Shadow's dependencies may also need to be updated.
 
           \`\`\`bash
-          # The cargo `upgrade` subcommand requires `cargo install cargo-edit`. `cargo upgrade`
-          # won't update the lock file for all dependencies, so `cargo update` is also needed.
+          # The cargo \`upgrade\` subcommand requires \`cargo install cargo-edit\`. \`cargo upgrade\`
+          # won't update the lock file for all dependencies, so \`cargo update\` is also needed.
           cd src && cargo upgrade --incompatible && cargo update
           \`\`\`
 


### PR DESCRIPTION
v6 uses Node 16 and is deprecated.
v7 uses Node 20.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Also fixed a syntax error causing the workflow to fail.