### PR TITLE
syscall handler: fix inverted "warn once" logic

### DIFF
--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -593,7 +593,7 @@ impl SyscallHandler {
                 // already-warned set. Also detect the (rare) case that another
                 // thread already warned after we released the read-lock above.
                 let has_already_warned = has_already_warned
-                    || WARNED_SET
+                    || !WARNED_SET
                         .write()
                         .unwrap()
                         .get_or_insert_with(HashSet::new)


### PR DESCRIPTION
Fixes a bug introduced in 0412e0af74f59790515a2cc6b7653005a98a4a63.