### PR TITLE
Fix error-handling for posix_spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ from the parent instead of reset to default (unless `CLONE_CLEAR_SIGHAND` is use
 * The build system now logs a warning when detecting golang version 1.21.x, which is
 incompatible with shadow's golang tests. (#3307, fixing #3267).
 * Changed some syscall error cases to return `ENOTSUP` instead of `ENOSYS` (#3314).
+* Fixed error detection and handling when spawning processes (#3344).
 
 Full changelog since v3.1.0:
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -410,11 +410,10 @@ impl Host {
             // TODO: Add support for FnOnce?
             let envv = envv.clone();
             let argv = argv.clone();
-            let plugin_name = plugin_name.clone();
 
             let process = Process::spawn(
                 host,
-                plugin_name,
+                plugin_name.clone(),
                 &plugin_path,
                 argv,
                 envv,
@@ -422,7 +421,7 @@ impl Host {
                 host.params.strace_logging_options,
                 expected_final_state,
             )
-            .expect("Failed to initialize application {plugin_name:?}");
+            .unwrap_or_else(|e| panic!("Failed to initialize application {plugin_name:?}: {e:?}"));
             let (process_id, thread_id) = {
                 let process = process.borrow(host.root());
                 (process.id(), process.thread_group_leader_id())

--- a/src/main/utility/childpid_watcher.rs
+++ b/src/main/utility/childpid_watcher.rs
@@ -249,7 +249,8 @@ impl ChildPidWatcher {
     /// an unrelated process with a recycled `pid`.
     pub fn register_pid(&self, pid: Pid) {
         let mut inner = self.inner.lock().unwrap();
-        let pidfd = pidfd_open(pid).unwrap();
+        let pidfd =
+            pidfd_open(pid).unwrap_or_else(|e| panic!("pidfd_open failed for {pid:?}: {e:?}"));
 
         let event = EpollEvent::new(EpollFlags::EPOLLIN, pid.as_raw().try_into().unwrap());
         self.epoll.add(&pidfd, event).unwrap();


### PR DESCRIPTION
On failure, `posix_spawn` and related functions return the error code
directly instead of through errno. This fixes our handling of the return
codes to correctly detect and interpret errors from these functions.