### PR TITLE
Small changes for rust 1.79

### DIFF
--- a/ci/rust-toolchain-nightly.toml
+++ b/ci/rust-toolchain-nightly.toml
@@ -9,6 +9,6 @@
 [toolchain]
 # Must be a version built with miri; check
 # https://rust-lang.github.io/rustup-components-history/
-channel = "nightly-2024-06-01"
+channel = "nightly-2024-06-07"
 # We don't add individual components here. CI individually
 # adds the ones they need (e.g. clippy, miri).

--- a/ci/rust-toolchain-stable.toml
+++ b/ci/rust-toolchain-stable.toml
@@ -7,4 +7,4 @@
 # See
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"

--- a/src/lib/pod/src/lib.rs
+++ b/src/lib/pod/src/lib.rs
@@ -115,9 +115,8 @@ impl<const N: usize, T: Pod> PodTransmute<N, T> {
     fn transmute_array(x: &[u8; N]) -> T {
         // this should perform a compile-time check
         #[allow(clippy::let_unit_value)]
-        {
-            let _ = Self::CHECK;
-        }
+        let _ = Self::CHECK;
+
         // this should perform a runtime check in case the above compile-time check didn't run, but
         // should be compiled out if the compile-time check did run
         assert_eq!(N, core::mem::size_of::<T>());

--- a/src/lib/scheduler/src/thread_per_core.rs
+++ b/src/lib/scheduler/src/thread_per_core.rs
@@ -28,8 +28,7 @@ impl<HostType: Host> ThreadPerCoreSched<HostType> {
     /// threads created will be the length of `cpu_ids`.
     pub fn new<T>(cpu_ids: &[Option<u32>], hosts: T, yield_spin: bool) -> Self
     where
-        T: IntoIterator<Item = HostType>,
-        <T as IntoIterator>::IntoIter: ExactSizeIterator,
+        T: IntoIterator<Item = HostType, IntoIter: ExactSizeIterator>,
     {
         let hosts = hosts.into_iter();
 

--- a/src/lib/scheduler/src/thread_per_host.rs
+++ b/src/lib/scheduler/src/thread_per_host.rs
@@ -36,8 +36,7 @@ impl<HostType: Host> ThreadPerHostSched<HostType> {
         hosts: T,
     ) -> Self
     where
-        T: IntoIterator<Item = HostType>,
-        <T as IntoIterator>::IntoIter: ExactSizeIterator,
+        T: IntoIterator<Item = HostType, IntoIter: ExactSizeIterator>,
     {
         let hosts = hosts.into_iter();
 

--- a/src/main/core/configuration.rs
+++ b/src/main/core/configuration.rs
@@ -1277,8 +1277,7 @@ impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for NullableOption
 
 impl<T> FromStr for NullableOption<T>
 where
-    <T as FromStr>::Err: std::fmt::Debug + std::fmt::Display,
-    T: FromStr,
+    T: FromStr<Err: std::fmt::Debug + std::fmt::Display>,
 {
     type Err = T::Err;
 

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -308,7 +308,6 @@ impl<'a> Manager<'a> {
                 dns: unsafe { SyncSendPointer::new(dns) },
                 num_plugin_errors: AtomicU32::new(0),
                 // allow the status logger's state to be updated from anywhere
-                #[allow(clippy::map_clone)]
                 status_logger_state: status_logger_state.map(Arc::clone),
                 runahead: Runahead::new(
                     self.config.experimental.use_dynamic_runahead.unwrap(),

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -262,7 +262,7 @@ impl From<DescriptorHandle> for u32 {
 
 impl From<DescriptorHandle> for i32 {
     fn from(x: DescriptorHandle) -> i32 {
-        const _: () = assert!(FD_MAX <= i32::MAX as u32);
+        const { assert!(FD_MAX <= i32::MAX as u32) };
         // the constructor makes sure this won't panic
         x.0.try_into().unwrap()
     }

--- a/src/main/utility/byte_queue.rs
+++ b/src/main/utility/byte_queue.rs
@@ -130,17 +130,11 @@ impl ByteQueue {
     /// Push packet data onto the queue in a single chunk. Exactly `size` bytes will be read into
     /// the packet.
     pub fn push_packet<R: Read>(&mut self, mut src: R, size: usize) -> std::io::Result<()> {
-        // we may need somewhere to store a new buffer
-        let mut new_buf;
-
         let unused = match &mut self.unused_buffer {
             // if the existing 'unused_buffer' has enough space
             Some(buf) if buf.len() >= size => buf,
             // otherwise allocate a new buffer
-            _ => {
-                new_buf = self.alloc_zeroed_buffer(size);
-                &mut new_buf
-            }
+            _ => &mut self.alloc_zeroed_buffer(size),
         };
         assert_eq!(unused.len(), unused.capacity());
 


### PR DESCRIPTION
Rust 1.79 will be released in a few days, and allows us to make a few small improvements to Shadow's code. This also updates the CI to use rust 1.79 (CI expected to fail until 1.79 is released).