### PR TITLE
Add `OnceSet` for unhandled syscall warnings

### DIFF
--- a/src/main/utility/macros.rs
+++ b/src/main/utility/macros.rs
@@ -33,6 +33,9 @@ macro_rules! log_once_at_level {
                 std::sync::atomic::Ordering::Relaxed,
                 std::sync::atomic::Ordering::Relaxed,
             ) {
+                // NOTE: Some parts of shadow duplicate the "(LOG_ONCE)" string in their own log
+                // messages (for example `SyscallHandler::run_handler`). If we change this string
+                // here, we should change it in other places as well.
                 Ok(_) => log::log!($lvl_once, "(LOG_ONCE) {}", format_args!($str $($x)*)),
                 Err(_) => log::log!($lvl_remaining, "(LOG_ONCE) {}", format_args!($str $($x)*)),
             }

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -13,6 +13,7 @@ pub mod counter;
 pub mod give;
 pub mod interval_map;
 pub mod legacy_callback_queue;
+pub mod once_set;
 pub mod pcap_writer;
 pub mod perf_timer;
 pub mod proc_maps;

--- a/src/main/utility/once_set.rs
+++ b/src/main/utility/once_set.rs
@@ -1,0 +1,60 @@
+use std::collections::HashSet;
+use std::sync::RwLock;
+
+/// A [`HashSet`] that only allows insertions and uses interior mutablity. This allows it to be used
+/// in a global static.
+#[derive(Debug, Default)]
+pub struct OnceSet<T>(RwLock<Option<HashSet<T>>>);
+
+impl<T> OnceSet<T>
+where
+    T: std::cmp::Eq + std::hash::Hash,
+{
+    pub const fn new() -> Self {
+        Self(RwLock::new(None))
+    }
+
+    /// Insert `val` into the set. Returns `false` if `val` had previously been added to the set;
+    /// otherwise returns `true`.
+    pub fn insert(&self, val: T) -> bool {
+        // first check with a (cheap) read-lock
+        if self
+            .0
+            .read()
+            .unwrap()
+            .as_ref()
+            .map(|x| x.contains(&val))
+            .unwrap_or(false)
+        {
+            // already added
+            return false;
+        }
+
+        // If it looks like we haven't already added the value, add it to the set. Also detect the
+        // (rare) case that another thread already added the value after we released the read-lock
+        // above.
+        self.0
+            .write()
+            .unwrap()
+            .get_or_insert_with(HashSet::new)
+            .insert(val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_once_set() {
+        let set = OnceSet::new();
+
+        assert!(set.insert("FOO".to_string()));
+        assert!(set.insert("BAR".to_string()));
+        assert!(!set.insert("FOO".to_string()));
+        assert!(!set.insert("BAR".to_string()));
+        assert!(!set.insert("BAR".to_string()));
+        assert!(set.insert("XYZ".to_string()));
+        assert!(!set.insert("XYZ".to_string()));
+    }
+}


### PR DESCRIPTION
This pulls the `OnceSet` commit out of #3332. It moves the locking correctness logic to its own type. This also adds changes for the following review comments from #3332:

- https://github.com/shadow/shadow/pull/3332#discussion_r1604012045
    > Nit: Maybe append
    >
    > ```rust
    > assert!(!set.insert("BAR".to_string()));
    > ```
    >
    > to make sure inserting still works after attempting to insert a duplicate?
- https://github.com/shadow/shadow/pull/3332#discussion_r1604020948
    > I think this is still replicating the `warn_once_then_debug` behavior though, right? If so, I would add that detail to the comment. And maybe a back reference to here from `warn_once_then_debug` so that if that function is ever changed we know to update this code too.