### PR TITLE
getsockopt/setsockopt: use log_once_per_value_at_level for unknown opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ MINOR changes (backwards-compatible):
 
 PATCH changes (bugfixes):
 
-*
+* Log messages about unrecognized sockopt values are now only logged at level WARN once for each distinct value (and at DEBUG afterwards) (#3353).
 
 Full changelog since v3.2.0:
 

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -1102,7 +1102,13 @@ impl LegacyTcpSocket {
                 Ok(bytes_written as libc::socklen_t)
             }
             _ => {
-                log::warn!("getsockopt called with unsupported level {level} and opt {optname}");
+                log_once_per_value_at_level!(
+                    (level, optname),
+                    (i32, i32),
+                    log::Level::Warn,
+                    log::Level::Debug,
+                    "getsockopt called with unsupported level {level} and opt {optname}"
+                );
                 Err(Errno::ENOPROTOOPT.into())
             }
         }
@@ -1247,7 +1253,13 @@ impl LegacyTcpSocket {
                 log::trace!("setsockopt SO_BROADCAST not yet implemented");
             }
             _ => {
-                log::warn!("setsockopt called with unsupported level {level} and opt {optname}");
+                log_once_per_value_at_level!(
+                    (level, optname),
+                    (i32, i32),
+                    log::Level::Warn,
+                    log::Level::Debug,
+                    "setsockopt called with unsupported level {level} and opt {optname}"
+                );
                 return Err(Errno::ENOPROTOOPT.into());
             }
         }

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -926,7 +926,13 @@ impl TcpSocket {
                 Ok(bytes_written as libc::socklen_t)
             }
             _ => {
-                log::warn!("getsockopt called with unsupported level {level} and opt {optname}");
+                log_once_per_value_at_level!(
+                    (level, optname),
+                    (i32, i32),
+                    log::Level::Warn,
+                    log::Level::Debug,
+                    "getsockopt called with unsupported level {level} and opt {optname}"
+                );
                 Err(Errno::ENOPROTOOPT.into())
             }
         }
@@ -958,7 +964,13 @@ impl TcpSocket {
                 log::trace!("setsockopt SO_BROADCAST not yet implemented");
             }
             _ => {
-                log::warn!("setsockopt called with unsupported level {level} and opt {optname}");
+                log_once_per_value_at_level!(
+                    (level, optname),
+                    (i32, i32),
+                    log::Level::Warn,
+                    log::Level::Debug,
+                    "setsockopt called with unsupported level {level} and opt {optname}"
+                );
                 return Err(Errno::ENOPROTOOPT.into());
             }
         }

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -852,11 +852,23 @@ impl UdpSocket {
                 Ok(bytes_written as libc::socklen_t)
             }
             (libc::SOL_SOCKET, _) => {
-                log::debug!("getsockopt called with unsupported level {level} and opt {optname}");
+                log_once_per_value_at_level!(
+                    (level, optname),
+                    (i32, i32),
+                    log::Level::Warn,
+                    log::Level::Debug,
+                    "getsockopt called with unsupported level {level} and opt {optname}"
+                );
                 Err(Errno::ENOPROTOOPT.into())
             }
             _ => {
-                log::debug!("getsockopt called with unsupported level {level} and opt {optname}");
+                log_once_per_value_at_level!(
+                    (level, optname),
+                    (i32, i32),
+                    log::Level::Warn,
+                    log::Level::Debug,
+                    "getsockopt called with unsupported level {level} and opt {optname}"
+                );
                 Err(Errno::EOPNOTSUPP.into())
             }
         }
@@ -945,7 +957,13 @@ impl UdpSocket {
                 );
             }
             _ => {
-                log::debug!("setsockopt called with unsupported level {level} and opt {optname}");
+                log_once_per_value_at_level!(
+                    (level, optname),
+                    (i32, i32),
+                    log::Level::Warn,
+                    log::Level::Debug,
+                    "setsockopt called with unsupported level {level} and opt {optname}"
+                );
                 return Err(Errno::ENOPROTOOPT.into());
             }
         }


### PR DESCRIPTION
These lines can otherwise be fairly noisy in large simulations.