### PR TITLE
Add exception for loom cfg in rust 1.80-beta

### DIFF
--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -3,6 +3,9 @@ name = "vasi-sync"
 edition.workspace = true
 publish.workspace = true
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
This is in preparation for the upcoming changes in rust 1.80:

https://blog.rust-lang.org/2024/05/06/check-cfg.html

Rust 1.80 will likely be released before we publish another Shadow release (end of July), so I don't think it hurts to merge now.

Fixes around 40 warnings of the form:

```
warning: unexpected `cfg` condition name: `loom`
   --> lib/vasi-sync/src/sync.rs:163:15
    |
163 |     #[cfg(not(loom))]
    |               ^^^^
    |
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(loom)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

On old (including the current) rust versions, this commit causes:

```
warning: lib/vasi-sync/Cargo.toml: unused manifest key: lints.rust.unexpected_cfgs.check-cfg
```
