### PR TITLE
Fix clippy warnings in rust 1.80-beta

### DIFF
--- a/src/lib/shim/src/clone.rs
+++ b/src/lib/shim/src/clone.rs
@@ -128,7 +128,7 @@ unsafe extern "C-unwind" fn tls_ipc_set(blk: *const ShMemBlockSerialized) {
 /// # Safety
 ///
 /// * `ctx` must be dereferenceable, and must be safe for the newly spawned
-/// child thread to restore.
+///   child thread to restore.
 /// * Other pointers, if non-null, must be safely dereferenceable.
 /// * `child_stack` must be "sufficiently big" for the child thread to run on.
 /// * `tls` if provided must point to correctly initialized thread local storage.
@@ -211,7 +211,7 @@ unsafe fn do_clone_process(ctx: &ucontext, event: &ShimEventAddThreadReq) -> i64
 /// # Safety
 ///
 /// * `ctx` must be dereferenceable, and must be safe for the newly spawned
-/// child thread to restore.
+///   child thread to restore.
 /// * Other pointers, if non-null, must be safely dereferenceable.
 /// * `child_stack` must be "sufficiently big" for the child thread to run on.
 /// * `tls` if provided must point to correctly initialized thread local storage.
@@ -336,7 +336,7 @@ unsafe fn do_clone_thread(ctx: &ucontext, event: &ShimEventAddThreadReq) -> i64 
 /// # Safety
 ///
 /// * `ctx` must be dereferenceable, and must be safe for the newly spawned
-/// child thread to restore.
+///   child thread to restore.
 /// * Other pointers, if non-null, must be safely dereferenceable.
 /// * `child_stack` must be "sufficiently big" for the child thread to run on.
 /// * `tls` if provided must point to correctly initialized thread local storage.

--- a/src/lib/shim/src/tls.rs
+++ b/src/lib/shim/src/tls.rs
@@ -59,12 +59,13 @@ pub enum Mode {
     ///
     /// This mode is nearly as fast as native, but:
     /// * Assumes that if the "thread pointer" in `%fs:0` is non-NULL for a
-    /// given thread, that it is stable and unique for the lifetime of that
-    /// thread.  This seems like a fairly reasonable assumption, and seems to
-    /// hold so far, but isn't guaranteed.
+    ///   given thread, that it is stable and unique for the lifetime of that
+    ///   thread.  This seems like a fairly reasonable assumption, and seems to
+    ///   hold so far, but isn't guaranteed.
     /// * Requires that each thread using thread local storage from this module
-    /// calls [`ThreadLocalStorage::unregister_current_thread`] before exiting, since the thread pointer
-    /// may subsequently be used for another thread.
+    ///   calls [`ThreadLocalStorage::unregister_current_thread`] before
+    ///   exiting, since the thread pointer may subsequently be used for another
+    ///   thread.
     ///
     /// [ELF-TLS]: "ELF Handling For Thread-Local Storage", by Ulrich Drepper.
     /// <https://www.akkadia.org/drepper/tls.pdf>
@@ -138,8 +139,9 @@ struct TlsOneThreadStorage {
 impl TlsOneThreadStorage {
     /// # Safety
     ///
-    /// * `alloc` must be dereferenceable and live for the lifetime of this process.
-    /// (A zeroed buffer is a valid dereferenceable instance of `Self`)
+    /// * `alloc` must be dereferenceable and live for the lifetime of this
+    ///   process. (A zeroed buffer is a valid dereferenceable instance of
+    ///   `Self`)
     /// * `alloc` must *only* be accessed through this function.
     pub unsafe fn from_static_lifetime_zeroed_allocation(
         alloc: *mut TlsOneThreadStorageAllocation,

--- a/src/lib/vasi-sync/src/scchannel.rs
+++ b/src/lib/vasi-sync/src/scchannel.rs
@@ -140,8 +140,8 @@ impl Display for SelfContainedChannelError {
 /// Breaking the documented API contracts may result both in immediate panics,
 /// and panics in subsequent operations on the channel. To avoid this, the user
 /// must:
-/// * Never allow parallel `send` or `receive` operations. This is a single-producer,
-/// single-consumer channel.
+/// * Never allow parallel `send` or `receive` operations. This is a
+///   single-producer, single-consumer channel.
 /// * Never call `send` when there is already a message pending.
 ///
 /// Loosely inspired by the channel implementation examples in "Rust Atomics and

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -5,10 +5,10 @@
 //!
 //! * Directly read or write process memory
 //! * Obtain smart pointers ([`ProcessMemoryRef`] and [`ProcessMemoryRefMut`])
-//! to process memory
+//!   to process memory
 //! * Obtain cursors to process memory implementing `std::io::Seek` and either
-//! `std::io::Read` or `std::io::Write` ([`MemoryReaderCursor`] and
-//! [`MemoryWriterCursor`])
+//!   `std::io::Read` or `std::io::Write` ([`MemoryReaderCursor`] and
+//!   [`MemoryWriterCursor`])
 //!
 //! For the [`MemoryManager`] to maintain a consistent view of the process's address space,
 //! and for it to be able to enforce Rust's safety requirements for references and sharing,


### PR DESCRIPTION
Example:

```
warning: doc list item missing indentation
   --> lib/vasi-sync/src/scchannel.rs:144:5
    |
144 | /// single-consumer channel.
    |     ^
    |
    = help: if this is supposed to be its own paragraph, add a blank line
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
    = note: `#[warn(clippy::doc_lazy_continuation)]` on by default
help: indent this line
    |
144 | ///   single-consumer channel.
    |     ++
```

(Aside:)

If anyone finds them useful, these are the vim settings I use for formatting rust comments, and they seem to work fairly well. Figured I'd might as well post them here:

```vim
" fix gq formatting: https://stackoverflow.com/a/28078855
autocmd Filetype rust set comments^=:///
autocmd Filetype rust set comments^=://!
" and for quote comments
autocmd Filetype rust set comments^=:///\ >
autocmd Filetype rust set comments^=://\ >
" wrap comments but not text
autocmd Filetype rust set formatoptions+=c
autocmd Filetype rust set formatoptions-=t
" https://stackoverflow.com/questions/37149002/vim-indenting-bullet-lists-within-comments-in-python
autocmd FileType rust,c,python set formatoptions+=n
autocmd FileType rust,c,python set formatlistpat=^\\s*[\\-\\+\\*]\\+\\s\\+
```