### PR TITLE
Add an assertion when an event is pushed

### DIFF
--- a/src/main/core/work/event_queue.rs
+++ b/src/main/core/work/event_queue.rs
@@ -25,7 +25,13 @@ impl EventQueue {
     /// Will panic if two events are pushed that have no relative order
     /// (`event_a.partial_cmp(&event_b) == None`). Will be non-deterministic if two events are
     /// pushed that are equal (`event_a == event_b`).
+    ///
+    /// Will panic if the event time is earlier than the last popped event time (time moves
+    /// backward).
     pub fn push(&mut self, event: Event) {
+        // make sure time never moves backward
+        assert!(event.time() >= self.last_popped_event_time);
+
         self.queue.push(Reverse(event.into()));
     }
 


### PR DESCRIPTION
In https://github.com/shadow/shadow/pull/3367#issuecomment-2230884488, shadow panics because an event is scheduled to occur at a time earlier than a previously run event, meaning that time moves backwards. I'm not actively debugging the linked issue, but I think it would good to have an assertion here anyways to catch this sort of thing earlier.

This PR checks that a pushed event does not occur before a previously popped event. We already had an equivalent check when popping an event (which is the panic in the linked issue), but by also checking when pushing an event, we should hopefully catch it sooner and get a more useful backtrace.