### PR TITLE
Various improvements to syscall handlers

### DIFF
--- a/src/lib/linux-api/src/fcntl.rs
+++ b/src/lib/linux-api/src/fcntl.rs
@@ -34,89 +34,87 @@ bitflags::bitflags! {
 
 /// fcntl commands, as used with `fcntl`.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
-#[repr(i32)]
+#[repr(u32)]
 #[allow(non_camel_case_types)]
 pub enum FcntlCommand {
-    F_DUPFD = const_conversions::i32_from_u32(bindings::LINUX_F_DUPFD),
-    F_GETFD = const_conversions::i32_from_u32(bindings::LINUX_F_GETFD),
-    F_SETFD = const_conversions::i32_from_u32(bindings::LINUX_F_SETFD),
-    F_GETFL = const_conversions::i32_from_u32(bindings::LINUX_F_GETFL),
-    F_SETFL = const_conversions::i32_from_u32(bindings::LINUX_F_SETFL),
-    F_GETLK = const_conversions::i32_from_u32(bindings::LINUX_F_GETLK),
-    F_SETLK = const_conversions::i32_from_u32(bindings::LINUX_F_SETLK),
-    F_SETLKW = const_conversions::i32_from_u32(bindings::LINUX_F_SETLKW),
-    F_SETOWN = const_conversions::i32_from_u32(bindings::LINUX_F_SETOWN),
-    F_GETOWN = const_conversions::i32_from_u32(bindings::LINUX_F_GETOWN),
-    F_SETSIG = const_conversions::i32_from_u32(bindings::LINUX_F_SETSIG),
-    F_GETSIG = const_conversions::i32_from_u32(bindings::LINUX_F_GETSIG),
-    F_SETOWN_EX = const_conversions::i32_from_u32(bindings::LINUX_F_SETOWN_EX),
-    F_GETOWN_EX = const_conversions::i32_from_u32(bindings::LINUX_F_GETOWN_EX),
-    F_GETOWNER_UIDS = const_conversions::i32_from_u32(bindings::LINUX_F_GETOWNER_UIDS),
-    F_OFD_GETLK = const_conversions::i32_from_u32(bindings::LINUX_F_OFD_GETLK),
-    F_OFD_SETLK = const_conversions::i32_from_u32(bindings::LINUX_F_OFD_SETLK),
-    F_OFD_SETLKW = const_conversions::i32_from_u32(bindings::LINUX_F_OFD_SETLKW),
-    F_SETLEASE = const_conversions::i32_from_u32(bindings::LINUX_F_SETLEASE),
-    F_GETLEASE = const_conversions::i32_from_u32(bindings::LINUX_F_GETLEASE),
-    F_DUPFD_CLOEXEC = const_conversions::i32_from_u32(bindings::LINUX_F_DUPFD_CLOEXEC),
-    F_NOTIFY = const_conversions::i32_from_u32(bindings::LINUX_F_NOTIFY),
-    F_SETPIPE_SZ = const_conversions::i32_from_u32(bindings::LINUX_F_SETPIPE_SZ),
-    F_GETPIPE_SZ = const_conversions::i32_from_u32(bindings::LINUX_F_GETPIPE_SZ),
-    F_ADD_SEALS = const_conversions::i32_from_u32(bindings::LINUX_F_ADD_SEALS),
-    F_GET_SEALS = const_conversions::i32_from_u32(bindings::LINUX_F_GET_SEALS),
-    F_CANCELLK = const_conversions::i32_from_u32(bindings::LINUX_F_CANCELLK),
-    F_GET_RW_HINT = const_conversions::i32_from_u32(bindings::LINUX_F_GET_RW_HINT),
-    F_SET_RW_HINT = const_conversions::i32_from_u32(bindings::LINUX_F_SET_RW_HINT),
-    F_GET_FILE_RW_HINT = const_conversions::i32_from_u32(bindings::LINUX_F_GET_FILE_RW_HINT),
-    F_SET_FILE_RW_HINT = const_conversions::i32_from_u32(bindings::LINUX_F_SET_FILE_RW_HINT),
+    F_DUPFD = bindings::LINUX_F_DUPFD,
+    F_GETFD = bindings::LINUX_F_GETFD,
+    F_SETFD = bindings::LINUX_F_SETFD,
+    F_GETFL = bindings::LINUX_F_GETFL,
+    F_SETFL = bindings::LINUX_F_SETFL,
+    F_GETLK = bindings::LINUX_F_GETLK,
+    F_SETLK = bindings::LINUX_F_SETLK,
+    F_SETLKW = bindings::LINUX_F_SETLKW,
+    F_SETOWN = bindings::LINUX_F_SETOWN,
+    F_GETOWN = bindings::LINUX_F_GETOWN,
+    F_SETSIG = bindings::LINUX_F_SETSIG,
+    F_GETSIG = bindings::LINUX_F_GETSIG,
+    F_SETOWN_EX = bindings::LINUX_F_SETOWN_EX,
+    F_GETOWN_EX = bindings::LINUX_F_GETOWN_EX,
+    F_GETOWNER_UIDS = bindings::LINUX_F_GETOWNER_UIDS,
+    F_OFD_GETLK = bindings::LINUX_F_OFD_GETLK,
+    F_OFD_SETLK = bindings::LINUX_F_OFD_SETLK,
+    F_OFD_SETLKW = bindings::LINUX_F_OFD_SETLKW,
+    F_SETLEASE = bindings::LINUX_F_SETLEASE,
+    F_GETLEASE = bindings::LINUX_F_GETLEASE,
+    F_DUPFD_CLOEXEC = bindings::LINUX_F_DUPFD_CLOEXEC,
+    F_NOTIFY = bindings::LINUX_F_NOTIFY,
+    F_SETPIPE_SZ = bindings::LINUX_F_SETPIPE_SZ,
+    F_GETPIPE_SZ = bindings::LINUX_F_GETPIPE_SZ,
+    F_ADD_SEALS = bindings::LINUX_F_ADD_SEALS,
+    F_GET_SEALS = bindings::LINUX_F_GET_SEALS,
+    F_CANCELLK = bindings::LINUX_F_CANCELLK,
+    F_GET_RW_HINT = bindings::LINUX_F_GET_RW_HINT,
+    F_SET_RW_HINT = bindings::LINUX_F_SET_RW_HINT,
+    F_GET_FILE_RW_HINT = bindings::LINUX_F_GET_FILE_RW_HINT,
+    F_SET_FILE_RW_HINT = bindings::LINUX_F_SET_FILE_RW_HINT,
 }
 
 /// Owner, as used with [`FcntlCommand::F_SETOWN_EX`] and [`FcntlCommand::F_GETOWN_EX`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
-#[repr(i32)]
+#[repr(u32)]
 #[allow(non_camel_case_types)]
 pub enum FcntlOwner {
-    F_OWNER_TID = const_conversions::i32_from_u32(bindings::LINUX_F_OWNER_TID),
-    F_OWNER_PID = const_conversions::i32_from_u32(bindings::LINUX_F_OWNER_PID),
-    F_OWNER_PGRP = const_conversions::i32_from_u32(bindings::LINUX_F_OWNER_PGRP),
+    F_OWNER_TID = bindings::LINUX_F_OWNER_TID,
+    F_OWNER_PID = bindings::LINUX_F_OWNER_PID,
+    F_OWNER_PGRP = bindings::LINUX_F_OWNER_PGRP,
 }
 
 /// Lease type, as used with [`FcntlCommand::F_SETLEASE`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
-#[repr(i32)]
+#[repr(u32)]
 #[allow(non_camel_case_types)]
 pub enum FcntlLeaseType {
-    F_RDLCK = const_conversions::i32_from_u32(bindings::LINUX_F_RDLCK),
-    F_WRLCK = const_conversions::i32_from_u32(bindings::LINUX_F_WRLCK),
-    F_UNLCK = const_conversions::i32_from_u32(bindings::LINUX_F_UNLCK),
-    F_EXLCK = const_conversions::i32_from_u32(bindings::LINUX_F_EXLCK),
-    F_SHLCK = const_conversions::i32_from_u32(bindings::LINUX_F_SHLCK),
+    F_RDLCK = bindings::LINUX_F_RDLCK,
+    F_WRLCK = bindings::LINUX_F_WRLCK,
+    F_UNLCK = bindings::LINUX_F_UNLCK,
+    F_EXLCK = bindings::LINUX_F_EXLCK,
+    F_SHLCK = bindings::LINUX_F_SHLCK,
 }
 
 /// Seal type, as used with [`FcntlCommand::F_ADD_SEALS`] and [`FcntlCommand::F_GET_SEALS`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
-#[repr(i32)]
+#[repr(u32)]
 #[allow(non_camel_case_types)]
 pub enum FcntlSealType {
-    F_SEAL_SEAL = const_conversions::i32_from_u32(bindings::LINUX_F_SEAL_SEAL),
-    F_SEAL_SHRINK = const_conversions::i32_from_u32(bindings::LINUX_F_SEAL_SHRINK),
-    F_SEAL_GROW = const_conversions::i32_from_u32(bindings::LINUX_F_SEAL_GROW),
-    F_SEAL_WRITE = const_conversions::i32_from_u32(bindings::LINUX_F_SEAL_WRITE),
-    F_SEAL_FUTURE_WRITE = const_conversions::i32_from_u32(bindings::LINUX_F_SEAL_FUTURE_WRITE),
+    F_SEAL_SEAL = bindings::LINUX_F_SEAL_SEAL,
+    F_SEAL_SHRINK = bindings::LINUX_F_SEAL_SHRINK,
+    F_SEAL_GROW = bindings::LINUX_F_SEAL_GROW,
+    F_SEAL_WRITE = bindings::LINUX_F_SEAL_WRITE,
+    F_SEAL_FUTURE_WRITE = bindings::LINUX_F_SEAL_FUTURE_WRITE,
 }
 
 /// Read-write hint, as used with [`FcntlCommand::F_GET_RW_HINT`] and [`FcntlCommand::F_SET_RW_HINT`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
-#[repr(i32)]
+#[repr(u32)]
 #[allow(non_camel_case_types)]
 pub enum FcntlRwHint {
-    RWH_WRITE_LIFE_NOT_SET =
-        const_conversions::i32_from_u32(bindings::LINUX_RWH_WRITE_LIFE_NOT_SET),
-    RWH_WRITE_LIFE_NONE = const_conversions::i32_from_u32(bindings::LINUX_RWH_WRITE_LIFE_NONE),
-    RWH_WRITE_LIFE_SHORT = const_conversions::i32_from_u32(bindings::LINUX_RWH_WRITE_LIFE_SHORT),
-    RWH_WRITE_LIFE_MEDIUM = const_conversions::i32_from_u32(bindings::LINUX_RWH_WRITE_LIFE_MEDIUM),
-    RWH_WRITE_LIFE_LONG = const_conversions::i32_from_u32(bindings::LINUX_RWH_WRITE_LIFE_LONG),
-    RWH_WRITE_LIFE_EXTREME =
-        const_conversions::i32_from_u32(bindings::LINUX_RWH_WRITE_LIFE_EXTREME),
+    RWH_WRITE_LIFE_NOT_SET = bindings::LINUX_RWH_WRITE_LIFE_NOT_SET,
+    RWH_WRITE_LIFE_NONE = bindings::LINUX_RWH_WRITE_LIFE_NONE,
+    RWH_WRITE_LIFE_SHORT = bindings::LINUX_RWH_WRITE_LIFE_SHORT,
+    RWH_WRITE_LIFE_MEDIUM = bindings::LINUX_RWH_WRITE_LIFE_MEDIUM,
+    RWH_WRITE_LIFE_LONG = bindings::LINUX_RWH_WRITE_LIFE_LONG,
+    RWH_WRITE_LIFE_EXTREME = bindings::LINUX_RWH_WRITE_LIFE_EXTREME,
 }
 
 bitflags::bitflags! {

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -287,11 +287,23 @@ impl From<DescriptorHandle> for u32 {
     }
 }
 
+impl From<DescriptorHandle> for u64 {
+    fn from(x: DescriptorHandle) -> u64 {
+        x.0.into()
+    }
+}
+
 impl From<DescriptorHandle> for i32 {
     fn from(x: DescriptorHandle) -> i32 {
         const _: () = assert!(FD_MAX <= i32::MAX as u32);
         // the constructor makes sure this won't panic
         x.0.try_into().unwrap()
+    }
+}
+
+impl From<DescriptorHandle> for i64 {
+    fn from(x: DescriptorHandle) -> i64 {
+        x.0.into()
     }
 }
 

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeSet, HashMap};
 
 use log::*;
 use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
+use shadow_shim_helper_rs::syscall_types::SyscallReg;
 
 use crate::host::descriptor::Descriptor;
 use crate::host::host::Host;
@@ -303,6 +304,12 @@ impl From<DescriptorHandle> for i32 {
 
 impl From<DescriptorHandle> for i64 {
     fn from(x: DescriptorHandle) -> i64 {
+        x.0.into()
+    }
+}
+
+impl From<DescriptorHandle> for SyscallReg {
+    fn from(x: DescriptorHandle) -> SyscallReg {
         x.0.into()
     }
 }

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -185,7 +185,7 @@ impl LegacyTcpSocket {
         self.peek_packet().is_some()
     }
 
-    pub fn getsockname(&self) -> Result<Option<SockaddrIn>, SyscallError> {
+    pub fn getsockname(&self) -> Result<Option<SockaddrIn>, Errno> {
         let mut ip: libc::in_addr_t = 0;
         let mut port: libc::in_port_t = 0;
 
@@ -203,7 +203,7 @@ impl LegacyTcpSocket {
         Ok(Some(addr.into()))
     }
 
-    pub fn getpeername(&self) -> Result<Option<SockaddrIn>, SyscallError> {
+    pub fn getpeername(&self) -> Result<Option<SockaddrIn>, Errno> {
         let mut ip: libc::in_addr_t = 0;
         let mut port: libc::in_port_t = 0;
 
@@ -211,7 +211,7 @@ impl LegacyTcpSocket {
         let okay =
             unsafe { c::legacysocket_getPeerName(self.as_legacy_socket(), &mut ip, &mut port) };
         if okay != 1 {
-            return Err(Errno::ENOTCONN.into());
+            return Err(Errno::ENOTCONN);
         }
 
         let ip = Ipv4Addr::from(u32::from_be(ip));

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -238,7 +238,7 @@ impl LegacyTcpSocket {
         addr: Option<&SockaddrStorage>,
         net_ns: &NetworkNamespace,
         rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         // if the address pointer was NULL
         let Some(addr) = addr else {
             return Err(Errno::EFAULT.into());
@@ -299,7 +299,7 @@ impl LegacyTcpSocket {
             )
         };
 
-        Ok(0.into())
+        Ok(())
     }
 
     pub fn readv(

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -633,7 +633,7 @@ impl LegacyTcpSocket {
         net_ns: &NetworkNamespace,
         rng: impl rand::Rng,
         _cb_queue: &mut CallbackQueue,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         let socket_ref = socket.borrow();
 
         // only listen on the socket if it is not used for other functions
@@ -641,7 +641,7 @@ impl LegacyTcpSocket {
             unsafe { c::tcp_isListeningAllowed(socket_ref.as_legacy_tcp()) } == 1;
         if !is_listening_allowed {
             log::debug!("Cannot listen on previously used socket");
-            return Err(Errno::EOPNOTSUPP.into());
+            return Err(Errno::EOPNOTSUPP);
         }
 
         // if we are already listening, just update the backlog and return 0

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -98,7 +98,7 @@ impl InetSocket {
         addr: Option<&SockaddrStorage>,
         net_ns: &NetworkNamespace,
         rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         match self {
             Self::LegacyTcp(socket) => LegacyTcpSocket::bind(socket, addr, net_ns, rng),
             Self::Tcp(socket) => TcpSocket::bind(socket, addr, net_ns, rng),

--- a/src/main/host/descriptor/socket/inet/mod.rs
+++ b/src/main/host/descriptor/socket/inet/mod.rs
@@ -279,7 +279,7 @@ impl InetSocketRef<'_> {
 
 // socket-specific functions
 impl InetSocketRef<'_> {
-    pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
+    pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, Errno> {
         match self {
             Self::LegacyTcp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
             Self::Tcp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
@@ -287,7 +287,7 @@ impl InetSocketRef<'_> {
         }
     }
 
-    pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
+    pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, Errno> {
         match self {
             Self::LegacyTcp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
             Self::Tcp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
@@ -369,7 +369,7 @@ impl InetSocketRefMut<'_> {
 
 // socket-specific functions
 impl InetSocketRefMut<'_> {
-    pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
+    pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, Errno> {
         match self {
             Self::LegacyTcp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
             Self::Tcp(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
@@ -377,7 +377,7 @@ impl InetSocketRefMut<'_> {
         }
     }
 
-    pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
+    pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, Errno> {
         match self {
             Self::LegacyTcp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
             Self::Tcp(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -555,7 +555,7 @@ impl TcpSocket {
         net_ns: &NetworkNamespace,
         rng: impl rand::Rng,
         cb_queue: &mut CallbackQueue,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         let socket_ref = &mut *socket.borrow_mut();
 
         // linux also makes this cast, so negative backlogs wrap around to large positive backlogs
@@ -588,14 +588,14 @@ impl TcpSocket {
                     rng,
                 )?;
 
-                Ok::<_, SyscallError>(Some(handle))
+                Ok::<_, Errno>(Some(handle))
             };
             socket_ref.with_tcp_state(cb_queue, |state| state.listen(backlog, associate_fn))
         };
 
         let handle = match rv {
             Ok(x) => x,
-            Err(tcp::ListenError::InvalidState) => return Err(Errno::EINVAL.into()),
+            Err(tcp::ListenError::InvalidState) => return Err(Errno::EINVAL),
             Err(tcp::ListenError::FailedAssociation(e)) => return Err(e),
         };
 

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -344,7 +344,7 @@ impl TcpSocket {
         addr: Option<&SockaddrStorage>,
         net_ns: &NetworkNamespace,
         rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         // if the address pointer was NULL
         let Some(addr) = addr else {
             return Err(Errno::EFAULT.into());
@@ -379,7 +379,7 @@ impl TcpSocket {
 
         socket_ref.association = Some(handle);
 
-        Ok(0.into())
+        Ok(())
     }
 
     pub fn readv(

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -288,7 +288,7 @@ impl TcpSocket {
         self.tcp_state.wants_to_send()
     }
 
-    pub fn getsockname(&self) -> Result<Option<SockaddrIn>, SyscallError> {
+    pub fn getsockname(&self) -> Result<Option<SockaddrIn>, Errno> {
         // The socket state won't always have the local address. For example if the socket was bound
         // but connect() hasn't yet been called, the socket state will not have a local or remote
         // address. Instead we should get the local address from the association.
@@ -300,7 +300,7 @@ impl TcpSocket {
         ))
     }
 
-    pub fn getpeername(&self) -> Result<Option<SockaddrIn>, SyscallError> {
+    pub fn getpeername(&self) -> Result<Option<SockaddrIn>, Errno> {
         // The association won't always have the peer address. For example if the socket was bound
         // before connect() was called, the association will have a peer of 0.0.0.0. Instead we
         // should get the peer address from the socket state.

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -244,7 +244,7 @@ impl UdpSocket {
         addr: Option<&SockaddrStorage>,
         net_ns: &NetworkNamespace,
         rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         // if the address pointer was NULL
         let Some(addr) = addr else {
             return Err(Errno::EFAULT.into());
@@ -293,7 +293,7 @@ impl UdpSocket {
             socket.association = Some(handle);
         }
 
-        Ok(0.into())
+        Ok(())
     }
 
     pub fn readv(

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -658,8 +658,8 @@ impl UdpSocket {
         _net_ns: &NetworkNamespace,
         _rng: impl rand::Rng,
         _cb_queue: &mut CallbackQueue,
-    ) -> Result<(), SyscallError> {
-        Err(Errno::EOPNOTSUPP.into())
+    ) -> Result<(), Errno> {
+        Err(Errno::EOPNOTSUPP)
     }
 
     pub fn connect(

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -202,7 +202,7 @@ impl UdpSocket {
         !self.send_buffer.is_empty()
     }
 
-    pub fn getsockname(&self) -> Result<Option<SockaddrIn>, SyscallError> {
+    pub fn getsockname(&self) -> Result<Option<SockaddrIn>, Errno> {
         let mut addr = self
             .bound_addr
             .unwrap_or(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0));
@@ -218,7 +218,7 @@ impl UdpSocket {
         Ok(Some(addr.into()))
     }
 
-    pub fn getpeername(&self) -> Result<Option<SockaddrIn>, SyscallError> {
+    pub fn getpeername(&self) -> Result<Option<SockaddrIn>, Errno> {
         Ok(Some(self.peer_addr.ok_or(Errno::ENOTCONN)?.into()))
     }
 

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use inet::{InetSocket, InetSocketRef, InetSocketRefMut};
+use linux_api::errno::Errno;
 use linux_api::ioctls::IoctlRequest;
 use linux_api::socket::Shutdown;
 use netlink::NetlinkSocket;
@@ -217,7 +218,7 @@ impl SocketRef<'_> {
 
 // socket-specific functions
 impl SocketRef<'_> {
-    pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
+    pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, Errno> {
         match self {
             Self::Unix(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
             Self::Inet(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
@@ -225,7 +226,7 @@ impl SocketRef<'_> {
         }
     }
 
-    pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
+    pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, Errno> {
         match self {
             Self::Unix(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
             Self::Inet(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
@@ -297,7 +298,7 @@ impl SocketRefMut<'_> {
 
 // socket-specific functions
 impl SocketRefMut<'_> {
-    pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
+    pub fn getpeername(&self) -> Result<Option<SockaddrStorage>, Errno> {
         match self {
             Self::Unix(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
             Self::Inet(socket) => socket.getpeername().map(|opt| opt.map(Into::into)),
@@ -305,7 +306,7 @@ impl SocketRefMut<'_> {
         }
     }
 
-    pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, SyscallError> {
+    pub fn getsockname(&self) -> Result<Option<SockaddrStorage>, Errno> {
         match self {
             Self::Unix(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),
             Self::Inet(socket) => socket.getsockname().map(|opt| opt.map(Into::into)),

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -90,7 +90,7 @@ impl Socket {
         addr: Option<&SockaddrStorage>,
         net_ns: &NetworkNamespace,
         rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         match self {
             Self::Unix(socket) => UnixSocket::bind(socket, addr, net_ns, rng),
             Self::Inet(socket) => InetSocket::bind(socket, addr, net_ns, rng),

--- a/src/main/host/descriptor/socket/mod.rs
+++ b/src/main/host/descriptor/socket/mod.rs
@@ -104,7 +104,7 @@ impl Socket {
         net_ns: &NetworkNamespace,
         rng: impl rand::Rng,
         cb_queue: &mut CallbackQueue,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         match self {
             Self::Unix(socket) => UnixSocket::listen(socket, backlog, net_ns, rng, cb_queue),
             Self::Inet(socket) => InetSocket::listen(socket, backlog, net_ns, rng, cb_queue),

--- a/src/main/host/descriptor/socket/netlink.rs
+++ b/src/main/host/descriptor/socket/netlink.rs
@@ -129,15 +129,15 @@ impl NetlinkSocket {
         self.common.has_open_file = val;
     }
 
-    pub fn getsockname(&self) -> Result<Option<nix::sys::socket::NetlinkAddr>, SyscallError> {
+    pub fn getsockname(&self) -> Result<Option<nix::sys::socket::NetlinkAddr>, Errno> {
         self.protocol_state.bound_address()
     }
 
-    pub fn getpeername(&self) -> Result<Option<nix::sys::socket::NetlinkAddr>, SyscallError> {
+    pub fn getpeername(&self) -> Result<Option<nix::sys::socket::NetlinkAddr>, Errno> {
         warn_once_then_debug!(
             "getpeername() syscall not yet supported for netlink sockets; Returning ENOSYS"
         );
-        Err(Errno::ENOSYS.into())
+        Err(Errno::ENOSYS)
     }
 
     pub fn address_family(&self) -> linux_api::socket::AddressFamily {
@@ -433,7 +433,7 @@ impl ProtocolState {
         }))
     }
 
-    fn bound_address(&self) -> Result<Option<NetlinkAddr>, SyscallError> {
+    fn bound_address(&self) -> Result<Option<NetlinkAddr>, Errno> {
         match self {
             Self::Initial(x) => x.as_ref().unwrap().bound_address(),
             Self::Closed(x) => x.as_ref().unwrap().bound_address(),
@@ -527,7 +527,7 @@ impl ProtocolState {
 }
 
 impl InitialState {
-    fn bound_address(&self) -> Result<Option<NetlinkAddr>, SyscallError> {
+    fn bound_address(&self) -> Result<Option<NetlinkAddr>, Errno> {
         Ok(self.bound_addr)
     }
 
@@ -952,7 +952,7 @@ impl InitialState {
 }
 
 impl ClosedState {
-    fn bound_address(&self) -> Result<Option<NetlinkAddr>, SyscallError> {
+    fn bound_address(&self) -> Result<Option<NetlinkAddr>, Errno> {
         Ok(None)
     }
 

--- a/src/main/host/descriptor/socket/netlink.rs
+++ b/src/main/host/descriptor/socket/netlink.rs
@@ -299,9 +299,9 @@ impl NetlinkSocket {
         _net_ns: &NetworkNamespace,
         _rng: impl rand::Rng,
         _cb_queue: &mut CallbackQueue,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         warn_once_then_debug!("We do not yet handle listen request on netlink sockets");
-        Err(Errno::EINVAL.into())
+        Err(Errno::EINVAL)
     }
 
     pub fn connect(

--- a/src/main/host/descriptor/socket/netlink.rs
+++ b/src/main/host/descriptor/socket/netlink.rs
@@ -232,7 +232,7 @@ impl NetlinkSocket {
         addr: Option<&SockaddrStorage>,
         _net_ns: &NetworkNamespace,
         rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         let socket_ref = &mut *socket.borrow_mut();
         socket_ref
             .protocol_state
@@ -478,7 +478,7 @@ impl ProtocolState {
         socket: &Arc<AtomicRefCell<NetlinkSocket>>,
         addr: Option<&SockaddrStorage>,
         rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         match self {
             Self::Initial(x) => x.as_mut().unwrap().bind(common, socket, addr, rng),
             Self::Closed(x) => x.as_mut().unwrap().bind(common, socket, addr, rng),
@@ -576,7 +576,7 @@ impl InitialState {
         _socket: &Arc<AtomicRefCell<NetlinkSocket>>,
         addr: Option<&SockaddrStorage>,
         _rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         // if already bound
         if self.bound_addr.is_some() {
             return Err(Errno::EINVAL.into());
@@ -610,7 +610,7 @@ impl InitialState {
             return Err(Errno::EINVAL.into());
         }
 
-        Ok(0.into())
+        Ok(())
     }
 
     fn sendmsg(
@@ -985,7 +985,7 @@ impl ClosedState {
         _socket: &Arc<AtomicRefCell<NetlinkSocket>>,
         _addr: Option<&SockaddrStorage>,
         _rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         // We follow the same approach as UnixSocket
         log::warn!("bind() while in state {}", std::any::type_name::<Self>());
         Err(Errno::EOPNOTSUPP.into())

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -142,7 +142,7 @@ impl UnixSocket {
         addr: Option<&SockaddrStorage>,
         _net_ns: &NetworkNamespace,
         rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         let socket_ref = &mut *socket.borrow_mut();
         socket_ref
             .protocol_state
@@ -561,7 +561,7 @@ impl ProtocolState {
         socket: &Arc<AtomicRefCell<UnixSocket>>,
         addr: Option<&SockaddrStorage>,
         rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         match self {
             Self::ConnOrientedInitial(x) => x.as_mut().unwrap().bind(common, socket, addr, rng),
             Self::ConnOrientedListening(x) => x.as_mut().unwrap().bind(common, socket, addr, rng),
@@ -898,7 +898,7 @@ where
         _socket: &Arc<AtomicRefCell<UnixSocket>>,
         _addr: Option<&SockaddrStorage>,
         _rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         log::warn!("bind() while in state {}", std::any::type_name::<Self>());
         Err(Errno::EOPNOTSUPP.into())
     }
@@ -1050,14 +1050,14 @@ impl Protocol for ConnOrientedInitial {
         socket: &Arc<AtomicRefCell<UnixSocket>>,
         addr: Option<&SockaddrStorage>,
         rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         // if already bound
         if self.bound_addr.is_some() {
             return Err(Errno::EINVAL.into());
         }
 
         self.bound_addr = Some(common.bind(socket, addr, rng)?);
-        Ok(0.into())
+        Ok(())
     }
 
     fn sendmsg(
@@ -1762,14 +1762,14 @@ impl Protocol for ConnLessInitial {
         socket: &Arc<AtomicRefCell<UnixSocket>>,
         addr: Option<&SockaddrStorage>,
         rng: impl rand::Rng,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         // if already bound
         if self.bound_addr.is_some() {
             return Err(Errno::EINVAL.into());
         }
 
         self.bound_addr = Some(common.bind(socket, addr, rng)?);
-        Ok(0.into())
+        Ok(())
     }
 
     fn sendmsg(

--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -888,7 +888,7 @@ impl MemoryMapper {
         addr: ForeignPtr<u8>,
         size: usize,
         prot: ProtFlags,
-    ) -> Result<i32, Errno> {
+    ) -> Result<(), Errno> {
         let (ctx, thread) = ctx.split_thread();
         trace!("mprotect({:?}, {}, {:?})", addr, size, prot);
         thread.native_mprotect(&ctx, addr, size, prot)?;
@@ -1004,7 +1004,7 @@ impl MemoryMapper {
                 }
             }
         }
-        Ok(0)
+        Ok(())
     }
 
     // Get a raw pointer to the plugin's memory, if it's been remapped into Shadow.

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -633,7 +633,7 @@ impl MemoryManager {
         flags: MapFlags,
         fd: i32,
         offset: i64,
-    ) -> Result<ForeignPtr<u8>, SyscallError> {
+    ) -> Result<ForeignPtr<u8>, Errno> {
         let addr = {
             let (ctx, thread) = ctx.split_thread();
             thread.native_mmap(&ctx, addr, length, prot, flags, fd, offset)?

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -699,7 +699,7 @@ impl MemoryManager {
         addr: ForeignPtr<u8>,
         size: usize,
         prot: ProtFlags,
-    ) -> Result<i32, SyscallError> {
+    ) -> Result<(), SyscallError> {
         match &mut self.memory_mapper {
             Some(mm) => Ok(mm.handle_mprotect(ctx, addr, size, prot)?),
             None => Err(SyscallError::Native),

--- a/src/main/host/syscall/handler/clone.rs
+++ b/src/main/host/syscall/handler/clone.rs
@@ -11,7 +11,7 @@ use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::host::descriptor::descriptor_table::DescriptorTable;
 use crate::host::process::ProcessId;
-use crate::host::syscall::types::{SyscallError, SyscallResult};
+use crate::host::syscall::types::SyscallError;
 use crate::host::thread::Thread;
 
 use super::{SyscallContext, SyscallHandler};
@@ -430,7 +430,7 @@ impl SyscallHandler {
         ctx: &mut SyscallContext,
         hdrp: ForeignPtr<user_cap_header>,
         datap: ForeignPtr<[user_cap_data; 2]>,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         // If the version is not 3, we return the error
         let hdrp = ctx.objs.process.memory_borrow().read(hdrp)?;
         if hdrp.version != LINUX_CAPABILITY_VERSION_3 {
@@ -454,7 +454,7 @@ impl SyscallHandler {
                 .memory_borrow_mut()
                 .write(datap, &[empty, empty])?;
         }
-        Ok(0.into())
+        Ok(())
     }
 
     log_syscall!(
@@ -467,7 +467,7 @@ impl SyscallHandler {
         ctx: &mut SyscallContext,
         hdrp: ForeignPtr<user_cap_header>,
         datap: ForeignPtr<[user_cap_data; 2]>,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         // If the version is not 3, we return the error
         let hdrp = ctx.objs.process.memory_borrow().read(hdrp)?;
         if hdrp.version != LINUX_CAPABILITY_VERSION_3 {
@@ -486,6 +486,6 @@ impl SyscallHandler {
                 return Err(Errno::EINVAL.into());
             }
         }
-        Ok(0.into())
+        Ok(())
     }
 }

--- a/src/main/host/syscall/handler/close_range.rs
+++ b/src/main/host/syscall/handler/close_range.rs
@@ -20,7 +20,7 @@ impl SyscallHandler {
         first: std::ffi::c_uint,
         last: std::ffi::c_uint,
         flags: std::ffi::c_uint,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<(), SyscallError> {
         // close_range(2):
         // > EINVAL: [...], or first is greater than last.
         if first > last {
@@ -29,7 +29,7 @@ impl SyscallHandler {
 
         // if the start of the range is larger than the max possible fd, then do nothing
         if first > descriptor_table::FD_MAX {
-            return Ok(0);
+            return Ok(());
         }
 
         // restrict the end of the range to the max possible fd
@@ -80,6 +80,6 @@ impl SyscallHandler {
             });
         }
 
-        Ok(0)
+        Ok(())
     }
 }

--- a/src/main/host/syscall/handler/epoll.rs
+++ b/src/main/host/syscall/handler/epoll.rs
@@ -95,7 +95,7 @@ impl SyscallHandler {
         op: std::ffi::c_int,
         fd: std::ffi::c_int,
         event_ptr: ForeignPtr<linux_api::epoll::epoll_event>,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<(), SyscallError> {
         // See here for the order that the input args are checked in Linux:
         // https://github.com/torvalds/linux/blob/2cf0f715623872823a72e451243bbf555d10d032/fs/eventpoll.c#L2111
 
@@ -189,7 +189,7 @@ impl SyscallHandler {
                     .ctl(op, fd, target, events, data, weak_epoll, cb_queue)
             })
         })?;
-        Ok(0)
+        Ok(())
     }
 
     log_syscall!(

--- a/src/main/host/syscall/handler/epoll.rs
+++ b/src/main/host/syscall/handler/epoll.rs
@@ -9,6 +9,7 @@ use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::core::worker::Worker;
 use crate::cshadow;
+use crate::host::descriptor::descriptor_table::DescriptorHandle;
 use crate::host::descriptor::epoll::Epoll;
 use crate::host::descriptor::{CompatFile, Descriptor, File, FileState, OpenFile};
 use crate::host::memory_manager::MemoryManager;
@@ -25,7 +26,7 @@ impl SyscallHandler {
     pub fn epoll_create(
         ctx: &mut SyscallContext,
         size: std::ffi::c_int,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<DescriptorHandle, SyscallError> {
         // epoll_create(2): "Since Linux 2.6.8, the size argument is ignored, but must be greater
         // than zero"
         if size <= 0 {
@@ -43,14 +44,14 @@ impl SyscallHandler {
     pub fn epoll_create1(
         ctx: &mut SyscallContext,
         flags: std::ffi::c_int,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<DescriptorHandle, SyscallError> {
         Self::epoll_create_helper(ctx, flags)
     }
 
     fn epoll_create_helper(
         ctx: &mut SyscallContext,
         flags: std::ffi::c_int,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<DescriptorHandle, SyscallError> {
         // See here for the order that the input args are checked in Linux:
         // https://github.com/torvalds/linux/blob/2cf0f715623872823a72e451243bbf555d10d032/fs/eventpoll.c#L2030
         let Some(flags) = EpollCreateFlags::from_bits(flags) else {
@@ -77,7 +78,7 @@ impl SyscallHandler {
 
         log::trace!("Created epoll fd {fd}");
 
-        Ok(fd.val().try_into().unwrap())
+        Ok(fd)
     }
 
     log_syscall!(

--- a/src/main/host/syscall/handler/eventfd.rs
+++ b/src/main/host/syscall/handler/eventfd.rs
@@ -5,6 +5,7 @@ use linux_api::errno::Errno;
 use linux_api::fcntl::DescriptorFlags;
 use nix::sys::eventfd::EfdFlags;
 
+use crate::host::descriptor::descriptor_table::DescriptorHandle;
 use crate::host::descriptor::eventfd;
 use crate::host::descriptor::{CompatFile, Descriptor, File, FileStatus, OpenFile};
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
@@ -19,7 +20,7 @@ impl SyscallHandler {
     pub fn eventfd(
         ctx: &mut SyscallContext,
         init_val: std::ffi::c_uint,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<DescriptorHandle, SyscallError> {
         Self::eventfd_helper(ctx, init_val, 0)
     }
 
@@ -33,7 +34,7 @@ impl SyscallHandler {
         ctx: &mut SyscallContext,
         init_val: std::ffi::c_uint,
         flags: std::ffi::c_int,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<DescriptorHandle, SyscallError> {
         Self::eventfd_helper(ctx, init_val, flags)
     }
 
@@ -41,12 +42,8 @@ impl SyscallHandler {
         ctx: &mut SyscallContext,
         init_val: std::ffi::c_uint,
         flags: std::ffi::c_int,
-    ) -> Result<std::ffi::c_int, SyscallError> {
-        log::trace!(
-            "eventfd() called with initval {} and flags {}",
-            init_val,
-            flags
-        );
+    ) -> Result<DescriptorHandle, SyscallError> {
+        log::trace!("eventfd() called with initval {init_val} and flags {flags}");
 
         // get the flags
         let flags = match EfdFlags::from_bits(flags) {
@@ -88,6 +85,6 @@ impl SyscallHandler {
 
         log::trace!("eventfd() returning fd {}", fd);
 
-        Ok(fd.val().try_into().unwrap())
+        Ok(fd)
     }
 }

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -1,12 +1,11 @@
 use linux_api::errno::Errno;
 use linux_api::fcntl::{DescriptorFlags, FcntlCommand, OFlag};
 use log::debug;
-use shadow_shim_helper_rs::syscall_types::SyscallReg;
 
 use crate::cshadow;
 use crate::host::descriptor::{CompatFile, File, FileStatus};
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
-use crate::host::syscall::types::SyscallResult;
+use crate::host::syscall::types::SyscallError;
 
 impl SyscallHandler {
     log_syscall!(
@@ -21,7 +20,7 @@ impl SyscallHandler {
         fd: std::ffi::c_uint,
         cmd: std::ffi::c_uint,
         arg: std::ffi::c_ulong,
-    ) -> SyscallResult {
+    ) -> Result<std::ffi::c_long, SyscallError> {
         // NOTE: this function should *not* run the C syscall handler if the cmd modifies the
         // descriptor
 
@@ -72,7 +71,7 @@ impl SyscallHandler {
                 let file = file.inner_file().borrow();
                 // combine the file status and access mode flags
                 let flags = file.status().as_o_flags() | file.mode().as_o_flags();
-                SyscallReg::from(flags.bits())
+                flags.bits().into()
             }
             FcntlCommand::F_SETFL => {
                 let file = match desc.file() {
@@ -135,14 +134,14 @@ impl SyscallHandler {
                 }
 
                 file.set_status(status);
-                SyscallReg::from(0)
+                0
             }
-            FcntlCommand::F_GETFD => SyscallReg::from(desc.flags().bits()),
+            FcntlCommand::F_GETFD => desc.flags().bits().into(),
             FcntlCommand::F_SETFD => {
                 let flags = i32::try_from(arg).or(Err(Errno::EINVAL))?;
                 let flags = DescriptorFlags::from_bits(flags).ok_or(Errno::EINVAL)?;
                 desc.set_flags(flags);
-                SyscallReg::from(0)
+                0
             }
             FcntlCommand::F_DUPFD => {
                 let min_fd = arg.try_into().or(Err(Errno::EINVAL))?;
@@ -151,7 +150,7 @@ impl SyscallHandler {
                 let new_fd = desc_table
                     .register_descriptor_with_min_fd(new_desc, min_fd)
                     .or(Err(Errno::EINVAL))?;
-                SyscallReg::from(i32::from(new_fd))
+                new_fd.into()
             }
             FcntlCommand::F_DUPFD_CLOEXEC => {
                 let min_fd = arg.try_into().or(Err(Errno::EINVAL))?;
@@ -160,7 +159,7 @@ impl SyscallHandler {
                 let new_fd = desc_table
                     .register_descriptor_with_min_fd(new_desc, min_fd)
                     .or(Err(Errno::EINVAL))?;
-                SyscallReg::from(i32::from(new_fd))
+                new_fd.into()
             }
             FcntlCommand::F_GETPIPE_SZ => {
                 let file = match desc.file() {
@@ -172,7 +171,7 @@ impl SyscallHandler {
                 };
 
                 if let File::Pipe(pipe) = file.inner_file() {
-                    SyscallReg::from(i32::try_from(pipe.borrow().max_size()).unwrap())
+                    pipe.borrow().max_size().try_into().unwrap()
                 } else {
                     return Err(Errno::EINVAL.into());
                 }

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -11,14 +11,15 @@ use crate::host::syscall::types::SyscallResult;
 impl SyscallHandler {
     log_syscall!(
         fcntl,
-        /* rv */ std::ffi::c_int,
-        /* fd */ std::ffi::c_int,
-        /* cmd */ std::ffi::c_int,
+        /* rv */ std::ffi::c_long,
+        /* fd */ std::ffi::c_uint,
+        /* cmd */ std::ffi::c_uint,
+        /* arg */ std::ffi::c_ulong,
     );
     pub fn fcntl(
         ctx: &mut SyscallContext,
-        fd: std::ffi::c_int,
-        cmd: std::ffi::c_int,
+        fd: std::ffi::c_uint,
+        cmd: std::ffi::c_uint,
         arg: std::ffi::c_ulong,
     ) -> SyscallResult {
         // NOTE: this function should *not* run the C syscall handler if the cmd modifies the

--- a/src/main/host/syscall/handler/file.rs
+++ b/src/main/host/syscall/handler/file.rs
@@ -122,8 +122,7 @@ impl SyscallHandler {
                 // if it's a legacy file, use the C syscall handler instead
                 CompatFile::Legacy(_) => {
                     drop(desc_table);
-                    return Self::legacy_syscall(cshadow::syscallhandler_lseek, ctx)
-                        .map(Into::into);
+                    return Self::legacy_syscall(cshadow::syscallhandler_lseek, ctx);
                 }
             }
         };

--- a/src/main/host/syscall/handler/futex.rs
+++ b/src/main/host/syscall/handler/futex.rs
@@ -25,7 +25,7 @@ impl SyscallHandler {
         _uaddr2: ForeignPtr<u32>,
         _val3: u32,
     ) -> Result<std::ffi::c_int, SyscallError> {
-        Ok(Self::legacy_syscall(c::syscallhandler_futex, ctx)?.into())
+        Self::legacy_syscall(c::syscallhandler_futex, ctx)
     }
 
     log_syscall!(

--- a/src/main/host/syscall/handler/mman.rs
+++ b/src/main/host/syscall/handler/mman.rs
@@ -110,7 +110,7 @@ impl SyscallHandler {
         addr: std::ffi::c_ulong,
         len: usize,
         prot: std::ffi::c_ulong,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<(), SyscallError> {
         let addr: usize = addr.try_into().unwrap();
         let addr = ForeignPtr::<()>::from(addr).cast::<u8>();
 

--- a/src/main/host/syscall/handler/mman.rs
+++ b/src/main/host/syscall/handler/mman.rs
@@ -268,10 +268,6 @@ impl SyscallHandler {
             offset,
         );
 
-        // we should have already run the mmap natively above, and it wouldn't make sense to return
-        // `SyscallError::Native` here
-        assert!(!matches!(mmap_result, Err(SyscallError::Native)));
-
         log::trace!(
             "Plugin-native mmap syscall at plugin addr {addr:p} with plugin fd {fd} for \
             {len} bytes returned {mmap_result:?}"
@@ -282,7 +278,7 @@ impl SyscallHandler {
             Self::close_plugin_file(ctx.objs, plugin_fd);
         }
 
-        mmap_result
+        Ok(mmap_result?)
     }
 
     fn open_plugin_file(

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -672,7 +672,10 @@ impl SyscallHandler {
     }
 
     /// Run a legacy C syscall handler.
-    fn legacy_syscall(syscall: LegacySyscallFn, ctx: &mut SyscallContext) -> SyscallResult {
+    fn legacy_syscall<T: From<SyscallReg>>(
+        syscall: LegacySyscallFn,
+        ctx: &mut SyscallContext,
+    ) -> Result<T, SyscallError> {
         let rv: SyscallResult =
             unsafe { syscall(ctx.handler, std::ptr::from_ref(ctx.args)) }.into();
 
@@ -689,7 +692,7 @@ impl SyscallHandler {
                 .expect("flushing syscall ptrs");
         }
 
-        rv
+        rv.map(Into::into)
     }
 }
 

--- a/src/main/host/syscall/handler/poll.rs
+++ b/src/main/host/syscall/handler/poll.rs
@@ -18,7 +18,7 @@ impl SyscallHandler {
         _nfds: std::ffi::c_uint,
         _timeout_msecs: std::ffi::c_int,
     ) -> Result<std::ffi::c_int, SyscallError> {
-        Ok(Self::legacy_syscall(c::syscallhandler_poll, ctx)?.into())
+        Self::legacy_syscall(c::syscallhandler_poll, ctx)
     }
 
     log_syscall!(
@@ -38,6 +38,6 @@ impl SyscallHandler {
         _sigmask: ForeignPtr<linux_api::signal::sigset_t>,
         _sigsetsize: libc::size_t,
     ) -> Result<std::ffi::c_int, SyscallError> {
-        Ok(Self::legacy_syscall(c::syscallhandler_ppoll, ctx)?.into())
+        Self::legacy_syscall(c::syscallhandler_ppoll, ctx)
     }
 }

--- a/src/main/host/syscall/handler/resource.rs
+++ b/src/main/host/syscall/handler/resource.rs
@@ -19,7 +19,7 @@ impl SyscallHandler {
         resource: std::ffi::c_uint,
         _new_rlim: ForeignPtr<()>,
         _old_rlim: ForeignPtr<()>,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<(), SyscallError> {
         log::trace!("prlimit64 called on pid {pid} for resource {resource}");
 
         // TODO: For determinism, we may want to enforce static limits for certain resources, like

--- a/src/main/host/syscall/handler/select.rs
+++ b/src/main/host/syscall/handler/select.rs
@@ -22,7 +22,7 @@ impl SyscallHandler {
         _exp: ForeignPtr<linux_api::posix_types::kernel_fd_set>,
         _tvp: ForeignPtr<linux_api::time::kernel_old_timeval>,
     ) -> Result<std::ffi::c_int, SyscallError> {
-        Ok(Self::legacy_syscall(c::syscallhandler_select, ctx)?.into())
+        Self::legacy_syscall(c::syscallhandler_select, ctx)
     }
 
     log_syscall!(
@@ -44,6 +44,6 @@ impl SyscallHandler {
         _tsp: ForeignPtr<linux_api::time::kernel_timespec>,
         _sig: ForeignPtr<()>,
     ) -> Result<std::ffi::c_int, SyscallError> {
-        Ok(Self::legacy_syscall(c::syscallhandler_pselect6, ctx)?.into())
+        Self::legacy_syscall(c::syscallhandler_pselect6, ctx)
     }
 }

--- a/src/main/host/syscall/handler/signal.rs
+++ b/src/main/host/syscall/handler/signal.rs
@@ -262,8 +262,8 @@ impl SyscallHandler {
         _oact: ForeignPtr<linux_api::signal::sigaction>,
         _sigsetsize: libc::size_t,
     ) -> Result<(), SyscallError> {
-        let rv = Self::legacy_syscall(c::syscallhandler_rt_sigaction, ctx)?;
-        assert_eq!(0, i32::from(rv));
+        let rv: i32 = Self::legacy_syscall(c::syscallhandler_rt_sigaction, ctx)?;
+        assert_eq!(rv, 0);
         Ok(())
     }
 
@@ -282,8 +282,8 @@ impl SyscallHandler {
         _oset: ForeignPtr<linux_api::signal::sigset_t>,
         _sigsetsize: libc::size_t,
     ) -> Result<(), SyscallError> {
-        let rv = Self::legacy_syscall(c::syscallhandler_rt_sigprocmask, ctx)?;
-        assert_eq!(0, i32::from(rv));
+        let rv: i32 = Self::legacy_syscall(c::syscallhandler_rt_sigprocmask, ctx)?;
+        assert_eq!(rv, 0);
         Ok(())
     }
 
@@ -298,8 +298,8 @@ impl SyscallHandler {
         _uss: ForeignPtr<linux_api::signal::stack_t>,
         _uoss: ForeignPtr<linux_api::signal::stack_t>,
     ) -> Result<(), SyscallError> {
-        let rv = Self::legacy_syscall(c::syscallhandler_sigaltstack, ctx)?;
-        assert_eq!(0, i32::from(rv));
+        let rv: i32 = Self::legacy_syscall(c::syscallhandler_sigaltstack, ctx)?;
+        assert_eq!(rv, 0);
         Ok(())
     }
 }

--- a/src/main/host/syscall/handler/stat.rs
+++ b/src/main/host/syscall/handler/stat.rs
@@ -28,7 +28,7 @@ impl SyscallHandler {
             // if it's a legacy file, use the C syscall handler instead
             CompatFile::Legacy(_) => {
                 drop(desc_table);
-                return Self::legacy_syscall(cshadow::syscallhandler_fstat, ctx).map(Into::into);
+                return Self::legacy_syscall(cshadow::syscallhandler_fstat, ctx);
             }
         };
 

--- a/src/main/host/syscall/handler/sysinfo.rs
+++ b/src/main/host/syscall/handler/sysinfo.rs
@@ -4,7 +4,7 @@ use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::core::worker::Worker;
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
-use crate::host::syscall::types::SyscallResult;
+use crate::host::syscall::types::SyscallError;
 
 impl SyscallHandler {
     log_syscall!(
@@ -15,7 +15,7 @@ impl SyscallHandler {
     pub fn sysinfo(
         ctx: &mut SyscallContext,
         info_ptr: ForeignPtr<linux_api::sysinfo::sysinfo>,
-    ) -> SyscallResult {
+    ) -> Result<(), SyscallError> {
         // Seconds are needed for uptime.
         let seconds = Worker::current_time()
             .unwrap()
@@ -49,6 +49,6 @@ impl SyscallHandler {
             .process
             .memory_borrow_mut()
             .write(info_ptr, &info)?;
-        Ok(0.into())
+        Ok(())
     }
 }

--- a/src/main/host/syscall/handler/timerfd.rs
+++ b/src/main/host/syscall/handler/timerfd.rs
@@ -82,7 +82,7 @@ impl SyscallHandler {
         ctx: &mut SyscallContext,
         fd: std::ffi::c_int,
         curr_value_ptr: ForeignPtr<linux_api::time::itimerspec>,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<(), SyscallError> {
         // Get the TimerFd object.
         let file = get_cloned_file(ctx, fd)?;
         let File::TimerFd(ref timerfd) = file else {
@@ -91,7 +91,7 @@ impl SyscallHandler {
 
         Self::timerfd_gettime_helper(ctx, timerfd, curr_value_ptr)?;
 
-        Ok(0)
+        Ok(())
     }
 
     fn timerfd_gettime_helper(
@@ -146,7 +146,7 @@ impl SyscallHandler {
         flags: std::ffi::c_int,
         new_value_ptr: ForeignPtr<linux_api::time::itimerspec>,
         old_value_ptr: ForeignPtr<linux_api::time::itimerspec>,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<(), SyscallError> {
         let Some(flags) = TimerSetTimeFlags::from_bits(flags) else {
             log::debug!("Invalid timerfd_settime flags: {flags}");
             return Err(Errno::EINVAL.into());
@@ -207,7 +207,7 @@ impl SyscallHandler {
             );
         }
 
-        Ok(0)
+        Ok(())
     }
 }
 

--- a/src/main/host/syscall/handler/timerfd.rs
+++ b/src/main/host/syscall/handler/timerfd.rs
@@ -10,6 +10,7 @@ use shadow_shim_helper_rs::{
 };
 
 use crate::core::worker::Worker;
+use crate::host::descriptor::descriptor_table::DescriptorHandle;
 use crate::host::descriptor::{
     timerfd::TimerFd, CompatFile, Descriptor, File, FileStatus, OpenFile,
 };
@@ -30,7 +31,7 @@ impl SyscallHandler {
         ctx: &mut SyscallContext,
         clockid: std::ffi::c_int,
         flags: std::ffi::c_int,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<DescriptorHandle, SyscallError> {
         let Ok(clockid) = ClockId::try_from(clockid) else {
             log::debug!("Invalid clockid: {clockid}");
             return Err(Errno::EINVAL.into());
@@ -68,7 +69,7 @@ impl SyscallHandler {
 
         log::trace!("timerfd_create() returning fd {fd}");
 
-        Ok(i32::try_from(fd.val()).unwrap())
+        Ok(fd)
     }
 
     log_syscall!(

--- a/src/main/host/syscall/handler/uio.rs
+++ b/src/main/host/syscall/handler/uio.rs
@@ -43,7 +43,7 @@ impl SyscallHandler {
                     // if it's a legacy file, use the C syscall handler instead
                     CompatFile::Legacy(_) => {
                         drop(desc_table);
-                        return Self::legacy_syscall(c::syscallhandler_readv, ctx).map(Into::into);
+                        return Self::legacy_syscall(c::syscallhandler_readv, ctx);
                     }
                 }
             }
@@ -111,7 +111,7 @@ impl SyscallHandler {
                     // if it's a legacy file, use the C syscall handler instead
                     CompatFile::Legacy(_) => {
                         drop(desc_table);
-                        return Self::legacy_syscall(c::syscallhandler_preadv, ctx).map(Into::into);
+                        return Self::legacy_syscall(c::syscallhandler_preadv, ctx);
                     }
                 }
             }
@@ -186,8 +186,7 @@ impl SyscallHandler {
                     // if it's a legacy file, use the C syscall handler instead
                     CompatFile::Legacy(_) => {
                         drop(desc_table);
-                        return Self::legacy_syscall(c::syscallhandler_preadv2, ctx)
-                            .map(Into::into);
+                        return Self::legacy_syscall(c::syscallhandler_preadv2, ctx);
                     }
                 }
             }
@@ -325,7 +324,7 @@ impl SyscallHandler {
                     // if it's a legacy file, use the C syscall handler instead
                     CompatFile::Legacy(_) => {
                         drop(desc_table);
-                        return Self::legacy_syscall(c::syscallhandler_writev, ctx).map(Into::into);
+                        return Self::legacy_syscall(c::syscallhandler_writev, ctx);
                     }
                 }
             }
@@ -393,8 +392,7 @@ impl SyscallHandler {
                     // if it's a legacy file, use the C syscall handler instead
                     CompatFile::Legacy(_) => {
                         drop(desc_table);
-                        return Self::legacy_syscall(c::syscallhandler_pwritev, ctx)
-                            .map(Into::into);
+                        return Self::legacy_syscall(c::syscallhandler_pwritev, ctx);
                     }
                 }
             }
@@ -469,8 +467,7 @@ impl SyscallHandler {
                     // if it's a legacy file, use the C syscall handler instead
                     CompatFile::Legacy(_) => {
                         drop(desc_table);
-                        return Self::legacy_syscall(c::syscallhandler_pwritev2, ctx)
-                            .map(Into::into);
+                        return Self::legacy_syscall(c::syscallhandler_pwritev2, ctx);
                     }
                 }
             }

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -207,7 +207,7 @@ impl SyscallHandler {
                     // if it's a legacy file, use the C syscall handler instead
                     CompatFile::Legacy(_) => {
                         drop(desc_table);
-                        return Self::legacy_syscall(c::syscallhandler_read, ctx).map(Into::into);
+                        return Self::legacy_syscall(c::syscallhandler_read, ctx);
                     }
                 }
             }
@@ -261,8 +261,7 @@ impl SyscallHandler {
                     // if it's a legacy file, use the C syscall handler instead
                     CompatFile::Legacy(_) => {
                         drop(desc_table);
-                        return Self::legacy_syscall(c::syscallhandler_pread64, ctx)
-                            .map(Into::into);
+                        return Self::legacy_syscall(c::syscallhandler_pread64, ctx);
                     }
                 }
             }
@@ -328,7 +327,7 @@ impl SyscallHandler {
                     // if it's a legacy file, use the C syscall handler instead
                     CompatFile::Legacy(_) => {
                         drop(desc_table);
-                        return Self::legacy_syscall(c::syscallhandler_write, ctx).map(Into::into);
+                        return Self::legacy_syscall(c::syscallhandler_write, ctx);
                     }
                 }
             }
@@ -382,8 +381,7 @@ impl SyscallHandler {
                     // if it's a legacy file, use the C syscall handler instead
                     CompatFile::Legacy(_) => {
                         drop(desc_table);
-                        return Self::legacy_syscall(c::syscallhandler_pwrite64, ctx)
-                            .map(Into::into);
+                        return Self::legacy_syscall(c::syscallhandler_pwrite64, ctx);
                     }
                 }
             }


### PR DESCRIPTION
Most of these changes involve changing argument/return types of syscall handlers.

- Made `SyscallHandler::legacy_syscall` nicer to call
- Fixed argument types for ioctl syscall handler
- Fixed argument types for fcntl syscall handler
- Improved the fcntl syscall handler
- Simplified mmap syscall handler error handling
- Improved getsockname/getpeername socket func return types
- Improved listen socket func return type
- Return `DescriptorHandle` directly from syscall handlers
- Changed syscall handlers to return `()` rather than 0