### PR TITLE
Return `Errno` from some syscall handlers

### DIFF
--- a/src/main/host/descriptor/epoll/mod.rs
+++ b/src/main/host/descriptor/epoll/mod.rs
@@ -154,7 +154,7 @@ impl Epoll {
         data: u64,
         weak_self: Weak<AtomicRefCell<Epoll>>,
         cb_queue: &mut CallbackQueue,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         let state = target_file.borrow().state();
         let key = Key::new(target_fd, target_file);
 
@@ -170,7 +170,7 @@ impl Epoll {
                 // TODO change this to an assertion when legacy tcp is removed.
                 if state.contains(FileState::CLOSED) {
                     log::warn!("Attempted to add a closed file {target_fd} to epoll");
-                    return Err(Errno::EBADF.into());
+                    return Err(Errno::EBADF);
                 }
 
                 let mut entry = Entry::new(events, data, state);
@@ -186,7 +186,7 @@ impl Epoll {
                 // From epoll_ctl(2): Returns EEXIST when "op was EPOLL_CTL_ADD, and the supplied
                 // file descriptor fd is already registered with this epoll instance."
                 match self.monitoring.entry(key.clone()) {
-                    HashMapEntry::Occupied(_) => return Err(Errno::EEXIST.into()),
+                    HashMapEntry::Occupied(_) => return Err(Errno::EEXIST),
                     HashMapEntry::Vacant(x) => x.insert(entry),
                 };
             }

--- a/src/main/host/syscall/handler/clone.rs
+++ b/src/main/host/syscall/handler/clone.rs
@@ -11,7 +11,6 @@ use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::host::descriptor::descriptor_table::DescriptorTable;
 use crate::host::process::ProcessId;
-use crate::host::syscall::types::SyscallError;
 use crate::host::thread::Thread;
 
 use super::{SyscallContext, SyscallHandler};
@@ -25,7 +24,7 @@ impl SyscallHandler {
         ptid: ForeignPtr<kernel_pid_t>,
         ctid: ForeignPtr<kernel_pid_t>,
         newtls: u64,
-    ) -> Result<kernel_pid_t, SyscallError> {
+    ) -> Result<kernel_pid_t, Errno> {
         // We use this for a consistency check to validate that we've inspected
         // and emulated all of the provided flags.
         let mut handled_flags = CloneFlags::empty();
@@ -50,16 +49,16 @@ impl SyscallHandler {
             // > CLONE_SIGHAND if CLONE_THREAD is specified
             if !flags.contains(CloneFlags::CLONE_SIGHAND) {
                 debug!("Missing CLONE_SIGHAND");
-                return Err(Errno::EINVAL.into());
+                return Err(Errno::EINVAL);
             }
             if !flags.contains(CloneFlags::CLONE_SETTLS) {
                 // Legal in Linux, but the shim will be broken and behave unpredictably.
                 warn!("CLONE_THREAD without CLONE_TLS not supported by shadow");
-                return Err(Errno::ENOTSUP.into());
+                return Err(Errno::ENOTSUP);
             }
             if exit_signal.is_some() {
                 warn!("Exit signal is unimplemented");
-                return Err(Errno::ENOTSUP.into());
+                return Err(Errno::ENOTSUP);
             }
             // The native clone call will:
             // - create a thread.
@@ -77,7 +76,7 @@ impl SyscallHandler {
         } else {
             if ctx.objs.process.memory_borrow().has_mapper() {
                 warn!("Fork with memory mapper unimplemented");
-                return Err(Errno::ENOTSUP.into());
+                return Err(Errno::ENOTSUP);
             }
             // Make shadow the parent process
             native_flags.insert(CloneFlags::CLONE_PARENT);
@@ -89,7 +88,7 @@ impl SyscallHandler {
             // > CLONE_SIGHAND is specified
             if !flags.contains(CloneFlags::CLONE_VM) {
                 debug!("Missing CLONE_VM");
-                return Err(Errno::EINVAL.into());
+                return Err(Errno::EINVAL);
             }
             // Currently a no-op since threads always share signal handlers,
             // and we don't yet support non-CLONE_THREAD.
@@ -153,7 +152,7 @@ impl SyscallHandler {
                 // exits) implies that this that the child may exist for more
                 // than a brief window before exec'ing.
                 warn!("CLONE_VM without CLONE_THREAD and without CLONE_VFORK unsupported");
-                return Err(Errno::ENOTSUP.into());
+                return Err(Errno::ENOTSUP);
             }
             handled_flags.insert(CloneFlags::CLONE_VM);
         }
@@ -179,7 +178,7 @@ impl SyscallHandler {
             // clone(2): Specifying this flag together with CLONE_SIGHAND is
             // nonsensical and disallowed.
             if flags.contains(CloneFlags::CLONE_SIGHAND) {
-                return Err(Errno::EINVAL.into());
+                return Err(Errno::EINVAL);
             }
             false
         } else {
@@ -197,7 +196,7 @@ impl SyscallHandler {
         let unhandled_flags = flags.difference(handled_flags);
         if !unhandled_flags.is_empty() {
             warn!("Unhandled clone flags: {unhandled_flags:?}");
-            return Err(Errno::ENOTSUP.into());
+            return Err(Errno::ENOTSUP);
         }
 
         let child_mthread = ctx.objs.thread.mthread().native_clone(
@@ -321,13 +320,13 @@ impl SyscallHandler {
         ptid: ForeignPtr<kernel_pid_t>,
         ctid: ForeignPtr<kernel_pid_t>,
         newtls: u64,
-    ) -> Result<kernel_pid_t, SyscallError> {
+    ) -> Result<kernel_pid_t, Errno> {
         let raw_flags = flags_and_exit_signal as u32 & !0xff;
         let raw_exit_signal = (flags_and_exit_signal as u32 & 0xff) as i32;
 
         let Some(flags) = CloneFlags::from_bits(raw_flags as u64) else {
             debug!("Couldn't parse clone flags: {raw_flags:x}");
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         };
 
         let exit_signal = if raw_exit_signal == 0 {
@@ -335,7 +334,7 @@ impl SyscallHandler {
         } else {
             let Ok(exit_signal) = Signal::try_from(raw_exit_signal) else {
                 debug!("Bad exit signal: {raw_exit_signal:?}");
-                return Err(Errno::EINVAL.into());
+                return Err(Errno::EINVAL);
             };
             Some(exit_signal)
         };
@@ -353,24 +352,24 @@ impl SyscallHandler {
         ctx: &mut SyscallContext,
         args: ForeignPtr<linux_api::sched::clone_args>,
         args_size: usize,
-    ) -> Result<kernel_pid_t, SyscallError> {
+    ) -> Result<kernel_pid_t, Errno> {
         if args_size != std::mem::size_of::<linux_api::sched::clone_args>() {
             // TODO: allow smaller size, and be careful to only read
             // as much as the caller specified, and zero-fill the rest.
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         }
         let args = ctx.objs.process.memory_borrow().read(args)?;
         trace!("clone3 args: {args:?}");
         let Some(flags) = CloneFlags::from_bits(args.flags) else {
             debug!("Couldn't parse clone flags: {:x}", args.flags);
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         };
         let exit_signal = if args.exit_signal == 0 {
             None
         } else {
             let Ok(exit_signal) = Signal::try_from(args.exit_signal as i32) else {
                 debug!("Bad signal number: {}", args.exit_signal);
-                return Err(Errno::EINVAL.into());
+                return Err(Errno::EINVAL);
             };
             Some(exit_signal)
         };
@@ -386,7 +385,7 @@ impl SyscallHandler {
     }
 
     log_syscall!(fork, /* rv */ kernel_pid_t);
-    pub fn fork(ctx: &mut SyscallContext) -> Result<kernel_pid_t, SyscallError> {
+    pub fn fork(ctx: &mut SyscallContext) -> Result<kernel_pid_t, Errno> {
         // This should be the correct call to `clone_internal`, but `clone_internal`
         // will currently return an error.
         Self::clone_internal(
@@ -401,7 +400,7 @@ impl SyscallHandler {
     }
 
     log_syscall!(vfork, /* rv */ kernel_pid_t);
-    pub fn vfork(ctx: &mut SyscallContext) -> Result<kernel_pid_t, SyscallError> {
+    pub fn vfork(ctx: &mut SyscallContext) -> Result<kernel_pid_t, Errno> {
         // This should be the correct call to `clone_internal`, but `clone_internal`
         // will currently return an error.
         Self::clone_internal(
@@ -416,7 +415,7 @@ impl SyscallHandler {
     }
 
     log_syscall!(gettid, /* rv */ kernel_pid_t);
-    pub fn gettid(ctx: &mut SyscallContext) -> Result<kernel_pid_t, SyscallError> {
+    pub fn gettid(ctx: &mut SyscallContext) -> Result<kernel_pid_t, Errno> {
         Ok(kernel_pid_t::from(ctx.objs.thread.id()))
     }
 
@@ -430,7 +429,7 @@ impl SyscallHandler {
         ctx: &mut SyscallContext,
         hdrp: ForeignPtr<user_cap_header>,
         datap: ForeignPtr<[user_cap_data; 2]>,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         // If the version is not 3, we return the error
         let hdrp = ctx.objs.process.memory_borrow().read(hdrp)?;
         if hdrp.version != LINUX_CAPABILITY_VERSION_3 {
@@ -438,7 +437,7 @@ impl SyscallHandler {
                 "The version of Linux capabilities is not supported ({})",
                 hdrp.version
             );
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         }
 
         if !datap.is_null() {
@@ -467,7 +466,7 @@ impl SyscallHandler {
         ctx: &mut SyscallContext,
         hdrp: ForeignPtr<user_cap_header>,
         datap: ForeignPtr<[user_cap_data; 2]>,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         // If the version is not 3, we return the error
         let hdrp = ctx.objs.process.memory_borrow().read(hdrp)?;
         if hdrp.version != LINUX_CAPABILITY_VERSION_3 {
@@ -475,7 +474,7 @@ impl SyscallHandler {
                 "The version of Linux capabilities is not supported ({})",
                 hdrp.version
             );
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         }
 
         let datap: [_; 2] = ctx.objs.process.memory_borrow().read(datap)?;
@@ -483,7 +482,7 @@ impl SyscallHandler {
             // We don't allow the plugin to set any capability
             if data.effective != 0 || data.permitted != 0 || data.inheritable != 0 {
                 warn_once_then_debug!("Setting Linux capabilities is not supported");
-                return Err(Errno::EINVAL.into());
+                return Err(Errno::EINVAL);
             }
         }
         Ok(())

--- a/src/main/host/syscall/handler/close_range.rs
+++ b/src/main/host/syscall/handler/close_range.rs
@@ -4,7 +4,6 @@ use linux_api::fcntl::DescriptorFlags;
 
 use crate::host::descriptor::descriptor_table;
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
-use crate::host::syscall::types::SyscallError;
 use crate::utility::callback_queue::CallbackQueue;
 
 impl SyscallHandler {
@@ -20,11 +19,11 @@ impl SyscallHandler {
         first: std::ffi::c_uint,
         last: std::ffi::c_uint,
         flags: std::ffi::c_uint,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         // close_range(2):
         // > EINVAL: [...], or first is greater than last.
         if first > last {
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         }
 
         // if the start of the range is larger than the max possible fd, then do nothing
@@ -43,12 +42,12 @@ impl SyscallHandler {
 
         let Some(flags) = CloseRangeFlags::from_bits(flags) else {
             log::debug!("Invalid close_range flags: {flags}");
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         };
 
         if flags.contains(CloseRangeFlags::CLOSE_RANGE_UNSHARE) {
             log::debug!("The CLOSE_RANGE_UNSHARE flag is not implemented");
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         }
 
         let mut desc_table = ctx.objs.thread.descriptor_table_borrow_mut(ctx.objs.host);

--- a/src/main/host/syscall/handler/eventfd.rs
+++ b/src/main/host/syscall/handler/eventfd.rs
@@ -9,7 +9,6 @@ use crate::host::descriptor::descriptor_table::DescriptorHandle;
 use crate::host::descriptor::eventfd;
 use crate::host::descriptor::{CompatFile, Descriptor, File, FileStatus, OpenFile};
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
-use crate::host::syscall::types::SyscallError;
 
 impl SyscallHandler {
     log_syscall!(
@@ -20,7 +19,7 @@ impl SyscallHandler {
     pub fn eventfd(
         ctx: &mut SyscallContext,
         init_val: std::ffi::c_uint,
-    ) -> Result<DescriptorHandle, SyscallError> {
+    ) -> Result<DescriptorHandle, Errno> {
         Self::eventfd_helper(ctx, init_val, 0)
     }
 
@@ -34,7 +33,7 @@ impl SyscallHandler {
         ctx: &mut SyscallContext,
         init_val: std::ffi::c_uint,
         flags: std::ffi::c_int,
-    ) -> Result<DescriptorHandle, SyscallError> {
+    ) -> Result<DescriptorHandle, Errno> {
         Self::eventfd_helper(ctx, init_val, flags)
     }
 
@@ -42,7 +41,7 @@ impl SyscallHandler {
         ctx: &mut SyscallContext,
         init_val: std::ffi::c_uint,
         flags: std::ffi::c_int,
-    ) -> Result<DescriptorHandle, SyscallError> {
+    ) -> Result<DescriptorHandle, Errno> {
         log::trace!("eventfd() called with initval {init_val} and flags {flags}");
 
         // get the flags
@@ -50,7 +49,7 @@ impl SyscallHandler {
             Some(x) => x,
             None => {
                 log::warn!("Invalid eventfd flags: {}", flags);
-                return Err(Errno::EINVAL.into());
+                return Err(Errno::EINVAL);
             }
         };
 

--- a/src/main/host/syscall/handler/futex.rs
+++ b/src/main/host/syscall/handler/futex.rs
@@ -40,9 +40,9 @@ impl SyscallHandler {
         _pid: std::ffi::c_int,
         _head_ptr: ForeignPtr<ForeignPtr<linux_api::futex::robust_list_head>>,
         _len_ptr: ForeignPtr<libc::size_t>,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         warn_once_then_debug!("get_robust_list was called but we don't yet support it");
-        Err(Errno::ENOSYS.into())
+        Err(Errno::ENOSYS)
     }
 
     log_syscall!(
@@ -55,8 +55,8 @@ impl SyscallHandler {
         _ctx: &mut SyscallContext,
         _head: ForeignPtr<linux_api::futex::robust_list_head>,
         _len: libc::size_t,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         warn_once_then_debug!("set_robust_list was called but we don't yet support it");
-        Err(Errno::ENOSYS.into())
+        Err(Errno::ENOSYS)
     }
 }

--- a/src/main/host/syscall/handler/ioctl.rs
+++ b/src/main/host/syscall/handler/ioctl.rs
@@ -23,7 +23,7 @@ impl SyscallHandler {
         cmd: std::ffi::c_uint,
         arg_ptr: ForeignPtr<()>,
     ) -> SyscallResult {
-        log::trace!("Called ioctl() on fd {} with cmd {}", fd, cmd);
+        log::trace!("Called ioctl() on fd {fd} with cmd {cmd}");
 
         let Ok(cmd) = IoctlRequest::try_from(cmd) else {
             debug!("Unrecognized ioctl cmd {cmd}");

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -733,42 +733,50 @@ pub trait SyscallHandlerFn<T> {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult;
 }
 
-impl<F, T0> SyscallHandlerFn<()> for F
+impl<F, E, T0> SyscallHandlerFn<()> for F
 where
-    F: Fn(&mut SyscallContext) -> Result<T0, SyscallError>,
+    F: Fn(&mut SyscallContext) -> Result<T0, E>,
+    E: Into<SyscallError>,
     T0: Into<SyscallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
-        self(ctx).map(Into::into)
+        self(ctx).map(Into::into).map_err(Into::into)
     }
 }
 
-impl<F, T0, T1> SyscallHandlerFn<(T1,)> for F
+impl<F, E, T0, T1> SyscallHandlerFn<(T1,)> for F
 where
-    F: Fn(&mut SyscallContext, T1) -> Result<T0, SyscallError>,
+    F: Fn(&mut SyscallContext, T1) -> Result<T0, E>,
+    E: Into<SyscallError>,
     T0: Into<SyscallReg>,
     T1: From<SyscallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
-        self(ctx, ctx.args.get(0).into()).map(Into::into)
+        self(ctx, ctx.args.get(0).into())
+            .map(Into::into)
+            .map_err(Into::into)
     }
 }
 
-impl<F, T0, T1, T2> SyscallHandlerFn<(T1, T2)> for F
+impl<F, E, T0, T1, T2> SyscallHandlerFn<(T1, T2)> for F
 where
-    F: Fn(&mut SyscallContext, T1, T2) -> Result<T0, SyscallError>,
+    F: Fn(&mut SyscallContext, T1, T2) -> Result<T0, E>,
+    E: Into<SyscallError>,
     T0: Into<SyscallReg>,
     T1: From<SyscallReg>,
     T2: From<SyscallReg>,
 {
     fn call(self, ctx: &mut SyscallContext) -> SyscallResult {
-        self(ctx, ctx.args.get(0).into(), ctx.args.get(1).into()).map(Into::into)
+        self(ctx, ctx.args.get(0).into(), ctx.args.get(1).into())
+            .map(Into::into)
+            .map_err(Into::into)
     }
 }
 
-impl<F, T0, T1, T2, T3> SyscallHandlerFn<(T1, T2, T3)> for F
+impl<F, E, T0, T1, T2, T3> SyscallHandlerFn<(T1, T2, T3)> for F
 where
-    F: Fn(&mut SyscallContext, T1, T2, T3) -> Result<T0, SyscallError>,
+    F: Fn(&mut SyscallContext, T1, T2, T3) -> Result<T0, E>,
+    E: Into<SyscallError>,
     T0: Into<SyscallReg>,
     T1: From<SyscallReg>,
     T2: From<SyscallReg>,
@@ -782,12 +790,14 @@ where
             ctx.args.get(2).into(),
         )
         .map(Into::into)
+        .map_err(Into::into)
     }
 }
 
-impl<F, T0, T1, T2, T3, T4> SyscallHandlerFn<(T1, T2, T3, T4)> for F
+impl<F, E, T0, T1, T2, T3, T4> SyscallHandlerFn<(T1, T2, T3, T4)> for F
 where
-    F: Fn(&mut SyscallContext, T1, T2, T3, T4) -> Result<T0, SyscallError>,
+    F: Fn(&mut SyscallContext, T1, T2, T3, T4) -> Result<T0, E>,
+    E: Into<SyscallError>,
     T0: Into<SyscallReg>,
     T1: From<SyscallReg>,
     T2: From<SyscallReg>,
@@ -803,12 +813,14 @@ where
             ctx.args.get(3).into(),
         )
         .map(Into::into)
+        .map_err(Into::into)
     }
 }
 
-impl<F, T0, T1, T2, T3, T4, T5> SyscallHandlerFn<(T1, T2, T3, T4, T5)> for F
+impl<F, E, T0, T1, T2, T3, T4, T5> SyscallHandlerFn<(T1, T2, T3, T4, T5)> for F
 where
-    F: Fn(&mut SyscallContext, T1, T2, T3, T4, T5) -> Result<T0, SyscallError>,
+    F: Fn(&mut SyscallContext, T1, T2, T3, T4, T5) -> Result<T0, E>,
+    E: Into<SyscallError>,
     T0: Into<SyscallReg>,
     T1: From<SyscallReg>,
     T2: From<SyscallReg>,
@@ -826,12 +838,14 @@ where
             ctx.args.get(4).into(),
         )
         .map(Into::into)
+        .map_err(Into::into)
     }
 }
 
-impl<F, T0, T1, T2, T3, T4, T5, T6> SyscallHandlerFn<(T1, T2, T3, T4, T5, T6)> for F
+impl<F, E, T0, T1, T2, T3, T4, T5, T6> SyscallHandlerFn<(T1, T2, T3, T4, T5, T6)> for F
 where
-    F: Fn(&mut SyscallContext, T1, T2, T3, T4, T5, T6) -> Result<T0, SyscallError>,
+    F: Fn(&mut SyscallContext, T1, T2, T3, T4, T5, T6) -> Result<T0, E>,
+    E: Into<SyscallError>,
     T0: Into<SyscallReg>,
     T1: From<SyscallReg>,
     T2: From<SyscallReg>,
@@ -851,6 +865,7 @@ where
             ctx.args.get(5).into(),
         )
         .map(Into::into)
+        .map_err(Into::into)
     }
 }
 

--- a/src/main/host/syscall/handler/random.rs
+++ b/src/main/host/syscall/handler/random.rs
@@ -4,7 +4,7 @@ use rand::RngCore;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
-use crate::host::syscall::types::{ForeignArrayPtr, SyscallResult};
+use crate::host::syscall::types::ForeignArrayPtr;
 
 impl SyscallHandler {
     log_syscall!(
@@ -19,11 +19,11 @@ impl SyscallHandler {
         buf_ptr: ForeignPtr<u8>,
         count: usize,
         _flags: std::ffi::c_uint,
-    ) -> SyscallResult {
+    ) -> Result<isize, Errno> {
         // We ignore the flags arg, because we use the same random source for both
         // random and urandom, and it never blocks anyway.
 
-        trace!("Trying to read {} random bytes.", count);
+        trace!("Trying to read {count} random bytes.");
 
         // Get a native-process mem buffer where we can copy the random bytes.
         let dst_ptr = ForeignArrayPtr::new(buf_ptr, count);
@@ -31,8 +31,8 @@ impl SyscallHandler {
         let mut mem_ref = match memory.memory_ref_mut_uninit(dst_ptr) {
             Ok(m) => m,
             Err(e) => {
-                warn!("Failed to get memory ref: {:?}", e);
-                return Err(Errno::EFAULT.into());
+                warn!("Failed to get memory ref: {e:?}");
+                return Err(Errno::EFAULT);
             }
         };
 
@@ -42,10 +42,10 @@ impl SyscallHandler {
 
         // We must flush the memory reference to write it back.
         match mem_ref.flush() {
-            Ok(()) => Ok(isize::try_from(count).unwrap().into()),
+            Ok(()) => Ok(isize::try_from(count).unwrap()),
             Err(e) => {
-                warn!("Failed to flush writes: {:?}", e);
-                Err(Errno::EFAULT.into())
+                warn!("Failed to flush writes: {e:?}");
+                Err(Errno::EFAULT)
             }
         }
     }

--- a/src/main/host/syscall/handler/sched.rs
+++ b/src/main/host/syscall/handler/sched.rs
@@ -5,7 +5,7 @@ use log::warn;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
-use crate::host::syscall::types::{ForeignArrayPtr, SyscallError};
+use crate::host::syscall::types::ForeignArrayPtr;
 use crate::host::thread::ThreadId;
 
 // We always report that the thread is running on CPU 0, Node 0
@@ -30,19 +30,19 @@ impl SyscallHandler {
         // > of type unsigned long *) impose no restriction on the size of the CPU
         // > mask
         mask_ptr: ForeignPtr<std::ffi::c_ulong>,
-    ) -> Result<std::ffi::c_int, SyscallError> {
+    ) -> Result<std::ffi::c_int, Errno> {
         let mask_ptr = mask_ptr.cast::<u8>();
         let mask_ptr = ForeignArrayPtr::new(mask_ptr, cpusetsize);
 
         let tid = ThreadId::try_from(tid).or(Err(Errno::ESRCH))?;
         if !ctx.objs.host.has_thread(tid) && kernel_pid_t::from(tid) != 0 {
-            return Err(Errno::ESRCH.into());
+            return Err(Errno::ESRCH);
         }
 
         // Shadow doesn't have users, so no need to check for permissions
 
         if cpusetsize == 0 {
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         }
 
         let mut mem = ctx.objs.process.memory_borrow_mut();
@@ -73,19 +73,19 @@ impl SyscallHandler {
         // > of type unsigned long *) impose no restriction on the size of the CPU
         // > mask
         mask_ptr: ForeignPtr<std::ffi::c_ulong>,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         let mask_ptr = mask_ptr.cast::<u8>();
         let mask_ptr = ForeignArrayPtr::new(mask_ptr, cpusetsize);
 
         let tid = ThreadId::try_from(tid).or(Err(Errno::ESRCH))?;
         if !ctx.objs.host.has_thread(tid) && kernel_pid_t::from(tid) != 0 {
-            return Err(Errno::ESRCH.into());
+            return Err(Errno::ESRCH);
         };
 
         // Shadow doesn't have users, so no need to check for permissions
 
         if cpusetsize == 0 {
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         }
 
         let mem = ctx.objs.process.memory_borrow_mut();
@@ -93,7 +93,7 @@ impl SyscallHandler {
 
         // this assumes little endian
         if mask[0] & 0x01 == 0 {
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         }
 
         Ok(())
@@ -113,7 +113,7 @@ impl SyscallHandler {
         rseq_len: u32,
         flags: std::ffi::c_int,
         sig: u32,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         let rseq_len = usize::try_from(rseq_len).unwrap();
         if rseq_len != std::mem::size_of::<rseq>() {
             // Probably worth a warning; decent chance that the bug is in Shadow
@@ -123,7 +123,7 @@ impl SyscallHandler {
                 rseq_len,
                 std::mem::size_of::<rseq>()
             );
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         }
         Self::rseq_impl(ctx, rseq_ptr, flags, sig)
     }
@@ -133,10 +133,10 @@ impl SyscallHandler {
         rseq_ptr: ForeignPtr<linux_api::rseq::rseq>,
         flags: i32,
         _sig: u32,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         if flags & (!RSEQ_FLAG_UNREGISTER) != 0 {
-            warn!("Unrecognized rseq flags: {}", flags);
-            return Err(Errno::EINVAL.into());
+            warn!("Unrecognized rseq flags: {flags}");
+            return Err(Errno::EINVAL);
         }
         if flags & RSEQ_FLAG_UNREGISTER != 0 {
             // TODO:

--- a/src/main/host/syscall/handler/shadow.rs
+++ b/src/main/host/syscall/handler/shadow.rs
@@ -3,17 +3,17 @@ use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::core::worker::Worker;
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
-use crate::host::syscall::types::{ForeignArrayPtr, SyscallError};
+use crate::host::syscall::types::ForeignArrayPtr;
 use crate::utility::case_insensitive_eq;
 
 impl SyscallHandler {
     log_syscall!(shadow_yield, /* rv */ std::ffi::c_int);
-    pub fn shadow_yield(_ctx: &mut SyscallContext) -> Result<(), SyscallError> {
+    pub fn shadow_yield(_ctx: &mut SyscallContext) -> Result<(), Errno> {
         Ok(())
     }
 
     log_syscall!(shadow_init_memory_manager, /* rv */ std::ffi::c_int);
-    pub fn shadow_init_memory_manager(ctx: &mut SyscallContext) -> Result<(), SyscallError> {
+    pub fn shadow_init_memory_manager(ctx: &mut SyscallContext) -> Result<(), Errno> {
         if !ctx.objs.host.params.use_mem_mapper {
             log::trace!("Not initializing memory mapper");
             return Ok(());
@@ -43,7 +43,7 @@ impl SyscallHandler {
         name_len: u64,
         addr_ptr: ForeignPtr<()>,
         addr_len: u64,
-    ) -> Result<(), SyscallError> {
+    ) -> Result<(), Errno> {
         log::trace!("Handling custom syscall shadow_hostname_to_addr_ipv4");
 
         let name_len: usize = name_len.try_into().unwrap();
@@ -51,7 +51,7 @@ impl SyscallHandler {
 
         if addr_len < std::mem::size_of::<u32>() {
             log::trace!("Invalid addr_len {addr_len}, returning EINVAL");
-            return Err(Errno::EINVAL.into());
+            return Err(Errno::EINVAL);
         }
 
         // TODO: Don't add 1 byte to length (if the application gave us a length of X bytes, don't
@@ -96,7 +96,7 @@ impl SyscallHandler {
         let Some(addr) = addr else {
             log::trace!("Unable to find address for name {lookup_name:?}");
             // return EFAULT like gethostname
-            return Err(Errno::EFAULT.into());
+            return Err(Errno::EFAULT);
         };
 
         log::trace!("Found address {addr} for name {lookup_name:?}");

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -629,7 +629,6 @@ impl SyscallHandler {
         };
 
         let File::Socket(socket) = file.inner_file() else {
-            drop(desc_table);
             return Err(Errno::ENOTSOCK);
         };
 
@@ -912,7 +911,6 @@ impl SyscallHandler {
         let how = Shutdown::try_from(how).or(Err(Errno::EINVAL))?;
 
         let File::Socket(socket) = file.inner_file() else {
-            drop(desc_table);
             return Err(Errno::ENOTSOCK.into());
         };
 
@@ -1109,7 +1107,6 @@ impl SyscallHandler {
         };
 
         let File::Socket(socket) = file.inner_file() else {
-            drop(desc_table);
             return Err(Errno::ENOTSOCK.into());
         };
 

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -944,24 +944,21 @@ impl SyscallHandler {
 
         // only AF_UNIX (AF_LOCAL) is supported on Linux (and technically AF_TIPC)
         if domain != libc::AF_UNIX {
-            warn!("Domain {} is not supported for socketpair()", domain);
+            warn!("Domain {domain} is not supported for socketpair()");
             return Err(Errno::EOPNOTSUPP.into());
         }
 
         let socket_type = match UnixSocketType::try_from(socket_type) {
             Ok(x) => x,
             Err(e) => {
-                warn!("{}", e);
+                warn!("Not a unix socket type: {e}");
                 return Err(Errno::EPROTONOSUPPORT.into());
             }
         };
 
         // unix sockets don't support any protocols
         if protocol != 0 {
-            warn!(
-                "Unsupported socket protocol {}, we only support default protocol 0",
-                protocol
-            );
+            warn!("Unsupported socket protocol {protocol}, we only support default protocol 0");
             return Err(Errno::EPROTONOSUPPORT.into());
         }
 


### PR DESCRIPTION
This extends the syscall handler trait to support functions that return `Into<SyscallError>`, and changes some syscall handlers to return `Errno` instead of `SyscallError` when it simplifies the code.