### PR TITLE
Add the fchmodat2 syscall handler and fix fchmodat

### DIFF
--- a/src/lib/preload-libc/gen_syscall_wrappers_c.py
+++ b/src/lib/preload-libc/gen_syscall_wrappers_c.py
@@ -90,6 +90,7 @@ skip.update([
 skip.update([
     'fchmod',
     'fchmodat',
+    'fchmodat2',
     'fsconfig',
     'fsmount',
     'fsopen',

--- a/src/main/host/syscall/handler/fileat.c
+++ b/src/main/host/syscall/handler/fileat.c
@@ -221,6 +221,28 @@ SyscallReturn syscallhandler_fchmodat(SyscallHandler* sys, const SyscallArgs* ar
         regularfile_fchmodat(dir_desc, pathname, mode, 0, plugin_cwd));
 }
 
+SyscallReturn syscallhandler_fchmodat2(SyscallHandler* sys, const SyscallArgs* args) {
+    int dirfd = args->args[0].as_i64;
+    UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
+    uid_t mode = args->args[2].as_u64;
+    int flags = args->args[3].as_i64;
+
+    /* Validate params. */
+    RegularFile* dir_desc = NULL;
+    const char* pathname;
+
+    int errcode = _syscallhandler_validateDirAndPathnameHelper(
+        sys, dirfd, pathnamePtr, &dir_desc, &pathname);
+    if (errcode < 0) {
+        return syscallreturn_makeDoneErrno(-errcode);
+    }
+
+    const char* plugin_cwd = process_getWorkingDir(rustsyscallhandler_getProcess(sys));
+
+    return syscallreturn_makeDoneI64(
+        regularfile_fchmodat(dir_desc, pathname, mode, flags, plugin_cwd));
+}
+
 SyscallReturn syscallhandler_futimesat(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*

--- a/src/main/host/syscall/handler/fileat.c
+++ b/src/main/host/syscall/handler/fileat.c
@@ -204,7 +204,6 @@ SyscallReturn syscallhandler_fchmodat(SyscallHandler* sys, const SyscallArgs* ar
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     uid_t mode = args->args[2].as_u64;
-    int flags = args->args[3].as_i64;
 
     /* Validate params. */
     RegularFile* dir_desc = NULL;
@@ -219,7 +218,7 @@ SyscallReturn syscallhandler_fchmodat(SyscallHandler* sys, const SyscallArgs* ar
     const char* plugin_cwd = process_getWorkingDir(rustsyscallhandler_getProcess(sys));
 
     return syscallreturn_makeDoneI64(
-        regularfile_fchmodat(dir_desc, pathname, mode, flags, plugin_cwd));
+        regularfile_fchmodat(dir_desc, pathname, mode, 0, plugin_cwd));
 }
 
 SyscallReturn syscallhandler_futimesat(SyscallHandler* sys, const SyscallArgs* args) {

--- a/src/main/host/syscall/handler/fileat.h
+++ b/src/main/host/syscall/handler/fileat.h
@@ -10,6 +10,7 @@
 
 SYSCALL_HANDLER(faccessat);
 SYSCALL_HANDLER(fchmodat);
+SYSCALL_HANDLER(fchmodat2);
 SYSCALL_HANDLER(fchownat);
 SYSCALL_HANDLER(futimesat);
 SYSCALL_HANDLER(linkat);

--- a/src/main/host/syscall/handler/fileat.rs
+++ b/src/main/host/syscall/handler/fileat.rs
@@ -35,6 +35,11 @@ impl SyscallHandler {
         Self::legacy_syscall(cshadow::syscallhandler_fchmodat, ctx)
     }
 
+    log_syscall!(fchmodat2, /* rv */ std::ffi::c_int);
+    pub fn fchmodat2(ctx: &mut SyscallContext) -> SyscallResult {
+        Self::legacy_syscall(cshadow::syscallhandler_fchmodat2, ctx)
+    }
+
     log_syscall!(fchownat, /* rv */ std::ffi::c_int);
     pub fn fchownat(ctx: &mut SyscallContext) -> SyscallResult {
         Self::legacy_syscall(cshadow::syscallhandler_fchownat, ctx)

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -406,6 +406,7 @@ impl SyscallHandler {
             SyscallNum::NR_fallocate => handle!(fallocate),
             SyscallNum::NR_fchmod => handle!(fchmod),
             SyscallNum::NR_fchmodat => handle!(fchmodat),
+            SyscallNum::NR_fchmodat2 => handle!(fchmodat2),
             SyscallNum::NR_fchown => handle!(fchown),
             SyscallNum::NR_fchownat => handle!(fchownat),
             SyscallNum::NR_fcntl => handle!(fcntl),


### PR DESCRIPTION
The 'fchmodat' syscall doesn't have a flags argument, and there was recently a 'fchmodat2' syscall that does.

The PR only needs a review for the last two commits. the others are from other dependent open PRs.