### PR TITLE
Upgrade rust version in CI to 1.80.1

### DIFF
--- a/ci/rust-toolchain-nightly.toml
+++ b/ci/rust-toolchain-nightly.toml
@@ -9,6 +9,6 @@
 [toolchain]
 # Must be a version built with miri; check
 # https://rust-lang.github.io/rustup-components-history/
-channel = "nightly-2024-08-03"
+channel = "nightly-2024-08-09"
 # We don't add individual components here. CI individually
 # adds the ones they need (e.g. clippy, miri).

--- a/ci/rust-toolchain-stable.toml
+++ b/ci/rust-toolchain-stable.toml
@@ -7,4 +7,4 @@
 # See
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.80.0"
+channel = "1.80.1"


### PR DESCRIPTION
https://blog.rust-lang.org/2024/08/08/Rust-1.80.1.html

> Rust 1.80.1 fixes two regressions that were recently reported.

Neither probably affects us, but probably a good idea to update.