### PR TITLE
Add missing `with_global_cb_queue` wrappers

### DIFF
--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -109,7 +109,11 @@ impl SyscallHandler {
         if let Some(replaced_desc) = replaced_desc {
             // from 'man 2 dup2': "If newfd was open, any errors that would have been reported at
             // close(2) time are lost"
-            CallbackQueue::queue_and_run(|cb_queue| replaced_desc.close(ctx.objs.host, cb_queue));
+            crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
+                CallbackQueue::queue_and_run(|cb_queue| {
+                    replaced_desc.close(ctx.objs.host, cb_queue)
+                })
+            });
         }
 
         // return the new fd
@@ -169,7 +173,11 @@ impl SyscallHandler {
         if let Some(replaced_desc) = replaced_desc {
             // from 'man 2 dup3': "If newfd was open, any errors that would have been reported at
             // close(2) time are lost"
-            CallbackQueue::queue_and_run(|cb_queue| replaced_desc.close(ctx.objs.host, cb_queue));
+            crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
+                CallbackQueue::queue_and_run(|cb_queue| {
+                    replaced_desc.close(ctx.objs.host, cb_queue)
+                })
+            });
         }
 
         // return the new fd

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -141,17 +141,19 @@ impl Thread {
                 })
                 .collect();
 
-            CallbackQueue::queue_and_run(|q| {
-                for handle in to_close {
-                    log::trace!("Unregistering FD_CLOEXEC descriptor {handle:?}");
-                    if let Some(Err(e)) = desc_table
-                        .deregister_descriptor(handle)
-                        .unwrap()
-                        .close(host, q)
-                    {
-                        log::debug!("Error closing {handle:?}: {e:?}");
-                    };
-                }
+            crate::utility::legacy_callback_queue::with_global_cb_queue(|| {
+                CallbackQueue::queue_and_run(|q| {
+                    for handle in to_close {
+                        log::trace!("Unregistering FD_CLOEXEC descriptor {handle:?}");
+                        if let Some(Err(e)) = desc_table
+                            .deregister_descriptor(handle)
+                            .unwrap()
+                            .close(host, q)
+                        {
+                            log::debug!("Error closing {handle:?}: {e:?}");
+                        };
+                    }
+                })
             });
 
             self.desc_table = Some(RootedRc::new(


### PR DESCRIPTION
This is likely causing #3390. We should have been calling `with_global_cb_queue` in `Thread::update_for_exec` to initialize the global thread-local callback queue so that callbacks made from C won't occur while we already have the rust socket borrowed. I also added `with_global_cb_queue` in a few other places where it was missing.