### PR TITLE
Allow signal handlers to switch to in-use stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ PATCH changes (bugfixes):
 * Log messages about unrecognized sockopt values are now only logged at level WARN once for each distinct value (and at DEBUG afterwards) (#3353).
 * Fixed rust/clippy warnings for rust 1.80. (#3354, #3355)
 * Fixed a build error on rust nightly (and future stable rust versions) by upgrading dependencies. (#3334)
+* Fixed a shim panic (which causes shadow to hang) when golang's default SIGTERM handler runs in a managed program (and potentially other cases where a signal handler stack is legitimately reused). (#3396)
 
 Full changelog since v3.2.0:
 

--- a/src/lib/shim/src/signals.rs
+++ b/src/lib/shim/src/signals.rs
@@ -190,9 +190,15 @@ pub unsafe fn process_signals(mut ucontext: Option<&mut ucontext>) -> bool {
             {
                 // The specified stack is already in use.
                 //
-                // Documentation is unclear what should happen, but switching to
-                // the already-in-use stack would almost certainly go badly.
-                panic!("Alternate stack already in use.")
+                // This *could* be ok, e.g. if the stack is in use by the
+                // current thread, and never unwound back to the earlier use;
+                // e.g. if the handler exits the process. golang appears to do
+                // this in its default SIGTERM handling. (See
+                // https://github.com/shadow/shadow/issues/3395).
+                //
+                // In other cases things could go horribly, but it'd be a bug in
+                // the managed process rather than in shadow itself.
+                log::debug!("Signal handler configured to switch to a stack that's already in use. This could go badly.")
             }
 
             // Update the signal-stack configuration while the handler is being run.

--- a/src/test/golang/CMakeLists.txt
+++ b/src/test/golang/CMakeLists.txt
@@ -94,3 +94,10 @@ add_shadow_tests(
       # This test can take a bit longer in debug builds
       TIMEOUT 40
       LABELS golang)
+
+add_golang_test_exe(BASENAME test_sigterm)
+add_shadow_tests(
+    BASENAME sigterm
+    CONFIGURATIONS extra
+    PROPERTIES
+      LABELS golang)

--- a/src/test/golang/sigterm.yaml
+++ b/src/test/golang/sigterm.yaml
@@ -1,0 +1,21 @@
+# Regression test for handling golang's default SIGTERM handler.
+# See https://github.com/shadow/shadow/issues/3395.
+general:
+  stop_time: 10s
+
+network:
+  graph:
+    type: 1_gbit_switch
+
+hosts:
+  host:
+    network_node_id: 0
+    processes:
+    # The test program just sleeps.
+    - path: ./test_sigterm
+      start_time: 1s
+      # Should be killed by the `kill` below.
+      expected_final_state: { signaled: SIGTERM }
+    - path: kill
+      args: "-s SIGTERM 1000"
+      start_time: 5s

--- a/src/test/golang/test_sigterm.go
+++ b/src/test/golang/test_sigterm.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+    "time"
+)
+
+func main() {
+    // Just sleep. We're waiting for a SIGTERM to be delivered externally.
+    // This is a regression test for handling golang's default SIGTERM handler,
+    // which appears to reuse an in-use stack just before exiting.
+    // See https://github.com/shadow/shadow/issues/3395.
+    time.Sleep(10000 * time.Second)
+}


### PR DESCRIPTION
This *can* be safe in some circumstances, and golang appears to do it in its default SIGTERM handler.

Fixes https://github.com/shadow/shadow/issues/3395