### PR TITLE
verify_plugin_path: support scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ MINOR changes (backwards-compatible):
 * Implemented the `chdir` syscall. (#3368)
 * Implemented the `close_range` syscall. (#3364)
 * Added partial support the `fstat` syscall with pipes. (#3361)
+* We now support direct execution of scripts in shadow's config file.
+Instead of specifying `{path: '/usr/bin/python3', args:
+'/path/to/my/script.py'}`, you can now use `{path: '/path/to/my/script.py'}`
+provided it has an appropriate "shebang" line (e.g. `#!/usr/bin/env python3`).
+Likewise execution of such scripts is now supported inside the simulation when
+spawning processes via `execve`.
 
 PATCH changes (bugfixes):
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1583,6 +1583,7 @@ dependencies = [
  "rustix",
  "signal-hook",
  "static_assertions",
+ "tempfile",
  "vasi-sync",
 ]
 

--- a/src/main/utility/mod.rs
+++ b/src/main/utility/mod.rs
@@ -25,7 +25,8 @@ pub mod syscall;
 pub mod units;
 
 use std::collections::HashSet;
-use std::ffi::CString;
+use std::ffi::{CString, OsStr};
+use std::io::Read;
 use std::marker::PhantomData;
 use std::os::unix::fs::{DirBuilderExt, MetadataExt};
 use std::os::unix::prelude::OsStrExt;
@@ -340,14 +341,34 @@ pub enum VerifyPluginPathError {
     NotFile,
     // File isn't executable.
     NotExecutable,
-    // File isn't a dynamically linked ELF.
-    // TODO: split these errors, and/or support `#!` interpreters?
+    // File appears to be an ELF, but an incompatible one. e.g. not dynamically
+    // linked.
     NotDynamicallyLinkedElf,
+    // File appears to be a script with a "shebang" line, but doesn't specify a
+    // compatible intepreter.
+    IncompatibleInterpreter(Box<VerifyPluginPathError>),
+    // Not an ELF nor a script.
+    UnknownFileType,
     // Permission denied traversing the path.
     PathPermissionDenied,
     UnhandledIoError(std::io::Error),
 }
 impl std::error::Error for VerifyPluginPathError {}
+
+impl From<std::io::Error> for VerifyPluginPathError {
+    fn from(value: std::io::Error) -> Self {
+        match value.kind() {
+            std::io::ErrorKind::NotFound => VerifyPluginPathError::NotFound,
+            std::io::ErrorKind::PermissionDenied => VerifyPluginPathError::PathPermissionDenied,
+            // TODO handle TooManyLinks when stabilized
+            // TODO handle InvalidFileName when stabilized
+            _ => {
+                log::warn!("Unhandled IO error");
+                VerifyPluginPathError::UnhandledIoError(value)
+            }
+        }
+    }
+}
 
 impl std::fmt::Display for VerifyPluginPathError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -362,70 +383,110 @@ impl std::fmt::Display for VerifyPluginPathError {
                 f.write_str("permission denied traversing path")
             }
             VerifyPluginPathError::UnhandledIoError(e) => write!(f, "unhandled io error: {e}"),
+            VerifyPluginPathError::IncompatibleInterpreter(e) => {
+                write!(f, "script with incompatible interpreter: {e}")
+            }
+            VerifyPluginPathError::UnknownFileType => f.write_str("Uncrecognized file type"),
         }
     }
 }
 
 /// Check that the plugin path is executable under Shadow.
-pub fn verify_plugin_path(path: impl AsRef<std::path::Path>) -> Result<(), VerifyPluginPathError> {
-    let path = path.as_ref();
-
-    let metadata = std::fs::metadata(path).map_err(|e| {
-        match e.kind() {
-            std::io::ErrorKind::NotFound => VerifyPluginPathError::NotFound,
-            std::io::ErrorKind::PermissionDenied => VerifyPluginPathError::PathPermissionDenied,
-            // TODO handle TooManyLinks when stabilized
-            // TODO handle InvalidFileName when stabilized
-            k => {
-                log::warn!("Unhandled error getting metadata for {path:?}: {k:?}");
-                VerifyPluginPathError::UnhandledIoError(e)
-            }
-        }
-    })?;
-
+fn verify_plugin_path_internal(
+    path: impl AsRef<std::path::Path> + std::fmt::Debug,
+) -> Result<(), VerifyPluginPathError> {
+    let file = std::fs::File::open(&path)?;
+    let metadata = file.metadata()?;
     if !metadata.is_file() {
         return Err(VerifyPluginPathError::NotFile);
     }
-
     // this mask doesn't guarantee that we can execute the file (the file might have S_IXUSR
     // but be owned by a different user), but it should catch most errors
     let mask = libc::S_IXUSR | libc::S_IXGRP | libc::S_IXOTH;
     if (metadata.mode() & mask) == 0 {
+        log::debug!("{path:?} not executable");
         return Err(VerifyPluginPathError::NotExecutable);
     }
+    // Get up to PATH_MAX bytes; that should be enough to ensure we get the
+    // interpreter name where applicable.
+    let mut buf = Vec::with_capacity(linux_api::limits::PATH_MAX);
+    file.take(linux_api::limits::PATH_MAX.try_into().unwrap())
+        .read_to_end(&mut buf)?;
+
+    if buf.starts_with(b"\x7fELF") {
+        // Looks like an ELF file.
+        if is_dynamic_bin(&path) {
+            Ok(())
+        } else {
+            log::debug!("{path:?} is ELF, but not dynamically linked");
+            Err(VerifyPluginPathError::NotDynamicallyLinkedElf)
+        }
+    } else if let Some(interp) = get_interpreter(&buf) {
+        // Looks like a script.
+        // Linux allows recursion here. It has a depth limit of 4, but trying to
+        // check and precisely match that doesn't seem worthwhile.
+        log::debug!("{path:?} has interpreter {interp:?}; checking");
+        verify_plugin_path(interp)
+            .map_err(|e| VerifyPluginPathError::IncompatibleInterpreter(Box::new(e)))
+    } else {
+        Err(VerifyPluginPathError::UnknownFileType)
+    }
+}
+
+/// Check that the plugin path is executable under Shadow.
+// Memoization wrapper around `verify_plugin_path_internal`
+// TODO: maybe move this cache into `sim_config.rs`? This seems slightly more
+// possible to go stale for paths exec'd by managed code.
+pub fn verify_plugin_path(path: impl AsRef<std::path::Path>) -> Result<(), VerifyPluginPathError> {
+    let path = path.as_ref();
 
     // a cache so we don't check the same path multiple times (assuming the user doesn't move any
     // binaries while shadow is running)
-    // TODO: maybe move this into `sim_config.rs`? This seems slightly more
-    // possible to go stale for paths exec'd by managed code.
-    static CHECKED_DYNAMIC_BINS: Lazy<RwLock<HashSet<PathBuf>>> =
-        Lazy::new(|| RwLock::new(HashSet::new()));
+    static CHECKED_BINS: Lazy<RwLock<HashSet<PathBuf>>> = Lazy::new(|| RwLock::new(HashSet::new()));
 
-    let is_known_dynamic = CHECKED_DYNAMIC_BINS.read().unwrap().contains(path);
-
-    // check if the binary is dynamically linked
-    if !is_known_dynamic {
-        let ld_path = "/lib64/ld-linux-x86-64.so.2";
-        let ld_output = std::process::Command::new(ld_path)
-            .arg("--verify")
-            .arg(path)
-            .output()
-            .expect("Unable to run '{ld_path}'");
-
-        if ld_output.status.success() {
-            CHECKED_DYNAMIC_BINS
-                .write()
-                .unwrap()
-                .insert(path.to_path_buf());
-        } else {
-            log::debug!("ld stderr: {:?}", ld_output.stderr);
-            // technically ld-linux could return errors for other reasons, but this is the most
-            // likely reason given that we already checked that the file exists
-            return Err(VerifyPluginPathError::NotDynamicallyLinkedElf);
-        }
+    if CHECKED_BINS.read().unwrap().contains(path) {
+        return Ok(());
     }
 
-    Ok(())
+    let res = verify_plugin_path_internal(path);
+    if res.is_ok() {
+        CHECKED_BINS.write().unwrap().insert(path.to_path_buf());
+    }
+    res
+}
+
+fn get_interpreter(header: &[u8]) -> Option<&Path> {
+    // Verify and strip "shebang"
+    let mut header = header.strip_prefix(b"#!")?;
+    // Skip any spaces. (Other whitespace isn't skipped AFAIK).
+    while header.first() == Some(&b' ') {
+        header = &header[1..];
+    }
+    // The path is the next contiguous set of non-space or newline characters.
+    let interp_path = header.split(|b| b == &b' ' || b == &b'\n').next()?;
+    let p = OsStr::from_bytes(interp_path);
+    Some(Path::new(p))
+}
+
+fn is_dynamic_bin(path: impl AsRef<std::path::Path>) -> bool {
+    let path = path.as_ref();
+
+    // check if the binary is dynamically linked
+    let ld_path = "/lib64/ld-linux-x86-64.so.2";
+    let ld_output = std::process::Command::new(ld_path)
+        .arg("--verify")
+        .arg(path)
+        .output()
+        .expect("Unable to run '{ld_path}'");
+
+    if ld_output.status.success() {
+        true
+    } else {
+        log::debug!("ld stderr: {:?}", ld_output.stderr);
+        // technically ld-linux could return errors for other reasons, but this is the most
+        // likely reason given that we already checked that the file exists
+        false
+    }
 }
 
 /// Inject `injected_preloads` into the environment `envv`.

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -239,3 +239,4 @@ signal-hook = "0.3.17"
 once_cell = "1.19.0"
 vasi-sync = { path = "../lib/vasi-sync" }
 static_assertions = "1.1.0"
+tempfile = "3.12.0"

--- a/src/test/clone/CMakeLists.txt
+++ b/src/test/clone/CMakeLists.txt
@@ -27,7 +27,11 @@ add_shadow_tests(
     ARGS --strace-logging-mode=off --use-memory-manager=false
 )
 
-add_linux_tests(BASENAME clone COMMAND sh -c "../../target/debug/test_clone --libc-passing")
+# FIXME: Currently broken, probably because this test
+# doesn't set up thread local storage properly in new threads.
+# https://github.com/shadow/shadow/issues/3403
+# add_linux_tests(BASENAME clone COMMAND sh -c "../../target/debug/test_clone --libc-passing")
+
 add_shadow_tests(
     BASENAME clone
     # Shim-side strace-logging use libc functions that assume native


### PR DESCRIPTION
We can handle scripts using the "shebang line" mechanism, provided that the specified interpreter is a dynamically linked ELF (or another script whose interpreter is a dynamically linked ELF, etc).

Fixes #3400