### PR TITLE
Upgrade rust version in CI to 1.81

### DIFF
--- a/ci/rust-toolchain-nightly.toml
+++ b/ci/rust-toolchain-nightly.toml
@@ -9,6 +9,6 @@
 [toolchain]
 # Must be a version built with miri; check
 # https://rust-lang.github.io/rustup-components-history/
-channel = "nightly-2024-08-09"
+channel = "nightly-2024-09-06"
 # We don't add individual components here. CI individually
 # adds the ones they need (e.g. clippy, miri).

--- a/ci/rust-toolchain-stable.toml
+++ b/ci/rust-toolchain-stable.toml
@@ -7,4 +7,4 @@
 # See
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.80.1"
+channel = "1.81"

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -407,10 +407,9 @@ impl RunnableProcess {
     #[track_caller]
     fn first_live_thread(&self, root: &Root) -> Option<Ref<RootedRc<RootedRefCell<Thread>>>> {
         Ref::filter_map(self.threads.borrow(), |threads| {
-            threads.values().next().map(|thread| {
+            threads.values().next().inspect(|thread| {
                 // There shouldn't be any non-running threads in the table.
                 assert!(thread.borrow(root).is_running());
-                thread
             })
         })
         .ok()


### PR DESCRIPTION
Also fixes a "clippy::manual_inspect" warning.

https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html