### PR TITLE
Drop packet instead of panicking if dst IP is unknown

### DIFF
--- a/src/test/regression/3148/CMakeLists.txt
+++ b/src/test/regression/3148/CMakeLists.txt
@@ -1,0 +1,2 @@
+# regression test for https://github.com/shadow/shadow/issues/3148
+add_shadow_tests(BASENAME regression-3148)

--- a/src/test/regression/3148/regression-3148.yaml
+++ b/src/test/regression/3148/regression-3148.yaml
@@ -1,0 +1,14 @@
+general:
+  stop_time: 10 seconds
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  testnode:
+    network_node_id: 0
+    processes:
+    - path: python3
+      args:
+        - -c
+        # send a packet to an unused IP address to make sure shadow doesn't crash
+        - 'import socket, time; socket.socket(socket.AF_INET, socket.SOCK_DGRAM).sendto(b"hello", ("13.62.123.22", 80)); time.sleep(1)'

--- a/src/test/regression/CMakeLists.txt
+++ b/src/test/regression/CMakeLists.txt
@@ -32,3 +32,4 @@ add_shadow_tests(
     )
 
 add_subdirectory(2210)
+add_subdirectory(3148)


### PR DESCRIPTION
Closes #3148. Also added a regression test.

This was really easy to add now that we have `log_once_per_value_at_level!()`.

```
[WARN] [testnode:11.0.0.1] [worker.rs:354] [shadow_rs::core::worker] (LOG_ONCE) Packet has destination 13.62.123.22 which doesn't exist in the simulation. Dropping the packet.
```