### PR TITLE
DNS: Allow assignment of restricted IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Instead of specifying `{path: '/usr/bin/python3', args:
 provided it has an appropriate "shebang" line (e.g. `#!/usr/bin/env python3`).
 Likewise execution of such scripts is now supported inside the simulation when
 spawning processes via `execve`.
+* Relaxed restriction on assigning restricted IPs (such as 192.168.0.*).
+Within the simulation these are treated as fully routable IPs, so are required
+to be unique as with any other IP address assignment. (#3414)
 
 PATCH changes (bugfixes):
 

--- a/src/main/routing/dns.c
+++ b/src/main/routing/dns.c
@@ -81,31 +81,6 @@ static gboolean _dns_isIPInRange(const in_addr_t netIP, const gchar* cidrStr) {
 }
 
 /* Address must be in network byte order. */
-static gboolean _dns_isRestricted(DNS* dns, in_addr_t netIP) {
-    /* http://en.wikipedia.org/wiki/Reserved_IP_addresses#Reserved_IPv4_addresses */
-    if(_dns_isIPInRange(netIP, "0.0.0.0/8") ||
-            _dns_isIPInRange(netIP, "10.0.0.0/8") ||
-            _dns_isIPInRange(netIP, "100.64.0.0/10") ||
-            _dns_isIPInRange(netIP, "127.0.0.0/8") ||
-            _dns_isIPInRange(netIP, "169.254.0.0/16") ||
-            _dns_isIPInRange(netIP, "172.16.0.0/12") ||
-            _dns_isIPInRange(netIP, "192.0.0.0/29") ||
-            _dns_isIPInRange(netIP, "192.0.2.0/24") ||
-            _dns_isIPInRange(netIP, "192.88.99.0/24") ||
-            _dns_isIPInRange(netIP, "192.168.0.0/16") ||
-            _dns_isIPInRange(netIP, "198.18.0.0/15") ||
-            _dns_isIPInRange(netIP, "198.51.100.0/24") ||
-            _dns_isIPInRange(netIP, "203.0.113.0/24") ||
-            _dns_isIPInRange(netIP, "224.0.0.0/4") ||
-            _dns_isIPInRange(netIP, "240.0.0.0/4") ||
-            _dns_isIPInRange(netIP, "255.255.255.255/32")) {
-        return TRUE;
-    } else {
-        return FALSE;
-    }
-}
-
-/* Address must be in network byte order. */
 static gboolean _dns_isIPUnique(DNS* dns, in_addr_t ip) {
     gboolean exists = g_hash_table_lookup_extended(dns->addressByIP, GUINT_TO_POINTER(ip), NULL, NULL);
     return exists ? FALSE : TRUE;
@@ -126,9 +101,7 @@ Address* dns_register(DNS* dns, HostId id, const gchar* name, in_addr_t requeste
         isLocal = TRUE;
     } else if (!_dns_isIPUnique(dns, requestedIP)) {
         gchar* ipStr = address_ipToNewString(requestedIP);
-        warning("Invalid IP %s (restricted: %s, unique: %s)", ipStr,
-                _dns_isRestricted(dns, requestedIP) ? "true" : "false",
-                _dns_isIPUnique(dns, requestedIP) ? "true" : "false");
+        warning("Non-unique IP assignment: %s", ipStr);
         g_free(ipStr);
         g_mutex_unlock(&dns->lock);
         return NULL;

--- a/src/main/routing/dns.c
+++ b/src/main/routing/dns.c
@@ -37,50 +37,6 @@ struct _DNS {
 };
 
 /* Address must be in network byte order. */
-static gboolean _dns_isIPInRange(const in_addr_t netIP, const gchar* cidrStr) {
-    utility_debugAssert(cidrStr);
-
-    gchar** cidrParts = g_strsplit(cidrStr, "/", 0);
-    gchar* cidrIPStr = cidrParts[0];
-    gint cidrBits = atoi(cidrParts[1]);
-    utility_debugAssert(cidrBits >= 0 && cidrBits <= 32);
-
-    /* first create the mask in host order */
-    in_addr_t netmask = 0;
-    for(gint i = 0; i < 32; i++) {
-        /* move one so LSB is 0 */
-        netmask = netmask << 1;
-        if(cidrBits > i) {
-            /* flip the LSB */
-            netmask++;
-        }
-    }
-
-    /* flip to network order */
-    netmask = htonl(netmask);
-
-    /* get the subnet ip in network order */
-    in_addr_t subnetIP = address_stringToIP(cidrIPStr);
-
-    g_strfreev(cidrParts);
-
-    /* all non-subnet bits should be flipped */
-    if((netIP & netmask) == (subnetIP & netmask)) {
-        gchar* ipStr = address_ipToNewString(netIP);
-        gchar* subnetIPStr = address_ipToNewString(subnetIP);
-        gchar* netmaskStr = address_ipToNewString(netmask);
-        trace("ip '%s' is in range '%s' using subnet '%s' and mask '%s'",
-                ipStr, cidrStr, subnetIPStr, netmaskStr);
-        g_free(ipStr);
-        g_free(subnetIPStr);
-        g_free(netmaskStr);
-        return TRUE;
-    } else {
-        return FALSE;
-    }
-}
-
-/* Address must be in network byte order. */
 static gboolean _dns_isIPUnique(DNS* dns, in_addr_t ip) {
     gboolean exists = g_hash_table_lookup_extended(dns->addressByIP, GUINT_TO_POINTER(ip), NULL, NULL);
     return exists ? FALSE : TRUE;

--- a/src/main/routing/dns.c
+++ b/src/main/routing/dns.c
@@ -120,10 +120,11 @@ Address* dns_register(DNS* dns, HostId id, const gchar* name, in_addr_t requeste
 
     gboolean isLocal = FALSE;
 
-    /* restricted is OK if this is a localhost address, otherwise it must be unique */
+    /* non-unique are OK only if this is a localhost address */
+    /* TODO: Support other localhost addresses; e.g. 127.0.0.2? */
     if (requestedIP == address_stringToIP("127.0.0.1")) {
         isLocal = TRUE;
-    } else if (_dns_isRestricted(dns, requestedIP) || !_dns_isIPUnique(dns, requestedIP)) {
+    } else if (!_dns_isIPUnique(dns, requestedIP)) {
         gchar* ipStr = address_ipToNewString(requestedIP);
         warning("Invalid IP %s (restricted: %s, unique: %s)", ipStr,
                 _dns_isRestricted(dns, requestedIP) ? "true" : "false",


### PR DESCRIPTION
The comment that was here indicated intent to allow restricted IP addresses as long as they were unique (or local), but the code rejected them.

I *think* we want to reject any non-unique + non-local IP address assignment, and don't otherwise care if it's in a restricted range.