### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/pr_labeler_conf.yml
+++ b/.github/pr_labeler_conf.yml
@@ -1,27 +1,47 @@
 "Component: Build":
-- "**/CMakeLists.txt"
-- "**/Cargo.toml"
-- "**/Cargo.lock"
+- changed-files:
+  - any-glob-to-any-file:
+    - "**/CMakeLists.txt"
+    - "**/Cargo.toml"
+    - "**/Cargo.lock"
 
 "Component: Documentation":
-- "**/*.md"
-- "docs/**/*"
+- changed-files:
+  - any-glob-to-any-file:
+    - "**/*.md"
+    - "docs/**/*"
 
 "Component: Libraries":
-- "src/lib/**/*"
+- changed-files:
+  - any-glob-to-any-file:
+    - "src/lib/**/*"
 
 "Component: Main":
-- "src/main/**/*"
+- changed-files:
+  - any-glob-to-any-file:
+    - "src/main/**/*"
 
 # Any change in src/test or any yml file changed in .github except pr labeler.
 # From https://github.com/actions/labeler:
-#  From a boolean logic perspective, top-level match objects are OR-ed together
-#  and individual match rules within an object are AND-ed. Combined with !
-#  negation, you can write complex matching rules.
+#  From a boolean logic perspective, top-level match objects, and options
+#  within all are AND-ed together and individual match rules within the any
+#  object are OR-ed.
+#
+#  [...]
+#
+#  If a base option is provided without a top-level key, then it will default
+#  to any.
 "Component: Testing":
-- any: ["src/test/**/*"]
-- any: [".github/**/*.yml", "!.github/pr_labeler_conf.yml",
-        "!.github/workflows/pr_metadata.yml"]
+- changed-files:
+  - any-glob-to-any-file:
+    - "src/test/**/*"
+- changed-files:
+  - any-glob-to-any-file:
+    - ".github/**/*.yml"
+    - "!.github/pr_labeler_conf.yml"
+    - "!.github/workflows/pr_metadata.yml"
 
 "Component: Tools":
-- "src/tools/**/*"
+- changed-files:
+  - any-glob-to-any-file:
+    - "src/tools/**/*"

--- a/.github/workflows/ci_maintenance.yml
+++ b/.github/workflows/ci_maintenance.yml
@@ -29,6 +29,7 @@ jobs:
           - rust default nightly version (\`ci/rust-toolchain-nightly.toml\`)
           - python version for the python lint (\`.github/workflows/lint.yml\`)
           - tor and tgen versions for the tor tests (\`.github/workflows/extra_tests.yml\`)
+          - versions of github actions (\`uses: <action-name@version>\` in \`.github/workflows/*.yml\`)
 
           Shadow's dependencies may also need to be updated.
 

--- a/.github/workflows/extra_tests.yml
+++ b/.github/workflows/extra_tests.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - run: apt-get update
       - name: Checkout shadow
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: shadow
           # Run on PR head instead of merge result. Running on the merge
@@ -156,7 +156,7 @@ jobs:
           key: tgen-build-key-${{ env.CONTAINER }}-816d68cd3d0ff7d0ec71e8bbbae24ecd6a636117
       - name: Checkout tgen
         if: steps.restore-tgen-build-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: tgen
           repository: shadow/tgen

--- a/.github/workflows/extra_tests.yml
+++ b/.github/workflows/extra_tests.yml
@@ -226,7 +226,7 @@ jobs:
       - run: apt-get update
 
       - name: Download shadow
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-shadow
 
@@ -237,7 +237,7 @@ jobs:
         run: apt-get install -y libglib2.0-0
 
       - name: Download tgen
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-tgen
           path: .
@@ -358,7 +358,7 @@ jobs:
       - run: apt-get update
 
       - name: Download shadow
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-shadow
 
@@ -369,7 +369,7 @@ jobs:
         run: apt-get install -y libglib2.0-0
 
       - name: Download tgen
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-tgen
           path: .
@@ -440,7 +440,7 @@ jobs:
       - run: apt-get update
 
       - name: Download shadow
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-shadow
 

--- a/.github/workflows/extra_tests.yml
+++ b/.github/workflows/extra_tests.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           echo "month=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
       - name: Restore cargo registry cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -85,7 +85,7 @@ jobs:
         run: |
           echo rustv=\"$(rustc --version)\" >> $GITHUB_OUTPUT
       - name: Restore sccache cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         continue-on-error: false
         with:
           path: ${{ env.SCCACHE_DIR }}
@@ -149,7 +149,7 @@ jobs:
     steps:
       - name: Restore cache
         id: restore-tgen-build-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: opt/tgen
           # Sync with env.CONTAINER, and with checkout ref below.
@@ -256,7 +256,7 @@ jobs:
 
       - name: Restore tor build cache
         id: restore-tor-build-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: opt/tor
           # sync with env.CONTAINER

--- a/.github/workflows/extra_tests.yml
+++ b/.github/workflows/extra_tests.yml
@@ -132,7 +132,7 @@ jobs:
           tar --no-recursion --append -f $TARFILE \
             shadow/build/src/shim/target/*/libshadow_shim.so
           gzip $TARFILE
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-shadow
           path: shadow.tar.gz
@@ -191,7 +191,7 @@ jobs:
       # We need to wrap in a tarball to preserve permissions.
       - name: Archive tgen
         run: tar -czf tgen.tar.gz opt/tgen
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-tgen
           path: tgen.tar.gz
@@ -324,14 +324,14 @@ jobs:
           for f in shadow/build/src/test/tor/**/*.data; do tar -cJf "$f.tar.xz" "$f/"; done
 
       - name: Upload shadow data directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.tor }}-shadow-data-dir
           path: shadow/build/src/test/tor/**/*.data.tar.xz
 
       - name: Upload shadow log file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.tor }}-shadow-log-file
@@ -407,14 +407,14 @@ jobs:
           for f in shadow/build/src/test/tgen/**/*.data; do tar -cJf "$f.tar.xz" "$f/"; done
 
       - name: Upload shadow data directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: tgen-shadow-data-dir
           path: shadow/build/src/test/tgen/**/*.data.tar.xz
 
       - name: Upload shadow log file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: tgen-shadow-log-file
@@ -495,14 +495,14 @@ jobs:
           for f in shadow/build/examples/**/*.data; do tar -cJf "$f.tar.xz" "$f/"; done
 
       - name: Upload shadow data directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: examples-shadow-data-dir
           path: shadow/build/examples/**/*.data.tar.xz
 
       - name: Upload shadow log file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: examples-shadow-log-file

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
   lint-python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           # Run on PR head instead of merge result. Running on the merge
@@ -33,7 +33,7 @@ jobs:
   lint-shell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           # Run on PR head instead of merge result. Running on the merge
@@ -47,7 +47,7 @@ jobs:
   lint-rust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Run on PR head instead of merge result. Running on the merge
           # result can give confusing results, and we require PR to be up to
@@ -66,7 +66,7 @@ jobs:
   lint-clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Run on PR head instead of merge result. Running on the merge
           # result can give confusing results, and we require PR to be up to
@@ -89,7 +89,7 @@ jobs:
   lint-cargo-lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cargo update check
         run: |
           # This will return an error if any versions of local crates in the Cargo.lock
@@ -100,7 +100,7 @@ jobs:
   lint-cargo-doc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Run on PR head instead of merge result. Running on the merge
           # result can give confusing results, and we require PR to be up to

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           # date with target branch before merging, anyway.
           # See https://github.com/shadow/shadow/issues/2166
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - run: pip install flake8

--- a/.github/workflows/pr_metadata.yml
+++ b/.github/workflows/pr_metadata.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Apply Labels
       # Add labels based on paths modified in PR
       # https://github.com/actions/labeler
-      uses: actions/labeler@v4
+      uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/pr_labeler_conf.yml

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -82,7 +82,7 @@ jobs:
       SCCACHE_CACHE_VERSION: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           # Run on PR head instead of merge result. Running on the merge

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -161,14 +161,14 @@ jobs:
           for f in build/**/*.data; do tar -cJf "$f.tar.xz" "$f/"; done
 
       - name: Upload shadow data directories
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: shadow-data-dirs
           path: build/**/*.data.tar.xz
 
       - name: Upload shadow log file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: shadow-log-file

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -103,7 +103,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Restore cargo registry cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -119,7 +119,7 @@ jobs:
         run: |
           echo rustv=\"$(rustc --version)\" >> $GITHUB_OUTPUT
       - name: Restore sccache cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         continue-on-error: false
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false
         # Run on PR head instead of merge result. Running on the merge
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false
         # Run on PR head instead of merge result. Running on the merge

--- a/ci/rust-toolchain-nightly.toml
+++ b/ci/rust-toolchain-nightly.toml
@@ -9,6 +9,6 @@
 [toolchain]
 # Must be a version built with miri; check
 # https://rust-lang.github.io/rustup-components-history/
-channel = "nightly-2024-09-06"
+channel = "nightly-2024-10-05"
 # We don't add individual components here. CI individually
 # adds the ones they need (e.g. clippy, miri).

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
@@ -123,7 +123,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -195,12 +195,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.8"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -214,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.8"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+checksum = "d0890061c4d3223e7267f3bad2ec40b997d64faac1c2815a4a9d95018e2b9e9c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -523,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "979f00864edc7516466d6b3157706e06c032f22715700ddd878228a91d02bc56"
+checksum = "dbb949699c3e4df3a183b1d2142cb24277057055ed23c68ed58894f76c517223"
 dependencies = [
  "cfg-if",
  "libc",
@@ -576,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -594,9 +595,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "home"
@@ -615,9 +616,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -625,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -651,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -675,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1012,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
@@ -1067,15 +1068,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plotters"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1086,15 +1087,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -1122,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
  "syn 2.0.79",
@@ -1413,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -1715,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.1"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c81f13d9a334a6c242465140bd262fae382b752ff2011c4f7419919a9c97922"
+checksum = "66d23aaf9f331227789a99e8de4c91bf46703add012bdfd45fdecdfb2975a005"
 dependencies = [
  "cfg-expr",
  "heck 0.5.0",
@@ -1862,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "serde",
@@ -2026,19 +2027,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -2051,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2061,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2074,15 +2076,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2279,9 +2281,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aho-corasick"
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "atomic_refcell"
@@ -101,17 +101,17 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -188,7 +188,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.72",
+ "syn 2.0.79",
  "tempfile",
  "toml",
 ]
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.14"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c937d4061031a6d0c8da4b9a4f98a172fc2976dfb1c19213a9cf7d0d3c837e36"
+checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.14"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85379ba512b21a328adf887e85f7742d12e96eb31f3ef077df4ffc26b506ffed"
+checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -291,14 +291,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -456,7 +456,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -704,7 +704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -716,7 +716,7 @@ dependencies = [
  "cbindgen",
  "libc",
  "linux-errno",
- "linux-raw-sys 0.6.4",
+ "linux-raw-sys 0.6.5",
  "linux-syscall",
  "log",
  "memoffset 0.9.1",
@@ -746,9 +746,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b5399f6804fbab912acbd8878ed3532d506b7c951b8f9f164ef90fef39e3f4"
+checksum = "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7"
 
 [[package]]
 name = "linux-syscall"
@@ -877,11 +877,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -902,7 +902,7 @@ checksum = "5b4123e70df5fe0bb370cff166ae453b9c5324a2cfc932c0f7e55498147a0475"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1007,7 +1007,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
@@ -1127,7 +1127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1359,7 +1359,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1370,22 +1370,22 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "serde"
-version = "1.0.205"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.205"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1396,14 +1396,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -1526,7 +1526,7 @@ dependencies = [
  "formatting-nostd",
  "libc",
  "linux-api",
- "linux-raw-sys 0.6.4",
+ "linux-raw-sys 0.6.5",
  "log",
  "log-c2rust",
  "logger",
@@ -1704,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1758,12 +1758,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
 dependencies = [
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1785,7 +1785,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1924,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1967,7 +1967,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "static_assertions",
- "syn 2.0.72",
+ "syn 2.0.79",
  "vasi",
 ]
 
@@ -2045,7 +2045,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -2067,7 +2067,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2090,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "6.0.2"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d9c5ed668ee1f17edb3b627225343d210006a90bb1e3745ce1f30b1fb115075"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
@@ -2138,7 +2138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2151,7 +2151,7 @@ dependencies = [
  "windows-interface",
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2162,7 +2162,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2173,7 +2173,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2182,7 +2182,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2192,16 +2192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2210,7 +2201,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2219,22 +2210,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2243,21 +2219,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2267,21 +2237,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2297,21 +2255,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2321,21 +2267,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2376,5 +2310,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.79",
 ]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -230,6 +230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,12 +952,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
 ]
@@ -1335,7 +1342,7 @@ dependencies = [
  "atomic_refcell",
  "crossbeam",
  "libc",
- "nix 0.27.1",
+ "nix 0.29.0",
  "rand",
 ]
 
@@ -1483,7 +1490,7 @@ dependencies = [
  "memoffset 0.9.1",
  "merge",
  "neli",
- "nix 0.27.1",
+ "nix 0.29.0",
  "once_cell",
  "paste",
  "petgraph",
@@ -1556,7 +1563,7 @@ dependencies = [
  "linux-api",
  "log",
  "logger",
- "nix 0.27.1",
+ "nix 0.29.0",
  "once_cell",
  "rand",
  "shadow-build-common",
@@ -1600,7 +1607,7 @@ dependencies = [
  "linux-syscall",
  "log",
  "logger",
- "nix 0.27.1",
+ "nix 0.29.0",
  "once_cell",
  "rand",
  "shadow-pod",
@@ -1979,7 +1986,7 @@ dependencies = [
  "criterion",
  "libc",
  "loom",
- "nix 0.27.1",
+ "nix 0.29.0",
  "num_enum",
  "rand",
  "rustc-hash 2.0.0",

--- a/src/lib/formatting-nostd/Cargo.toml
+++ b/src/lib/formatting-nostd/Cargo.toml
@@ -6,12 +6,12 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = { version = "0.2.155", default-features = false }
-rustix = { version = "0.38.34", default-features = false }
+libc = { version = "0.2.159", default-features = false }
+rustix = { version = "0.38.37", default-features = false }
 va_list = { version = "0.2.0", default-features = false }
 
 [dev-dependencies]
-rustix = { version = "0.38.34", default-features = false, features=["pipe"] }
+rustix = { version = "0.38.37", default-features = false, features=["pipe"] }
 
 [build-dependencies]
 cc = { version = "1.1", features = ["parallel"] }

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -23,12 +23,12 @@ bytemuck = "1.18.0"
 linux-syscall = "1.0.0"
 linux-errno = "1.0.1"
 naked-function = "0.1.5"
-linux-raw-sys = "0.6.4"
-rustix = { optional = true, version = "0.38.34", default-features = false, features = ["process"] }
-libc = { optional = true, default-features = false, version = "0.2.155" }
+linux-raw-sys = "0.6.5"
+rustix = { optional = true, version = "0.38.37", default-features = false, features = ["process"] }
+libc = { optional = true, default-features = false, version = "0.2.159" }
 
 [dev-dependencies]
-rustix = { version = "0.38.34", default-features=false, features = ["thread", "process", "time"] }
+rustix = { version = "0.38.37", default-features=false, features = ["thread", "process", "time"] }
 
 [build-dependencies]
 shadow-build-common = { optional = true, path = "../shadow-build-common", features = ["cbindgen"] }

--- a/src/lib/pod/Cargo.toml
+++ b/src/lib/pod/Cargo.toml
@@ -6,4 +6,4 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = { version = "0.2.155", default-features = false }
+libc = { version = "0.2.159", default-features = false }

--- a/src/lib/scheduler/Cargo.toml
+++ b/src/lib/scheduler/Cargo.toml
@@ -7,7 +7,7 @@ publish.workspace = true
 atomic_refcell = "0.1"
 crossbeam = "0.8.4"
 libc = "0.2"
-nix = { version = "0.27.1", features = ["process", "sched"] }
+nix = { version = "0.29.0", features = ["process", "sched"] }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/src/lib/scheduler/src/sync/simple_latch.rs
+++ b/src/lib/scheduler/src/sync/simple_latch.rs
@@ -156,7 +156,7 @@ pub fn libc_futex(
     } else {
         let errno = unsafe { *libc::__errno_location() };
         debug_assert_eq!(rv, -1);
-        Err(Errno::from_i32(errno))
+        Err(Errno::from_raw(errno))
     }
 }
 

--- a/src/lib/shadow-shim-helper-rs/Cargo.toml
+++ b/src/lib/shadow-shim-helper-rs/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["rlib", "staticlib"]
 
 [dependencies]
 libc = "0.2"
-nix = { version = "0.27.1", features = ["event", "fs", "socket"] }
+nix = { version = "0.29.0", features = ["event", "fs", "socket"] }
 # don't log debug or trace levels in release mode
 log = { version = "0.4", features = ["release_max_level_debug"] }
 logger = { path = "../logger" }

--- a/src/lib/shadow-shim-helper-rs/Cargo.toml
+++ b/src/lib/shadow-shim-helper-rs/Cargo.toml
@@ -14,7 +14,7 @@ nix = { version = "0.27.1", features = ["event", "fs", "socket"] }
 # don't log debug or trace levels in release mode
 log = { version = "0.4", features = ["release_max_level_debug"] }
 logger = { path = "../logger" }
-once_cell = "1.20.0"
+once_cell = "1.20.2"
 shadow-pod = { path = "../pod" }
 rand = "0.8.5"
 shadow_shmem = { path = "../shmem" }

--- a/src/lib/shim/Cargo.toml
+++ b/src/lib/shim/Cargo.toml
@@ -22,8 +22,8 @@ shadow_tsc = { path = "../tsc" }
 logger = { path = "../logger" }
 log = { version = "0.4.22", default-features = false }
 log-c2rust = { path = "../log-c2rust" }
-rustix = { version = "0.38.34", default-features = false, features = ["process", "thread", "time", "mm"] }
-linux-raw-sys = { version = "0.6.4" }
+rustix = { version = "0.38.37", default-features = false, features = ["process", "thread", "time", "mm"] }
+linux-raw-sys = { version = "0.6.5" }
 shadow-pod = { path = "../pod" }
 vasi-sync = { path = "../vasi-sync"}
 static_assertions = "1.1.0"

--- a/src/lib/shmem/Cargo.toml
+++ b/src/lib/shmem/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = { version = "1.5.0", features = ["spin_no_std"] }
 linux-api = { path = "../linux-api" }
 linux-syscall = "1.0.0"
 log = { version = "0.4", default-features = false }
-nix = "0.27.1"
+nix = "0.29.0"
 static_assertions = "1.1.0"
 
 [dev-dependencies]

--- a/src/lib/shmem/Cargo.toml
+++ b/src/lib/shmem/Cargo.toml
@@ -13,7 +13,7 @@ vasi = { path = "../vasi" }
 vasi-sync = { path = "../vasi-sync" }
 
 anyhow = { version = "1.0", default-features = false }
-once_cell = "1.20.0"
+once_cell = "1.20.2"
 lazy_static = { version = "1.5.0", features = ["spin_no_std"] }
 linux-api = { path = "../linux-api" }
 linux-syscall = "1.0.0"

--- a/src/lib/vasi-macro/Cargo.toml
+++ b/src/lib/vasi-macro/Cargo.toml
@@ -10,8 +10,8 @@ proc-macro=true
 
 [dependencies]
 proc-macro2 = "1.0.86"
-quote = "1.0.36"
-syn = "2.0.72"
+quote = "1.0.37"
+syn = "2.0.79"
 
 [dev-dependencies]
 static_assertions = "1.1.0"

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -10,7 +10,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
 
 [dependencies]
 num_enum = { version = "0.7.3", default-features = false }
-rustix = { version = "0.38.34", default-features = false, features = ["fs", "thread", "process"] }
+rustix = { version = "0.38.37", default-features = false, features = ["fs", "thread", "process"] }
 static_assertions = "1.1.0"
 vasi = { path = "../vasi" }
 rustc-hash = { version = "2.0.0", default-features = false }
@@ -18,7 +18,7 @@ rustc-hash = { version = "2.0.0", default-features = false }
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.5"
-rustix = { version = "0.38.34", default-features = false, features = ["process"] }
+rustix = { version = "0.38.37", default-features = false, features = ["process"] }
 libc = "0.2"
 nix = "0.27.1"
 

--- a/src/lib/vasi-sync/Cargo.toml
+++ b/src/lib/vasi-sync/Cargo.toml
@@ -20,11 +20,11 @@ criterion = "0.5.1"
 rand = "0.8.5"
 rustix = { version = "0.38.37", default-features = false, features = ["process"] }
 libc = "0.2"
-nix = "0.27.1"
+nix = "0.29.0"
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.7", features = ["checkpoint"] }
-nix = { version = "0.27.1", features = ["process"] }
+nix = { version = "0.29.0", features = ["process"] }
 
 [target.'cfg(miri)'.dependencies]
 libc = { version ="0.2", default-features = false }

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -33,7 +33,7 @@ lzma-rs = "0.3"
 memoffset = "0.9.1"
 merge = "0.1"
 neli = "0.6.4"
-nix = { version = "0.27.1", features = ["feature", "ioctl", "mman", "net", "personality", "resource", "sched", "signal", "socket", "time", "uio", "user"] }
+nix = { version = "0.29.0", features = ["feature", "ioctl", "mman", "net", "personality", "resource", "sched", "signal", "socket", "time", "uio", "user"] }
 shadow-pod = { path = "../lib/pod" }
 once_cell = "1.20"
 paste = "1.0.15"

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -10,15 +10,15 @@ path = "lib.rs"
 crate-type = ["rlib", "staticlib"]
 
 [dependencies]
-anyhow = "1.0.86"
+anyhow = "1.0.89"
 atomic_refcell = "0.1"
-backtrace = "0.3.73"
+backtrace = "0.3.74"
 bitflags = "2.6"
 # custom version of the bytes crate required to make the 'try_unsplit' method public
 # issue: https://github.com/tokio-rs/bytes/issues/287
 # pr: https://github.com/tokio-rs/bytes/pull/513
 bytes = { git = "https://github.com/shadow/bytes", rev = "c48bd4439e7e043300521925524ecdcce7ff6bcc" }
-clap = { version = "4.5.14", features = ["derive", "wrap_help"] }
+clap = { version = "4.5.19", features = ["derive", "wrap_help"] }
 crossbeam = "0.8.4"
 gml-parser = { path = "../lib/gml-parser" }
 libc = "0.2"
@@ -46,7 +46,7 @@ rayon = "1.10.0"
 regex = "1"
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.122"
+serde_json = "1.0.128"
 serde_yaml = "0.9"
 shadow-build-info = { path = "../lib/shadow-build-info" }
 shadow_shmem = { path = "../lib/shmem" }
@@ -64,9 +64,9 @@ vasi-sync = { path = "../lib/vasi-sync" }
 # `c_variadic` is stabilized, or if we decide to enable it anyway.
 # https://github.com/rust-lang/rust/issues/44930
 vsprintf = { git = "https://github.com/shadow/vsprintf", rev = "fa9a307e3043a972501b3157323ed8a9973ad45a" }
-which = "6.0.2"
+which = "6.0.3"
 bytemuck = "1.18.0"
-rustix = { version = "0.38.34", features = ["event", "mm", "pipe"] }
+rustix = { version = "0.38.37", features = ["event", "mm", "pipe"] }
 
 [features]
 perf_timers = []

--- a/src/main/core/logger/shadow_logger.rs
+++ b/src/main/core/logger/shadow_logger.rs
@@ -117,7 +117,12 @@ fn get_thread_name() -> String {
         )
     };
     // The most likely cause of failure is a bug in the caller.
-    debug_assert_eq!(res, 0, "pthread_getname_np: {}", nix::errno::from_i32(res));
+    debug_assert_eq!(
+        res,
+        0,
+        "pthread_getname_np: {}",
+        nix::errno::Errno::from_raw(res),
+    );
     if res == 0 {
         // SAFETY: We just initialized the input buffer `thread_name`, and
         // `thread_name_cstr` won't outlive it.

--- a/src/main/utility/sockaddr.rs
+++ b/src/main/utility/sockaddr.rs
@@ -553,6 +553,8 @@ fn i8_to_u8_slice(s: &[i8]) -> &[u8] {
 mod tests {
     use super::*;
 
+    use std::net::Ipv4Addr;
+
     /// Convert from a `sockaddr_in` to a `SockaddrStorage`.
     #[test]
     fn storage_from_inet_ptr() {
@@ -634,7 +636,10 @@ mod tests {
         let addr = addr.as_inet().unwrap();
 
         assert_eq!(addr.port(), u16::from_be(addr_in.sin_port));
-        assert_eq!(addr.ip(), u32::from_be(addr_in.sin_addr.s_addr));
+        assert_eq!(
+            addr.ip(),
+            Ipv4Addr::from(u32::from_be(addr_in.sin_addr.s_addr)),
+        );
     }
 
     /// Convert from a `SockaddrIn` to a `SockaddrStorage` to a `sockaddr_in`.
@@ -651,7 +656,10 @@ mod tests {
 
         assert_eq!(addr.sin_family, libc::AF_INET as u16);
         assert_eq!(u16::from_be(addr.sin_port), addr_original.port());
-        assert_eq!(u32::from_be(addr.sin_addr.s_addr), addr_original.ip());
+        assert_eq!(
+            Ipv4Addr::from(u32::from_be(addr.sin_addr.s_addr)),
+            addr_original.ip(),
+        );
     }
 
     /// Convert from a `sockaddr_nl` to a `SockaddrStorage` to a `NetlinkAddr`.

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -227,16 +227,16 @@ name = "test_close_range"
 path = "close_range/test_close_range.rs"
 
 [dependencies]
-anyhow = "1.0.86"
+anyhow = "1.0.89"
 formatting-nostd = { path = "../lib/formatting-nostd" }
 libc = "0.2"
 linux-api = { path = "../lib/linux-api", features = ["rustix", "std", "libc"] }
 neli = "0.6.4"
 nix = { version = "0.26.4", features = ["event", "feature", "fs", "poll", "process", "sched", "signal", "socket", "uio"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
-rustix = { version = "0.38.34", default-features = false, features = ["fs", "mm", "pipe", "time", "thread"] }
+rustix = { version = "0.38.37", default-features = false, features = ["fs", "mm", "pipe", "time", "thread"] }
 signal-hook = "0.3.17"
-once_cell = "1.20.0"
+once_cell = "1.20.2"
 vasi-sync = { path = "../lib/vasi-sync" }
 static_assertions = "1.1.0"
 tempfile = "3.13.0"


### PR DESCRIPTION
Closes #3419.

Upgrades rust dependencies (except for nix in the shadow-tests crate) and github actions versions. The "labeler" action changed its config format, so hopefully I updated it correctly. The tor and tgen versions have not changed so we don't need to upgrade them.