### PR TITLE
Fix nightly warnings

### DIFF
--- a/src/main/utility/macros.rs
+++ b/src/main/utility/macros.rs
@@ -140,10 +140,13 @@ macro_rules! log_syscall {
         paste::paste! { log_syscall!([< _syscall_logger_ $name >]; $name, $rv, $($args),*); }
     };
     ($const_name:ident; $name:ident, $rv:ty, $($args:ty),*) => {
-        // we use a constant as a hack so that we can do "impl SyscallLogger { ... }" while
-        // already inside a "impl SyscallHandler { ... }" block
+        // We use a constant as a hack so that we can do "impl SyscallLogger { ... }" while already
+        // inside a "impl SyscallHandler { ... }" block. Apparently they may make this a hard error
+        // (with no way to opt-out with an `allow`) in the future:
+        // https://github.com/rust-lang/rust/issues/120363
         #[doc(hidden)]
         #[allow(non_upper_case_globals)]
+        #[allow(non_local_definitions)]
         const $const_name : () = {
             impl crate::utility::macros::SyscallLogger {
                 pub fn $name(

--- a/src/test/signal/test_signals.rs
+++ b/src/test/signal/test_signals.rs
@@ -1161,7 +1161,7 @@ fn test_validate_context() -> Result<(), Box<dyn Error>> {
         assert_eq!(rv, 0);
         // The signal handler sees the syscall return value stored in RAX.
         assert_eq!(
-            unsafe { DO_SETCONTEXT_RES.take() },
+            unsafe { std::ptr::replace(std::ptr::addr_of_mut!(DO_SETCONTEXT_RES), None) },
             Some(DoSetcontextHandlerResult {
                 ctx_rax: -(libc::EINTR as i64)
             })
@@ -1190,7 +1190,7 @@ fn test_validate_context() -> Result<(), Box<dyn Error>> {
         // context, but it's unclear that just "fixing" that register without
         // fixing the others would have much point. Don't assert anything about it;
         // just clear it.
-        unsafe { DO_SETCONTEXT_RES.take() };
+        unsafe { std::ptr::replace(std::ptr::addr_of_mut!(DO_SETCONTEXT_RES), None) };
     }
 
     // Same thing again, but sleep using a direct syscall, which will be
@@ -1208,7 +1208,7 @@ fn test_validate_context() -> Result<(), Box<dyn Error>> {
     assert!(matches!(res, NanosleepRelativeResult::Ok));
     // The signal handler sees the original syscall return value stored in RAX.
     assert_eq!(
-        unsafe { DO_SETCONTEXT_RES.take() },
+        unsafe { std::ptr::replace(std::ptr::addr_of_mut!(DO_SETCONTEXT_RES), None) },
         Some(DoSetcontextHandlerResult {
             ctx_rax: -(libc::EINTR as i64)
         })


### PR DESCRIPTION
Fixes `elided_named_lifetimes`, `static_mut_refs`, and `non_local_definitions` warnings.

[Apparently](https://github.com/rust-lang/rust/issues/120363) they are considering making non-local `impl` definitions a hard error in the future (so we won't be able to `allow(non_local_definitions)` anymore), which would be unfortunate since we wouldn't be able to have our syscall logger macros at the beginning of the syscall handler functions anymore. But this wouldn't take effect until 2028, so I'm happy to ignore this.

For `static_mut_refs` we can make it a little nicer using raw references when they release in rust 1.82 in ~10 days.