### PR TITLE
Replace `--log-errors-to-tty` with `--report-errors-to-stderr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ PATCH changes (bugfixes):
 * Fixed rust/clippy warnings for rust 1.80. (#3354, #3355)
 * Fixed a build error on rust nightly (and future stable rust versions) by upgrading dependencies. (#3334)
 * Fixed a shim panic (which causes shadow to hang) when golang's default SIGTERM handler runs in a managed program (and potentially other cases where a signal handler stack is legitimately reused). (#3396)
+* Replaced the experimental option `--log-errors-to-tty` with the (still experimental) option
+`--report-errors-to-stderr`. The new option no longer tries to detect whether
+`stdout` or `stderr` are terminals (or the same destination), and instead
+reports errors in a different format on `stderr` to make the duplication easier
+to sort out in the case that `stdout` and `stderr` are merged. (#3428)
 
 Full changelog since v3.2.0:
 

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -540,13 +540,12 @@ if not using the thread-per-core scheduler.
 
 This may improve runtime performance in some environments.
 
-#### `experimental.log_errors_to_tty`
+#### `experimental.log_errors_to_stderr`
 
 Default: true  
 Type: Bool
 
-Log `Error`-level log lines to shadow's `stderr` in addition to `stdout`, if
-`stdout` is not a tty but `stderr` is.
+Log `Error`-level log lines to shadow's `stderr` in addition to `stdout`.
 
 #### `host_option_defaults`
 

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -76,8 +76,8 @@ hosts:
 - [`experimental.host_heartbeat_log_info`](#experimentalhost_heartbeat_log_info)
 - [`experimental.host_heartbeat_log_level`](#experimentalhost_heartbeat_log_level)
 - [`experimental.interface_qdisc`](#experimentalinterface_qdisc)
-- [`experimental.log_errors_to_tty`](#experimentallog_errors_to_tty)
 - [`experimental.max_unapplied_cpu_latency`](#experimentalmax_unapplied_cpu_latency)
+- [`experimental.report_errors_to_stderr`](#experimentalreport_errors_to_stderr)
 - [`experimental.runahead`](#experimentalrunahead)
 - [`experimental.scheduler`](#experimentalscheduler)
 - [`experimental.socket_recv_autotune`](#experimentalsocket_recv_autotune)
@@ -355,6 +355,14 @@ Ignored when
 [`general.model_unblocked_syscall_latency`](#generalmodel_unblocked_syscall_latency)
 is false.
 
+#### `experimental.report_errors_to_stderr`
+
+Default: true  
+Type: Bool
+
+Report `Error`-level log messages to shadow's `stderr` in addition to logging
+them to `stdout`.
+
 #### `experimental.runahead`
 
 Default: "1 ms"  
@@ -539,13 +547,6 @@ Each worker thread will spin in a `sched_yield` loop while waiting for a new tas
 if not using the thread-per-core scheduler.
 
 This may improve runtime performance in some environments.
-
-#### `experimental.log_errors_to_stderr`
-
-Default: true  
-Type: Bool
-
-Log `Error`-level log lines to shadow's `stderr` in addition to `stdout`.
 
 #### `host_option_defaults`
 

--- a/src/main/core/configuration.rs
+++ b/src/main/core/configuration.rs
@@ -471,11 +471,11 @@ pub struct ExperimentalOptions {
     #[clap(help = EXP_HELP.get("scheduler").unwrap().as_str())]
     pub scheduler: Option<Scheduler>,
 
-    /// When true, log error-level messages to stderr in addition to stdout.
+    /// When true, report error-level messages to stderr in addition to logging to stdout.
     #[clap(hide_short_help = true)]
     #[clap(long, value_name = "bool")]
-    #[clap(help = EXP_HELP.get("log_errors_to_stderr").unwrap().as_str())]
-    pub log_errors_to_stderr: Option<bool>,
+    #[clap(help = EXP_HELP.get("report_errors_to_stderr").unwrap().as_str())]
+    pub report_errors_to_stderr: Option<bool>,
 
     /// Use the rust TCP implementation
     #[clap(hide_short_help = true)]
@@ -530,7 +530,7 @@ impl Default for ExperimentalOptions {
             ))),
             strace_logging_mode: Some(StraceLoggingMode::Off),
             scheduler: Some(Scheduler::ThreadPerCore),
-            log_errors_to_stderr: Some(true),
+            report_errors_to_stderr: Some(true),
             use_new_tcp: Some(false),
         }
     }

--- a/src/main/core/configuration.rs
+++ b/src/main/core/configuration.rs
@@ -471,12 +471,11 @@ pub struct ExperimentalOptions {
     #[clap(help = EXP_HELP.get("scheduler").unwrap().as_str())]
     pub scheduler: Option<Scheduler>,
 
-    /// When true, log error-level messages to stderr in addition to stdout when
-    /// stdout is not a tty but stderr is.
+    /// When true, log error-level messages to stderr in addition to stdout.
     #[clap(hide_short_help = true)]
     #[clap(long, value_name = "bool")]
-    #[clap(help = EXP_HELP.get("log_errors_to_tty").unwrap().as_str())]
-    pub log_errors_to_tty: Option<bool>,
+    #[clap(help = EXP_HELP.get("log_errors_to_stderr").unwrap().as_str())]
+    pub log_errors_to_stderr: Option<bool>,
 
     /// Use the rust TCP implementation
     #[clap(hide_short_help = true)]
@@ -531,7 +530,7 @@ impl Default for ExperimentalOptions {
             ))),
             strace_logging_mode: Some(StraceLoggingMode::Off),
             scheduler: Some(Scheduler::ThreadPerCore),
-            log_errors_to_tty: Some(true),
+            log_errors_to_stderr: Some(true),
             use_new_tcp: Some(false),
         }
     }

--- a/src/main/core/logger/shadow_logger.rs
+++ b/src/main/core/logger/shadow_logger.rs
@@ -218,8 +218,17 @@ impl ShadowLogger {
                 let stderr_locked = stderr_unlocked.lock();
                 let mut stderr = std::io::BufWriter::new(stderr_locked);
                 writeln!(stderr, "Error: {}", record.message)?;
+
+                // Explicitly flush before dropping to detect errors.
+                stderr.flush()?;
+                drop(stderr);
             }
         }
+
+        // Explicitly flush before dropping to detect errors.
+        stdout.flush()?;
+        drop(stdout);
+
         if let Some(done_sender) = done_sender {
             // We can't log from this thread without risking deadlock, so in the
             // unlikely case that the calling thread has gone away, just print

--- a/src/main/core/logger/shadow_logger.rs
+++ b/src/main/core/logger/shadow_logger.rs
@@ -200,17 +200,13 @@ impl ShadowLogger {
             toflush -= 1;
 
             if record.level <= Level::Error && *self.log_errors_to_stderr.get().unwrap() {
-                // Send to both stdout and stderr.
+                // Summarize on stderr.
                 let stderr_unlocked = std::io::stderr();
                 let stderr_locked = stderr_unlocked.lock();
                 let mut stderr = std::io::BufWriter::new(stderr_locked);
-
-                let line = format!("{record}");
-                write!(stdout, "{line}")?;
-                write!(stderr, "{line}")?;
-            } else {
-                write!(stdout, "{record}")?;
+                writeln!(stderr, "Error: {}", record.message)?;
             }
+            write!(stdout, "{record}")?;
         }
         if let Some(done_sender) = done_sender {
             // We can't log from this thread without risking deadlock, so in the

--- a/src/main/core/logger/shadow_logger.rs
+++ b/src/main/core/logger/shadow_logger.rs
@@ -30,9 +30,12 @@ const MIN_FLUSH_FREQUENCY: Duration = Duration::from_secs(10);
 static SHADOW_LOGGER: Lazy<ShadowLogger> = Lazy::new(ShadowLogger::new);
 
 /// Initialize the Shadow logger.
-pub fn init(max_log_level: LevelFilter, log_errors_to_stderr: bool) -> Result<(), SetLoggerError> {
+pub fn init(
+    max_log_level: LevelFilter,
+    report_errors_to_stderr: bool,
+) -> Result<(), SetLoggerError> {
     SHADOW_LOGGER.set_max_level(max_log_level);
-    SHADOW_LOGGER.set_log_errors_to_stderr(log_errors_to_stderr);
+    SHADOW_LOGGER.set_report_errors_to_stderr(report_errors_to_stderr);
 
     log::set_logger(&*SHADOW_LOGGER)?;
 
@@ -97,8 +100,8 @@ pub struct ShadowLogger {
     // The maximum log level, unless overridden by a host-specific log level.
     max_log_level: OnceCell<LevelFilter>,
 
-    // Whether to log errors to stderr in addition to stdout.
-    log_errors_to_stderr: OnceCell<bool>,
+    // Whether to report errors to stderr in addition to logging to stdout.
+    report_errors_to_stderr: OnceCell<bool>,
 }
 
 thread_local!(static SENDER: RefCell<Option<Sender<LoggerCommand>>> = const{ RefCell::new(None)});
@@ -148,7 +151,7 @@ impl ShadowLogger {
             command_receiver: Mutex::new(receiver),
             buffering_enabled: RwLock::new(false),
             max_log_level: OnceCell::new(),
-            log_errors_to_stderr: OnceCell::new(),
+            report_errors_to_stderr: OnceCell::new(),
         }
     }
 
@@ -199,7 +202,7 @@ impl ShadowLogger {
             };
             toflush -= 1;
 
-            if record.level <= Level::Error && *self.log_errors_to_stderr.get().unwrap() {
+            if record.level <= Level::Error && *self.report_errors_to_stderr.get().unwrap() {
                 // Summarize on stderr.
                 let stderr_unlocked = std::io::stderr();
                 let stderr_locked = stderr_unlocked.lock();
@@ -245,12 +248,12 @@ impl ShadowLogger {
         self.max_log_level.set(level).unwrap()
     }
 
-    /// Set whether to log errors to stderr in addition to stdout.
+    /// Set whether to report errors to stderr in addition to logging on stdout.
     ///
     /// Is only intended to be called from `init()`. Will panic if called more
     /// than once.
-    fn set_log_errors_to_stderr(&self, val: bool) {
-        self.log_errors_to_stderr.set(val).unwrap()
+    fn set_report_errors_to_stderr(&self, val: bool) {
+        self.report_errors_to_stderr.set(val).unwrap()
     }
 
     // Send a flush command to the logger thread.

--- a/src/main/shadow.rs
+++ b/src/main/shadow.rs
@@ -114,7 +114,7 @@ pub fn run_shadow(args: Vec<&OsStr>) -> anyhow::Result<()> {
     // start up the logging subsystem to handle all future messages
     shadow_logger::init(
         log_level.to_level_filter(),
-        shadow_config.experimental.log_errors_to_stderr.unwrap(),
+        shadow_config.experimental.report_errors_to_stderr.unwrap(),
     )
     .unwrap();
 

--- a/src/main/shadow.rs
+++ b/src/main/shadow.rs
@@ -5,7 +5,6 @@
 use std::borrow::Borrow;
 use std::ffi::{CStr, OsStr};
 use std::fmt::Write;
-use std::io::IsTerminal;
 use std::os::unix::ffi::OsStrExt;
 use std::thread;
 
@@ -113,10 +112,11 @@ pub fn run_shadow(args: Vec<&OsStr>) -> anyhow::Result<()> {
     let log_level: log::Level = log_level.into();
 
     // start up the logging subsystem to handle all future messages
-    let log_errors_to_stderr = shadow_config.experimental.log_errors_to_tty.unwrap()
-        && !std::io::stdout().lock().is_terminal()
-        && std::io::stderr().lock().is_terminal();
-    shadow_logger::init(log_level.to_level_filter(), log_errors_to_stderr).unwrap();
+    shadow_logger::init(
+        log_level.to_level_filter(),
+        shadow_config.experimental.log_errors_to_stderr.unwrap(),
+    )
+    .unwrap();
 
     // disable log buffering during startup so that we see every message immediately in the terminal
     shadow_logger::set_buffering_enabled(false);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -103,6 +103,13 @@ macro(add_shadow_tests)
       list(APPEND SHADOW_TEST_ARGS "--parallelism" "1")
    endif()
 
+   # If mirroring output to stderr is not explicitly set, we disable it, since
+   # tests are normally run with stdout and stderr merged into one stream,
+   # causing duplication.
+   if(NOT "${SHADOW_TEST_ARGS}" MATCHES ".*--log-errors-to-stderr.*")
+      list(APPEND SHADOW_TEST_ARGS "--log-errors-to-stderr" "false")
+   endif()
+
    string(REPLACE ";" " " SHADOW_TEST_ARGS "${SHADOW_TEST_ARGS}")
 
    set(SHADOW_TEST_NAME ${SHADOW_TEST_BASENAME}-shadow)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -103,11 +103,11 @@ macro(add_shadow_tests)
       list(APPEND SHADOW_TEST_ARGS "--parallelism" "1")
    endif()
 
-   # If mirroring output to stderr is not explicitly set, we disable it, since
+   # If mirroring errors to stderr is not explicitly set, we disable it, since
    # tests are normally run with stdout and stderr merged into one stream,
    # causing duplication.
-   if(NOT "${SHADOW_TEST_ARGS}" MATCHES ".*--log-errors-to-stderr.*")
-      list(APPEND SHADOW_TEST_ARGS "--log-errors-to-stderr" "false")
+   if(NOT "${SHADOW_TEST_ARGS}" MATCHES ".*--report-errors-to-stderr.*")
+      list(APPEND SHADOW_TEST_ARGS "--report-errors-to-stderr" "false")
    endif()
 
    string(REPLACE ";" " " SHADOW_TEST_ARGS "${SHADOW_TEST_ARGS}")

--- a/src/test/cli/help-long-expected
+++ b/src/test/cli/help-long-expected
@@ -95,15 +95,16 @@ Experimental (Unstable and may change or be removed at any time, regardless of S
       --interface-qdisc <mode>
           The queueing discipline to use at the network interface [default: "fifo"]
 
-      --log-errors-to-stderr <bool>
-          When true, log error-level messages to stderr in addition to stdout. [default: true]
-
       --max-unapplied-cpu-latency <seconds>
           Max amount of execution-time latency allowed to accumulate before the clock is moved
           forward. Moving the clock forward is a potentially expensive operation, so larger values
           reduce simulation overhead, at the cost of coarser time jumps. Note also that
           accumulated-but-unapplied latency is discarded when a thread is blocked on a syscall.
           [default: "1 μs"]
+
+      --report-errors-to-stderr <bool>
+          When true, report error-level messages to stderr in addition to logging to stdout.
+          [default: true]
 
       --runahead <seconds>
           If set, overrides the automatically calculated minimum time workers may run ahead when

--- a/src/test/cli/help-long-expected
+++ b/src/test/cli/help-long-expected
@@ -95,9 +95,8 @@ Experimental (Unstable and may change or be removed at any time, regardless of S
       --interface-qdisc <mode>
           The queueing discipline to use at the network interface [default: "fifo"]
 
-      --log-errors-to-tty <bool>
-          When true, log error-level messages to stderr in addition to stdout when stdout is not a
-          tty but stderr is. [default: true]
+      --log-errors-to-stderr <bool>
+          When true, log error-level messages to stderr in addition to stdout. [default: true]
 
       --max-unapplied-cpu-latency <seconds>
           Max amount of execution-time latency allowed to accumulate before the clock is moved


### PR DESCRIPTION
Trying to detect whether stdout and stderr are terminals and deduplicating based on that can be tricky, e.g. in CI environments..

Instead:

* Make the `stderr` version more of a human-consumable message instead of the raw log line, which also makes the duplication easier to understand in the case where stdout and stderr are merged.
* Disable this feature in our cmake tests, where stdout and and stderr are merged.

New output on a process failure in the unmerged case (where stdout is written to a file and stderr is the terminal):

    ** Starting Shadow 3.2.0
    Error: process 'testnode.test_sleep.1000' exited with status Normal(101); expected end state was exited: 0 but was exited: 101
    Error: Failed to run the simulation
    Error:
    Error: Caused by:
    Error:     1 managed processes in unexpected final state
    ** Shadow did not complete successfully: Failed to run the simulation
    **   1 managed processes in unexpected final state
    ** See the log for details

The merged case is a little ugly, but at least it's harder to mistake the duplicated message on stderr for a second distinct log line:

    ...
    00:00:00.016603 [507267:shadow-worker] 00:00:01.000000000 [DEBUG] [testnode:11.0.0.1] [process.rs:1486] [shadow_rs::host::process] process 'testnode.test_sleep.1000' has completed or is otherwise no longer running
    Error: process 'testnode.test_sleep.1000' exited with status Normal(101); expected end state was exited: 0 but was exited: 101
    00:00:00.016660 [507267:shadow-worker] 00:00:01.000000000 [ERROR] [testnode:11.0.0.1] [process.rs:1571] [shadow_rs::host::process] process 'testnode.test_sleep.1000' exited with status Normal(101); expected end state was exited: 0 but was exited: 101
    00:00:00.016710 [507267:shadow-worker] 00:00:01.000000000 [TRACE] [testnode:11.0.0.1] [process.rs:750] [shadow_rs::host::process] Not notifying parent of exit: no signal specified
    ...

Progress on https://github.com/shadow/shadow/issues/3426.
