### PR TITLE
Stubs for UDP socket options SO_BROADCAST, SO_REUSEADDR, SO_REUSEPORT

### DIFF
--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -856,6 +856,12 @@ impl UdpSocket {
 
                 Ok(bytes_written as libc::socklen_t)
             }
+            (libc::SOL_SOCKET, libc::SO_BROADCAST) => {
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                let bytes_written = write_partial(mem, &0, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
             (libc::SOL_SOCKET, _) => {
                 log_once_per_value_at_level!(
                     (level, optname),
@@ -943,12 +949,10 @@ impl UdpSocket {
             (libc::SOL_SOCKET, libc::SO_REUSEADDR) => {
                 // TODO: implement this
                 warn_once_then_debug!("setsockopt SO_REUSEADDR not yet implemented for udp");
-                return Err(Errno::ENOPROTOOPT.into());
             }
             (libc::SOL_SOCKET, libc::SO_REUSEPORT) => {
                 // TODO: implement this
                 warn_once_then_debug!("setsockopt SO_REUSEPORT not yet implemented for udp");
-                return Err(Errno::ENOPROTOOPT.into());
             }
             (libc::SOL_SOCKET, libc::SO_KEEPALIVE) => {
                 // TODO: implement this


### PR DESCRIPTION
I've managed to run Ethereum Java client [Teku](https://github.com/Consensys/teku) inside Shadow (specifically with [Ethshadow](https://github.com/ethereum/ethshadow)). 
However I had to add the following stubs to make it working finally:
- UDP `SO_BROADCAST`: [Netty library](https://github.com/netty/netty) (widely adopted jvm network lib) [asks](https://github.com/netty/netty/blob/4.1/transport/src/main/java/io/netty/channel/AbstractChannel.java#L547) for this socket option prior to binding a UDP port. No workarounds on a client code side were found for this. 
- UDP `SO_REUSEADDR` & `SO_REUSEPORT`: the option is set in the [Teku app](https://github.com/ConsenSys/teku/blob/master/infrastructure/io/src/main/java/tech/pegasys/teku/infrastructure/io/PortAvailability.java#L47) itself to check is the specified port is not busy and fail fast if busy. Not sure if it's that necessary here, but it makes sense because this port is then promptly closed and reopened again (when actual port binding occurs). This may potentially fail due to socket close delay in OS (probably it may be the case just in some specific OS) 

To be honest I'm not quite sure if it's the right thing to merge these stubs as is (relates to #3280), so kindly asking for devs assistance. 