### PR TITLE
main crate: fix link order for libremora

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ PATCH changes (bugfixes):
 `stdout` or `stderr` are terminals (or the same destination), and instead
 reports errors in a different format on `stderr` to make the duplication easier
 to sort out in the case that `stdout` and `stderr` are merged. (#3428)
+* Fixed a link error for rust 1.82. (#3447)
 
 Full changelog since v3.2.0:
 

--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -430,8 +430,11 @@ fn main() {
     run_cbindgen(&build_common);
     run_bindgen(&build_common);
 
-    build_remora(&build_common);
+    // The order here controls the link order linking this crate. Since
+    // libshadow-c depends on remora, remora must appear *after* it to avoid
+    // getting dropped in the link step.
     build_shadow_c(&build_common);
+    build_remora(&build_common);
 
     println!("cargo:rustc-env=SHADOW_BUILD_INFO={}", build_info());
 }


### PR DESCRIPTION
As of rust 1.82.0, `cargo test` no longer automatically uses the `--whole-archive` linker directive. Before this PR, this results in a linker error.

Verified the bug and fix locally on 1.82.0. Will leave actually bumping our toolchain for a separate PR.

Fixes https://github.com/shadow/shadow/issues/3445