### PR TITLE
Bump rust to 1.82 and fix link error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ PATCH changes (bugfixes):
 `stdout` or `stderr` are terminals (or the same destination), and instead
 reports errors in a different format on `stderr` to make the duplication easier
 to sort out in the case that `stdout` and `stderr` are merged. (#3428)
+* Fixed a link error for rust 1.82. (#3445)
 
 Full changelog since v3.2.0:
 

--- a/ci/rust-toolchain-nightly.toml
+++ b/ci/rust-toolchain-nightly.toml
@@ -9,6 +9,6 @@
 [toolchain]
 # Must be a version built with miri; check
 # https://rust-lang.github.io/rustup-components-history/
-channel = "nightly-2024-10-05"
+channel = "nightly-2024-11-26"
 # We don't add individual components here. CI individually
 # adds the ones they need (e.g. clippy, miri).

--- a/ci/rust-toolchain-stable.toml
+++ b/ci/rust-toolchain-stable.toml
@@ -7,4 +7,4 @@
 # See
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.81"
+channel = "1.82"

--- a/src/main/build.rs
+++ b/src/main/build.rs
@@ -430,8 +430,11 @@ fn main() {
     run_cbindgen(&build_common);
     run_bindgen(&build_common);
 
-    build_remora(&build_common);
+    // The order here controls the link order linking this crate. Since
+    // libshadow-c depends on remora, remora must appear *after* it to avoid
+    // getting dropped in the link step.
     build_shadow_c(&build_common);
+    build_remora(&build_common);
 
     println!("cargo:rustc-env=SHADOW_BUILD_INFO={}", build_info());
 }


### PR DESCRIPTION
Fix link error with rust 1.82 (#3445), and bump our toolchain version to 1.82.