### PR TITLE
Remove support for debian:10

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,8 +26,6 @@ jobs:
           - 'ubuntu:22.04'
           # End of standard support: June 2029 https://wiki.ubuntu.com/Releases
           - 'ubuntu:24.04'
-          # EOL ~August 2024 https://wiki.debian.org/LTS
-          - 'debian:10-slim'
           # EOL ~June 2026 https://wiki.debian.org/LTS
           - 'debian:11-slim'
           # EOL June 2028 https://wiki.debian.org/LTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ spawning processes via `execve`.
 Within the simulation these are treated as fully routable IPs, so are required
 to be unique as with any other IP address assignment. (#3414)
 * Removed the experimental tracker feature that logged heartbeat messages for every host every second. Also removed the corresponding python scripts for parsing and plotting tracker log messages and data. (#3446)
+* Removed support for Debian 10 (Buster), which has [passed EOL](https://wiki.debian.org/LTS).
 
 PATCH changes (bugfixes):
 

--- a/ci/container_scripts/install_deps.sh
+++ b/ci/container_scripts/install_deps.sh
@@ -10,6 +10,7 @@ APT_PACKAGES=(
   golang-go
   iproute2
   libc-dbg
+  libclang-dev
   libglib2.0-0
   libglib2.0-dev
   make
@@ -20,18 +21,6 @@ APT_PACKAGES=(
   xz-utils
   util-linux
   )
-
-case "$CONTAINER" in
-  # We need to force a newer-than-default version of libclang
-  # on some platforms. Some older versions have trouble finding
-  # compiler header files in bindgen, when compiling with gcc.
-  debian:10*)
-    APT_PACKAGES+=(libclang-13-dev)
-    ;;
-  *)
-    APT_PACKAGES+=(libclang-dev)
-    ;;
-esac
 
 # packages that are only required for our CI environment
 APT_CI_PACKAGES=(


### PR DESCRIPTION
It's passed EOL: https://wiki.debian.org/LTS. Its python3 package is also pretty old (3.7), which would have required substantial changes to #3449 to support.