### PR TITLE
shadowtools: add PEP 561 type annotation marker

### DIFF
--- a/shadowtools/pyproject.toml
+++ b/shadowtools/pyproject.toml
@@ -36,3 +36,10 @@ Issues = "https://github.com/shadow/shadow/issues"
 
 [project.scripts]
 shadow-exec = "shadowtools.shadow_exec:__main__"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+# Mark package as having type annotations (PEP 561)
+"shadowtools" = ["py.typed"]


### PR DESCRIPTION
When tools like mypy analyze *other* code that *imports* shadowtools, this tells the tool that shadowtools has inline type annotations. Otherwise it treats the package as untyped.
