### PR TITLE
Make 'shadowtools-tests' an "extra" test

### DIFF
--- a/shadowtools/CMakeLists.txt
+++ b/shadowtools/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_test(
     NAME shadowtools-tests
     COMMAND python3 -m unittest discover ${CMAKE_CURRENT_SOURCE_DIR}
+    CONFIGURATIONS extra
 )
 # Set PYTHONPATH so that the modules can be loaded.
 set_property(


### PR DESCRIPTION
Most people won't have the python dependencies installed (they're not shadow's dependencies), so this shouldn't run by default.