### PR TITLE
Bump pinned action images to ubuntu 24.04

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,6 +100,10 @@ jobs:
           # See https://github.com/shadow/shadow/issues/2166
           ref: ${{ github.event.pull_request.head.sha }}
 
+      # Our rust build scripts require libglib.
+      - name: Install system dependencies
+        run: sudo apt-get install -y libglib2.0-dev
+
       - name: Set Rust toolchain
         run: ln -s ci/rust-toolchain-stable.toml rust-toolchain.toml
 
@@ -133,6 +137,9 @@ jobs:
           # date with target branch before merging, anyway.
           # See https://github.com/shadow/shadow/issues/2166
           ref: ${{ github.event.pull_request.head.sha }}
+      # Our rust build scripts require libglib.
+      - name: Install system dependencies
+        run: sudo apt-get install -y libglib2.0-dev
       - name: Set Rust toolchain
         run: ln -s ci/rust-toolchain-stable.toml rust-toolchain.toml
       - name: check rust version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ env:
 jobs:
 
   lint-python:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,7 +31,7 @@ jobs:
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude src/external
 
   lint-python-mypy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -57,7 +57,7 @@ jobs:
       - run: mypy --strict shadowtools
 
   lint-shell:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,7 +71,7 @@ jobs:
       - run: find . -name '*.sh' | xargs shellcheck
 
   lint-rust:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -90,7 +90,7 @@ jobs:
         run: (cd src && cargo fmt -- --check)
 
   lint-clippy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -117,7 +117,7 @@ jobs:
         run: (cd src && cargo clippy -- -Dwarnings)
 
   lint-cargo-lock:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Cargo update check
@@ -128,7 +128,7 @@ jobs:
           (cd src && cargo update --locked --workspace)
 
   lint-cargo-doc:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   miri:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
 
   # See <https://docs.rs/loom/latest/loom/>
   loom:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -23,6 +23,10 @@ jobs:
         # See https://github.com/shadow/shadow/issues/2166
         ref: ${{ github.event.pull_request.head.sha }}
 
+    # Our rust build scripts require libglib.
+    - name: Install system dependencies
+      run: sudo apt-get install -y libglib2.0-dev
+
     - name: Set Rust toolchain
       run: ln -s ci/rust-toolchain-nightly.toml rust-toolchain.toml
 


### PR DESCRIPTION
* Install libglib in workflows that run our rust build scripts
* Bump our pinned action images from ubuntu 22.04 to 24.04

Fixes #3459 