### PR TITLE
Limit dns scope

### DIFF
--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -772,17 +772,6 @@ mod export {
         EmulatedTime::to_c_emutime(Worker::current_time())
     }
 
-    #[no_mangle]
-    pub extern "C-unwind" fn worker_resolveIPToAddress(
-        ip: libc::in_addr_t,
-    ) -> *const cshadow::Address {
-        Worker::with(|w| {
-            let dns = w.shared.dns.ptr();
-            unsafe { cshadow::dns_resolveIPToAddress(dns, ip) }
-        })
-        .unwrap()
-    }
-
     /// Returns a pointer to the current running host. The returned pointer is
     /// invalidated the next time the worker switches hosts.
     #[no_mangle]

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -677,8 +677,10 @@ mod export {
     use super::*;
 
     #[no_mangle]
-    pub extern "C-unwind" fn worker_getDNS() -> *mut cshadow::DNS {
-        Worker::with_dns(std::ptr::from_ref).cast_mut()
+    pub extern "C-unwind" fn worker_getHostsFilePath() -> *mut std::ffi::c_char {
+        Worker::with_dns(|dns| unsafe {
+            cshadow::dns_getHostsFilePath(std::ptr::from_ref(dns).cast_mut())
+        })
     }
 
     /// Addresses must be provided in network byte order.

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -172,7 +172,7 @@ impl Worker {
     /// Run `f` with a reference to the global DNS.
     ///
     /// Panics if the Worker or its DNS hasn't yet been initialized.
-    pub fn with_dns<F, R>(f: F) -> R
+    fn with_dns<F, R>(f: F) -> R
     where
         F: FnOnce(&cshadow::DNS) -> R,
     {

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -296,7 +296,7 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
         file->type = FILE_TYPE_RANDOM;
     } else if (!strcmp("/etc/hosts", abspath)) {
         file->type = FILE_TYPE_HOSTS;
-        char* hostspath = dns_getHostsFilePath(worker_getDNS());
+        char* hostspath = worker_getHostsFilePath();
         if (hostspath && abspath) {
             free(abspath);
             abspath = hostspath;

--- a/src/main/routing/dns.c
+++ b/src/main/routing/dns.c
@@ -93,27 +93,6 @@ void dns_register(DNS* dns, HostId id, const gchar* name, in_addr_t requestedIP)
     g_mutex_unlock(&dns->lock);
 }
 
-void dns_deregister(DNS* dns, in_addr_t ip) {
-    MAGIC_ASSERT(dns);
-    g_mutex_lock(&dns->lock);
-
-    Address* address = g_hash_table_lookup(dns->addressByIP, GUINT_TO_POINTER(ip));
-
-    if (address != NULL && !address_isLocal(address)) {
-        /* these remove functions will call address_unref as necessary */
-        g_hash_table_remove(dns->addressByName, address_toHostName(address));
-        g_hash_table_remove(dns->addressByIP, GUINT_TO_POINTER(ip));
-
-        /* Any existing hosts file needs to be (lazily) updated. */
-        if (dns->hosts_file_fd >= 0) {
-            close(dns->hosts_file_fd);
-            dns->hosts_file_fd = -1;
-        }
-    }
-
-    g_mutex_unlock(&dns->lock);
-}
-
 /* Address must be in network byte order. */
 Address* dns_resolveIPToAddress(DNS* dns, in_addr_t ip) {
     MAGIC_ASSERT(dns);

--- a/src/main/routing/dns.h
+++ b/src/main/routing/dns.h
@@ -20,7 +20,6 @@ void dns_free(DNS* dns);
 
 /* Address must be in network byte order. */
 void dns_register(DNS* dns, HostId id, const gchar* name, in_addr_t requestedIP);
-void dns_deregister(DNS* dns, in_addr_t ip);
 
 /* Address must be in network byte order. */
 Address* dns_resolveIPToAddress(DNS* dns, in_addr_t ip);


### PR DESCRIPTION
Limit accesses to C DNS in preparation for removing the C Address and DNS code.

Follow-up to #3455 ; this should be rebased and merged AFTER #3455 is merged.