### PR TITLE
Fix clippy warnings in unit tests and add '--all-targets' to clippy CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -114,7 +114,7 @@ jobs:
         run: rustup component add clippy
 
       - name: clippy
-        run: (cd src && cargo clippy -- -Dwarnings)
+        run: (cd src && cargo clippy --all-targets -- -Dwarnings)
 
   lint-cargo-lock:
     runs-on: ubuntu-24.04

--- a/docs/coding_style.md
+++ b/docs/coding_style.md
@@ -56,7 +56,7 @@ We use [Clippy](https://doc.rust-lang.org/stable/clippy/index.html) to help
 detect errors and non-idiomatic Rust code. You can run `clippy` locally with:
 
 ```bash
-(cd src && cargo clippy)
+(cd src && cargo clippy --all-targets)
 ```
 
 ## Including headers

--- a/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
+++ b/src/lib/shadow-shim-helper-rs/src/simulation_time.rs
@@ -749,7 +749,7 @@ mod tests {
             timeval::try_from(SimulationTime::MAX),
             Ok(timeval {
                 tv_sec: SimulationTime::MAX.as_secs().try_into().unwrap(),
-                tv_usec: SimulationTime::MAX.subsec_micros().try_into().unwrap(),
+                tv_usec: SimulationTime::MAX.subsec_micros().into(),
             })
         );
     }
@@ -788,7 +788,7 @@ mod tests {
                 tv,
                 timeval {
                     tv_sec: d.as_secs().try_into().unwrap(),
-                    tv_usec: d.subsec_micros().try_into().unwrap()
+                    tv_usec: d.subsec_micros().into(),
                 }
             );
         }
@@ -984,7 +984,7 @@ mod tests {
                 ts,
                 timespec {
                     tv_sec: d.as_secs().try_into().unwrap(),
-                    tv_nsec: d.subsec_nanos().try_into().unwrap()
+                    tv_nsec: d.subsec_nanos().into(),
                 }
             );
         }

--- a/src/lib/shmem/src/allocator.rs
+++ b/src/lib/shmem/src/allocator.rs
@@ -489,6 +489,9 @@ mod tests {
         let block_addr = &original_block as *const ShMemBlock<T>;
         let data_addr = *original_block as *const T;
 
+        // Use an `Option` to move the `ShMemBlock`. We have no guarantee here that it actually
+        // moves and that the compiler doesn't optimize the move away, so the before/after addresses
+        // are compared below.
         let block = Some(original_block);
 
         // Validate that the block itself actually moved.
@@ -499,6 +502,7 @@ mod tests {
         let new_data_addr = **(block.as_ref().unwrap()) as *const T;
         assert_eq!(data_addr, new_data_addr);
 
+        #[allow(clippy::unnecessary_literal_unwrap)]
         shfree(block.unwrap());
     }
 

--- a/src/lib/tcp/src/lib.rs
+++ b/src/lib/tcp/src/lib.rs
@@ -642,6 +642,7 @@ bitflags::bitflags! {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
 pub struct TcpConfig {
     pub(crate) window_scaling_enabled: bool,
 }

--- a/src/lib/tcp/src/tests/mod.rs
+++ b/src/lib/tcp/src/tests/mod.rs
@@ -56,6 +56,10 @@ impl std::fmt::Debug for Event {
     }
 }
 
+// `Ord` and `PartialEq` must be consistent, which they are here (except for the panic condition in
+// `<Event as Ord>::cmp`) because `<Event as Ord>::cmp` depends on the output of
+// `<Event as PartialOrd>::partial_cmp`
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for Event {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         if std::ptr::eq(self, other) {

--- a/src/lib/tcp/src/tests/send_recv.rs
+++ b/src/lib/tcp/src/tests/send_recv.rs
@@ -441,7 +441,7 @@ fn test_incoming_payload_after_close() {
     // try to recv on the socket, but there should be no data and we should receive an EOF
     // (typically on linux we'd receive an ECONNRESET for the first read, but we don't use the error
     // state in our test socket wrapper)
-    let mut recv_buf = vec![0; 5];
+    let mut recv_buf = [0; 5];
     assert_eq!(TcpSocket::recvmsg(&tcp, &mut recv_buf[..], 5), Ok(0));
 }
 
@@ -499,6 +499,6 @@ fn test_incoming_payload_after_shutdown_read() {
     // try to recv on the socket, but there should be no data and we should receive an EOF
     // (typically on linux we'd receive an ECONNRESET for the first read, but we don't use the error
     // state in our test socket wrapper)
-    let mut recv_buf = vec![0; 5];
+    let mut recv_buf = [0; 5];
     assert_eq!(TcpSocket::recvmsg(&tcp, &mut recv_buf[..], 5), Ok(0));
 }

--- a/src/lib/tcp/src/tests/window_scale.rs
+++ b/src/lib/tcp/src/tests/window_scale.rs
@@ -17,8 +17,10 @@ fn test_peer_no_window_scaling() {
     }
 
     // make sure it has window scaling enabled
-    let mut config = TcpConfig::default();
-    config.window_scaling_enabled = true;
+    let config = TcpConfig {
+        window_scaling_enabled: true,
+        ..Default::default()
+    };
 
     let tcp = TcpSocket::new(&scheduler, config);
     assert!(s(&tcp).as_init().is_some());
@@ -78,8 +80,10 @@ fn test_local_no_window_scaling() {
     }
 
     // make sure it has window scaling disabled
-    let mut config = TcpConfig::default();
-    config.window_scaling_enabled = false;
+    let config = TcpConfig {
+        window_scaling_enabled: false,
+        ..Default::default()
+    };
 
     let tcp = TcpSocket::new(&scheduler, config);
     assert!(s(&tcp).as_init().is_some());
@@ -139,8 +143,10 @@ fn test_both_without_window_scaling() {
     }
 
     // make sure it has window scaling disabled
-    let mut config = TcpConfig::default();
-    config.window_scaling_enabled = false;
+    let config = TcpConfig {
+        window_scaling_enabled: false,
+        ..Default::default()
+    };
 
     let tcp = TcpSocket::new(&scheduler, config);
     assert!(s(&tcp).as_init().is_some());
@@ -200,8 +206,10 @@ fn test_both_with_window_scaling() {
     }
 
     // make sure it has window scaling enabled
-    let mut config = TcpConfig::default();
-    config.window_scaling_enabled = true;
+    let config = TcpConfig {
+        window_scaling_enabled: true,
+        ..Default::default()
+    };
 
     let tcp = TcpSocket::new(&scheduler, config);
     assert!(s(&tcp).as_init().is_some());
@@ -264,8 +272,10 @@ fn test_large_window_scale() {
     }
 
     // make sure it has window scaling enabled
-    let mut config = TcpConfig::default();
-    config.window_scaling_enabled = true;
+    let config = TcpConfig {
+        window_scaling_enabled: true,
+        ..Default::default()
+    };
 
     let tcp = TcpSocket::new(&scheduler, config);
     assert!(s(&tcp).as_init().is_some());
@@ -326,8 +336,10 @@ fn test_window_scale_after_receiving_syn_without() {
     }
 
     // make sure it has window scaling enabled
-    let mut config = TcpConfig::default();
-    config.window_scaling_enabled = true;
+    let config = TcpConfig {
+        window_scaling_enabled: true,
+        ..Default::default()
+    };
 
     let tcp = TcpSocket::new(&scheduler, config);
     assert!(s(&tcp).as_init().is_some());
@@ -407,8 +419,10 @@ fn test_window_scale_after_receiving_syn_with() {
     }
 
     // make sure it has window scaling enabled
-    let mut config = TcpConfig::default();
-    config.window_scaling_enabled = true;
+    let config = TcpConfig {
+        window_scaling_enabled: true,
+        ..Default::default()
+    };
 
     let tcp = TcpSocket::new(&scheduler, config);
     assert!(s(&tcp).as_init().is_some());
@@ -489,8 +503,10 @@ fn test_duplicate_syn_with_different_window_scale() {
     }
 
     // make sure it has window scaling enabled
-    let mut config = TcpConfig::default();
-    config.window_scaling_enabled = true;
+    let config = TcpConfig {
+        window_scaling_enabled: true,
+        ..Default::default()
+    };
 
     let tcp = TcpSocket::new(&scheduler, config);
     assert!(s(&tcp).as_init().is_some());

--- a/src/lib/vasi-sync/tests/sync/mod.rs
+++ b/src/lib/vasi-sync/tests/sync/mod.rs
@@ -22,9 +22,9 @@ where
 /// Overrides the default preemption bound. Useful for tests that
 /// are otherwise too slow.
 ///
-/// >  In practice, setting the thread pre-emption bound to 2 or 3 is enough to
-/// catch most bugs while significantly reducing the number of possible
-/// executions.
+/// > In practice, setting the thread pre-emption bound to 2 or 3 is enough to
+/// > catch most bugs while significantly reducing the number of possible
+/// > executions.
 ///
 /// <https://docs.rs/loom/latest/loom/#large-models>
 pub fn model_with_max_preemptions<F>(max_preemptions: usize, f: F)

--- a/src/main/utility/shm_cleanup.rs
+++ b/src/main/utility/shm_cleanup.rs
@@ -130,6 +130,7 @@ mod tests {
     fn touch(path: impl AsRef<Path>) -> io::Result<()> {
         OpenOptions::new()
             .create(true)
+            .truncate(false)
             .write(true)
             .open(path.as_ref())?;
         Ok(())


### PR DESCRIPTION
Closes #3468.

This is branched from #3469, ~so the first 4 commits should be ignored.~