### PR TITLE
Improve `SO_BROADCAST` stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ to be unique as with any other IP address assignment. (#3414)
 * Added a python package `shadowtools` with auxiliary tools. It currently contains a python module for facilitating dynamic generation of shadow config files, and a command-line tool `shadow-exec` for streamlining single-host simulations. (#3449)
 * Improved support for netlink sockets with Go. (#3441)
 * Replaced C DNS module with a Rust implementation. Also removed the C Address type. (#3464)
+* Added support for `SO_BROADCAST` with `getsockopt` for TCP and UDP,
+  which always returns 0 as Shadow doesn't support broadcast sockets.
+  (#3471)
 
 PATCH changes (bugfixes):
 

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -930,6 +930,13 @@ impl TcpSocket {
 
                 Ok(bytes_written as libc::socklen_t)
             }
+            (libc::SOL_SOCKET, libc::SO_BROADCAST) => {
+                let optval_ptr = optval_ptr.cast::<libc::c_int>();
+                // we don't support broadcast sockets, so just just return the default 0
+                let bytes_written = write_partial(mem, &0, optval_ptr, optlen as usize)?;
+
+                Ok(bytes_written as libc::socklen_t)
+            }
             _ => {
                 log_once_per_value_at_level!(
                     (level, optname),
@@ -947,9 +954,9 @@ impl TcpSocket {
         &mut self,
         level: libc::c_int,
         optname: libc::c_int,
-        _optval_ptr: ForeignPtr<()>,
-        _optlen: libc::socklen_t,
-        _mem: &MemoryManager,
+        optval_ptr: ForeignPtr<()>,
+        optlen: libc::socklen_t,
+        mem: &MemoryManager,
     ) -> Result<(), SyscallError> {
         match (level, optname) {
             (libc::SOL_SOCKET, libc::SO_REUSEADDR) => {
@@ -965,8 +972,23 @@ impl TcpSocket {
                 log::trace!("setsockopt SO_KEEPALIVE not yet implemented");
             }
             (libc::SOL_SOCKET, libc::SO_BROADCAST) => {
-                // TODO: implement this, pkg.go.dev/net uses it
-                log::trace!("setsockopt SO_BROADCAST not yet implemented");
+                type OptType = libc::c_int;
+
+                if usize::try_from(optlen).unwrap() < std::mem::size_of::<OptType>() {
+                    return Err(Errno::EINVAL.into());
+                }
+
+                let optval_ptr = optval_ptr.cast::<OptType>();
+                let val = mem.read(optval_ptr)?;
+
+                if val == 0 {
+                    // we don't support broadcast sockets, so an attempt to disable is okay
+                } else {
+                    // TODO: implement this, pkg.go.dev/net uses it
+                    warn_once_then_debug!(
+                        "setsockopt SO_BROADCAST not yet implemented for tcp; ignoring and returning 0"
+                    );
+                }
             }
             _ => {
                 log_once_per_value_at_level!(


### PR DESCRIPTION
Previously, we had stubs for setsockopt with `SO_BROADCAST` for tcp and udp:

```rust
(libc::SOL_SOCKET, libc::SO_BROADCAST) => {
    // TODO: implement this, pkg.go.dev/net uses it
    log::trace!("setsockopt SO_BROADCAST not yet implemented");
}
```

The old behaviour for tcp/udp was:

- getsockopt:
    - return ENOPROTOOPT
- setsockopt:
    - show trace (for tcp) or "warn_once_then_debug" (for udp) log and return 0

The new behaviour for tcp/udp is:

- getsockopt:
    - always returns 0 since we don't support broadcast sockets
- setsockopt:
    - if value is 0, do nothing and return 0
    - if value is not 0, show "warn_once_then_debug" log and return 0

Our tests aren't set up to test get/setsockopt for unix sockets, so I didn't implement the option for unix sockets. I would expect it to return an error.

Closes #3439.