### PR TITLE
Remove backtrace from logs when disabling ASLR fails

### DIFF
--- a/src/main/shadow.rs
+++ b/src/main/shadow.rs
@@ -425,8 +425,9 @@ fn raise_rlimit(resource: resource::Resource) -> anyhow::Result<()> {
 }
 
 fn disable_aslr() -> anyhow::Result<()> {
-    let pers = personality::get()?;
-    personality::set(pers | personality::Persona::ADDR_NO_RANDOMIZE)?;
+    let pers = personality::get().context("Could not get personality")?;
+    personality::set(pers | personality::Persona::ADDR_NO_RANDOMIZE)
+        .context("Could not set personality")?;
     Ok(())
 }
 

--- a/src/main/shadow.rs
+++ b/src/main/shadow.rs
@@ -177,7 +177,7 @@ pub fn run_shadow(args: Vec<&OsStr>) -> anyhow::Result<()> {
     // branch on memory addresses.
     match disable_aslr() {
         Ok(()) => log::debug!("ASLR disabled for processes forked from this parent process"),
-        Err(e) => log::warn!("Could not disable address space layout randomization. This may affect determinism: {:?}", e),
+        Err(e) => log::warn!("Could not disable address space layout randomization. This may affect determinism: {e:#}"),
     };
 
     // check sidechannel mitigations


### PR DESCRIPTION
Before:

```text
00:00:00.194137 [70289:shadow] n/a [WARN] [n/a] [shadow.rs:180] [shadow_rs::shadow] Could not disable address space layout randomization. This may affect determinism: ENOSYS: Function not implemented

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
             at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.89/src/backtrace.rs:27:14
   1: shadow_rs::shadow::run_shadow
             at /shadow/src/main/shadow.rs:178:11
   2: main_runShadow
             at /shadow/src/main/shadow.rs:473:22
   3: main
             at /shadow/src/main/main.c:17:12
   4: __libc_start_call_main
   5: __libc_start_main@@GLIBC_2.34
   6: _start
```

After:

```text
00:00:00.000205 [113136:shadow] n/a [WARN] [n/a] [shadow.rs:180] [shadow_rs::shadow] Could not disable address space layout randomization. This may affect determinism: Could not set personality: ENOSYS: Function not implemented
```