### PR TITLE
Add `SyscallNonDeterministicArg` strace logger wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ PATCH changes (bugfixes):
 reports errors in a different format on `stderr` to make the duplication easier
 to sort out in the case that `stdout` and `stderr` are merged. (#3428)
 * Sending a packet to an unknown IP address no longer causes Shadow to panic. (#3411)
+* Improved the "deterministic" strace logging mode by hiding some non-deterministic syscall arguments. (#3473)
 
 Full changelog since v3.2.0:
 

--- a/src/main/host/syscall/formatter.rs
+++ b/src/main/host/syscall/formatter.rs
@@ -81,6 +81,17 @@ impl<'a, T> SyscallVal<'a, T> {
             _phantom: PhantomData,
         }
     }
+
+    /// Cast a syscall argument or return value to another type.
+    pub fn cast<V>(&self) -> SyscallVal<'a, V> {
+        SyscallVal {
+            reg: self.reg,
+            args: self.args,
+            options: self.options,
+            mem: self.mem,
+            _phantom: PhantomData,
+        }
+    }
 }
 
 impl<'a, T> Display for SyscallVal<'a, T>

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -5,6 +5,7 @@ use log::debug;
 use crate::cshadow;
 use crate::host::descriptor::{CompatFile, File, FileStatus};
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
+use crate::host::syscall::type_formatting::SyscallNonDeterministicArg;
 use crate::host::syscall::types::SyscallError;
 
 impl SyscallHandler {
@@ -13,7 +14,7 @@ impl SyscallHandler {
         /* rv */ std::ffi::c_long,
         /* fd */ std::ffi::c_uint,
         /* cmd */ std::ffi::c_uint,
-        /* arg */ std::ffi::c_ulong,
+        /* arg */ SyscallNonDeterministicArg<std::ffi::c_ulong>,
     );
     pub fn fcntl(
         ctx: &mut SyscallContext,

--- a/src/main/host/syscall/handler/futex.rs
+++ b/src/main/host/syscall/handler/futex.rs
@@ -3,6 +3,7 @@ use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::cshadow as c;
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
+use crate::host::syscall::type_formatting::SyscallNonDeterministicArg;
 use crate::host::syscall::types::SyscallError;
 
 impl SyscallHandler {
@@ -14,7 +15,7 @@ impl SyscallHandler {
         /* val */ u32,
         /* utime */ *const std::ffi::c_void,
         /* uaddr2 */ *const u32,
-        /* val3 */ u32,
+        /* val3 */ SyscallNonDeterministicArg<u32>,
     );
     pub fn futex(
         ctx: &mut SyscallContext,

--- a/src/main/host/syscall/handler/ioctl.rs
+++ b/src/main/host/syscall/handler/ioctl.rs
@@ -7,6 +7,7 @@ use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 use crate::cshadow as c;
 use crate::host::descriptor::{CompatFile, FileStatus};
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
+use crate::host::syscall::type_formatting::SyscallNonDeterministicArg;
 use crate::host::syscall::types::SyscallResult;
 
 impl SyscallHandler {
@@ -15,7 +16,7 @@ impl SyscallHandler {
         /* rv */ std::ffi::c_int,
         /* fd */ std::ffi::c_uint,
         /* cmd */ std::ffi::c_uint,
-        /* arg */ std::ffi::c_ulong,
+        /* arg */ SyscallNonDeterministicArg<std::ffi::c_ulong>,
     );
     pub fn ioctl(
         ctx: &mut SyscallContext,


### PR DESCRIPTION
This makes the determinism tests pass again on my computer.

Example:

```text
00:00:01.000000000 [tid 1000] futex(<pointer>, 265, 1001, <pointer>, <pointer>, <non-deterministic>) = 0
```

Closes #3460.