### PR TITLE
Fix `dead_code` warning in `canary_check` in release builds

### DIFF
--- a/src/lib/shmem/src/shmalloc_impl.rs
+++ b/src/lib/shmem/src/shmalloc_impl.rs
@@ -35,6 +35,8 @@ const CANARY: CanaryBuf = [];
 
 trait Canary {
     fn canary_init(&mut self);
+
+    #[cfg_attr(not(debug_assertions), allow(dead_code))]
     fn canary_check(&self) -> bool;
 
     #[cfg(debug_assertions)]


### PR DESCRIPTION
This adds a `dead_code` exception in release builds, which wasn't caught since we only do debug builds in the CI.