### PR TITLE
Bummp Tor version in the CI extra test

### DIFF
--- a/.github/workflows/extra_tests.yml
+++ b/.github/workflows/extra_tests.yml
@@ -220,7 +220,7 @@ jobs:
       matrix:
         # when changing the tor versions, make sure to also update the
         # required CI tests in the GitHub repository settings
-        tor: ['tor-0.4.8.12']
+        tor: ['tor-0.4.8.13']
 
     steps:
       - run: apt-get update


### PR DESCRIPTION
Tor 0.4.8.13 fixes some conflux issues.

- https://forum.torproject.org/t/new-tor-stable-release-0-4-8-13/15397
- https://gitlab.torproject.org/tpo/core/tor/-/raw/release-0.4.8/ReleaseNotes