### PR TITLE
Fix fifo qdisc

### DIFF
--- a/src/main/host/network/network_queuing_disciplines.c
+++ b/src/main/host/network/network_queuing_disciplines.c
@@ -94,6 +94,7 @@ static gint _compareSocket(const InetSocket* sa, const InetSocket* sb, FifoSocke
     bool foundb = g_hash_table_lookup_extended(fifo->items, (gpointer)sb, NULL, (gpointer*)&itemb);
     utility_debugAssert(founda && foundb);
 
+    /*
     uint64_t pa = 0;
     uint64_t pb = 0;
 
@@ -110,6 +111,7 @@ static gint _compareSocket(const InetSocket* sa, const InetSocket* sb, FifoSocke
         itema->priority = pa;
         itemb->priority = pb;
     }
+    */
 
     if (itema->priority < itemb->priority) {
         return -1;

--- a/src/main/host/network/network_queuing_disciplines.c
+++ b/src/main/host/network/network_queuing_disciplines.c
@@ -79,18 +79,50 @@ bool rrsocketqueue_find(RrSocketQueue* self, const InetSocket* socket) {
     return g_queue_find_custom(self->queue, (void*)socket, _compareInetSocket);
 }
 
-static gint _compareSocket(const InetSocket* sa, const InetSocket* sb) {
+typedef struct _FifoItem FifoItem;
+struct _FifoItem {
+    uint64_t priority;
+    uint64_t push_order;
+};
+
+static gint _compareSocket(const InetSocket* sa, const InetSocket* sb, FifoSocketQueue* fifo) {
+    utility_debugAssert(fifo);
+
+    FifoItem* itema = 0;
+    FifoItem* itemb = 0;
+    bool founda = g_hash_table_lookup_extended(fifo->items, (gpointer)sa, NULL, (gpointer*)&itema);
+    bool foundb = g_hash_table_lookup_extended(fifo->items, (gpointer)sb, NULL, (gpointer*)&itemb);
+    utility_debugAssert(founda && foundb);
+
     uint64_t pa = 0;
     uint64_t pb = 0;
 
-    if (inetsocket_peekNextPacketPriority(sa, &pa) != 0) {
-        return -1;
-    }
-    if (inetsocket_peekNextPacketPriority(sb, &pb) != 0) {
-        return +1;
+    // The item->priority values were locked in at push time, but this compare function is called to
+    // dynamically adjust them whenever the priority queue rebalances. This allows a socket that had
+    // only bad priority packets when it was initially pushed into the queue to move up in priority
+    // when it suddenly has new packets with better priority. This case can happen often in the
+    // legacy TCP stack because it assigns priority=0 to control packets (ACKS) without data. This
+    // means we can be more responsive to TCP controls.
+    if (inetsocket_peekNextPacketPriority(sa, &pa) == 0 &&
+        inetsocket_peekNextPacketPriority(sb, &pb) == 0) {
+        // Typically this would be considered to violate the assumption that a queued item's
+        // priority does not change while the item is enqueued!
+        itema->priority = pa;
+        itemb->priority = pb;
     }
 
-    return pa > pb ? +1 : -1;
+    if (itema->priority < itemb->priority) {
+        return -1;
+    } else if (itema->priority > itemb->priority) {
+        return +1;
+    } else if (itema->push_order < itemb->push_order) {
+        return -1;
+    } else if (itema->push_order > itemb->push_order) {
+        return +1;
+    } else {
+        utility_debugAssert(false);
+        return 0;
+    }
 }
 
 // casts the return value from a bool to an int
@@ -99,8 +131,11 @@ static int _inetsocket_eqVoid(gconstpointer a, gconstpointer b) { return inetsoc
 void fifosocketqueue_init(FifoSocketQueue* self) {
     utility_debugAssert(self != NULL);
     utility_debugAssert(self->queue == NULL);
+    utility_debugAssert(self->items == NULL);
     self->queue = priorityqueue_new(
-        (GCompareDataFunc)_compareSocket, NULL, NULL, inetsocket_hashVoid, _inetsocket_eqVoid);
+        (GCompareDataFunc)_compareSocket, self, NULL, inetsocket_hashVoid, _inetsocket_eqVoid);
+    self->items = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, g_free);
+    self->push_order_counter = 0;
 }
 
 void fifosocketqueue_destroy(FifoSocketQueue* self, void (*fn_processItem)(const InetSocket*)) {
@@ -123,6 +158,9 @@ void fifosocketqueue_destroy(FifoSocketQueue* self, void (*fn_processItem)(const
 
     priorityqueue_free(self->queue);
     self->queue = NULL;
+    g_hash_table_destroy(self->items);
+    self->items = NULL;
+    self->push_order_counter = 0;
 }
 
 bool fifosocketqueue_isEmpty(FifoSocketQueue* self) {
@@ -140,6 +178,9 @@ bool fifosocketqueue_pop(FifoSocketQueue* self, InetSocket** socket) {
         return false;
     }
 
+    // The item is destroyed using g_free() as set in g_hash_table_new_full()
+    g_hash_table_remove(self->items, *socket);
+
     return true;
 }
 
@@ -147,6 +188,17 @@ void fifosocketqueue_push(FifoSocketQueue* self, const InetSocket* socket) {
     utility_debugAssert(self != NULL);
     utility_debugAssert(self->queue != NULL);
     utility_debugAssert(socket != NULL);
+
+    uint64_t priority = 0;
+    bool has_packet = inetsocket_peekNextPacketPriority(socket, &priority) == 0;
+    utility_debugAssert(has_packet == true);
+
+    FifoItem* item = g_new0(FifoItem, 1);
+    item->priority = priority;
+    item->push_order = self->push_order_counter++;
+    utility_debugAssert(!g_hash_table_contains(self->items, socket));
+    g_hash_table_insert(self->items, (gpointer)socket, item);
+
     gboolean successful = priorityqueue_push(self->queue, (void*)socket);
     // if this returned FALSE, it would mean that the socket was already in the queue and we would
     // need to drop the socket to avoid a memory leak

--- a/src/main/host/network/network_queuing_disciplines.h
+++ b/src/main/host/network/network_queuing_disciplines.h
@@ -22,6 +22,8 @@ struct _RrSocketQueue {
 typedef struct _FifoSocketQueue FifoSocketQueue;
 struct _FifoSocketQueue {
     PriorityQueue* queue;
+    GHashTable* items;
+    uint64_t push_order_counter;
 };
 
 void rrsocketqueue_init(RrSocketQueue* self);


### PR DESCRIPTION
Our fifo qdisc violates the assumption that a queued item's priority does not change while the item is enqueued. This allows a socket that had only bad priority packets when it was initially pushed into the queue to move up in priority when it suddenly has new packets with better priority. This case can happen often in the legacy TCP stack because it assigns priority=0 to control packets (ACKS) without data. This means we can be more responsive to TCP controls.

This PR does two things:
1. Fixes the fifo qdisc so that it always produces a non-equal sort order over sockets. This is done by tracking the push order of the sockets and using the push order to break equality ties.
2. Tracks the socket priority that existed at push time to enable us to show the performance difference when sorting based on that priority vs the priorities that are recomputed every time the priority queue rebalances and calls the compare function on a socket.

If we only apply the first commit, the performance should be identical to nightly. If we apply both commits, the performance should be identical to #3480.