### PR TITLE
Fix 'dangling_pointers_from_temporaries' warning in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ to be unique as with any other IP address assignment. (#3414)
 PATCH changes (bugfixes):
 
 * Log messages about unrecognized sockopt values are now only logged at level WARN once for each distinct value (and at DEBUG afterwards) (#3353).
-* Fixed rust/clippy errors and warnings for rust 1.83. (#3334, #3354, #3355, #3405, #3406, #3421, #3467)
+* Fixed rust/clippy errors and warnings up to rust 1.84. (#3334, #3354, #3355, #3405, #3406, #3421, #3467, #3491)
 * Fixed a link error for rust 1.82. (#3445)
 * Fixed a shim panic (which causes shadow to hang) when golang's default SIGTERM handler runs in a managed program (and potentially other cases where a signal handler stack is legitimately reused). (#3396)
 * Replaced the experimental option `--log-errors-to-tty` with the (still experimental) option

--- a/src/test/clone/test_fork.rs
+++ b/src/test/clone/test_fork.rs
@@ -1797,7 +1797,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                     .into_iter()
                     .chain(args.iter().map(|s| CString::new(*s).unwrap()))
                     .collect();
-                let env: Vec<CString> = Vec::new();
+                let args = execv_argvec(&args);
+                let env = execv_argvec(&[] as &[CString; 0]);
                 let raw_pid: i64;
                 // A function that returns twice in the same address space, such as vfork,
                 // is unsound in Rust. We work around this by doing the vfork+exec in a single
@@ -1822,8 +1823,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                         // r12 shouldn't be clobbered by the vfork syscall
                         in("r12") libc::SYS_execve,
                         in("rdi") path.as_ptr(),
-                        in("rsi") execv_argvec(&args).as_ptr(),
-                        in("rdx") execv_argvec(&env).as_ptr(),
+                        in("rsi") args.as_ptr(),
+                        in("rdx") env.as_ptr(),
                         clobber_abi("C"),
                     )
                 };


### PR DESCRIPTION
This is a new warning in rust 1.84.

There are two warnings of the form:

```text
warning: a dangling pointer will be produced because the temporary `Vec<*const i8>` will be dropped
    --> test/clone/test_fork.rs:1825:55
     |
1825 |                         in("rsi") execv_argvec(&args).as_ptr(),
     |                                   ------------------- ^^^^^^ this pointer will immediately be invalid
     |                                   |
     |                                   this `Vec<*const i8>` is deallocated at the end of the statement, bind it to a variable to extend its lifetime
     |
     = note: pointers do not have a lifetime; when calling `as_ptr` the `Vec<*const i8>` will be deallocated at the end of the statement because nothing is referencing it as far as the type system is concerned
     = help: for more information, see <https://doc.rust-lang.org/reference/destructors.html>
     = note: `#[warn(dangling_pointers_from_temporaries)]` on by default
```