### PR TITLE
Fix the expired timeout issue in the futex syscall handler

### DIFF
--- a/src/main/host/syscall/handler/futex.c
+++ b/src/main/host/syscall/handler/futex.c
@@ -117,9 +117,14 @@ static SyscallReturn _syscallhandler_futexWaitHelper(SyscallHandler* sys,
         (Trigger){.type = TRIGGER_FUTEX, .object = futex, .state = FileState_FUTEX_WAKEUP};
     SysCallCondition* cond = syscallcondition_new(trigger);
     if (timeoutSimTime != SIMTIME_INVALID) {
+        CEmulatedTime now = worker_getCurrentEmulatedTime();
         CEmulatedTime timeoutEmulatedTime = (type == TIMEOUT_RELATIVE)
-                                                ? timeoutSimTime + worker_getCurrentEmulatedTime()
+                                                ? timeoutSimTime + now
                                                 : timeoutSimTime;
+        if (timeoutEmulatedTime < now) {
+            // The timeout has already expired
+            timeoutEmulatedTime = now;
+        }
         syscallcondition_setTimeout(cond, timeoutEmulatedTime);
     }
 


### PR DESCRIPTION
In the current futex syscall handler:


https://github.com/shadow/shadow/blob/85d08b739741479f00100a4e5650136dc1c0acf9/src/main/host/syscall/handler/futex.c#L118-L124

When the `futex_op` is `FUTEX_WAIT_BITSET`, the timeout argument points to a `timespec` structure specifying the absolute timeout. If the provided timestamp is earlier than the current emulated time, the worker panics during event scheduling:

https://github.com/shadow/shadow/blob/85d08b739741479f00100a4e5650136dc1c0acf9/src/main/host/timer.rs#L191-L199

To fix this, I simply set `timeoutEmulatedTime` to the current emulated time in that case. I also added a unit test for this fix.