### PR TITLE
Fix 'clippy::unnecessary_map_or' warning

### DIFF
--- a/src/main/network/router/codel_queue.rs
+++ b/src/main/network/router/codel_queue.rs
@@ -185,7 +185,7 @@ impl CoDelQueue {
 
             item = self.codel_pop(now);
 
-            match item.as_ref().map_or(false, |x| x.ok_to_drop) {
+            match item.as_ref().is_some_and(|x| x.ok_to_drop) {
                 true => {
                     // Set the next drop time based on CoDel control law.
                     // `self.drop_next` is already set in `drop_from_store_mode()`


### PR DESCRIPTION
I have no idea why this started failing in the CI when it previously passed.