### PR TITLE
Upgrade 'nom' to 8.0.0

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -570,6 +570,7 @@ name = "gml-parser"
 version = "0.0.0"
 dependencies = [
  "nom 8.0.0",
+ "nom-language",
 ]
 
 [[package]]
@@ -981,6 +982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
+dependencies = [
+ "nom 8.0.0",
 ]
 
 [[package]]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -210,7 +210,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -569,7 +569,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 name = "gml-parser"
 version = "0.0.0"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -972,6 +972,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/src/lib/gml-parser/Cargo.toml
+++ b/src/lib/gml-parser/Cargo.toml
@@ -7,3 +7,4 @@ publish.workspace = true
 
 [dependencies]
 nom = { version = "8.0", features = ["alloc"] }
+nom-language = "0.1.0"

--- a/src/lib/gml-parser/Cargo.toml
+++ b/src/lib/gml-parser/Cargo.toml
@@ -6,4 +6,4 @@ publish.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nom = { version = "7.1", features = ["alloc"] }
+nom = { version = "8.0", features = ["alloc"] }

--- a/src/lib/gml-parser/src/lib.rs
+++ b/src/lib/gml-parser/src/lib.rs
@@ -53,8 +53,8 @@ use nom::Finish;
 /// };
 /// ```
 pub fn parse(gml_str: &str) -> Result<gml::Gml, String> {
-    match parser::gml::<nom::error::VerboseError<&str>>(gml_str).finish() {
+    match parser::gml::<nom_language::error::VerboseError<&str>>(gml_str).finish() {
         Ok((_remaining, graph)) => Ok(graph),
-        Err(e) => Err(nom::error::convert_error(gml_str, e)),
+        Err(e) => Err(nom_language::error::convert_error(gml_str, e)),
     }
 }

--- a/src/lib/gml-parser/src/parser.rs
+++ b/src/lib/gml-parser/src/parser.rs
@@ -11,7 +11,7 @@ use nom::{
     combinator::{self, map_res, recognize, verify},
     error::{ErrorKind, FromExternalError, ParseError},
     sequence::tuple,
-    IResult,
+    IResult, Parser,
 };
 
 use crate::gml::{Edge, Gml, GmlItem, Node, Value};
@@ -38,7 +38,7 @@ fn take_verify<'a, E: GmlParseError<'a>>(
     count: u32,
     cond: impl Fn(char) -> bool,
 ) -> impl Fn(&'a str) -> IResult<&'a str, &'a str, E> {
-    move |i| verify(take(count), |s: &str| s.chars().all(&cond))(i)
+    move |i| verify(take(count), |s: &str| s.chars().all(&cond)).parse(i)
 }
 
 /// Parse a GML key.
@@ -46,7 +46,7 @@ pub fn key<'a, E: GmlParseError<'a>>(input: &'a str) -> IResult<&'a str, &'a str
     // a key starts with the a character [a-zA-Z_], and has remaining characters [a-zA-Z0-9_]
     let take_first = take_verify(1, |chr| is_alphabetic(chr as u8) || chr == '_');
     let take_remaining = take_while(|chr| is_alphanumeric(chr as u8) || chr == '_');
-    let (input, key) = recognize(tuple((take_first, take_remaining)))(input)?;
+    let (input, key) = recognize(tuple((take_first, take_remaining))).parse(input)?;
     Ok((input, key))
 }
 
@@ -72,7 +72,7 @@ pub fn gml<'a, E: GmlParseError<'a>>(input: &'a str) -> IResult<&'a str, Gml<'a>
     let (input, _) = tag("[")(input)?;
     let (input, _) = newline(input)?;
 
-    let (input, (items, _)) = nom::multi::many_till(item, tag("]"))(input)?;
+    let (input, (items, _)) = nom::multi::many_till(item, tag("]")).parse(input)?;
 
     let [nodes, edges, directed, others]: [Vec<_>; 4] = partition(items.into_iter(), |x| match x {
         GmlItem::Node(_) => 0,
@@ -155,7 +155,8 @@ fn node<'a, E: GmlParseError<'a>>(input: &'a str) -> IResult<&'a str, Node<'a>, 
     let (input, _) = tag("[")(input)?;
     let (input, _) = newline(input)?;
 
-    let (input, (key_values, _)) = nom::multi::many_till(tuple((key, value)), tag("]"))(input)?;
+    let (input, (key_values, _)) =
+        nom::multi::many_till(tuple((key, value)), tag("]")).parse(input)?;
     let expected_len = key_values.len();
     let mut key_values: HashMap<_, _> = key_values.into_iter().collect();
     if key_values.len() != expected_len {
@@ -183,7 +184,8 @@ fn edge<'a, E: GmlParseError<'a>>(input: &'a str) -> IResult<&'a str, Edge<'a>, 
     let (input, _) = tag("[")(input)?;
     let (input, _) = newline(input)?;
 
-    let (input, (key_values, _)) = nom::multi::many_till(tuple((key, value)), tag("]"))(input)?;
+    let (input, (key_values, _)) =
+        nom::multi::many_till(tuple((key, value)), tag("]")).parse(input)?;
     let expected_len = key_values.len();
     let mut key_values: HashMap<_, _> = key_values.into_iter().collect();
     if key_values.len() != expected_len {
@@ -218,18 +220,20 @@ fn value<'a, E: GmlParseError<'a>>(input: &'a str) -> IResult<&'a str, Value<'a>
         tuple((int, newline)),
         tuple((float, newline)),
         tuple((string, newline)),
-    ))(input)?;
+    ))
+    .parse(input)?;
 
     Ok((input, value))
 }
 
 fn int<'a, E: GmlParseError<'a>>(input: &'a str) -> IResult<&'a str, Value<'a>, E> {
-    let (input, value) = map_res(recognize(digit1), str::parse)(input)?;
+    let (input, value) = map_res(recognize(digit1), str::parse).parse(input)?;
     Ok((input, Value::Int(value)))
 }
 
 fn float<'a, E: GmlParseError<'a>>(input: &'a str) -> IResult<&'a str, Value<'a>, E> {
-    let (input, value) = map_res(nom::number::complete::recognize_float, str::parse)(input)?;
+    let (input, value) =
+        map_res(nom::number::complete::recognize_float, str::parse).parse(input)?;
     Ok((input, Value::Float(value)))
 }
 
@@ -250,7 +254,7 @@ fn string<'a, E: GmlParseError<'a>>(input: &'a str) -> IResult<&'a str, Value<'a
 }
 
 fn newline<'a, E: GmlParseError<'a>>(input: &'a str) -> IResult<&'a str, &'a str, E> {
-    recognize(tuple((space0, multispace1, space0)))(input)
+    recognize(tuple((space0, multispace1, space0))).parse(input)
 }
 
 fn int_to_bool(x: i32) -> Result<bool, &'static str> {


### PR DESCRIPTION
nom 8.0.0 introduces a new way of writing parsers with a `Parser` trait, but it's unclear when we're supposed to write parsers in this way rather than the old function way. So I think everything is being done the old way now. But it builds without warnings so I think this is good enough for now.