### PR TITLE
Make tests compatible with --model-unblocked-syscall-latency

### DIFF
--- a/src/test/epoll/CMakeLists.txt
+++ b/src/test/epoll/CMakeLists.txt
@@ -14,5 +14,7 @@ add_shadow_tests(BASENAME epoll-rs)
 set(CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/epoll-edge-rs.yaml")
 
 add_linux_tests(BASENAME epoll-edge-rs COMMAND ../../target/debug/test_epoll_edge --libc-passing)
-add_shadow_tests(BASENAME epoll-edge-rs)
-add_shadow_tests(BASENAME epoll-edge-rs-new-tcp SHADOW_CONFIG "${CONFIG}" ARGS --use-new-tcp true)
+# We explicitly disable modeling syscall latency in these, because some of the
+# tests require precise timing.
+add_shadow_tests(BASENAME epoll-edge-rs ARGS --model-unblocked-syscall-latency false)
+add_shadow_tests(BASENAME epoll-edge-rs-new-tcp SHADOW_CONFIG "${CONFIG}" ARGS --model-unblocked-syscall-latency false --use-new-tcp true)

--- a/src/test/udp/udp.yaml
+++ b/src/test/udp/udp.yaml
@@ -1,5 +1,5 @@
 general:
-  stop_time: 5
+  stop_time: 10
 network:
   graph:
     type: 1_gbit_switch
@@ -8,20 +8,20 @@ hosts:
     network_node_id: 0
     processes:
     - path: ./test-udp
-      args: client localhost:5678
-      start_time: 1
-    - path: ./test-udp
       args: server localhost:5678
       start_time: 1
-  testclient:
-    network_node_id: 0
-    processes:
     - path: ./test-udp
-      args: client testserver:5678
+      args: client localhost:5678
       start_time: 2
   testserver:
     network_node_id: 0
     processes:
     - path: ./test-udp
       args: server 0.0.0.0:5678
-      start_time: 2
+      start_time: 3
+  testclient:
+    network_node_id: 0
+    processes:
+    - path: ./test-udp
+      args: client testserver:5678
+      start_time: 4


### PR DESCRIPTION
I was experimenting with enabling `--model-unblocked-syscall-latency` by default in the shadow binary or in our test macro. There's a bit more to do before considering actually doing that, but these fix some test failures we would otherwise get.