### PR TITLE
Fix forked timers

### DIFF
--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -215,7 +215,7 @@ impl Host {
         preload_paths: Arc<Vec<PathBuf>>,
     ) -> Self {
         #[cfg(feature = "perf_timers")]
-        let execution_timer = RefCell::new(PerfTimer::new());
+        let execution_timer = RefCell::new(PerfTimer::new_started());
 
         let root = Root::new();
         let random = RefCell::new(Xoshiro256PlusPlus::seed_from_u64(params.node_seed));

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -653,7 +653,7 @@ impl RunnableProcess {
             dumpable: self.dumpable.clone(),
             native_pid,
             #[cfg(feature = "perf_timers")]
-            cpu_delay_timer: RefCell::new(PerfTimer::new()),
+            cpu_delay_timer: RefCell::new(PerfTimer::new_started()),
             #[cfg(feature = "perf_timers")]
             total_run_time: Cell::new(Duration::ZERO),
             itimer_real,
@@ -997,7 +997,7 @@ impl Process {
 
         #[cfg(feature = "perf_timers")]
         let cpu_delay_timer = {
-            let mut t = PerfTimer::new();
+            let mut t = PerfTimer::new_started();
             t.stop();
             RefCell::new(t)
         };

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -653,7 +653,7 @@ impl RunnableProcess {
             dumpable: self.dumpable.clone(),
             native_pid,
             #[cfg(feature = "perf_timers")]
-            cpu_delay_timer: RefCell::new(PerfTimer::new_started()),
+            cpu_delay_timer: RefCell::new(PerfTimer::new_stopped()),
             #[cfg(feature = "perf_timers")]
             total_run_time: Cell::new(Duration::ZERO),
             itimer_real,

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -995,17 +995,6 @@ impl Process {
             std::fs::canonicalize(host.data_dir_path()).unwrap(),
         );
 
-        #[cfg(feature = "perf_timers")]
-        let cpu_delay_timer = {
-            let mut t = PerfTimer::new_started();
-            t.stop();
-            RefCell::new(t)
-        };
-
-        // TODO: measure execution time of creating the main_thread with
-        // cpu_delay_timer? We previously did, but it's a little complex to do so,
-        // and it shouldn't matter much.
-
         {
             let mut descriptor_table = desc_table.borrow_mut(host.root());
             Self::open_stdio_file_helper(
@@ -1118,7 +1107,7 @@ impl Process {
                         unsafe_borrows: RefCell::new(Vec::new()),
                         threads,
                         #[cfg(feature = "perf_timers")]
-                        cpu_delay_timer,
+                        cpu_delay_timer: RefCell::new(PerfTimer::new_stopped()),
                         #[cfg(feature = "perf_timers")]
                         total_run_time: Cell::new(Duration::ZERO),
                         child_process_event_listeners: Default::default(),

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -167,7 +167,7 @@ impl SyscallHandler {
         }
 
         #[cfg(feature = "perf_timers")]
-        let timer = PerfTimer::new();
+        let timer = PerfTimer::new_started();
 
         let mut rv = self.run_handler(ctx, args);
 

--- a/src/main/utility/perf_timer.rs
+++ b/src/main/utility/perf_timer.rs
@@ -8,8 +8,8 @@ pub struct PerfTimer {
 }
 
 impl PerfTimer {
-    /// Create timer, which starts running.
-    pub fn new() -> Self {
+    /// Create a timer, and start it.
+    pub fn new_started() -> Self {
         Self {
             start_time: Some(Instant::now()),
             elapsed: Duration::new(0, 0),
@@ -46,6 +46,6 @@ impl PerfTimer {
 
 impl Default for PerfTimer {
     fn default() -> Self {
-        Self::new()
+        Self::new_started()
     }
 }

--- a/src/main/utility/perf_timer.rs
+++ b/src/main/utility/perf_timer.rs
@@ -16,6 +16,14 @@ impl PerfTimer {
         }
     }
 
+    /// Create a timer, but don't start it.
+    pub fn new_stopped() -> Self {
+        Self {
+            start_time: None,
+            elapsed: Duration::new(0, 0),
+        }
+    }
+
     /// Start the timer, which must not already be running.
     pub fn start(&mut self) {
         compiler_fence(Ordering::SeqCst);


### PR DESCRIPTION
When creating a forked process, initialize with a stopped performance timer instead of a started one.

Fixes #3232 