### PR TITLE
linux-api: add wrappers for getitimer and setitimer

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -159,6 +159,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
+name = "bytemuck_derive"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +733,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags 2.8.0",
  "bytemuck",
+ "bytemuck_derive",
  "cbindgen",
  "libc",
  "linux-errno",

--- a/src/lib/linux-api/Cargo.toml
+++ b/src/lib/linux-api/Cargo.toml
@@ -26,6 +26,7 @@ naked-function = "0.1.5"
 linux-raw-sys = "0.8.0"
 rustix = { optional = true, version = "0.38.37", default-features = false, features = ["process"] }
 libc = { optional = true, default-features = false, version = "0.2.159" }
+bytemuck_derive = "1.8.1"
 
 [dev-dependencies]
 rustix = { version = "0.38.37", default-features=false, features = ["thread", "process", "time"] }

--- a/src/lib/linux-api/gen-kernel-bindings.sh
+++ b/src/lib/linux-api/gen-kernel-bindings.sh
@@ -120,6 +120,7 @@ bindgen_flags+=("--allowlist-type=itimerval")
 # More time types (time_types.h)
 bindgen_flags+=("--allowlist-type=__kernel_timespec")
 bindgen_flags+=("--allowlist-type=__kernel_old_timeval")
+bindgen_flags+=("--allowlist-type=__kernel_old_itimerval")
 
 # Sched types
 bindgen_flags+=("--allowlist-type=clone_args")

--- a/src/lib/linux-api/src/bindings.rs
+++ b/src/lib/linux-api/src/bindings.rs
@@ -2636,6 +2636,48 @@ fn bindgen_test_layout___kernel_old_timeval() {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct linux___kernel_old_itimerval {
+    pub it_interval: linux___kernel_old_timeval,
+    pub it_value: linux___kernel_old_timeval,
+}
+#[test]
+fn bindgen_test_layout___kernel_old_itimerval() {
+    const UNINIT: ::core::mem::MaybeUninit<linux___kernel_old_itimerval> =
+        ::core::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::core::mem::size_of::<linux___kernel_old_itimerval>(),
+        32usize,
+        concat!("Size of: ", stringify!(linux___kernel_old_itimerval))
+    );
+    assert_eq!(
+        ::core::mem::align_of::<linux___kernel_old_itimerval>(),
+        8usize,
+        concat!("Alignment of ", stringify!(linux___kernel_old_itimerval))
+    );
+    assert_eq!(
+        unsafe { ::core::ptr::addr_of!((*ptr).it_interval) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(linux___kernel_old_itimerval),
+            "::",
+            stringify!(it_interval)
+        )
+    );
+    assert_eq!(
+        unsafe { ::core::ptr::addr_of!((*ptr).it_value) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(linux___kernel_old_itimerval),
+            "::",
+            stringify!(it_value)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct linux_rusage {
     pub ru_utime: linux___kernel_old_timeval,
     pub ru_stime: linux___kernel_old_timeval,

--- a/src/lib/linux-api/src/signal.rs
+++ b/src/lib/linux-api/src/signal.rs
@@ -809,11 +809,19 @@ pub type linux_sigset_t = bindings::linux_sigset_t;
 /// Compatible with the Linux kernel's definition of sigset_t on x86_64.
 ///
 /// This is analagous to, but typically smaller than, libc's sigset_t.
+#[derive(
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Debug,
+    Default,
+    VirtualAddressSpaceIndependent,
+    bytemuck_derive::TransparentWrapper,
+)]
 #[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, VirtualAddressSpaceIndependent)]
 #[allow(non_camel_case_types)]
 pub struct sigset_t(linux_sigset_t);
-unsafe impl TransparentWrapper<linux_sigset_t> for sigset_t {}
 unsafe impl shadow_pod::Pod for sigset_t {}
 
 impl sigset_t {

--- a/src/main/host/syscall/handler/time.rs
+++ b/src/main/host/syscall/handler/time.rs
@@ -30,7 +30,7 @@ impl SyscallHandler {
         getitimer,
         /* rv */ std::ffi::c_int,
         /* which */ linux_api::time::ITimerId,
-        /*curr_value*/ *const std::ffi::c_void,
+        /*curr_value*/ *const linux_api::time::kernel_old_itimerval,
     );
     pub fn getitimer(
         ctx: &mut SyscallContext,
@@ -60,8 +60,8 @@ impl SyscallHandler {
         setitimer,
         /* rv */ std::ffi::c_int,
         /* which */ linux_api::time::ITimerId,
-        /* new_value */ *const std::ffi::c_void,
-        /* old_value */ *const std::ffi::c_void,
+        /* new_value */ *const linux_api::time::kernel_old_itimerval,
+        /* old_value */ *const linux_api::time::kernel_old_itimerval,
     );
     pub fn setitimer(
         ctx: &mut SyscallContext,

--- a/src/main/host/syscall/type_formatting.rs
+++ b/src/main/host/syscall/type_formatting.rs
@@ -201,6 +201,7 @@ deref_pointer_impl!(linux_api::sched::clone_args);
 deref_pointer_impl!(linux_api::time::timespec);
 deref_pointer_impl!(linux_api::time::kernel_timespec);
 deref_pointer_impl!(linux_api::time::kernel_old_timeval);
+deref_pointer_impl!(linux_api::time::kernel_old_itimerval);
 
 deref_array_impl!(i8, i16, i32, i64, isize);
 deref_array_impl!(u8, u16, u32, u64, usize);


### PR DESCRIPTION
Generally useful, and to be potentially used for https://github.com/shadow/shadow/issues/2066