### PR TITLE
shim: improve execution context tracking

### DIFF
--- a/src/lib/linux-api/build.rs
+++ b/src/lib/linux-api/build.rs
@@ -14,6 +14,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
             "linux_siginfo_t".into(),
             "linux___kernel_mode_t".into(),
             "linux_stack_t".into(),
+            "linux_ucontext".into(),
         ],
         // Not sure why cbindgen tries to wrap this. The bindings it generates
         // are broken though because the individual Errno values are translated

--- a/src/lib/linux-api/src/ucontext.rs
+++ b/src/lib/linux-api/src/ucontext.rs
@@ -1,5 +1,7 @@
+pub use crate::bindings::linux_ucontext;
 #[allow(non_camel_case_types)]
-pub type ucontext = crate::bindings::linux_ucontext;
+pub type ucontext = linux_ucontext;
 
+pub use crate::bindings::linux_sigcontext;
 #[allow(non_camel_case_types)]
-pub type sigcontext = crate::bindings::linux_sigcontext;
+pub type sigcontext = linux_sigcontext;

--- a/src/lib/shim/build.rs
+++ b/src/lib/shim/build.rs
@@ -58,6 +58,7 @@ fn run_cbindgen(build_common: &ShadowBuildCommon) {
     ];
     config.includes = vec![
         "lib/log-c2rust/rustlogger.h".into(),
+        "lib/linux-api/linux-api.h".into(),
         "lib/shadow-shim-helper-rs/shim_helper.h".into(),
     ];
     config.after_includes = {

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -67,7 +67,7 @@ static void _shim_parent_init_memory_manager_internal() {
 // Tell Shadow to initialize the MemoryManager, which includes remapping the
 // stack.
 static void _shim_parent_init_memory_manager() {
-    bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
+    ExecutionContext prev_context = shim_swapExecutionContext(EXECUTION_CONTEXT_SHADOW);
 
     // Temporarily allocate some memory for a separate stack. The MemoryManager
     // is going to remap the original stack, and we can't actively use it while
@@ -103,7 +103,7 @@ static void _shim_parent_init_memory_manager() {
         panic("munmap: %s", strerror(errno));
     }
 
-    shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
+    shim_swapExecutionContext(prev_context);
 }
 
 static void _shim_parent_init_seccomp() {
@@ -115,7 +115,7 @@ static void _shim_parent_init_rdtsc_emu() {
 }
 
 void _shim_parent_init_preload() {
-    bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
+    ExecutionContext prev_context = shim_swapExecutionContext(EXECUTION_CONTEXT_SHADOW);
 
     _shim_parent_init_ipc();
     _shim_ipc_wait_for_start_event();
@@ -132,27 +132,27 @@ void _shim_parent_init_preload() {
     _shim_parent_init_seccomp();
     _shim_parent_close_stdin();
 
-    shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
+    shim_swapExecutionContext(prev_context);
 }
 
 void _shim_child_thread_init_preload() {
-    bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
+    ExecutionContext prev_ctx = shim_swapExecutionContext(EXECUTION_CONTEXT_SHADOW);
 
     _shim_preload_only_child_ipc_wait_for_start_event();
 
     _shim_init_signal_stack();
 
-    shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
+    shim_swapExecutionContext(prev_ctx);
 }
 
 void _shim_child_process_init_preload() {
-    bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
+    ExecutionContext prev_ctx = shim_swapExecutionContext(EXECUTION_CONTEXT_SHADOW);
 
     _shim_preload_only_child_ipc_wait_for_start_event();
     _shim_init_signal_stack();
     _shim_init_death_signal();
 
-    shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
+    shim_swapExecutionContext(prev_ctx);
 }
 
 void shim_ensure_init() { _shim_load(); }

--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -239,8 +239,8 @@ static bool _shim_api_hostname_to_addr_ipv4(const char* node, uint32_t* addr) {
     // can intercept it, but we want to send to Shadow through shmem in preload mode. Let
     // shim_syscall figure it out.
     trace("Performing custom shadow syscall SYS_shadow_hostname_to_addr_ipv4 for name %s", node);
-    int rv = shim_syscall(
-        NULL, SYS_shadow_hostname_to_addr_ipv4, node, strlen(node), addr, sizeof(*addr));
+    int rv =
+        shim_api_syscall(SYS_shadow_hostname_to_addr_ipv4, node, strlen(node), addr, sizeof(*addr));
 
     if (rv == 0) {
 #ifdef DEBUG

--- a/src/lib/shim/shim_api_c.h
+++ b/src/lib/shim/shim_api_c.h
@@ -10,15 +10,20 @@
 #include <netdb.h>
 #include <stdarg.h>
 
-/// This module defines functions that can be called by external (preloaded)
-/// libraries that are linked to the shim. Those libraries should only call
-/// functions defined here after including this header file.
+#include "lib/shim/shim_api.h"
+
+/// This module defines *C implementations* of functions that can be called by
+/// external (preloaded) libraries that are linked to the shim. Those libraries
+/// should only call functions defined here after including this header file.
+///
+/// The public interfaces to access these are defined in Rust, without prefix
+/// `shim_api_` instead of `shimc_api`.
 
 // The entry point for handling an intercepted syscall. This function remaps the
 // return value into errno upon error so that errno will be set correctly upon
 // returning control to the managed process. Be careful not to do something that
 // would overwrite errno after this function returns.
-long shimc_api_syscall(long n, ...);
+long shimc_api_syscall(ExecutionContext exe_ctx, long n, ...);
 
 // Shim implementation of `man 3 getaddrinfo`.
 int shimc_api_getaddrinfo(const char* node, const char* service, const struct addrinfo* hints,

--- a/src/lib/shim/shim_api_syscall.c
+++ b/src/lib/shim/shim_api_syscall.c
@@ -21,15 +21,10 @@ static long _shim_api_retval_to_errno(long retval) {
     return retval;
 }
 
-long shimc_api_syscallv(long n, va_list args) {
-    long rv = shim_syscallv(NULL, n, args);
-    return _shim_api_retval_to_errno(rv);
-}
-
-long shimc_api_syscall(long n, ...) {
+long shimc_api_syscall(ExecutionContext ctx, long n, ...) {
     va_list(args);
     va_start(args, n);
-    long rv = shimc_api_syscallv(n, args);
+    long rv = shim_syscallv(NULL, ctx, n, args);
     va_end(args);
-    return rv;
+    return _shim_api_retval_to_errno(rv);
 }

--- a/src/lib/shim/shim_sys.c
+++ b/src/lib/shim/shim_sys.c
@@ -155,7 +155,7 @@ bool shim_sys_handle_syscall_locally(long syscall_num, long* rv, va_list args) {
         uint64_t emulated_time_ms = shim_sys_get_simtime_nanos();
         pid_t tid = shimshmem_getThreadId(shim_threadSharedMem());
 
-        bool oldNativeSyscallFlag = shim_swapAllowNativeSyscalls(true);
+        ExecutionContext prev_ctx = shim_swapExecutionContext(EXECUTION_CONTEXT_SHADOW);
 
         char buf[100] = {0};
         int len = snprintf(buf, sizeof(buf), "%018ld [tid %d] %s(...) = %ld\n", emulated_time_ms,
@@ -178,7 +178,7 @@ bool shim_sys_handle_syscall_locally(long syscall_num, long* rv, va_list args) {
             }
         }
 
-        shim_swapAllowNativeSyscalls(oldNativeSyscallFlag);
+        shim_swapExecutionContext(prev_ctx);
     }
 
     if (shimshmem_getModelUnblockedSyscallLatency(shim_hostSharedMem())) {

--- a/src/lib/shim/shim_syscall.c
+++ b/src/lib/shim/shim_syscall.c
@@ -40,11 +40,13 @@ long shim_syscallv(ucontext_t* ctx, long n, va_list args) {
 
     long rv;
 
-    if (shim_interpositionEnabled() && shim_sys_handle_syscall_locally(n, &rv, args)) {
+    if (shim_getExecutionContext() == EXECUTION_CONTEXT_APPLICATION &&
+        shim_sys_handle_syscall_locally(n, &rv, args)) {
         // No inter-process syscall needed, we handled it on the shim side! :)
         trace("Handled syscall %ld from the shim; we avoided inter-process overhead.", n);
         // rv was already set
-    } else if ((shim_interpositionEnabled() || syscall_num_is_shadow(n)) &&
+    } else if ((shim_getExecutionContext() == EXECUTION_CONTEXT_APPLICATION ||
+                syscall_num_is_shadow(n)) &&
                shim_thisThreadEventIPC()) {
         // The syscall is made using the shmem IPC channel.
         trace("Making syscall %ld indirectly; we ask shadow to handle it using the shmem IPC "

--- a/src/lib/shim/shim_syscall.h
+++ b/src/lib/shim/shim_syscall.h
@@ -6,13 +6,15 @@
 #include <sys/ucontext.h>
 
 #include "lib/shadow-shim-helper-rs/shim_helper.h"
+#include "lib/shim/shim_api.h"
 
 // Ask the shim to handle a syscall. Internally decides whether to execute a
-// native syscall or to emulate the syscall through Shadow.
-long shim_syscall(ucontext_t* ctx, long n, ...);
+// native syscall or to emulate the syscall through Shadow based e.g. on the
+// syscall number and the `exe_ctx`.
+long shim_syscall(ucontext_t* ctx, ExecutionContext exe_ctx, long n, ...);
 
 // Same as `shim_syscall()`, but accepts a variable argument list.
-long shim_syscallv(ucontext_t* ctx, long n, va_list args);
+long shim_syscallv(ucontext_t* ctx, ExecutionContext exe_ctx, long n, va_list args);
 
 // Force the native execution of a syscall instruction (using asm so it can't be
 // intercepted).

--- a/src/lib/shim/src/lib.rs
+++ b/src/lib/shim/src/lib.rs
@@ -50,9 +50,13 @@ pub fn simtime() -> Option<SimulationTime> {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum ExecutionContext {
-    Shadow,
-    Application,
+    // Redirect through constants below so that we can access in const contexts.
+    Shadow = EXECUTION_CONTEXT_SHADOW_CONST,
+    Application = EXECUTION_CONTEXT_APPLICATION_CONST,
 }
+
+pub const EXECUTION_CONTEXT_SHADOW_CONST: u8 = 0;
+pub const EXECUTION_CONTEXT_APPLICATION_CONST: u8 = 1;
 
 static CURRENT_EXECUTION_CONTEXT: ShimTlsVar<Cell<ExecutionContext>> =
     ShimTlsVar::new(&SHIM_TLS, || Cell::new(ExecutionContext::Application));
@@ -127,6 +131,7 @@ mod tls_thread_signal_stack {
     /// This should be called once per thread before any signal handlers run.
     /// Panics if already called on the current thread.
     pub fn init() {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         if THREAD_SIGNAL_STACK.get().get().is_null() {
             // Allocate
             let new_stack = unsafe {
@@ -185,6 +190,7 @@ mod tls_thread_signal_stack {
     /// this, since we know Shadow won't permit another thread to run
     /// preemptively before the curent thread has a chance to finish exiting.
     pub unsafe fn free() {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         // A signal stack waiting to be freed.
         //
         // We can't free the current thread's signal stack, since we may be running on it.
@@ -219,6 +225,7 @@ mod tls_ipc {
 
     // Panics if this thread's IPC hasn't been initialized yet.
     pub fn with<O>(f: impl FnOnce(&IPCData) -> O) -> O {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         let ipc = IPC_DATA_BLOCK.get();
         let ipc = ipc.borrow();
         ipc.as_ref().map(|block| f(block)).unwrap()
@@ -231,6 +238,7 @@ mod tls_ipc {
     /// `blk` must contained a serialized block referencing a `ShMemBlock` of type `IPCData`.
     /// The `ShMemBlock` must outlive the current thread.
     pub unsafe fn set(blk: &ShMemBlockSerialized) {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         let blk: ShMemBlockAlias<IPCData> = unsafe { shdeserialize(blk) };
         IPC_DATA_BLOCK.get().replace(Some(blk));
     }
@@ -244,6 +252,7 @@ mod tls_thread_shmem {
 
     /// Panics if `set` hasn't been called yet.
     pub fn with<O>(f: impl FnOnce(&ThreadShmem) -> O) -> O {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         f(SHMEM.get().borrow().as_ref().unwrap())
     }
 
@@ -254,6 +263,7 @@ mod tls_thread_shmem {
     /// `blk` must contained a serialized block referencing a `ShMemBlock` of
     /// type `ThreadShmem`.  The `ShMemBlock` must outlive the current thread.
     pub unsafe fn set(blk: &ShMemBlockSerialized) {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         // SAFETY: Caller guarantees correct type.
         let blk = unsafe { shdeserialize(blk) };
         SHMEM.get().borrow_mut().replace(blk);
@@ -270,6 +280,7 @@ mod global_manager_shmem {
     // The actual block is in a `LazyLock`, which is much faster to access.
     // It uses `INITIALIZER` to do its one-time init.
     static SHMEM: LazyLock<ShMemBlockAlias<ManagerShmem>> = LazyLock::const_new(|| {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         let serialized = INITIALIZER.lock().take().unwrap();
         unsafe { shdeserialize(&serialized) }
     });
@@ -279,6 +290,7 @@ mod global_manager_shmem {
     /// `blk` must contained a serialized block referencing a `ShMemBlock` of type `ManagerShmem`.
     /// The `ShMemBlock` must outlive this process.
     pub unsafe fn set(blk: &ShMemBlockSerialized) {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         assert!(!SHMEM.initd());
         assert!(INITIALIZER.lock().replace(*blk).is_none());
         // Ensure that `try_get` returns true (without it having to take the
@@ -290,12 +302,14 @@ mod global_manager_shmem {
     /// Panics if `set` hasn't been called yet.
     pub fn get() -> impl core::ops::Deref<Target = ShMemBlockAlias<'static, ManagerShmem>> + 'static
     {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         SHMEM.force()
     }
 
     pub fn try_get()
     -> Option<impl core::ops::Deref<Target = ShMemBlockAlias<'static, ManagerShmem>> + 'static>
     {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         if !SHMEM.initd() {
             // No need to do the more-expensive `INITIALIZER` check; `set`
             // forces `SHMEM` to initialize.
@@ -316,6 +330,7 @@ mod global_host_shmem {
     // The actual block is in a `LazyLock`, which is much faster to access.
     // It uses `INITIALIZER` to do its one-time init.
     static SHMEM: LazyLock<ShMemBlockAlias<HostShmem>> = LazyLock::const_new(|| {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         let serialized = INITIALIZER.lock().take().unwrap();
         unsafe { shdeserialize(&serialized) }
     });
@@ -325,6 +340,7 @@ mod global_host_shmem {
     /// `blk` must contained a serialized block referencing a `ShMemBlock` of type `HostShmem`.
     /// The `ShMemBlock` must outlive this process.
     pub unsafe fn set(blk: &ShMemBlockSerialized) {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         assert!(!SHMEM.initd());
         assert!(INITIALIZER.lock().replace(*blk).is_none());
         // Ensure that `try_get` returns true (without it having to take the
@@ -335,11 +351,13 @@ mod global_host_shmem {
 
     /// Panics if `set` hasn't been called yet.
     pub fn get() -> impl core::ops::Deref<Target = ShMemBlockAlias<'static, HostShmem>> + 'static {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         SHMEM.force()
     }
 
     pub fn try_get()
     -> Option<impl core::ops::Deref<Target = ShMemBlockAlias<'static, HostShmem>> + 'static> {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         if !SHMEM.initd() {
             // No need to do the more-expensive `INITIALIZER` check; `set`
             // forces `SHMEM` to initialize.
@@ -358,6 +376,7 @@ mod tls_process_shmem {
 
     /// Panics if `set` hasn't been called yet.
     pub fn with<O>(f: impl FnOnce(&ProcessShmem) -> O) -> O {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         f(SHMEM.get().borrow().as_ref().unwrap())
     }
 
@@ -368,6 +387,7 @@ mod tls_process_shmem {
     /// `blk` must contained a serialized block referencing a `ShMemBlock` of
     /// type `ProcessShmem`.  The `ShMemBlock` must outlive the current thread.
     pub unsafe fn set(blk: &ShMemBlockSerialized) {
+        debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
         // SAFETY: Caller guarantees correct type.
         let blk = unsafe { shdeserialize(blk) };
         SHMEM.get().borrow_mut().replace(blk);
@@ -401,6 +421,7 @@ static SHIM_TLS: ThreadLocalStorage = unsafe { ThreadLocalStorage::new(tls::Mode
 /// access thread local storage again from the current thread, e.g.
 /// using `std::panic::catch_unwind` or a custom panic hook.
 pub unsafe fn release_and_exit_current_thread(exit_status: i32) -> ! {
+    debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
     // Block all signals, to ensure a signal handler can't run and attempt to
     // access thread local storage.
     rt_sigprocmask(
@@ -425,6 +446,7 @@ pub unsafe fn release_and_exit_current_thread(exit_status: i32) -> ! {
 ///
 /// Uses C ABI so that we can call from `asm`.
 extern "C" fn init_thread() {
+    debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
     unsafe { bindings::_shim_child_thread_init_preload() };
     log::trace!("Finished shim thread init");
 }
@@ -433,6 +455,7 @@ extern "C" fn init_thread() {
 ///
 /// Safe and cheap to call repeatedly; e.g. from API entry points.
 fn init_process() {
+    debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
     static STARTED_INIT: LazyLock<()> = LazyLock::const_new(|| ());
     if STARTED_INIT.initd() {
         // Avoid recursion in initialization.
@@ -450,6 +473,7 @@ fn init_process() {
 /// Wait for "start" event from Shadow, use it to initialize the thread shared
 /// memory block, and optionally to initialize the process shared memory block.
 fn wait_for_start_event(get_initial_working_dir: bool) {
+    debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
     log::trace!("waiting for start event");
 
     let mut working_dir = [0u8; linux_api::limits::PATH_MAX];
@@ -518,7 +542,10 @@ pub mod export {
         arg5: u64,
         arg6: u64,
     ) -> i64 {
-        unsafe { bindings::shimc_api_syscall(n, arg1, arg2, arg3, arg4, arg5, arg6) }
+        let _prev = ExecutionContext::Shadow.enter();
+        unsafe {
+            bindings::shimc_api_syscall(_prev.ctx().into(), n, arg1, arg2, arg3, arg4, arg5, arg6)
+        }
     }
 
     /// # Safety
@@ -531,6 +558,7 @@ pub mod export {
         hints: *const libc::addrinfo,
         res: *mut *mut libc::addrinfo,
     ) -> i32 {
+        let _prev = ExecutionContext::Shadow.enter();
         unsafe { bindings::shimc_api_getaddrinfo(node, service, hints, res) }
     }
 
@@ -540,6 +568,7 @@ pub mod export {
     /// * `res` is invalidated afterwards.
     #[unsafe(no_mangle)]
     pub unsafe extern "C-unwind" fn shim_api_freeaddrinfo(res: *mut libc::addrinfo) {
+        let _prev = ExecutionContext::Shadow.enter();
         unsafe { bindings::shimc_api_freeaddrinfo(res) }
     }
 
@@ -548,6 +577,10 @@ pub mod export {
     /// Pointers must be dereferenceable
     #[unsafe(no_mangle)]
     pub unsafe extern "C-unwind" fn shim_api_getifaddrs(ifap: *mut *mut libc::ifaddrs) -> i32 {
+        // We *don't* enter ExecutionContext::Shadow here, because this
+        // implementation is pure "userspace"; it doesn't directly access shadow
+        // internal functionality, but *does* use libc in a way that we want the
+        // underlying syscalls to be interposed.
         unsafe { bindings::shimc_api_getifaddrs(ifap) }
     }
 
@@ -557,6 +590,10 @@ pub mod export {
     /// * `ifa` is invalidated afterwards.
     #[unsafe(no_mangle)]
     pub unsafe extern "C-unwind" fn shim_api_freeifaddrs(ifa: *mut libc::ifaddrs) {
+        // We *don't* enter ExecutionContext::Shadow here, because this
+        // implementation is pure "userspace"; it doesn't directly access shadow
+        // internal functionality, but *does* use libc in a way that we want the
+        // underlying syscalls to be interposed.
         unsafe { bindings::shimc_api_freeifaddrs(ifa) }
     }
 

--- a/src/lib/shim/src/lib.rs
+++ b/src/lib/shim/src/lib.rs
@@ -566,22 +566,14 @@ pub mod export {
     /// Typical usage is to set this to the desired value at the beginning of an
     /// operation, and restore the old value afterwards.
     #[unsafe(no_mangle)]
-    pub extern "C-unwind" fn shim_swapAllowNativeSyscalls(new: bool) -> bool {
-        let new = if new {
-            ExecutionContext::Shadow
-        } else {
-            ExecutionContext::Application
-        };
-        match new.enter_without_restorer() {
-            ExecutionContext::Shadow => true,
-            ExecutionContext::Application => false,
-        }
+    pub extern "C-unwind" fn shim_swapExecutionContext(new: ExecutionContext) -> ExecutionContext {
+        new.enter_without_restorer()
     }
 
     /// Whether syscall interposition is currently enabled.
     #[unsafe(no_mangle)]
-    pub extern "C-unwind" fn shim_interpositionEnabled() -> bool {
-        ExecutionContext::current() == ExecutionContext::Application
+    pub extern "C-unwind" fn shim_getExecutionContext() -> ExecutionContext {
+        ExecutionContext::current()
     }
 
     /// Allocates and installs a signal stack.

--- a/src/lib/shim/src/lib.rs
+++ b/src/lib/shim/src/lib.rs
@@ -9,6 +9,7 @@ use core::mem::MaybeUninit;
 use crate::tls::ShimTlsVar;
 
 use linux_api::signal::{SigProcMaskAction, rt_sigprocmask};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use shadow_shim_helper_rs::ipc::IPCData;
 use shadow_shim_helper_rs::shim_event::{ShimEventStartReq, ShimEventToShadow, ShimEventToShim};
 use shadow_shim_helper_rs::shim_shmem::{HostShmem, ManagerShmem, ProcessShmem, ThreadShmem};
@@ -44,18 +45,56 @@ pub fn simtime() -> Option<SimulationTime> {
     SimulationTime::from_c_simtime(unsafe { bindings::shim_sys_get_simtime_nanos() })
 }
 
-mod tls_allow_native_syscalls {
-    use super::*;
+/// Describes whether something is within the context of the shadow (shim) code,
+/// or the application/plugin code.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum ExecutionContext {
+    Shadow,
+    Application,
+}
 
-    static ALLOW_NATIVE_SYSCALLS: ShimTlsVar<Cell<bool>> =
-        ShimTlsVar::new(&SHIM_TLS, || Cell::new(false));
+static CURRENT_EXECUTION_CONTEXT: ShimTlsVar<Cell<ExecutionContext>> =
+    ShimTlsVar::new(&SHIM_TLS, || Cell::new(ExecutionContext::Application));
 
-    pub fn get() -> bool {
-        ALLOW_NATIVE_SYSCALLS.get().get()
+impl ExecutionContext {
+    /// Returns the current context for the current thread.
+    pub fn current() -> ExecutionContext {
+        CURRENT_EXECUTION_CONTEXT.get().get()
     }
 
-    pub fn swap(new: bool) -> bool {
-        ALLOW_NATIVE_SYSCALLS.get().replace(new)
+    /// Enter this context for the current thread, and return a restorer that
+    /// will restore the previous context when dropped.
+    pub fn enter(&self) -> ExecutionContextRestorer {
+        ExecutionContextRestorer {
+            prev: CURRENT_EXECUTION_CONTEXT.get().replace(*self),
+        }
+    }
+
+    /// Enter this context for the current thread, *without* creating a
+    /// restorer. Returns the previous context.
+    pub fn enter_without_restorer(&self) -> ExecutionContext {
+        CURRENT_EXECUTION_CONTEXT.get().replace(*self)
+    }
+}
+
+/// Restores an execution context when droped.
+#[must_use]
+#[derive(Debug)]
+pub struct ExecutionContextRestorer {
+    prev: ExecutionContext,
+}
+
+impl ExecutionContextRestorer {
+    /// Returns the context that this object will restore.
+    pub fn ctx(&self) -> ExecutionContext {
+        self.prev
+    }
+}
+
+impl Drop for ExecutionContextRestorer {
+    fn drop(&mut self) {
+        ExecutionContext::enter_without_restorer(&self.prev);
     }
 }
 
@@ -528,13 +567,21 @@ pub mod export {
     /// operation, and restore the old value afterwards.
     #[unsafe(no_mangle)]
     pub extern "C-unwind" fn shim_swapAllowNativeSyscalls(new: bool) -> bool {
-        tls_allow_native_syscalls::swap(new)
+        let new = if new {
+            ExecutionContext::Shadow
+        } else {
+            ExecutionContext::Application
+        };
+        match new.enter_without_restorer() {
+            ExecutionContext::Shadow => true,
+            ExecutionContext::Application => false,
+        }
     }
 
     /// Whether syscall interposition is currently enabled.
     #[unsafe(no_mangle)]
     pub extern "C-unwind" fn shim_interpositionEnabled() -> bool {
-        !tls_allow_native_syscalls::get()
+        ExecutionContext::current() == ExecutionContext::Application
     }
 
     /// Allocates and installs a signal stack.

--- a/src/lib/shim/src/signals.rs
+++ b/src/lib/shim/src/signals.rs
@@ -29,10 +29,14 @@ static SIGUSR1_SIGINFO: ShimTlsVar<Cell<Option<Sigusr1Info>>> =
     ShimTlsVar::new(&crate::SHIM_TLS, || Cell::new(None));
 
 extern "C" fn handle_sigusr1(_signo: i32, _info: *mut siginfo_t, ctx: *mut core::ffi::c_void) {
+    debug_assert_eq!(
+        ExecutionContext::current(),
+        ExecutionContext::Shadow,
+        "Native sigusr1 unexpectedly raised from non-shadow code"
+    );
+
     let mut info = SIGUSR1_SIGINFO.get().take().unwrap();
     let signo = info.siginfo.signal().unwrap().as_i32();
-    let prev = ExecutionContext::Application.enter();
-    assert_eq!(prev.ctx(), ExecutionContext::Shadow);
     // SAFETY: Should have been initialized correctly in `process_signals`.
     let handler = unsafe { info.action.handler() };
 
@@ -47,7 +51,10 @@ extern "C" fn handle_sigusr1(_signo: i32, _info: *mut siginfo_t, ctx: *mut core:
     // we don't attempt to analyze or sandbox. A "well behaved" handler should be safe to
     // call here, but it could do anything including things that are unsound in Rust.
     match handler {
-        linux_api::signal::SignalHandler::Handler(handler_fn) => unsafe { handler_fn(signo) },
+        linux_api::signal::SignalHandler::Handler(handler_fn) => {
+            let _prev = ExecutionContext::Application.enter();
+            unsafe { handler_fn(signo) }
+        }
         linux_api::signal::SignalHandler::Action(action_fn) => unsafe {
             // If there's an "earlier" context, we use it. This might be important e.g.
             // when handling a signal like SIGSEGV, where the handler might actually
@@ -63,7 +70,10 @@ extern "C" fn handle_sigusr1(_signo: i32, _info: *mut siginfo_t, ctx: *mut core:
             } else {
                 info.ctx
             };
-            action_fn(signo, &mut info.siginfo, ctx.cast::<core::ffi::c_void>())
+            {
+                let _prev = ExecutionContext::Application.enter();
+                action_fn(signo, &mut info.siginfo, ctx.cast::<core::ffi::c_void>())
+            }
         },
         linux_api::signal::SignalHandler::SigIgn | linux_api::signal::SignalHandler::SigDfl => {
             panic!("No handler")
@@ -92,15 +102,13 @@ fn die_with_fatal_signal(sig: Signal) -> ! {
 /// Handle pending unblocked signals, and return whether *all* corresponding
 /// signal actions had the SA_RESTART flag set.
 ///
-/// `ucontext` may be NULL.
-///
 /// # Safety
-///
-/// `ucontext` must be dereferenceable if not NULL.
 ///
 /// Configured handlers for all pending unblocked signals must be safe to call. (Which
 /// we basically can't ensure).
 pub unsafe fn process_signals(mut ucontext: Option<&mut ucontext>) -> bool {
+    debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
+
     let mut host = crate::global_host_shmem::get();
     let mut host_lock = host.protected().lock();
 
@@ -307,6 +315,16 @@ pub unsafe fn process_signals(mut ucontext: Option<&mut ucontext>) -> bool {
         let tid = rustix::thread::gettid();
         linux_api::signal::tgkill(pid.into(), tid.into(), Some(Signal::SIGUSR1)).unwrap();
 
+        // It's not unheard of for a signal handler to use setcontext to jump
+        // out of the signal handler to the point where the signal was raised
+        // instead of returning normally, e.g. for userspace scheduling.
+        // In that case we'll still be in `ExecutionContext::Application`, since
+        // the jump would have skipped over the execution context restorer's
+        // drop impl above. This is done in our `test_signals.rs` test.
+        //
+        // Force back to `ExecutionContext::Shadow`.
+        ExecutionContext::Shadow.enter_without_restorer();
+
         // Reacquire locks and references.
         host = crate::global_host_shmem::get();
         host_lock = host.protected().lock();
@@ -326,16 +344,19 @@ pub unsafe fn process_signals(mut ucontext: Option<&mut ucontext>) -> bool {
     restartable
 }
 
-extern "C" fn handle_hardware_error_signal(
-    signo: i32,
-    info: *mut siginfo_t,
-    ctx: *mut core::ffi::c_void,
+/// Handle a hardware error signal that was raised in `exe_ctx`.
+///
+/// # Safety
+///
+/// Configured handlers for all pending unblocked signals must be safe to call. (Which
+/// we basically can't ensure).
+unsafe fn handle_hardware_error_signal_inner(
+    exe_ctx: ExecutionContext,
+    signal: Signal,
+    info: &mut siginfo_t,
+    uctx: Option<&mut ucontext>,
 ) {
-    let prev_ctx = ExecutionContext::Shadow.enter();
-
-    let signal = Signal::try_from(signo).unwrap();
-
-    if prev_ctx.ctx() == ExecutionContext::Shadow {
+    if exe_ctx == ExecutionContext::Shadow {
         // Error was raised from shim code.
         die_with_fatal_signal(signal);
     }
@@ -352,14 +373,26 @@ extern "C" fn handle_hardware_error_signal(
         } else {
             let mut thread_protected = thread.protected.borrow_mut(&host_lock.root);
             thread_protected.pending_signals |= signal.into();
-            thread_protected
-                .set_pending_standard_siginfo(signal, unsafe { info.as_ref().unwrap() });
+            thread_protected.set_pending_standard_siginfo(signal, info);
         }
     });
 
-    let ctx = ctx.cast::<ucontext>();
+    unsafe { process_signals(uctx) };
+}
+
+unsafe extern "C" fn handle_hardware_error_signal(
+    signo: i32,
+    info: *mut siginfo_t,
+    uctx: *mut core::ffi::c_void,
+) {
+    let prev_ctx = ExecutionContext::Shadow.enter();
+    let signal = Signal::try_from(signo).unwrap();
+    // SAFETY: The kernel should have given us a valid `siginfo_t` here.
+    let info = unsafe { info.as_mut().unwrap() };
     // SAFETY: The kernel should have given us a valid `ucontext` here.
-    unsafe { process_signals(ctx.as_mut()) };
+    let uctx = unsafe { uctx.cast::<ucontext>().as_mut() };
+    // SAFETY: We can only assume that the signal handlers are sound.
+    unsafe { handle_hardware_error_signal_inner(prev_ctx.ctx(), signal, info, uctx) };
 }
 
 pub fn install_hardware_error_handlers() {
@@ -427,15 +460,30 @@ mod export {
         install_hardware_error_handlers()
     }
 
+    /// Handle a hardware error signal that was raised in `exe_ctx`.
+    ///
     /// More-specialized error handlers (e.g. for rdtsc) can invoke this handler
     /// directly when unable to handle the current signal (e.g. when a SIGSEGV wasn't
-    /// caused by an rdtsc instruction)
+    /// caused by an rdtsc instruction).
+    ///
+    /// # Safety
+    ///
+    /// `info` and `ctx` must be non-NULL and safely dereferenceable.
     #[unsafe(no_mangle)]
     pub unsafe extern "C-unwind" fn shim_handle_hardware_error_signal(
+        exe_ctx: ExecutionContext,
         signo: i32,
         info: *mut siginfo_t,
-        ctx: *mut core::ffi::c_void,
+        uctx: *mut linux_api::ucontext::linux_ucontext,
     ) {
-        handle_hardware_error_signal(signo, info, ctx)
+        let signal = Signal::try_from(signo).unwrap();
+        // SAFETY: Caller ensures.
+        let info = unsafe { info.as_mut().unwrap() };
+        // SAFETY: Caller ensures.
+        let uctx = unsafe { uctx.as_mut() };
+        // SAFETY: We can only assume that the signal handlers are sound.
+        unsafe {
+            handle_hardware_error_signal_inner(exe_ctx, signal, info, uctx);
+        }
     }
 }

--- a/src/lib/shim/src/syscall.rs
+++ b/src/lib/shim/src/syscall.rs
@@ -174,6 +174,8 @@ unsafe fn emulated_syscall_event(
 }
 
 pub mod export {
+    use crate::ExecutionContext;
+
     use super::*;
 
     /// # Safety
@@ -185,7 +187,7 @@ pub mod export {
         n: core::ffi::c_long,
         mut args: va_list::VaList,
     ) -> core::ffi::c_long {
-        let old_native_syscall_flag = crate::tls_allow_native_syscalls::swap(true);
+        let _prev = ExecutionContext::Shadow.enter();
 
         let syscall_args = SyscallArgs {
             number: n,
@@ -203,8 +205,6 @@ pub mod export {
         let ctx = ctx.cast::<ucontext>();
         let ctx = unsafe { ctx.as_mut() };
         let retval = unsafe { emulated_syscall_event(ctx, &event) };
-
-        crate::tls_allow_native_syscalls::swap(old_native_syscall_flag);
 
         retval.into()
     }


### PR DESCRIPTION
* Replaces the previous boolean flag which (sort of) identified whether native syscalls were currently allowed, with an enum identifying whether the calling context is shadow code or application/managed code. This can be used to help decide whether a particular syscall ought to be native or emulated, but isn't quite 1:1 with whether syscalls are currently allowed.
* Move where we set and restore this context out to API edges where we enter/leave shadow code. This sometimes we mean to explicitly propagate the "original" execution context through multiple API layers, e.g. to keep track of whether a syscall originated from shadow code or application code, but is generally clearer and more accurate.

This is motivated primarily to help write a robust implementation of #2066, where we'll want to accurately determine in a timer signal handler whether we were running in shadow code or application code (and/or more-accurately enable/disable the timer when transitioning between the two). Even if we don't go forward with that though, these changes improve clarity and robustness IMO.