### PR TITLE
Add preemption to escape pure-cpu busy-loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ to be unique as with any other IP address assignment. (#3414)
   using this option. (#3478)
 * Converted the network interface and queuing disciplines to Rust and removed the legacy C implementations. (#3480)
 * Converted the legacy C packet and payload structs to Rust for safer reference counting. This also eliminates a payload copy in Rust TCP and UDP code. (#3492)
+* Added the experimental option `--native-preemption-enabled` for escaping pure-CPU busy-loops. (#3520)
 
 PATCH changes (bugfixes):
 

--- a/src/lib/linux-api/src/time.rs
+++ b/src/lib/linux-api/src/time.rs
@@ -63,21 +63,25 @@ pub use bindings::linux_timespec;
 #[allow(non_camel_case_types)]
 pub type timespec = linux_timespec;
 unsafe impl shadow_pod::Pod for timespec {}
+unsafe impl vasi::VirtualAddressSpaceIndependent for timespec {}
 
 pub use bindings::linux___kernel_timespec;
 #[allow(non_camel_case_types)]
 pub type kernel_timespec = linux___kernel_timespec;
 unsafe impl shadow_pod::Pod for kernel_timespec {}
+unsafe impl vasi::VirtualAddressSpaceIndependent for kernel_timespec {}
 
 pub use bindings::linux_timeval;
 #[allow(non_camel_case_types)]
 pub type timeval = linux_timeval;
 unsafe impl shadow_pod::Pod for timeval {}
+unsafe impl vasi::VirtualAddressSpaceIndependent for timeval {}
 
 pub use bindings::linux___kernel_old_timeval;
 #[allow(non_camel_case_types)]
 pub type kernel_old_timeval = linux___kernel_old_timeval;
 unsafe impl shadow_pod::Pod for kernel_old_timeval {}
+unsafe impl vasi::VirtualAddressSpaceIndependent for kernel_old_timeval {}
 
 pub fn clock_gettime_raw(clockid: linux___kernel_clockid_t) -> Result<timespec, Errno> {
     let mut t = shadow_pod::zeroed();
@@ -95,16 +99,19 @@ pub use bindings::linux_itimerspec;
 #[allow(non_camel_case_types)]
 pub type itimerspec = linux_itimerspec;
 unsafe impl shadow_pod::Pod for itimerspec {}
+unsafe impl vasi::VirtualAddressSpaceIndependent for itimerspec {}
 
 pub use bindings::linux_itimerval;
 #[allow(non_camel_case_types)]
 pub type itimerval = linux_itimerval;
 unsafe impl shadow_pod::Pod for itimerval {}
+unsafe impl vasi::VirtualAddressSpaceIndependent for itimerval {}
 
 pub use bindings::linux___kernel_old_itimerval;
 #[allow(non_camel_case_types)]
 pub type kernel_old_itimerval = linux___kernel_old_itimerval;
 unsafe impl shadow_pod::Pod for kernel_old_itimerval {}
+unsafe impl vasi::VirtualAddressSpaceIndependent for kernel_old_itimerval {}
 
 /// Raw `alarm` syscall. Permits u64 arg and return value for generality with
 /// the general syscall ABI, but note that the `alarm` syscall definition itself

--- a/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
+++ b/src/lib/shadow-shim-helper-rs/src/shim_shmem.rs
@@ -48,8 +48,23 @@ macro_rules! assert_shmem_safe {
 
 #[derive(VirtualAddressSpaceIndependent)]
 #[repr(C)]
+pub struct NativePreemptionConfig {
+    /// Maximum wall-clock time to allow managed code to run before preempting
+    /// to move time forward.
+    // Using `kernel_old_timeval` here leaks implementation details from the
+    // shim a bit, but lets us do the fiddly time conversion and potential error
+    // reporting from the shadow process up-front.
+    pub native_duration: linux_api::time::kernel_old_timeval,
+    /// Amount of simulation-time to move forward after `native_duration_micros`
+    /// has elapsed without returning control to Shadow.
+    pub sim_duration: SimulationTime,
+}
+
+#[derive(VirtualAddressSpaceIndependent)]
+#[repr(C)]
 pub struct ManagerShmem {
     pub log_start_time_micros: i64,
+    pub native_preemption_config: FfiOption<NativePreemptionConfig>,
 }
 
 #[derive(VirtualAddressSpaceIndependent)]

--- a/src/lib/shim/shim.c
+++ b/src/lib/shim/shim.c
@@ -132,6 +132,7 @@ void _shim_parent_init_preload() {
     _shim_parent_init_rdtsc_emu();
     _shim_parent_init_seccomp();
     _shim_parent_close_stdin();
+    preempt_process_init();
 }
 
 void _shim_child_thread_init_preload() {

--- a/src/lib/shim/src/lib.rs
+++ b/src/lib/shim/src/lib.rs
@@ -33,6 +33,7 @@ mod bindings {
 
 pub mod clone;
 pub mod mmap_box;
+pub mod preempt;
 pub mod shimlogger;
 pub mod syscall;
 pub mod tls;
@@ -77,14 +78,43 @@ impl ExecutionContext {
     /// will restore the previous context when dropped.
     pub fn enter(&self) -> ExecutionContextRestorer {
         ExecutionContextRestorer {
-            prev: CURRENT_EXECUTION_CONTEXT.get().replace(*self),
+            prev: self.enter_without_restorer(),
         }
     }
 
     /// Enter this context for the current thread, *without* creating a
     /// restorer. Returns the previous context.
     pub fn enter_without_restorer(&self) -> ExecutionContext {
-        CURRENT_EXECUTION_CONTEXT.get().replace(*self)
+        let peeked_prev = CURRENT_EXECUTION_CONTEXT.get().get();
+
+        // Potentially enable/disable preemption, being careful that the current
+        // context is set to shadow when calling other internal functions that
+        // require it.
+        let replaced_prev = match (peeked_prev, *self) {
+            (ExecutionContext::Shadow, ExecutionContext::Application) => {
+                // Call preempt::enable before changing context from shadow, so
+                // that it can access shim state.
+                // SAFETY: We only ever switch threads from the shadow execution
+                // context, and we disable preemption when entering the shadow
+                // execution context, so preemption should be disabled for all
+                // other threads in this process.
+                unsafe { preempt::enable() };
+                CURRENT_EXECUTION_CONTEXT.get().replace(*self)
+            }
+            (ExecutionContext::Application, ExecutionContext::Shadow) => {
+                // Change context to shadow before calling preempt::disable, so
+                // that it can access shim state.
+                let c = CURRENT_EXECUTION_CONTEXT.get().replace(*self);
+                preempt::disable();
+                c
+            }
+            _ => CURRENT_EXECUTION_CONTEXT.get().replace(*self),
+        };
+        // It *shouldn't* be possible for the execution context to have changed
+        // out from under us in between the initial peek and the actual
+        // replacement.
+        assert_eq!(peeked_prev, replaced_prev);
+        peeked_prev
     }
 }
 

--- a/src/lib/shim/src/preempt.rs
+++ b/src/lib/shim/src/preempt.rs
@@ -1,0 +1,206 @@
+//! Native preemption for managed code.
+//!
+//! This module is used to regain control from managed code that would otherwise
+//! run indefinitely (or for a long time) without otherwise returning control to
+//! Shadow. When control is regained in this way, simulated time is moved
+//! forward some amount, and the current thread potentially rescheduled.
+//!
+//! `process_init` should be called once per process, before any other methods are called.
+//!
+//! `enable` should be called to enable preemption for the current thread, and
+//! `disable` to disable preemption for the current thread.
+use linux_api::signal::{SigActionFlags, siginfo_t, sigset_t};
+use log::{debug, trace};
+use shadow_shim_helper_rs::option::FfiOption;
+use shadow_shim_helper_rs::shadow_syscalls::ShadowSyscallNum;
+use shadow_shim_helper_rs::shim_event::ShimEventSyscall;
+use shadow_shim_helper_rs::syscall_types::SyscallArgs;
+
+use crate::ExecutionContext;
+
+// The signal we use for preemption.
+const PREEMPTION_SIGNAL: linux_api::signal::Signal = linux_api::signal::Signal::SIGVTALRM;
+
+extern "C" fn handle_timer_signal(signo: i32, _info: *mut siginfo_t, _ctx: *mut core::ffi::c_void) {
+    let prev = ExecutionContext::Shadow.enter();
+    trace!("Got preemption timer signal.");
+
+    assert_eq!(signo, i32::from(PREEMPTION_SIGNAL));
+
+    if prev.ctx() == ExecutionContext::Shadow {
+        // There's a small chance of us getting here when the timer signal fires
+        // just as we're switching contexts. It's simpler to just ignore it here than
+        // to completely prevent this possibility.
+        trace!("Got timer signal in shadow context. Ignoring.");
+        return;
+    }
+
+    let FfiOption::Some(config) = &crate::global_manager_shmem::get().native_preemption_config
+    else {
+        // Not configured.
+        panic!("Preemption signal handler somehow invoked when it wasn't configured.");
+    };
+
+    // Preemption should be rare. Probably worth at least a debug-level message.
+    debug!(
+        "Native preemption incrementing simulated CPU latency by {:?} after waiting {:?}",
+        config.sim_duration, config.native_duration
+    );
+
+    {
+        // Move simulated time forward.
+        let host = crate::global_host_shmem::get();
+        let mut host_lock = host.protected().lock();
+        host_lock.unapplied_cpu_latency += config.sim_duration;
+    }
+    // Transfer control to shadow, which will handle the time update and potentially
+    // reschedule this thread.
+    //
+    // We *could* try to apply the cpu-latency here and avoid yielding to shadow
+    // if we haven't yet reached the maximum runahead time, as we do in
+    // `shim_sys_handle_syscall_locally`, but in practice `config.sim_duration`
+    // should be large enough that shadow will always choose to reschedule this
+    // thread anyway, so we wouldn't actually get any performance benefit in
+    // exchange for the additional complexity.
+    let syscall_event = ShimEventSyscall {
+        syscall_args: SyscallArgs {
+            number: i64::from(u32::from(ShadowSyscallNum::shadow_yield)),
+            args: [0.into(); 6],
+        },
+    };
+    unsafe { crate::syscall::emulated_syscall_event(None, &syscall_event) };
+}
+
+/// Initialize state for the current native process. This does not yet actually
+/// enable preemption, which is done by calling `enable`.
+pub fn process_init() {
+    debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
+    let FfiOption::Some(_config) = &crate::global_manager_shmem::get().native_preemption_config
+    else {
+        // Not configured.
+        return;
+    };
+
+    let handler = linux_api::signal::SignalHandler::Action(handle_timer_signal);
+    let flags = SigActionFlags::SA_SIGINFO | SigActionFlags::SA_ONSTACK;
+    let mask = sigset_t::EMPTY;
+    let action = linux_api::signal::sigaction::new_with_default_restorer(handler, flags, mask);
+    unsafe { linux_api::signal::rt_sigaction(PREEMPTION_SIGNAL, &action, None).unwrap() };
+}
+
+/// Disable preemption for the current thread.
+pub fn disable() {
+    debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
+    let Some(manager_shmem) = &crate::global_manager_shmem::try_get() else {
+        // Not initialized yet. e.g. we get here the first time we enter the
+        // Shadow execution context, before completing initialization.
+        // In any case, there should be nothing to disable.
+        return;
+    };
+    let FfiOption::Some(_config) = &manager_shmem.native_preemption_config else {
+        // Not configured.
+        return;
+    };
+
+    log::trace!("Disabling preemption");
+
+    // Disable the itimer, effectively discarding any CPU-time we've spent.
+    //
+    // Functionality-wise this isn't *strictly* required for purposes of
+    // supporting cpu-only-busy-loop-escape, since we also block the signal
+    // below. However we currently want to minimize the effects of this feature
+    // on the simulation, and hence don't want to "accumulate" progress towards
+    // the timer firing and then cause regular preemptions even in the absence
+    // of long cpu-only operations.
+    //
+    // Allowing such accumulation is also undesirable since we currently use a
+    // process-wide itimer, with the `ITIMER_VIRTUAL` clock that measures
+    // process-wide CPU time.  Hence time spent running in one thread without
+    // the timer firing would bring *all* threads in that process closer to
+    // firing. That issue *could* be addressed by using `timer_create` timers,
+    // which support a thread-cpu-time clock `CLOCK_THREAD_CPUTIME_ID`.
+    let zero = linux_api::time::kernel_old_timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    };
+    linux_api::time::setitimer(
+        linux_api::time::ITimerId::ITIMER_VIRTUAL,
+        &linux_api::time::kernel_old_itimerval {
+            it_interval: zero,
+            it_value: zero,
+        },
+        None,
+    )
+    .unwrap();
+
+    // Block the timer's signal for this thread.
+    // We're using a process-wide signal, so need to do this to ensure *this*
+    // thread doesn't get awoken if shadow ends up suspending this thread and
+    // running another, and that thread re-enables the timer and has it fire.
+    //
+    // We *could* consider using timers created via `timer_create`, which
+    // supports being configured to fire thread-targeted signals, and thus
+    // wouldn't require us to unblock and re-block the signal when enabling and
+    // disabling. However, we'd probably then want to *destroy* the timer when
+    // disabling, and re-create when enabling, to avoid bumping into the system
+    // limit on the number of such timers (and any potential undocumented
+    // scalability issues with having a large number of such timers). This is
+    // likely to be at least as expensive as blocking and unblocking the signal.
+    linux_api::signal::rt_sigprocmask(
+        linux_api::signal::SigProcMaskAction::SIG_BLOCK,
+        &PREEMPTION_SIGNAL.into(),
+        None,
+    )
+    .unwrap();
+}
+
+/// Enable preemption for the current thread.
+///
+/// # Safety
+///
+/// Preemption must not currently be enabled for any other threads in the current process.
+pub unsafe fn enable() {
+    debug_assert_eq!(ExecutionContext::current(), ExecutionContext::Shadow);
+    let FfiOption::Some(config) = &crate::global_manager_shmem::get().native_preemption_config
+    else {
+        return;
+    };
+    log::trace!(
+        "Enabling preemption with native duration {:?}",
+        config.native_duration
+    );
+    linux_api::time::setitimer(
+        linux_api::time::ITimerId::ITIMER_VIRTUAL,
+        &linux_api::time::kernel_old_itimerval {
+            // We *usually* don't need the timer to repeat, since normally it'll
+            // fire when we're in the managed application context, and the
+            // signal handler will cause the timer to be re-armed after
+            // finishing. However there are some edge cases where the timer can
+            // fire while in the shim context, in which case the signal handler
+            // just returns, and the timer won't be re-armed. We *could*
+            // explicitly re-arm the timer there, but probably more robust to
+            // just have an interval here.
+            it_interval: config.native_duration,
+            it_value: config.native_duration,
+        },
+        None,
+    )
+    .unwrap();
+    // Allow this thread to receive the preemption signal, which we would have
+    // blocked in the last call to `disable`.
+    linux_api::signal::rt_sigprocmask(
+        linux_api::signal::SigProcMaskAction::SIG_UNBLOCK,
+        &PREEMPTION_SIGNAL.into(),
+        None,
+    )
+    .unwrap();
+}
+
+mod export {
+    use super::*;
+
+    #[unsafe(no_mangle)]
+    pub extern "C-unwind" fn preempt_process_init() {
+        process_init();
+    }
+}

--- a/src/lib/shim/src/syscall.rs
+++ b/src/lib/shim/src/syscall.rs
@@ -52,7 +52,7 @@ unsafe fn native_syscall(args: &SyscallArgs) -> SyscallReg {
 /// # Safety
 ///
 /// `ctx` must be valid if provided.
-unsafe fn emulated_syscall_event(
+pub(crate) unsafe fn emulated_syscall_event(
     mut ctx: Option<&mut ucontext>,
     syscall_event: &ShimEventSyscall,
 ) -> SyscallReg {
@@ -70,7 +70,6 @@ unsafe fn emulated_syscall_event(
         log::trace!("waiting for event");
         let res = crate::tls_ipc::with(|ipc| ipc.from_shadow().receive().unwrap());
         log::trace!("got response {res:?}");
-
         match res {
             ShimEventToShim::SyscallComplete(syscall_complete) => {
                 // Shadow has returned a result for the emulated syscall

--- a/src/main/core/manager.rs
+++ b/src/main/core/manager.rs
@@ -17,7 +17,8 @@ use scheduler::thread_per_host::ThreadPerHostSched;
 use scheduler::{HostIter, Scheduler};
 use shadow_shim_helper_rs::HostId;
 use shadow_shim_helper_rs::emulated_time::EmulatedTime;
-use shadow_shim_helper_rs::shim_shmem::ManagerShmem;
+use shadow_shim_helper_rs::option::FfiOption;
+use shadow_shim_helper_rs::shim_shmem::{ManagerShmem, NativePreemptionConfig};
 use shadow_shim_helper_rs::simulation_time::SimulationTime;
 use shadow_shmem::allocator::ShMemBlock;
 
@@ -197,6 +198,14 @@ impl<'a> Manager<'a> {
 
         let shmem = shadow_shmem::allocator::shmalloc(ManagerShmem {
             log_start_time_micros: unsafe { c::logger_get_global_start_time_micros() },
+            native_preemption_config: if config.native_preemption_enabled() {
+                FfiOption::Some(NativePreemptionConfig {
+                    native_duration: config.native_preemption_native_interval()?,
+                    sim_duration: config.native_preemption_sim_interval(),
+                })
+            } else {
+                FfiOption::None
+            },
         });
 
         Ok(Self {

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -269,50 +269,52 @@ impl SyscallHandler {
         }
 
         if ctx.process.is_running() && !matches!(rv, Err(SyscallError::Blocked(_))) {
-            let max_unapplied_cpu_latency = ctx.host.shim_shmem().max_unapplied_cpu_latency;
+            let host_shmem = ctx.host.shim_shmem();
+            let mut host_shmem_prot = ctx.host.shim_shmem_lock_borrow_mut().unwrap();
 
             // increment unblocked syscall latency, but only for non-shadow-syscalls, since the
             // latter are part of Shadow's internal plumbing; they shouldn't necessarily "consume"
             // time
             if ctx.host.shim_shmem().model_unblocked_syscall_latency && !is_shadow_syscall(syscall)
             {
-                ctx.host
-                    .shim_shmem_lock_borrow_mut()
-                    .unwrap()
-                    .unapplied_cpu_latency += ctx.host.shim_shmem().unblocked_syscall_latency;
+                host_shmem_prot.unapplied_cpu_latency += host_shmem.unblocked_syscall_latency;
             }
-
-            let unapplied_cpu_latency = ctx
-                .host
-                .shim_shmem_lock_borrow()
-                .unwrap()
-                .unapplied_cpu_latency;
 
             log::trace!(
                 "Unapplied CPU latency amt={}ns max={}ns",
-                unapplied_cpu_latency.as_nanos(),
-                max_unapplied_cpu_latency.as_nanos()
+                host_shmem_prot.unapplied_cpu_latency.as_nanos(),
+                host_shmem.max_unapplied_cpu_latency.as_nanos()
             );
 
-            if unapplied_cpu_latency > max_unapplied_cpu_latency {
-                let new_time = Worker::current_time().unwrap() + unapplied_cpu_latency;
-                let max_time = Worker::max_event_runahead_time(ctx.host);
-
-                if new_time <= max_time {
-                    log::trace!("Reached unblocked syscall limit; Incrementing time");
-
-                    ctx.host
-                        .shim_shmem_lock_borrow_mut()
-                        .unwrap()
-                        .unapplied_cpu_latency = SimulationTime::ZERO;
+            if host_shmem_prot.unapplied_cpu_latency > host_shmem.max_unapplied_cpu_latency {
+                let new_time = Worker::current_time().unwrap()
+                    + core::mem::replace(
+                        &mut host_shmem_prot.unapplied_cpu_latency,
+                        SimulationTime::ZERO,
+                    );
+                if new_time <= Worker::max_event_runahead_time(ctx.host) {
+                    // The new time is early enough that we can safely just increment to that time.
+                    // i.e. there are no threads or other events scheduled to
+                    // run on this worker before `new_time`.
+                    log::trace!(
+                        "Reached max-unapplied-cpu-latency, but not max runahead; Incrementing time"
+                    );
                     Worker::set_current_time(new_time);
                 } else {
-                    log::trace!("Reached unblocked syscall limit; Yielding");
+                    // We can't safely increment to the new time, e.g. because
+                    // there are other events or the end of the current
+                    // scheduler round scheduled to happen first.  Reschedule
+                    // the current thread to run at the new time instead of
+                    // incrementing it.
+                    log::trace!(
+                        "Reached max-unapplied-cpu-latency, and max runahead; Rescheduling"
+                    );
 
-                    // block instead, but save the result so that we can return it later instead of
-                    // re-executing the syscall
+                    // Save the syscall result so that we can return it later
+                    // instead of re-executing the syscall.
                     assert!(self.pending_result.is_none());
                     self.pending_result = Some(rv);
+
                     rv = Err(SyscallError::new_blocked_until(new_time, false));
                 }
             }

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -268,16 +268,14 @@ impl SyscallHandler {
                 .expect("flushing syscall ptrs");
         }
 
-        if ctx.host.shim_shmem().model_unblocked_syscall_latency
-            && ctx.process.is_running()
-            && !matches!(rv, Err(SyscallError::Blocked(_)))
-        {
+        if ctx.process.is_running() && !matches!(rv, Err(SyscallError::Blocked(_))) {
             let max_unapplied_cpu_latency = ctx.host.shim_shmem().max_unapplied_cpu_latency;
 
             // increment unblocked syscall latency, but only for non-shadow-syscalls, since the
             // latter are part of Shadow's internal plumbing; they shouldn't necessarily "consume"
             // time
-            if !is_shadow_syscall(syscall) {
+            if ctx.host.shim_shmem().model_unblocked_syscall_latency && !is_shadow_syscall(syscall)
+            {
                 ctx.host
                     .shim_shmem_lock_borrow_mut()
                     .unwrap()

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -191,6 +191,10 @@ name = "test_busy_wait"
 path = "regression/test_busy_wait.rs"
 
 [[bin]]
+name = "test_cpu_busy_wait"
+path = "regression/test_cpu_busy_wait.rs"
+
+[[bin]]
 name = "test_itimer"
 path = "time/itimer/test_itimer.rs"
 

--- a/src/test/cli/help-long-expected
+++ b/src/test/cli/help-long-expected
@@ -93,6 +93,23 @@ Experimental (Unstable and may change or be removed at any time, regardless of S
           accumulated-but-unapplied latency is discarded when a thread is blocked on a syscall.
           [default: "1 μs"]
 
+      --native-preemption-enabled <bool>
+          When true, and when managed code runs for an extended time without returning control to
+          shadow (e.g. by making a syscall), shadow preempts the managed code and moves simulated
+          time forward. This can be used to escape "pure-CPU busy-loops", but isn't usually needed,
+          breaks simulation determinism, and significantly affects simulation performance. [default:
+          false]
+
+      --native-preemption-native-interval <seconds>
+          When `native_preemption_enabled` is true, amount of native CPU-time to wait before
+          preempting managed code that hasn't returned control to shadow. Only supports microsecond
+          granularity, and values below 1 microsecond are rejected. [default: "100 ms"]
+
+      --native-preemption-sim-interval <seconds>
+          When `native_preemption_enabled` is true, amount of simulated time to consume after
+          `native_preemption_native_interval` has elapsed without returning control to shadow.
+          [default: "10 ms"]
+
       --report-errors-to-stderr <bool>
           When true, report error-level messages to stderr in addition to logging to stdout.
           [default: true]

--- a/src/test/regression/CMakeLists.txt
+++ b/src/test/regression/CMakeLists.txt
@@ -31,5 +31,14 @@ add_shadow_tests(
       TIMEOUT 5
     )
 
+add_linux_tests(BASENAME cpu_busy_wait COMMAND ../../target/debug/test_cpu_busy_wait)
+add_shadow_tests(
+    BASENAME cpu_busy_wait
+    PROPERTIES
+      # This test should be very fast when it succeeds, but will generally take
+      # the full timeout to fail otherwise.
+      TIMEOUT 5
+    )
+    
 add_subdirectory(2210)
 add_subdirectory(3148)

--- a/src/test/regression/cpu_busy_wait.yaml
+++ b/src/test/regression/cpu_busy_wait.yaml
@@ -1,0 +1,18 @@
+# https://github.com/shadow/shadow/issues/1968
+
+general:
+  stop_time: 15s
+
+experimental:
+  native_preemption_enabled: true
+
+network:
+  graph:
+    type: 1_gbit_switch
+
+hosts:
+  host:
+    network_node_id: 0
+    processes:
+    - path: ../../target/debug/test_cpu_busy_wait
+      start_time: 1s

--- a/src/test/regression/test_busy_wait.rs
+++ b/src/test/regression/test_busy_wait.rs
@@ -32,7 +32,7 @@ fn test_wait_for_rdtsc_timeout() {
 }
 
 // Regression test for https://github.com/shadow/shadow/issues/2681
-fn test_wait_for_other_thread() {
+fn test_wait_for_other_thread_with_inline_sched_yield() {
     let ready_flag = Arc::new(<AtomicBool>::new(false));
     let waiter = {
         let ready_flag = ready_flag.clone();
@@ -52,7 +52,10 @@ fn test_wait_for_other_thread() {
 }
 
 fn main() {
+    println!("test_wait_for_timeout");
     test_wait_for_timeout();
+    println!("test_wait_for_rdtsc_timeout");
     test_wait_for_rdtsc_timeout();
-    test_wait_for_other_thread();
+    println!("test_wait_for_other_thread_with_inline_sched_yield");
+    test_wait_for_other_thread_with_inline_sched_yield();
 }

--- a/src/test/regression/test_cpu_busy_wait.rs
+++ b/src/test/regression/test_cpu_busy_wait.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::time::Duration;
+
+// One thread waits for another thread to modify memory, with the waitee not
+// performing any syscalls. Regression test for
+// <https://github.com/shadow/shadow/issues/2066>.
+fn test_wait_for_other_thread_with_cpu_only_loop() {
+    let ready_flag = Arc::new(<AtomicBool>::new(false));
+    let waiter = {
+        let ready_flag = ready_flag.clone();
+        std::thread::spawn(move || {
+            while !ready_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                // *nothing* here, particularly nothing that would return
+                // control to shadow such as a syscall.
+            }
+        })
+    };
+    let waitee = std::thread::spawn(move || {
+        // Wait long enough to ensure the spawned thread gets a chance to run
+        // and get stuck in its pure-CPU busy loop.
+        std::thread::sleep(Duration::from_millis(1));
+        // Trigger exit condition of the other thread's busy loop.
+        ready_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+    });
+    waiter.join().unwrap();
+    waitee.join().unwrap();
+}
+
+fn main() {
+    println!("test_wait_for_other_thread_with_cpu_only_loop");
+    test_wait_for_other_thread_with_cpu_only_loop();
+}


### PR DESCRIPTION
This new feature is off by default, and enabled via the new experimental `--native-preemption-enabled` option.

When enabled, the shim code uses a native timer to interrupt managed code that runs for longer than `--native-preemption-native-interval` (100 ms by default) without returning control to shadow, and moves simulated time forward by `--native-preemption-sim-interval` (10 ms by default).

It is intended to be used to escape CPU-only busy loops.

Fixes #2066