### PR TITLE
Fix CI failures due to rustup 1.28.0 changes

### DIFF
--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -64,6 +64,10 @@ source "$HOME/.cargo/env"
 # Pin the Rust toolchain to our pinned stable version.
 ln -s ci/rust-toolchain-stable.toml rust-toolchain.toml
 
+# As of rustup 1.28.0 rustup will no longer automatically install the active
+# toolchain if it is not installed, so we need to install it manually.
+rustup toolchain install
+
 # This forces installation of the toolchain required in Shadow's
 # "rust-toolchain.toml" (if this script is run from the shadow directory). When
 # used with Docker, this causes the rust installation to get "baked in" to the


### PR DESCRIPTION
I expect this to fix the failures in our CI and benchmarks.

```text
This is usually done by running one of the following (note the leading DOT):
. "$HOME/.cargo/env"            # For sh/bash/zsh/ash/dash/pdksh
source "$HOME/.cargo/env.fish"  # For fish
source "$HOME/.cargo/env.nu"    # For nushell
info: default host triple is x86_64-unknown-linux-gnu
info: skipping toolchain installation
error: toolchain '1.85-x86_64-unknown-linux-gnu' is not installed
help: run `rustup toolchain install 1.85-x86_64-unknown-linux-gnu` to install it
```

https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html

> The following improvements might require changes to how you use rustup:
> - rustup will no longer automatically install the active toolchain if it is not installed.