### PR TITLE
Drop support for Ubuntu 20.04

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,8 +20,6 @@ jobs:
     strategy:
       matrix:
         container:
-          # End of standard support: April 2025 https://wiki.ubuntu.com/Releases
-          - 'ubuntu:20.04'
           # End of standard support: April 2027 https://wiki.ubuntu.com/Releases
           - 'ubuntu:22.04'
           # End of standard support: June 2029 https://wiki.ubuntu.com/Releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Within the simulation these are treated as fully routable IPs, so are required
 to be unique as with any other IP address assignment. (#3414)
   * Re-added restrictions for broadcast, multicast, and unspecified addresses which Shadow cannot route (#3474)
 * Removed the experimental tracker feature that logged heartbeat messages for every host every second. Also removed the corresponding python scripts for parsing and plotting tracker log messages and data. (#3446)
-* Removed support for Debian 10 (Buster), which has [passed EOL](https://wiki.debian.org/LTS).
+* Removed support for Debian 10 (Buster) and Ubuntu 20.04 (Focal), which have passed EOL. (#3504, #3535)
 * Added a python package `shadowtools` with auxiliary tools. It currently contains a python module for facilitating dynamic generation of shadow config files, and a command-line tool `shadow-exec` for streamlining single-host simulations. (#3449)
 * Improved support for netlink sockets with Go. (#3441)
 * Replaced C DNS module with a Rust implementation. Also removed the C Address type. (#3464)

--- a/ci/container_scripts/build_and_install.sh
+++ b/ci/container_scripts/build_and_install.sh
@@ -9,9 +9,6 @@ gcc)
 clang)
   export CXX="clang++"
   ;;
-clang-12)
-  export CXX="clang++-12"
-  ;;
 *)
   echo "Unknown cc $CC"
   exit 1

--- a/ci/container_scripts/install_extra_deps.sh
+++ b/ci/container_scripts/install_extra_deps.sh
@@ -34,22 +34,6 @@ case "$CC" in
     clang)
         install_packages clang
         ;;
-    clang-12)
-        case "$CONTAINER" in
-            ubuntu:*|debian:*)
-                curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /usr/share/keyrings/llvm-archive-keyring.gpg
-        esac
-        case "$CONTAINER" in
-            ubuntu:20.04)
-                echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main" \
-                  >> /etc/apt/sources.list
-        esac
-        case "$CONTAINER" in
-            ubuntu:*|debian:*)
-                apt-get update
-        esac
-        install_packages clang-12
-        ;;
     *)
         echo "Unhandled cc $CC"
         exit 1

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -4,7 +4,7 @@
 
 We support the following Linux x86-64 distributions:
 
-- Ubuntu 20.04, 22.04, 24.04
+- Ubuntu 22.04, 24.04
 - Debian 11, 12
 - Fedora 40
 
@@ -25,8 +25,8 @@ distribution (the GA kernel). However,
 we are currently only able to regularly test on the latest Ubuntu kernel,
 since that's what GitHub Actions provides.
 
-By these criteria, Shadow's oldest supported kernel version is currently 5.4
-(the GA kernel in Ubuntu 20.04.0).
+By these criteria, Shadow's oldest supported kernel version is currently 5.10
+(the default kernel in Debian 11).
 
 ## Docker
 

--- a/shadowtools/pyproject.toml
+++ b/shadowtools/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "shadowtools"
 version = "0.0.1"
 description = "Libraries and tools for use with the shadow network simulator"
-# Oldest python version on a supported platform (ubuntu 20.04).
-requires-python = ">=3.8.2"
+# Oldest python version on a supported platform (debian 11).
+requires-python = ">=3.9.2"
 # Strings from https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 1 - Planning",


### PR DESCRIPTION
The CI workflow says Ubuntu 20.04 EOL is April 2025, so just queuing up an MR so that we can drop support in April.

We also had some code for installing 'clang-12' in the container scripts. I don't think we need this anymore, so I also dropped that code.