### PR TITLE
Fix a bug with UDP implicit bind after `sendto()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@ to sort out in the case that `stdout` and `stderr` are merged. (#3428)
   vector, fixing (#3539). This improves determinism, especially for golang
   programs (#2693), including tor simulations that include golang programs such
   as the obfs4proxy pluggable transport (#3538). (#3542)
-* Fix the behavior of sockets bound to the loopback interface: Shadow no longer panics in some cases where `connect` and `sendmsg` syscalls are used with a non-loopback address. (#3531)
+* Fixed the behavior of sockets bound to the loopback interface: Shadow no longer panics in some cases where `connect` and `sendmsg` syscalls are used with a non-loopback address. (#3531)
+* Fixed the behaviour of an implicit bind during a `sendmsg` syscall for UDP sockets. (#3545)
 
 Full changelog since v3.2.0:
 

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -338,6 +338,8 @@ impl UdpSocket {
             return Err(Errno::EINVAL.into());
         };
 
+        // TODO: If we have a peer AND a destination address is provided, should we use the peer or
+        // the destination address? Do we have a test for this?
         let dst_addr = match args.addr {
             Some(addr) => match addr.as_inet() {
                 // an inet socket address
@@ -389,13 +391,8 @@ impl UdpSocket {
             assert!(socket_ref.peer_addr.is_none());
             assert!(socket_ref.association.is_none());
 
-            // implicit bind (use default interface unless the remote peer is on loopback)
-            // TODO: is this correct? or should we bind to UNSPECIFIED?
-            let local_addr = if dst_addr.ip() == &std::net::Ipv4Addr::LOCALHOST {
-                SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)
-            } else {
-                SocketAddrV4::new(net_ns.default_ip, 0)
-            };
+            // implicit bind to 0.0.0.0
+            let local_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
 
             // this will allow us to receive packets from any peer
             let unspecified_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);


### PR DESCRIPTION
Previously a UDP socket that called `sendto()` would be implicitly bound to an address on the same interface. So sending to 127.0.0.1 would cause the socket to be bound to 127.0.0.1. Sending to 1.2.3.4 would cause the socket to be bound to the public IP address of the host.

This PR fixes the behaviour so that regardless of the address used with `sendto()`, the socket will always be bound to 0.0.0.0.

This, along with #3531, should fix #3526.