### PR TITLE
Add better error logging to `test_siocgstamp` socket test

### DIFF
--- a/src/test/socket/ioctl/test_ioctl.rs
+++ b/src/test/socket/ioctl/test_ioctl.rs
@@ -303,7 +303,11 @@ fn test_siocgstamp(init_method: SocketInitMethod, sock_type: libc::c_int) -> Res
 
                 // since it was sent over localhost, the difference between the send time and
                 // receive time should be very small
-                test_utils::result_assert(difference < threshold, "Time difference was too large")?;
+                test_utils::result_assert_lt(
+                    difference,
+                    threshold,
+                    "Time difference was too large",
+                )?;
             }
             Some(e) => test_utils::result_assert_eq(
                 ioctl_siocgstamp(fd_peer),

--- a/src/test/test_utils.rs
+++ b/src/test/test_utils.rs
@@ -157,6 +157,30 @@ where
     }
 }
 
+/// Return a formatted error message if `a < b` is not true.
+pub fn result_assert_lt<T>(a: T, b: T, message: &str) -> Result<(), String>
+where
+    T: std::fmt::Debug + std::cmp::PartialOrd,
+{
+    if a < b {
+        Ok(())
+    } else {
+        Err(format!("!({:?} < {:?}) -- {}", a, b, message))
+    }
+}
+
+/// Return a formatted error message if `a > b` is not true.
+pub fn result_assert_gt<T>(a: T, b: T, message: &str) -> Result<(), String>
+where
+    T: std::fmt::Debug + std::cmp::PartialOrd,
+{
+    if a > b {
+        Ok(())
+    } else {
+        Err(format!("!({:?} > {:?}) -- {}", a, b, message))
+    }
+}
+
 /// Run the function and then close any given file descriptors, even if there was an error.
 pub fn run_and_close_fds<'a, I, F, U>(fds: I, f: F) -> U
 where


### PR DESCRIPTION
Just outputs some extra info if the test fails.

Related: #3546