### PR TITLE
Remove duplicate "Profiling" page from book

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -36,7 +36,6 @@
 - [Developer Guide]()
     - [Coding](coding.md)
     - [Debugging](debugging.md)
-    - [Profiling](profiling.md)
     - [Testing for Nondeterminism](testing_determinism.md)
     - [Extra Tests](extra_tests.md)
     - [Continuous integration tests](ci.md)


### PR DESCRIPTION
This duplicate causes mdbook to fail as of version 0.4.48.

We can remove it from either the "Performance Tuning" section, or the "Developer Guide" section. I removed it from the "Developer Guide" section, but don't have a preference. If anyone would like the other removed instead, let me know.

```text
Error: -01 01:03:04 [ERROR] (mdbook::utils): Error: Summary parsing failed for file="/home/runner/work/docs/docs/shadow/mdbook/../docs/SUMMARY.md"
Error: -01 01:03:04 [ERROR] (mdbook::utils): 	Caused By: Duplicate file in SUMMARY.md: "profiling.md"
Error: Process completed with exit code 101.
```

https://github.com/shadow/docs/actions/runs/14184634206/job/39737649175