### PR TITLE
Fix the test for getauxval when the type is not found

### DIFF
--- a/src/lib/shim/src/reinit_auxvec_random.rs
+++ b/src/lib/shim/src/reinit_auxvec_random.rs
@@ -97,9 +97,18 @@ mod test {
         assert_eq!(super::getauxval(AuxVecTag::AT_RANDOM).unwrap(), unsafe {
             libc::getauxval(libc::AT_RANDOM)
         });
-        assert_eq!(
-            super::getauxval(AuxVecTag::AT_MINSIGSTKSZ).unwrap(),
-            unsafe { libc::getauxval(libc::AT_MINSIGSTKSZ) }
-        );
+        for value in 0..100 {
+            if value == libc::AT_HWCAP || value == libc::AT_HWCAP2 {
+                // libc handles AT_HWCAP and AT_HWCAP2 differently
+                continue;
+            }
+            if let Ok(tag) = AuxVecTag::try_from(value) {
+                assert_eq!(
+                    super::getauxval(tag).unwrap_or(0),
+                    unsafe { libc::getauxval(value) },
+                    "value mismatch for type {tag:?}",
+                );
+            }
+        }
     }
 }

--- a/src/lib/shim/src/reinit_auxvec_random.rs
+++ b/src/lib/shim/src/reinit_auxvec_random.rs
@@ -94,21 +94,43 @@ mod test {
     #[cfg(not(miri))]
     fn test_getauxvec() {
         // Test consistency with libc
-        assert_eq!(super::getauxval(AuxVecTag::AT_RANDOM).unwrap(), unsafe {
-            libc::getauxval(libc::AT_RANDOM)
-        });
-        for value in 0..100 {
-            if value == libc::AT_HWCAP || value == libc::AT_HWCAP2 {
-                // libc handles AT_HWCAP and AT_HWCAP2 differently
-                continue;
-            }
-            if let Ok(tag) = AuxVecTag::try_from(value) {
-                assert_eq!(
-                    super::getauxval(tag).unwrap_or(0),
-                    unsafe { libc::getauxval(value) },
-                    "value mismatch for type {tag:?}",
-                );
-            }
+        let tags = [
+            (AuxVecTag::AT_NULL, libc::AT_NULL),
+            (AuxVecTag::AT_IGNORE, libc::AT_IGNORE),
+            (AuxVecTag::AT_EXECFD, libc::AT_EXECFD),
+            (AuxVecTag::AT_PHDR, libc::AT_PHDR),
+            (AuxVecTag::AT_PHENT, libc::AT_PHENT),
+            (AuxVecTag::AT_PHNUM, libc::AT_PHNUM),
+            (AuxVecTag::AT_PAGESZ, libc::AT_PAGESZ),
+            (AuxVecTag::AT_BASE, libc::AT_BASE),
+            (AuxVecTag::AT_FLAGS, libc::AT_FLAGS),
+            (AuxVecTag::AT_ENTRY, libc::AT_ENTRY),
+            (AuxVecTag::AT_NOTELF, libc::AT_NOTELF),
+            (AuxVecTag::AT_UID, libc::AT_UID),
+            (AuxVecTag::AT_EUID, libc::AT_EUID),
+            (AuxVecTag::AT_GID, libc::AT_GID),
+            (AuxVecTag::AT_EGID, libc::AT_EGID),
+            (AuxVecTag::AT_PLATFORM, libc::AT_PLATFORM),
+            // libc doesn't return the raw value: (AuxVecTag::AT_HWCAP, libc::AT_HWCAP),
+            (AuxVecTag::AT_CLKTCK, libc::AT_CLKTCK),
+            (AuxVecTag::AT_SECURE, libc::AT_SECURE),
+            (AuxVecTag::AT_BASE_PLATFORM, libc::AT_BASE_PLATFORM),
+            (AuxVecTag::AT_RANDOM, libc::AT_RANDOM),
+            (AuxVecTag::AT_HWCAP2, libc::AT_HWCAP2),
+            // No libc constant: (AuxVecTag::AT_RSEQ_FEATURE_SIZE, libc::AT_RSEQ_FEATURE_SIZE),
+            // No libc constant: (AuxVecTag::AT_RSEQ_ALIGN, libc::AT_RSEQ_ALIGN),
+            // No libc constant: (AuxVecTag::AT_HWCAP3, libc::AT_HWCAP3),
+            // No libc constant: (AuxVecTag::AT_HWCAP4, libc::AT_HWCAP4),
+            (AuxVecTag::AT_EXECFN, libc::AT_EXECFN),
+            (AuxVecTag::AT_MINSIGSTKSZ, libc::AT_MINSIGSTKSZ),
+        ];
+        for (linux_tag, libc_tag) in tags {
+            assert_eq!(
+                // libc returns 0 for tags that aren't present in the auxvec
+                super::getauxval(linux_tag).unwrap_or(0),
+                unsafe { libc::getauxval(libc_tag) },
+                "value mismatch for type {linux_tag:?}",
+            );
         }
     }
 }


### PR DESCRIPTION
`AT_MINSIGSTKSZ` is not available for amd64 until Linux 5.14 ([source](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1c33bb0507508af24fd754dd7123bd8e997fab2f)), so this test will fail on earlier kernel versions.

https://github.com/shadow/shadow/blob/c7976835f8cb183de76ede64155d0a3b4009eb68/src/lib/shim/src/reinit_auxvec_random.rs#L99-L104


```
test tls::test::test_multithread_mutate_mixed_alignments ... ok
test tls::test::test_multithread_mutate_small_alignment ... ok

failures:

---- reinit_auxvec_random::test::test_getauxvec stdout ----

thread 'reinit_auxvec_random::test::test_getauxvec' panicked at lib/shim/src/reinit_auxvec_random.rs:101:57:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    reinit_auxvec_random::test::test_getauxvec
```

This PR simply sets 0 as the default value when the type is not found (see man `getauxval(3)`), and adds additional tests to cover all auxiliary vector types.