### PR TITLE
Fix packet order of FIN from `SHUT_WR`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ to sort out in the case that `stdout` and `stderr` are merged. (#3428)
   as the obfs4proxy pluggable transport (#3538). (#3542)
 * Fixed the behavior of sockets bound to the loopback interface: Shadow no longer panics in some cases where `connect` and `sendmsg` syscalls are used with a non-loopback address. (#3531)
 * Fixed the behaviour of an implicit bind during a `sendmsg` syscall for UDP sockets. (#3545)
+* Fixed a bug in `shutdown()` for TCP sockets, causing the FIN packet to be sent out of order. (#3562)
 
 Full changelog since v3.2.0:
 

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -914,9 +914,11 @@ static Packet* _tcp_createPacketWithoutPayload(TCP* tcp, const Host* host, Proto
     gboolean isFinNotAck = ((flags & PTCP_FIN) && !(flags & PTCP_ACK));
     guint sequence = !isEmpty || isFinNotAck || (flags & PTCP_SYN) ? tcp->send.next : 0;
 
-    /* empty (control) packets get priority 0, data packets get the next priority sequence. */
+    /* control packets get priority 0, data packets get the next priority sequence. */
+    /* we want to make sure any packets with a sequence number get a priority, so that packets with
+     * a higher sequence number are not sent before other packets with a lower sequence nubmer. */
     uint64_t priority = 0;
-    if (!isEmpty) {
+    if (sequence != 0) {
         priority = host_getNextPacketPriority(host);
     }
 

--- a/src/test/regression/3100/CMakeLists.txt
+++ b/src/test/regression/3100/CMakeLists.txt
@@ -1,0 +1,2 @@
+# regression test for https://github.com/shadow/shadow/issues/3100
+add_shadow_tests(BASENAME regression-3100)

--- a/src/test/regression/3100/regression-3100.yaml
+++ b/src/test/regression/3100/regression-3100.yaml
@@ -1,0 +1,53 @@
+general:
+  stop_time: 10 seconds
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  server:
+    network_node_id: 0
+    processes:
+    - path: python3
+      args:
+        - '-u'
+        - '-c'
+        - |
+          import socket
+          server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+          server.bind(('0.0.0.0', 8080))
+          server.listen(100)
+          (s, _) = server.accept()
+          server.close()
+          print("Accepted socket")
+
+          bytes = s.recv(1)
+          print("First recv:", bytes)
+          assert bytes == b'0', str(bytes)
+
+          # expect that the client's SHUT_WR will send a FIN, so we should receive an EOF
+          bytes = s.recv(1)
+          print("Second recv:", bytes)
+          assert bytes == b'', str(bytes)
+          s.close()
+  client:
+    network_node_id: 0
+    processes:
+    - path: python3
+      start_time: 100 ms
+      expected_final_state: running
+      args:
+        - '-u'
+        - '-c'
+        - |
+          import socket, time
+          s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+          s.connect(('server', 8080))
+          print("Connected")
+
+          s.send(b'0')
+          s.shutdown(socket.SHUT_WR)
+
+          # don't close the socket, we want to keep the socket open until the
+          # end of the simulation so that closing the socket doesn't send a FIN
+          print("Sleeping")
+          time.sleep(100000)

--- a/src/test/regression/CMakeLists.txt
+++ b/src/test/regression/CMakeLists.txt
@@ -41,4 +41,5 @@ add_shadow_tests(
     )
     
 add_subdirectory(2210)
+add_subdirectory(3100)
 add_subdirectory(3148)


### PR DESCRIPTION
Shadow assigns a priority to packets, and packets with a lower priority will be sent before other packets. Previously, shadow only assigned a priority to non-empty packets (here meaning containing a payload), and a priority of 0 to other packets. But this meant that empty packets like FIN (with a priority of 0) could be sent before other packets, even if the FIN had a higher sequence number. Shadow seems to have discarded these out-of-order FIN packets. See #3100 for an example.

This MR changes the legacy TCP code to always assign a non-zero priority if the packets has a sequence number, so that they won't be sent out of order. This (**edit:** partially; see https://github.com/shadow/shadow/issues/3100#issuecomment-2823009618) fixes (**edit:** \<text to prevent github from closing the linked issue\>) #3100, but there are still a lot of other shutdown-related bugs (see all the disabled tests in `src/test/socket/shutdown/test_shutdown.rs`), so `shutdown()` still won't work 100% as expected.

Related: #3558 (I think this MR fixes this shutdown issue as well, but it looks like there are still some other issues.)