### PR TITLE
test EOF behavior and fix missing EPOLLRDHUP events for TCP sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ to sort out in the case that `stdout` and `stderr` are merged. (#3428)
 * Fixed the behavior of sockets bound to the loopback interface: Shadow no longer panics in some cases where `connect` and `sendmsg` syscalls are used with a non-loopback address. (#3531)
 * Fixed the behaviour of an implicit bind during a `sendmsg` syscall for UDP sockets. (#3545)
 * Fixed a TCP socket bug causing the FIN packet to be sent out of order. (#3562, #3570)
+* Fixed (lack of) `EPOLLRDHUP` reporting in `epoll` for TCP sockets (#3574), which in turn
+fixes network connections sometimes trying to read indefinitely after the other
+end has closed the connection in Rust's tokio async runtime (as in
+https://gitlab.torproject.org/tpo/core/arti/-/issues/1972).
 
 Full changelog since v3.2.0:
 

--- a/src/main/host/descriptor/epoll/entry.rs
+++ b/src/main/host/descriptor/epoll/entry.rs
@@ -176,6 +176,9 @@ impl Entry {
         if state.intersects(FileState::WRITABLE) {
             events.insert(EpollEvents::EPOLLOUT);
         }
+        if state.intersects(FileState::RDHUP) {
+            events.insert(EpollEvents::EPOLLRDHUP);
+        }
 
         events
     }
@@ -188,6 +191,9 @@ impl Entry {
         }
         if events.intersects(EpollEvents::EPOLLOUT) {
             state.insert(FileState::WRITABLE)
+        }
+        if events.intersects(EpollEvents::EPOLLRDHUP) {
+            state.insert(FileState::RDHUP)
         }
 
         state

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -136,6 +136,9 @@ bitflags::bitflags! {
         /// A listening socket is allowing connections. Only applicable to connection-oriented unix
         /// sockets.
         const SOCKET_ALLOWING_CONNECT = 1 << 6;
+        /// "read hangup" - Stream socket peer has shut down connection for
+        /// writing (or completely closed it), as for EPOLLRDHUP.
+        const RDHUP = 1 << 7;
     }
 }
 

--- a/src/main/host/descriptor/tcp.c
+++ b/src/main/host/descriptor/tcp.c
@@ -2086,6 +2086,7 @@ static void _tcp_processPacket(LegacySocket* socket, const Host* host, Packet* p
         if(!(tcp->state & TCPS_LISTEN) && !(tcp->error & TCPE_CONNECTION_RESET)) {
             tcp->error |= TCPE_CONNECTION_RESET;
             tcp->flags |= TCPF_REMOTE_CLOSED;
+            legacyfile_adjustStatus((LegacyFile*)tcp, FileState_RDHUP, TRUE, 0);
 
             _tcp_setState(tcp, host, TCPS_TIMEWAIT);
 
@@ -2234,6 +2235,7 @@ static void _tcp_processPacket(LegacySocket* socket, const Host* host, Packet* p
 
                 /* other side of connection closed */
                 tcp->flags |= TCPF_REMOTE_CLOSED;
+                legacyfile_adjustStatus((LegacyFile*)tcp, FileState_RDHUP, TRUE, 0);
                 responseFlags |= (PTCP_FIN|PTCP_ACK);
                 _tcp_setState(tcp, host, TCPS_CLOSEWAIT);
 
@@ -2254,6 +2256,7 @@ static void _tcp_processPacket(LegacySocket* socket, const Host* host, Packet* p
                 flags |= TCP_PF_PROCESSED;
                 responseFlags |= (PTCP_FIN|PTCP_ACK);
                 tcp->flags |= TCPF_REMOTE_CLOSED;
+                legacyfile_adjustStatus((LegacyFile*)tcp, FileState_RDHUP, TRUE, 0);
                 _tcp_setState(tcp, host, TCPS_CLOSING);
 
                 /* it will send no more user data after this sequence */
@@ -2268,6 +2271,7 @@ static void _tcp_processPacket(LegacySocket* socket, const Host* host, Packet* p
                 flags |= TCP_PF_PROCESSED;
                 responseFlags |= (PTCP_FIN|PTCP_ACK);
                 tcp->flags |= TCPF_REMOTE_CLOSED;
+                legacyfile_adjustStatus((LegacyFile*)tcp, FileState_RDHUP, TRUE, 0);
                 _tcp_setState(tcp, host, TCPS_TIMEWAIT);
 
                 /* it will send no more user data after this sequence */

--- a/src/test/epoll/epoll-rs.yaml
+++ b/src/test/epoll/epoll-rs.yaml
@@ -8,3 +8,4 @@ hosts:
     network_node_id: 0
     processes:
     - path: ../../target/debug/test_epoll
+      args: --shadow-passing

--- a/src/test/epoll/test_epoll.rs
+++ b/src/test/epoll/test_epoll.rs
@@ -75,7 +75,7 @@ fn test_threads_edge() -> anyhow::Result<()> {
 
         // One of the threads should have gotten an event, but we don't know which one.
         // Sort results by number of events received.
-        results.sort_by(|lhs, rhs| lhs.events.len().cmp(&rhs.events.len()));
+        results.sort_by_key(|x| x.events.len());
 
         // One thread should have timed out with no events received.
         ensure_ord!(results[0].epoll_res, ==, Ok(0));
@@ -184,7 +184,7 @@ fn test_threads_eof(
         // With edge-triggering, only one of the threads should have gotten an
         // event, but we don't know which one.  Sort results by number of events
         // received.
-        results.sort_by(|lhs, rhs| lhs.events.len().cmp(&rhs.events.len()));
+        results.sort_by_key(|x| x.events.len());
 
         let expected_mask = match (fd_type, use_rdhup, make_readable) {
             (FdType::Pipe, _, MakeReadable::Yes) => EpollFlags::EPOLLHUP | EpollFlags::EPOLLIN,
@@ -297,7 +297,7 @@ fn test_threads_level_with_late_read() -> anyhow::Result<()> {
 
         // One of the threads should have gotten an event, but we don't know which one.
         // Sort results by number of events received.
-        results.sort_by(|lhs, rhs| lhs.events.len().cmp(&rhs.events.len()));
+        results.sort_by_key(|x| x.events.len());
 
         // One thread should have timed out with no events received.
         ensure_ord!(results[0].epoll_res, ==, Ok(0));

--- a/src/test/epoll/test_epoll.rs
+++ b/src/test/epoll/test_epoll.rs
@@ -1,3 +1,4 @@
+use std::os::fd::IntoRawFd;
 use std::time::Duration;
 
 use nix::errno::Errno;
@@ -85,6 +86,133 @@ fn test_threads_edge() -> anyhow::Result<()> {
         ensure_ord!(results[1].duration, <, timeout);
         ensure_ord!(results[1].events[0], ==, epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0));
 
+        Ok(())
+    })
+}
+
+#[derive(Copy, Clone, Debug)]
+enum UseEPOLLET {
+    Yes,
+    No,
+}
+
+#[derive(Copy, Clone, Debug)]
+enum UseEPOLLRDHUP {
+    Yes,
+    No,
+}
+
+#[derive(Copy, Clone, Debug)]
+enum MakeReadable {
+    Yes,
+    No,
+}
+
+#[derive(Copy, Clone, Debug)]
+enum FdType {
+    Pipe,
+    TcpStream,
+}
+
+// Test various combination of behavior when EOF is reached.
+// Notably, the Rust async runtime tokio seems to rely on receiving EPOLLRDHUP for sockets.
+fn test_threads_eof(
+    use_edge: UseEPOLLET,
+    use_rdhup: UseEPOLLRDHUP,
+    make_readable: MakeReadable,
+    fd_type: FdType,
+) -> anyhow::Result<()> {
+    let (readfd, writefd) = match fd_type {
+        FdType::Pipe => {
+            let (readfd, writefd) = unistd::pipe()?;
+            (readfd, writefd)
+        }
+        FdType::TcpStream => {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let client = std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+            let server = listener.accept().unwrap();
+            (client.into_raw_fd(), server.0.into_raw_fd())
+        }
+    };
+
+    let epollfd = epoll::epoll_create()?;
+
+    test_utils::run_and_close_fds(&[epollfd, readfd], || {
+        // We don't need to subscribe to EPOLLHUP; those events should
+        // be generated regardless.
+        // from epoll_ctl(2):
+        // > epoll_wait(2) will always wait for this event; it is not necessary
+        // > to set it in events when calling epoll_ctl().
+        let mut events = EpollFlags::EPOLLIN;
+        match use_rdhup {
+            UseEPOLLRDHUP::Yes => events |= EpollFlags::EPOLLRDHUP,
+            UseEPOLLRDHUP::No => (),
+        };
+        match use_edge {
+            UseEPOLLET::Yes => events |= EpollFlags::EPOLLET,
+            UseEPOLLET::No => (),
+        };
+        let mut event = epoll::EpollEvent::new(events, 0);
+        epoll::epoll_ctl(
+            epollfd,
+            epoll::EpollOp::EpollCtlAdd,
+            readfd,
+            Some(&mut event),
+        )?;
+
+        // We do the close and (optional) write *before* calling epoll_wait to
+        // be sure that the result has both events (when we do the optional
+        // write).
+
+        // Optionally make the read-end readable.
+        match make_readable {
+            MakeReadable::Yes => {
+                unistd::write(writefd, &[0])?;
+            }
+            MakeReadable::No => {}
+        }
+        unistd::close(writefd)?;
+
+        let timeout = Duration::from_millis(100);
+        let threads = [
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
+        ];
+
+        let mut results = threads.map(|t| t.join().unwrap());
+
+        // With edge-triggering, only one of the threads should have gotten an
+        // event, but we don't know which one.  Sort results by number of events
+        // received.
+        results.sort_by(|lhs, rhs| lhs.events.len().cmp(&rhs.events.len()));
+
+        let expected_mask = match (fd_type, use_rdhup, make_readable) {
+            (FdType::Pipe, _, MakeReadable::Yes) => EpollFlags::EPOLLHUP | EpollFlags::EPOLLIN,
+            (FdType::Pipe, _, MakeReadable::No) => EpollFlags::EPOLLHUP,
+            (FdType::TcpStream, UseEPOLLRDHUP::Yes, _) => {
+                EpollFlags::EPOLLRDHUP | EpollFlags::EPOLLIN
+            }
+            (FdType::TcpStream, UseEPOLLRDHUP::No, _) => EpollFlags::EPOLLIN,
+        };
+
+        match use_edge {
+            UseEPOLLET::No => {
+                // Both threads get the event
+                ensure_ord!(results[0].epoll_res, ==, Ok(1));
+                ensure_ord!(results[0].duration, <, timeout);
+                ensure_ord!(results[0].events[0], ==, epoll::EpollEvent::new(expected_mask, 0));
+            }
+            UseEPOLLET::Yes => {
+                // One thread should have timed out with no events received.
+                ensure_ord!(results[0].epoll_res, ==, Ok(0));
+                ensure_ord!(results[0].duration, >=, timeout);
+            }
+        }
+
+        // The other should have gotten a single event.
+        ensure_ord!(results[1].epoll_res, ==, Ok(1));
+        ensure_ord!(results[1].duration, <, timeout);
+        ensure_ord!(results[1].events[0], ==, epoll::EpollEvent::new(expected_mask, 0));
         Ok(())
     })
 }
@@ -356,9 +484,25 @@ fn main() -> anyhow::Result<()> {
             test_wait_negative_timeout,
             all_envs.clone(),
         ),
-        ShadowTest::new("test_ctl_invalid_op", test_ctl_invalid_op, all_envs),
+        ShadowTest::new("test_ctl_invalid_op", test_ctl_invalid_op, all_envs.clone()),
     ];
-
+    for use_edge in [UseEPOLLET::Yes, UseEPOLLET::No] {
+        for use_rdhup in [UseEPOLLRDHUP::Yes, UseEPOLLRDHUP::No] {
+            for make_readable in [MakeReadable::Yes, MakeReadable::No] {
+                for fd_type in [FdType::Pipe, FdType::TcpStream] {
+                    let passing = match (fd_type, use_rdhup) {
+                        (FdType::TcpStream, UseEPOLLRDHUP::No) => all_envs.clone(),
+                        _ => set![TestEnvironment::Libc],
+                    };
+                    tests.push(ShadowTest::new(
+                        &format!("threads-eof-edge:{use_edge:?}-rdhup:{use_rdhup:?}-readable:{make_readable:?}-type:{fd_type:?}"),
+                        move || test_threads_eof(use_edge, use_rdhup, make_readable, fd_type),
+                        passing,
+                    ));
+                }
+            }
+        }
+    }
     if filter_shadow_passing {
         tests.retain(|x| x.passing(TestEnvironment::Shadow));
     }

--- a/src/test/epoll/test_epoll.rs
+++ b/src/test/epoll/test_epoll.rs
@@ -490,9 +490,11 @@ fn main() -> anyhow::Result<()> {
         for use_rdhup in [UseEPOLLRDHUP::Yes, UseEPOLLRDHUP::No] {
             for make_readable in [MakeReadable::Yes, MakeReadable::No] {
                 for fd_type in [FdType::Pipe, FdType::TcpStream] {
-                    let passing = match (fd_type, use_rdhup) {
-                        (FdType::TcpStream, UseEPOLLRDHUP::No) => all_envs.clone(),
-                        _ => set![TestEnvironment::Libc],
+                    let passing = match fd_type {
+                        FdType::TcpStream => all_envs.clone(),
+                        // pipes should get EPOLLHUP events but these aren't implemented.
+                        // https://github.com/shadow/shadow/issues/2181
+                        FdType::Pipe => set![TestEnvironment::Libc],
                     };
                     tests.push(ShadowTest::new(
                         &format!("threads-eof-edge:{use_edge:?}-rdhup:{use_rdhup:?}-readable:{make_readable:?}-type:{fd_type:?}"),


### PR DESCRIPTION
While debugging
https://gitlab.torproject.org/tpo/core/arti/-/issues/1972, it became apparent that the tokio runtime seems to rely on EPOLLRDHUP to know when a socket is closed, at least in some circumstances.

This adds tests for this and several variations of EOF behavior.

A second commit adds EPOLLRDHUP support for TCP sockets and enables running the corresponding tests under shadow.