### PR TITLE
Fix faccessat and add faccessat2

### DIFF
--- a/src/main/host/syscall/handler/fileat.c
+++ b/src/main/host/syscall/handler/fileat.c
@@ -297,7 +297,7 @@ SyscallReturn syscallhandler_utimensat(SyscallHandler* sys, const SyscallArgs* a
         regularfile_utimensat(dir_desc, pathname, times, flags, plugin_cwd));
 }
 
-SyscallReturn syscallhandler_faccessat(SyscallHandler* sys, const SyscallArgs* args) {
+SyscallReturn syscallhandler_faccessat2(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
     int mode = args->args[2].as_i64;

--- a/src/main/host/syscall/handler/fileat.c
+++ b/src/main/host/syscall/handler/fileat.c
@@ -297,6 +297,27 @@ SyscallReturn syscallhandler_utimensat(SyscallHandler* sys, const SyscallArgs* a
         regularfile_utimensat(dir_desc, pathname, times, flags, plugin_cwd));
 }
 
+SyscallReturn syscallhandler_faccessat(SyscallHandler* sys, const SyscallArgs* args) {
+    int dirfd = args->args[0].as_i64;
+    UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*
+    int mode = args->args[2].as_i64;
+
+    /* Validate params. */
+    RegularFile* dir_desc = NULL;
+    const char* pathname;
+
+    int errcode = _syscallhandler_validateDirAndPathnameHelper(
+        sys, dirfd, pathnamePtr, &dir_desc, &pathname);
+    if (errcode < 0) {
+        return syscallreturn_makeDoneErrno(-errcode);
+    }
+
+    const char* plugin_cwd = process_getWorkingDir(rustsyscallhandler_getProcess(sys));
+
+    return syscallreturn_makeDoneI64(
+        regularfile_faccessat(dir_desc, pathname, mode, 0, plugin_cwd));
+}
+
 SyscallReturn syscallhandler_faccessat2(SyscallHandler* sys, const SyscallArgs* args) {
     int dirfd = args->args[0].as_i64;
     UntypedForeignPtr pathnamePtr = args->args[1].as_ptr; // const char*

--- a/src/main/host/syscall/handler/fileat.h
+++ b/src/main/host/syscall/handler/fileat.h
@@ -8,7 +8,7 @@
 
 #include "main/host/syscall/protected.h"
 
-SYSCALL_HANDLER(faccessat);
+SYSCALL_HANDLER(faccessat2);
 SYSCALL_HANDLER(fchmodat);
 SYSCALL_HANDLER(fchmodat2);
 SYSCALL_HANDLER(fchownat);

--- a/src/main/host/syscall/handler/fileat.h
+++ b/src/main/host/syscall/handler/fileat.h
@@ -8,6 +8,7 @@
 
 #include "main/host/syscall/protected.h"
 
+SYSCALL_HANDLER(faccessat);
 SYSCALL_HANDLER(faccessat2);
 SYSCALL_HANDLER(fchmodat);
 SYSCALL_HANDLER(fchmodat2);

--- a/src/main/host/syscall/handler/fileat.rs
+++ b/src/main/host/syscall/handler/fileat.rs
@@ -25,9 +25,9 @@ impl SyscallHandler {
         Self::legacy_syscall(cshadow::syscallhandler_openat, ctx)
     }
 
-    log_syscall!(faccessat, /* rv */ std::ffi::c_int);
-    pub fn faccessat(ctx: &mut SyscallContext) -> SyscallResult {
-        Self::legacy_syscall(cshadow::syscallhandler_faccessat, ctx)
+    log_syscall!(faccessat2, /* rv */ std::ffi::c_int);
+    pub fn faccessat2(ctx: &mut SyscallContext) -> SyscallResult {
+        Self::legacy_syscall(cshadow::syscallhandler_faccessat2, ctx)
     }
 
     log_syscall!(fchmodat, /* rv */ std::ffi::c_int);

--- a/src/main/host/syscall/handler/fileat.rs
+++ b/src/main/host/syscall/handler/fileat.rs
@@ -25,6 +25,11 @@ impl SyscallHandler {
         Self::legacy_syscall(cshadow::syscallhandler_openat, ctx)
     }
 
+    log_syscall!(faccessat, /* rv */ std::ffi::c_int);
+    pub fn faccessat(ctx: &mut SyscallContext) -> SyscallResult {
+        Self::legacy_syscall(cshadow::syscallhandler_faccessat, ctx)
+    }
+
     log_syscall!(faccessat2, /* rv */ std::ffi::c_int);
     pub fn faccessat2(ctx: &mut SyscallContext) -> SyscallResult {
         Self::legacy_syscall(cshadow::syscallhandler_faccessat2, ctx)

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -398,7 +398,7 @@ impl SyscallHandler {
             SyscallNum::NR_execve => handle!(execve),
             SyscallNum::NR_execveat => handle!(execveat),
             SyscallNum::NR_exit_group => handle!(exit_group),
-            SyscallNum::NR_faccessat => handle!(faccessat),
+            SyscallNum::NR_faccessat2 => handle!(faccessat2),
             SyscallNum::NR_fadvise64 => handle!(fadvise64),
             SyscallNum::NR_fallocate => handle!(fallocate),
             SyscallNum::NR_fchmod => handle!(fchmod),

--- a/src/main/host/syscall/handler/mod.rs
+++ b/src/main/host/syscall/handler/mod.rs
@@ -398,6 +398,7 @@ impl SyscallHandler {
             SyscallNum::NR_execve => handle!(execve),
             SyscallNum::NR_execveat => handle!(execveat),
             SyscallNum::NR_exit_group => handle!(exit_group),
+            SyscallNum::NR_faccessat => handle!(faccessat),
             SyscallNum::NR_faccessat2 => handle!(faccessat2),
             SyscallNum::NR_fadvise64 => handle!(fadvise64),
             SyscallNum::NR_fallocate => handle!(fallocate),

--- a/src/test/file/CMakeLists.txt
+++ b/src/test/file/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories(${GLIB_INCLUDE_DIRS})
 link_libraries(${GLIB_LIBRARIES})
-add_executable(test-file test_file.c)
+add_executable(test-file test_file.c ../test_common.c)
 add_linux_tests(BASENAME file COMMAND test-file)
 add_shadow_tests(BASENAME file)


### PR DESCRIPTION
Our `faccessat` handler incorrectly took an extra flags parameter, which was garbage data. This led to a heisenbug in chutney shell scripts, since sometimes the corresponding register would happen to have 0 and work, but sometimes it would have garbage data and cause the syscall to return an error.

This renames the old handler to `faccessat2`, which *does* take the flags parameter, and adds `faccessat`, which doesn't.
