### PR TITLE
Small documentation and `debug_assert` related to `FileState`

### DIFF
--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -109,9 +109,15 @@ impl FileMode {
 }
 
 bitflags::bitflags! {
-    /// Flags representing the state of a file. Listeners can subscribe to state changes using
-    /// [`FileRefMut::add_listener`] (or similar methods on [`SocketRefMut`][socket::SocketRefMut],
-    /// [`Pipe`][pipe::Pipe], etc).
+    /// Flags representing the state of a file.
+    ///
+    /// Listeners can subscribe to state changes using [`FileRefMut::add_listener`] (or similar
+    /// methods on [`SocketRefMut`][socket::SocketRefMut], [`Pipe`][pipe::Pipe], etc).
+    ///
+    /// When setting these flags on a file, they should match the result of an epoll-wait on the
+    /// file. For example if an epoll-wait on a file would return `EPOLLIN`, then the file should
+    /// have the `READABLE` state flag. If an epoll-wait would *not* return `EPOLLIN`, then the file
+    /// should not have the `READABLE` state flag.
     #[derive(Default, Copy, Clone, Debug)]
     #[repr(transparent)]
     pub struct FileState: u16 {

--- a/src/main/host/syscall/handler/uio.rs
+++ b/src/main/host/syscall/handler/uio.rs
@@ -281,9 +281,14 @@ impl SyscallHandler {
         if result == Err(Errno::EWOULDBLOCK.into()) && !file_status.contains(FileStatus::NONBLOCK) {
             // TODO: should we block on the READABLE, HUP, and RDHUP states?
             // https://github.com/shadow/shadow/issues/2181
+            let wait_for = FileState::READABLE;
+
+            // check that we're not already in the state that we're going to wait for
+            debug_assert!(!file.borrow().state().intersects(wait_for));
+
             return Err(SyscallError::new_blocked_on_file(
                 file.clone(),
-                FileState::READABLE,
+                wait_for,
                 file.borrow().supports_sa_restart(),
             ));
         }
@@ -556,9 +561,14 @@ impl SyscallHandler {
         if result == Err(Errno::EWOULDBLOCK.into()) && !file_status.contains(FileStatus::NONBLOCK) {
             // TODO: should we block on the WRITABLE and HUP states?
             // https://github.com/shadow/shadow/issues/2181
+            let wait_for = FileState::WRITABLE;
+
+            // check that we're not already in the state that we're going to wait for
+            debug_assert!(!file.borrow().state().intersects(wait_for));
+
             return Err(SyscallError::new_blocked_on_file(
                 file.clone(),
-                FileState::WRITABLE,
+                wait_for,
                 file.borrow().supports_sa_restart(),
             ));
         }

--- a/src/main/host/syscall/handler/uio.rs
+++ b/src/main/host/syscall/handler/uio.rs
@@ -279,6 +279,8 @@ impl SyscallHandler {
 
         // if the syscall would block and it's a blocking descriptor
         if result == Err(Errno::EWOULDBLOCK.into()) && !file_status.contains(FileStatus::NONBLOCK) {
+            // TODO: should we block on the READABLE, HUP, and RDHUP states?
+            // https://github.com/shadow/shadow/issues/2181
             return Err(SyscallError::new_blocked_on_file(
                 file.clone(),
                 FileState::READABLE,
@@ -552,6 +554,8 @@ impl SyscallHandler {
 
         // if the syscall would block and it's a blocking descriptor
         if result == Err(Errno::EWOULDBLOCK.into()) && !file_status.contains(FileStatus::NONBLOCK) {
+            // TODO: should we block on the WRITABLE and HUP states?
+            // https://github.com/shadow/shadow/issues/2181
             return Err(SyscallError::new_blocked_on_file(
                 file.clone(),
                 FileState::WRITABLE,


### PR DESCRIPTION
Based on the discussion in #2181. I think the `debug_assert!` might be helpful in the future to make sure we don't try to block a syscall by waiting for the file to enter a state that it's already in.