### PR TITLE
Upgrade 'merge' to 0.2

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "merge"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bbef93abb1da61525bbc45eeaff6473a41907d19f8f9aa5168d214e10693e9"
+checksum = "56e520ba58faea3487f75df198b1d079644ec226ea3b0507d002c6fa4b8cf93a"
 dependencies = [
  "merge_derive",
  "num-traits",
@@ -915,14 +915,14 @@ dependencies = [
 
 [[package]]
 name = "merge_derive"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209d075476da2e63b4b29e72a2ef627b840589588e71400a25e3565c4f849d07"
+checksum = "5c8f8ce6efff81cbc83caf4af0905c46e58cb46892f63ad3835e81b47eaf7968"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1223,27 +1223,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -31,7 +31,7 @@ scheduler = { path = "../lib/scheduler" }
 shadow-shim-helper-rs = { path = "../lib/shadow-shim-helper-rs", features = ["nix", "std"] }
 lzma-rs = "0.3"
 memoffset = "0.9.1"
-merge = "0.1"
+merge = "0.2"
 neli = "0.6.4"
 nix = { version = "0.29.0", features = ["feature", "ioctl", "mman", "net", "personality", "resource", "sched", "signal", "socket", "time", "uio", "user"] }
 shadow-pod = { path = "../lib/pod" }

--- a/src/main/core/configuration.rs
+++ b/src/main/core/configuration.rs
@@ -225,6 +225,7 @@ static GENERAL_HELP: Lazy<std::collections::HashMap<String, String>> =
 #[clap(next_help_heading = "General (Override configuration file options)")]
 #[clap(next_display_order = None)]
 #[serde(deny_unknown_fields)]
+#[merge(strategy = merge::option::overwrite_none)]
 pub struct GeneralOptions {
     /// The simulated time at which simulated processes are sent a SIGKILL signal
     #[clap(long, value_name = "seconds")]
@@ -310,6 +311,7 @@ static NETWORK_HELP: Lazy<std::collections::HashMap<String, String>> =
 #[clap(next_help_heading = "Network (Override network options)")]
 #[clap(next_display_order = None)]
 #[serde(deny_unknown_fields)]
+#[merge(strategy = merge::option::overwrite_none)]
 pub struct NetworkOptions {
     /// The network topology graph
     #[clap(skip)]
@@ -342,6 +344,7 @@ static EXP_HELP: Lazy<std::collections::HashMap<String, String>> =
 )]
 #[clap(next_display_order = None)]
 #[serde(default, deny_unknown_fields)]
+#[merge(strategy = merge::option::overwrite_none)]
 pub struct ExperimentalOptions {
     /// Use the SCHED_FIFO scheduler. Requires CAP_SYS_NICE. See sched(7), capabilities(7)
     #[clap(hide_short_help = true)]
@@ -587,6 +590,7 @@ static HOST_HELP: Lazy<std::collections::HashMap<String, String>> =
 #[serde(default, deny_unknown_fields)]
 // serde will default all fields to `None`, but in the cli help we want the actual defaults
 #[schemars(default = "HostDefaultOptions::new_with_defaults")]
+#[merge(strategy = merge::option::overwrite_none)]
 pub struct HostDefaultOptions {
     /// Log level at which to print node messages
     #[clap(long = "host-log-level", name = "host-log-level")]


### PR DESCRIPTION
It appears that the merge crate doesn't provide an impl for `Option` anymore, so we need to specify the merge strategy manually. Since all of the struct fields are `Option`, we can thankfully just put the `#[merge(...)]` at the top of each struct rather than on each field.

Supersedes #3561.

Part of #3555.