### PR TITLE
Change `--werror` to also convert rust warnings to errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,10 @@ if(SHADOW_EXTRA_TESTS STREQUAL ON)
   set(TEST_FEATURES "${TEST_FEATURES} extra_tests")
 endif()
 
+if(SHADOW_WERROR STREQUAL ON)
+  set(RUSTFLAGS "${RUSTFLAGS} -Dwarnings")
+endif()
+
 # Propagate global C and C++ flags to the Rust build
 set(RUST_CFLAGS "${CMAKE_C_FLAGS}")
 set(RUST_CXXFLAGS "${CMAKE_CXX_FLAGS}")

--- a/src/lib/shadow-shim-helper-rs/src/rootedcell/rc.rs
+++ b/src/lib/shadow-shim-helper-rs/src/rootedcell/rc.rs
@@ -128,11 +128,11 @@ impl<T> RootedRcCommon<T> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", debug_assertions))]
 fn already_panicking() -> bool {
     std::thread::panicking()
 }
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), debug_assertions))]
 fn already_panicking() -> bool {
     false
 }


### PR DESCRIPTION
The `setup` script has a `--werror` option to turn warnings into errors for C code. This is useful in the CI to avoid merging changes that have warnings. But this doesn't enable the equivalent option for rust code.

In the clippy CI lint test, we use `cargo clippy --all-targets -- -Dwarnings` to convert clippy and rust warnings into errors. But this only affects debug mode builds. Warnings in release builds will not be caught by this.

I think it's best that the `--werror` setup script option also enables `-Dwarnings` for rust code during the regular build. Then warnings will be caught in the CI, which uses `--werror` in `ci/container_scripts/build_and_install.sh`. This PR makes that change, and also fixes a rust warning in release builds.

Closes #3571.