### PR TITLE
Fix warnings for rust 1.87 and upgrade CI rust version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ to be unique as with any other IP address assignment. (#3414)
 PATCH changes (bugfixes):
 
 * Log messages about unrecognized sockopt values are now only logged at level WARN once for each distinct value (and at DEBUG afterwards) (#3353).
-* Fixed rust/clippy errors and warnings up to rust 1.86. (#3334, #3354, #3355, #3405, #3406, #3421, #3467, #3491, #3515, #3556)
+* Fixed rust/clippy errors and warnings up to rust 1.87. (#3334, #3354, #3355, #3405, #3406, #3421, #3467, #3491, #3515, #3556, #3591)
 * Fixed a link error for rust 1.82. (#3445)
 * Fixed a shim panic (which causes shadow to hang) when golang's default SIGTERM handler runs in a managed program (and potentially other cases where a signal handler stack is legitimately reused). (#3396)
 * Replaced the experimental option `--log-errors-to-tty` with the (still experimental) option

--- a/ci/rust-toolchain-nightly.toml
+++ b/ci/rust-toolchain-nightly.toml
@@ -9,6 +9,6 @@
 [toolchain]
 # Must be a version built with miri; check
 # https://rust-lang.github.io/rustup-components-history/
-channel = "nightly-2025-04-05"
+channel = "nightly-2025-05-16"
 # We don't add individual components here. CI individually
 # adds the ones they need (e.g. clippy, miri).

--- a/ci/rust-toolchain-stable.toml
+++ b/ci/rust-toolchain-stable.toml
@@ -7,4 +7,4 @@
 # See
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.86"
+channel = "1.87"

--- a/src/lib/shmem/src/raw_syscall.rs
+++ b/src/lib/shmem/src/raw_syscall.rs
@@ -22,7 +22,7 @@ pub const S_IRGRP: u32 = S_IRUSR >> 3;
 pub const S_IWGRP: u32 = S_IWUSR >> 3;
 
 fn null_terminated(string: &[u8]) -> bool {
-    string.iter().any(|x| *x == 0)
+    string.contains(&0)
 }
 
 /// # Safety

--- a/src/main/core/sim_stats.rs
+++ b/src/main/core/sim_stats.rs
@@ -92,16 +92,10 @@ impl SimStatsForOutput {
     pub fn new(stats: &SharedSimStats) -> Self {
         Self {
             objects: ObjectStatsForOutput {
-                alloc_counts: std::mem::replace(
-                    &mut stats.alloc_counts.lock().unwrap(),
-                    Counter::new(),
-                ),
-                dealloc_counts: std::mem::replace(
-                    &mut stats.dealloc_counts.lock().unwrap(),
-                    Counter::new(),
-                ),
+                alloc_counts: std::mem::take(&mut stats.alloc_counts.lock().unwrap()),
+                dealloc_counts: std::mem::take(&mut stats.dealloc_counts.lock().unwrap()),
             },
-            syscalls: std::mem::replace(&mut stats.syscall_counts.lock().unwrap(), Counter::new()),
+            syscalls: std::mem::take(&mut stats.syscall_counts.lock().unwrap()),
         }
     }
 }

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -192,7 +192,7 @@ impl DescriptorTable {
     /// Remove and return all descriptors.
     pub fn remove_all(&mut self) -> impl Iterator<Item = Descriptor> {
         // reset the descriptor table
-        let old_self = std::mem::replace(self, Self::new());
+        let old_self = std::mem::take(self);
         // return the old descriptors
         old_self.descriptors.into_values()
     }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -812,6 +812,10 @@ impl ZombieProcess {
 }
 
 /// Inner implementation of a simulated process.
+// We could box the variants, but it's unclear whether it's really worth the extra code and extra
+// allocations. Most of the values of this type will be in the larger `Runnable` variant rather than
+// the smaller `Zombie` variant anyways.
+#[allow(clippy::large_enum_variant)]
 enum ProcessState {
     Runnable(RunnableProcess),
     Zombie(ZombieProcess),

--- a/src/test/random/test_random.rs
+++ b/src/test/random/test_random.rs
@@ -60,7 +60,7 @@ fn check_randomness(fracs: &[f64]) -> Result<(), String> {
         buckets[j] += 1;
     }
 
-    let fail = buckets.iter().any(|&i| i == 0);
+    let fail = buckets.contains(&0);
     println!("bucket values:");
     for (i, val) in buckets.iter().enumerate() {
         println!("bucket[{}] = {}", i, val);

--- a/src/test/socket/socket/test_socket.rs
+++ b/src/test/socket/socket/test_socket.rs
@@ -12,8 +12,8 @@ enum Cond<'a, T> {
 impl<T: std::cmp::Eq> Cond<'_, T> {
     fn matches(&self, compare: T) -> bool {
         match self {
-            Cond::Only(vals) => vals.iter().any(|val| *val == compare),
-            Cond::Not(vals) => vals.iter().all(|val| *val != compare),
+            Cond::Only(vals) => vals.contains(&compare),
+            Cond::Not(vals) => !vals.contains(&compare),
             Cond::Any => true,
         }
     }


### PR DESCRIPTION
Fixes clippy warnings in rust 1.87, and upgrades the rust version in CI.

When running clippy with rust 1.88-beta, we get "'shadow-rs' (lib test) generated 152 warnings", so we have that to look forward to in 6 weeks :)