### PR TITLE
Update 'setup' script to pass "OFF" to cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ fixes network connections sometimes trying to read indefinitely after the other
 end has closed the connection in Rust's tokio async runtime (as in
 https://gitlab.torproject.org/tpo/core/arti/-/issues/1972).
 * Fixed the `faccessat` syscall handler to not incorrectly take a `flags` parameter, and added support the `faccessat2` syscall which *does* take a `flags` parameter. (#3578)
+* Flags passed to the `setup` script will now pass "OFF" to CMake explicitly, rather than omitting the value and letting CMake choose whether it's "ON" or "OFF". (#3592)
 
 Full changelog since v3.2.0:
 

--- a/setup
+++ b/setup
@@ -192,13 +192,17 @@ def build(args, remaining):
     # build up args string for the cmake command
     cmake_cmd = ["cmake", rootdir, "-D", "CMAKE_INSTALL_PREFIX=" + installdir]
 
+    # returns "ON" if truthy, else "OFF"
+    def on_off(b):
+        return "ON" if b else "OFF"
+
     # other cmake options
     cmake_cmd.extend(["-D", "CMAKE_BUILD_TYPE=" + ("Debug" if args.do_debug else "Release")])
     if args.do_verbose: os.putenv("VERBOSE", "1")
-    if args.do_test: cmake_cmd.extend(["-D", "SHADOW_TEST=ON"])
-    if args.do_werror: cmake_cmd.extend(["-D", "SHADOW_WERROR=ON"])
-    if args.do_extra_test: cmake_cmd.extend(["-D", "SHADOW_EXTRA_TESTS=ON"])
-    if args.do_use_perf_timers: cmake_cmd.extend(["-D", "SHADOW_USE_PERF_TIMERS=ON"])
+    cmake_cmd.extend(["-D", "SHADOW_TEST=" + on_off(args.do_test)])
+    cmake_cmd.extend(["-D", "SHADOW_WERROR=" + on_off(args.do_werror)])
+    cmake_cmd.extend(["-D", "SHADOW_EXTRA_TESTS=" + on_off(args.do_extra_test)])
+    cmake_cmd.extend(["-D", "SHADOW_USE_PERF_TIMERS=" + on_off(args.do_use_perf_timers)])
 
     # add extra search directories as absolution paths
     make_paths_absolute(args.search_prefix)


### PR DESCRIPTION
Closes #3586.

```text
$ ./setup build
[...]
-- SHADOW_TEST=OFF
-- SHADOW_WERROR=OFF
-- SHADOW_EXTRA_TESTS=OFF
-- SHADOW_USE_PERF_TIMERS=OFF
$ ./setup build --test --werror
[...]
-- SHADOW_TEST=ON
-- SHADOW_WERROR=ON
-- SHADOW_EXTRA_TESTS=OFF
-- SHADOW_USE_PERF_TIMERS=OFF
$ ./setup build
[...]
-- SHADOW_TEST=OFF
-- SHADOW_WERROR=OFF
-- SHADOW_EXTRA_TESTS=OFF
-- SHADOW_USE_PERF_TIMERS=OFF
```