### PR TITLE
DescriptorTable store descriptors in deterministic order

### DIFF
--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use log::*;
 use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
@@ -16,7 +16,7 @@ pub const FD_MAX: u32 = i32::MAX as u32;
 /// [`Thread`][crate::host::thread::Thread].
 #[derive(Clone)]
 pub struct DescriptorTable {
-    descriptors: HashMap<DescriptorHandle, Descriptor>,
+    descriptors: BTreeMap<DescriptorHandle, Descriptor>,
 
     // Indices less than `next_index` known to be available.
     available_indices: BTreeSet<u32>,
@@ -31,7 +31,7 @@ pub struct DescriptorTable {
 impl DescriptorTable {
     pub fn new() -> Self {
         DescriptorTable {
-            descriptors: HashMap::new(),
+            descriptors: Default::default(),
             available_indices: BTreeSet::new(),
             next_index: 0,
             _counter: ObjectCounter::new("DescriptorTable"),


### PR DESCRIPTION
Previously we were storing them in the `HashMap`'s arbitrary order, and them in that arbitrary order `DescriptorTable::remove_all` and `DescriptorTable::remove_range`. Callers of both then close the descriptors and push callbacks in that arbitrary order..

Changing the data structure to `BTreeMap` ensures we process the descriptors in a deterministic (sorted) order. Alternatively we could just sort the descriptors returned by `DescriptorTable::remove_range` and `DescriptorTable::remov_all`, but using a sorted data structure in the first place will make it harder for future subtle bugs of this nature to sneak back in.

This seems to fix some of the nondeterministic scheduling (presumably due to callbacks being called in different order) and nondeterministic file descriptor assignments observed in #3610. Unfortunately not all of it though, and it's difficult to be sure whether it's actually making a difference due to the, err, nondeterministic nondeterminism.