### PR TITLE
Change `MemoryMapper::get_mut` to take a `&mut self`

### DIFF
--- a/src/main/host/memory_manager/memory_mapper.rs
+++ b/src/main/host/memory_manager/memory_mapper.rs
@@ -1072,8 +1072,11 @@ impl MemoryMapper {
         Some(unsafe { std::slice::from_raw_parts(notnull_debug(ptr), src.len()) })
     }
 
-    #[allow(clippy::mut_from_ref)]
-    pub unsafe fn get_mut<T: Pod>(&self, src: ForeignArrayPtr<T>) -> Option<&mut [T]> {
+    // This takes `&mut self` even though it doesn't *need* a mutable reference. But it helps to
+    // prevent accidental overlapping mutable borrows. If in the future we want to support getting
+    // multiple disjoint mutable references, we could change this to a `&self`, and perform runtime
+    // bounds checking on memory ranges.
+    pub unsafe fn get_mut<T: Pod>(&mut self, src: ForeignArrayPtr<T>) -> Option<&mut [T]> {
         if src.is_empty() {
             return Some(&mut []);
         }

--- a/src/main/host/memory_manager/mod.rs
+++ b/src/main/host/memory_manager/mod.rs
@@ -342,7 +342,7 @@ impl MemoryManager {
     // `memory_mapper`.  Calling methods should fall back to the `memory_copier`
     // on failure.
     fn mapped_mut<T: Pod>(&mut self, ptr: ForeignArrayPtr<T>) -> Option<&mut [T]> {
-        let mm = self.memory_mapper.as_ref()?;
+        let mm = self.memory_mapper.as_mut()?;
         // SAFETY: No other refs to process memory exist by preconditions of
         // MemoryManager::new + we have an exclusive reference.
         unsafe { mm.get_mut(ptr) }


### PR DESCRIPTION
This clippy error was added in rust 1.88. In shadow#3632 I added an `#[allow(...)]`, but I think it would be better using a `&mut self` for now.

See https://github.com/shadow/shadow/pull/3632#issuecomment-3111528848 for context.

```text
error: mutable borrow from immutable input(s)
    --> main/host/memory_manager/memory_mapper.rs:1079:77
     |
1079 |     pub unsafe fn get_mut<T: Pod>(&self, src: ForeignArrayPtr<T>) -> Option<&mut [T]> {
     |                                                                             ^^^^^^^^
     |
note: immutable borrow here
    --> main/host/memory_manager/memory_mapper.rs:1079:35
     |
1079 |     pub unsafe fn get_mut<T: Pod>(&self, src: ForeignArrayPtr<T>) -> Option<&mut [T]> {
     |                                   ^^^^^
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mut_from_ref
     = note: `#[deny(clippy::mut_from_ref)]` on by default
```

-------

We previously used the mutable reference in a higher-layer type (`MemoryManager::mapped_mut`) to ensure there would be only one mutable reference to plugin memory. This PR changes `MemoryMapper::get_mut` to also take a mutable reference to ensure we don't accidentally introduce a bug where we allow multiple mutable references.