### PR TITLE
Upgrade schemars to 1.0.4

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1876,6 +1876,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,11 +2062,12 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -2054,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -45,7 +45,7 @@ rand_core = "0.9.0"
 rand_xoshiro = "0.7.0"
 rayon = "1.10.0"
 regex = "1"
-schemars = "0.8"
+schemars = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.128"
 serde_yaml = "0.9"


### PR DESCRIPTION
Closes shadow#3625.

There have been some changes to schemars here. The "cli" tests make sure that there are no changes to the final cli help rendering.

One slightly painful change is that schemars has changed how they format the description for a field. So if a field is:

```rust
/// Hello
/// world.
foo: String,
```

It will now have a description of "Hello\nworld." instead of "Hello world" like in the previous schemars version. This causes clap to also format it as two lines. So we need to perform some rudimentary formatting to replace the new lines with spaces. This isn't ideal, but is close to what schemars was doing originally. If we find that this is too limiting, we can add some markdown parser into shadow in the future.

For my own reference, this is where clap-derive does it's parsing/formatting: https://github.com/clap-rs/clap/blob/4c039309b614ee4523c67a243afc38af11860de9/clap_derive/src/utils/doc_comments.rs#L9