### PR TITLE
TCP: Un-parent child sockets once they've been accepted

### DIFF
--- a/src/main/utility/utility.h
+++ b/src/main/utility/utility.h
@@ -72,7 +72,11 @@
  * Assert that a struct declared with MAGIC_DECLARE and initialized with
  * MAGIC_INIT still holds the value MAGIC_VALUE.
  */
-#define MAGIC_ASSERT(object) utility_debugAssert((object) && ((object)->magic == MAGIC_VALUE))
+#define MAGIC_ASSERT(object)                                                                       \
+    do {                                                                                           \
+        utility_debugAssert(object);                                                               \
+        utility_debugAssert((object)->magic == MAGIC_VALUE);                                       \
+    } while (0)
 
 /**
  * CLear a magic value. Future assertions with MAGIC_ASSERT will fail.

--- a/src/test/socket/accept/test_accept.rs
+++ b/src/test/socket/accept/test_accept.rs
@@ -224,6 +224,19 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
                                 set![TestEnv::Libc, TestEnv::Shadow],
                             ),
                         ]);
+                        if sock_type != libc::SOCK_DGRAM {
+                            tests.push(test_utils::ShadowTest::new(
+                                &append_args("test_close_connection_without_accept"),
+                                move || {
+                                    test_close_connection_without_accept(
+                                        domain, sock_type, sock_flag,
+                                    )
+                                },
+                                // shadow doesn't handle this correctly:
+                                // https://github.com/shadow/shadow/issues/3644
+                                set![TestEnv::Libc],
+                            ));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Once a child socket has been `accept`ed (associated with a file descriptor and moved off of the listening socket's queue), we now remove the parent-child relationship and associate the local:remote address pair directly with the corresponding network interface, instead of continuing to route packets to the listening socket and having the listening socket route them to the child.

This allows a listening socket to be unbound and cleaned up when it's closed instead of keeping it around to route packets to the child sockets, which allows us to reuse the address it had been bound to.

Fixes #3563.

I noticed and filed #3644 while working on this but verified that it was present before this PR as well.