### PR TITLE
Unref the `SysCallCondition` before waking the thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ https://gitlab.torproject.org/tpo/core/arti/-/issues/1972).
 * Intercept reads to `/proc/sys/kernel/random/uuid` and return a simulated pseudorandom result instead of letting the host systerm return an actually-random result. (#3617, fixing #3188).
 * Trap and emulate the `cpuid` instruction where the platform supports it (currently on relatively new intel processors), to report that the `rdrand` and `rdseed` instructions are unavailable. (#3619, fixing #1561 and #3610)
 * Fixed an error when running clippy on Shadow and using newer compiler versions. (#3631)
+* Fixed a bug where a listening TCP socket would be cleaned up only after all its child sockets were closed. (#3643)
+* Fixed a bug where files could have their `close()` delayed until the application next made a blocking syscall. (#3652)
 
 Full changelog since v3.2.0:
 

--- a/src/test/regression/3650/CMakeLists.txt
+++ b/src/test/regression/3650/CMakeLists.txt
@@ -1,0 +1,2 @@
+# regression test for https://github.com/shadow/shadow/issues/3650
+add_shadow_tests(BASENAME regression-3650)

--- a/src/test/regression/3650/regression-3650.yaml
+++ b/src/test/regression/3650/regression-3650.yaml
@@ -1,0 +1,59 @@
+general:
+  stop_time: 30s
+  # we set this explicitly in case we make this the default in the future
+  model_unblocked_syscall_latency: false
+experimental:
+  strace_logging_mode: standard
+network:
+  graph:
+    type: 1_gbit_switch
+hosts:
+  server:
+    network_node_id: 0
+    processes:
+    - path: python3
+      args:
+        - '-u'
+        - '-c'
+        - |
+          import socket
+
+          server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+          server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+          server.bind(('0.0.0.0', 8080))
+          server.listen(100)
+          print("Listening")
+
+          (s, _) = server.accept()
+          s.close()
+          print("Accepted socket")
+
+          server.close()
+          print("Closed listening socket")
+
+          # all sockets have been closed, so we expect this to work
+          server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+          server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+          server.bind(('0.0.0.0', 8080))
+          server.listen(100)
+          server.close()
+  client:
+    network_node_id: 0
+    processes:
+    - path: python3
+      start_time: 100 ms
+      expected_final_state: running
+      args:
+        - '-u'
+        - '-c'
+        - |
+          import socket, time
+
+          s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+          s.connect(('server', 8080))
+          print("Connected")
+
+          # don't close the socket, we want to keep the socket open until the
+          # end of the simulation so that closing the socket doesn't send a FIN
+          print("Sleeping")
+          time.sleep(100000)

--- a/src/test/regression/CMakeLists.txt
+++ b/src/test/regression/CMakeLists.txt
@@ -43,3 +43,4 @@ add_shadow_tests(
 add_subdirectory(2210)
 add_subdirectory(3100)
 add_subdirectory(3148)
+add_subdirectory(3650)

--- a/src/test/socket/bind/test_bind.rs
+++ b/src/test/socket/bind/test_bind.rs
@@ -249,11 +249,6 @@ fn test_tcp_reuse_addr_with_orphaned_child_socket() -> Result<(), String> {
         unsafe { libc::accept(listen_fd, std::ptr::null_mut(), std::ptr::null_mut()) };
     assert_with_errno!(accepted_fd >= 0);
 
-    // https://github.com/shadow/shadow/issues/3563: some non-zero time needs to pass
-    // for shadow to clean up state and recognize the address as being available again.
-    // Unclear why.
-    std::thread::sleep(std::time::Duration::from_nanos(1));
-
     assert_with_errno!(unsafe { libc::close(listen_fd) } == 0);
     let listen_fd = unsafe { libc::socket(domain, sock_type | socket_flag, 0) };
     assert_with_errno!(listen_fd >= 0);


### PR DESCRIPTION
This fixes the example in #3650 and fixes #3564. It unrefs the `SysCallCondition` before we call `host_continue` in the wakeup task. This allows us to unref its `OpenFile`, otherwise the file cannot be closed until `host_continue()` finishes.

Let me know if there's a nicer way to do this, but I don't see one.

The explanation of what's happening is in https://github.com/shadow/shadow/issues/3650#issuecomment-3263556897. Lmk if that comment isn't very clear.