### PR TITLE
Add `*.egg-info/` to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ build
 # area for local temp files
 /local
 /install
+# python build files
+*.egg-info/
 # ide-specific settings
 .vscode
 cscope.*


### PR DESCRIPTION
This ignores the `shadowtools/src/shadowtools.egg-info/` directory that's generated when you pip install the 'shadowtools' python project.