### PR TITLE
Update TGen tools link to README (was 404)

### DIFF
--- a/docs/getting_started_tgen.md
+++ b/docs/getting_started_tgen.md
@@ -118,5 +118,5 @@ $ {{#include ../examples/docs/traffic-generation/show.sh:body_2}}
 You can also parse the TGen output logged to the stdout files using the
 `tgentools` program from the TGen repo, and plot the data in graphical format to
 visualize the performance characteristics of the transfers. [This
-page](https://github.com/shadow/tgen/blob/main/doc/Tools-Setup.md) describes how
+page](https://github.com/shadow/tgen/blob/main/tools/README.md) describes how
 to get started.


### PR DESCRIPTION
I couldn't find https://github.com/shadow/tgen/blob/main/doc/Tools-Setup.md, but the README.md for that dir looks like it contains useful information.

For such a small change it seemed unnecessarily formal to first create an issue.

Before submitting your pull request, please see our documentation about contributing to Shadow:

https://shadow.github.io/docs/guide/contributing.html
