### PR TITLE
Fix host upload bandwidth initialization

### DIFF
--- a/src/main/core/sim_config.rs
+++ b/src/main/core/sim_config.rs
@@ -250,7 +250,7 @@ fn build_host(
             .bandwidth_down
             .map(|x| x.convert(units::SiPrefixUpper::Base).unwrap().value()),
         bandwidth_up_bits: host
-            .bandwidth_down
+            .bandwidth_up
             .map(|x| x.convert(units::SiPrefixUpper::Base).unwrap().value()),
 
         ip_addr: host.ip_addr.map(|x| x.into()),


### PR DESCRIPTION
When running some simulations I saw a difference between setting host upload bandwidth via the host config option vs the network node upload bandwidth. 