### PR TITLE
Update apt before installing packages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,6 +67,7 @@ jobs:
           # date with target branch before merging, anyway.
           # See https://github.com/shadow/shadow/issues/2166
           ref: ${{ github.event.pull_request.head.sha }}
+      - run: sudo apt-get update
       - run: sudo apt-get install shellcheck
       - run: find . -name '*.sh' | xargs shellcheck
 
@@ -101,6 +102,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       # Our rust build scripts require libglib.
+      - run: sudo apt-get update
       - name: Install system dependencies
         run: sudo apt-get install -y libglib2.0-dev
 
@@ -138,6 +140,7 @@ jobs:
           # See https://github.com/shadow/shadow/issues/2166
           ref: ${{ github.event.pull_request.head.sha }}
       # Our rust build scripts require libglib.
+      - run: sudo apt-get update
       - name: Install system dependencies
         run: sudo apt-get install -y libglib2.0-dev
       - name: Set Rust toolchain

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -24,6 +24,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
 
     # Our rust build scripts require libglib.
+    - run: sudo apt-get update
     - name: Install system dependencies
       run: sudo apt-get install -y libglib2.0-dev
 


### PR DESCRIPTION
Whenever using apt, we should be updating it first to pull in any package server changes made since the OS image was created.

~~(Also, I think apt is more modern than apt-get. apt-get output is stable while apt is not, but we're not relying on the output here so :shrug: I made the change.)~~
