### PR TITLE
resolver: map ::1 to loopback in getaddrinfo

### DIFF
--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -164,6 +164,17 @@ static void _getaddrinfo_appendv6(struct addrinfo** head, struct addrinfo** tail
     }
 }
 
+// Returns the IPv4-mapped IPv6 address for the IPv4 address `addr`.
+static struct in6_addr _getaddrinfo_make_v4mapped_addr(uint32_t addr) {
+    static const unsigned char prefix[] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff,
+    };
+    struct in6_addr mapped_addr = {0};
+    memcpy(mapped_addr.s6_addr, prefix, sizeof(prefix));
+    memcpy(&mapped_addr.s6_addr[sizeof(prefix)], &addr, sizeof(addr));
+    return mapped_addr;
+}
+
 // Looks for matching IPv4 addresses in /etc/hosts and them to the list
 // specified by `head` and `tail`.
 static void _getaddrinfo_add_matching_hosts_ipv4(struct addrinfo** head, struct addrinfo** tail,
@@ -403,27 +414,25 @@ int shimc_api_getaddrinfo(const char* node, const char* service, const struct ad
     }
 
     // "`node` specifies either a numerical network address..."
+    // Parse both families when needed so we can distinguish a wrong-family
+    // numeric address (EAI_ADDRFAMILY) from a nonnumeric string
+    // (EAI_NONAME with AI_NUMERICHOST).
+    const bool check_ipv6_numeric = add_ipv6 || hints->ai_family == AF_INET;
+    const bool check_ipv4_numeric = add_ipv4 || hints->ai_family == AF_INET6;
+
     struct in6_addr addr6;
-    const bool parsed_ipv6 = inet_pton(AF_INET6, node, &addr6) == 1;
+    const bool parsed_ipv6 = check_ipv6_numeric && inet_pton(AF_INET6, node, &addr6) == 1;
     if (parsed_ipv6 && add_ipv6) {
         _getaddrinfo_appendv6(res, &tail, add_tcp, add_udp, add_raw, &addr6, port);
     }
     uint32_t addr;
-    const bool parsed_ipv4 = inet_pton(AF_INET, node, &addr) == 1;
+    const bool parsed_ipv4 = check_ipv4_numeric && inet_pton(AF_INET, node, &addr) == 1;
     if (parsed_ipv4) {
         if (add_ipv4) {
             _getaddrinfo_appendv4(res, &tail, add_tcp, add_udp, add_raw, addr, port);
         } else if (hints->ai_family == AF_INET6 && (hints->ai_flags & AI_V4MAPPED)) {
-            struct in6_addr mapped_addr = {
-                .s6_addr =
-                    {
-                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                        0x00, 0x00, 0xff, 0xff,
-                    },
-            };
-            memcpy(&mapped_addr.s6_addr[12], &addr, sizeof(addr));
-            _getaddrinfo_appendv6(
-                res, &tail, add_tcp, add_udp, add_raw, &mapped_addr, port);
+            struct in6_addr mapped_addr = _getaddrinfo_make_v4mapped_addr(addr);
+            _getaddrinfo_appendv6(res, &tail, add_tcp, add_udp, add_raw, &mapped_addr, port);
         }
     }
     // If we successfully parsed as a numeric address, there's no need to
@@ -432,6 +441,8 @@ int shimc_api_getaddrinfo(const char* node, const char* service, const struct ad
         return 0;
     }
     if (parsed_ipv4 || parsed_ipv6) {
+        // We recognized `node` as a numeric address, but it doesn't belong to
+        // an address family that this lookup is allowed to return.
         return EAI_ADDRFAMILY;
     }
     // "If  hints.ai_flags  contains the  AI_NUMERICHOST  flag,  then  node

--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -88,8 +88,8 @@ static int _getaddrinfo_service(in_port_t* port, const char* service,
 // Creates an `addrinfo` pointing to `addr`, and adds it to the linked list
 // specified by `head` and `tail`. An empty list can be passed in by setting
 // `*head` and `*tail` to NULL.
-static void _getaddrinfo_append(struct addrinfo** head, struct addrinfo** tail, int socktype,
-                                struct sockaddr* addr, socklen_t addrlen) {
+static void _getaddrinfo_append(struct addrinfo** head, struct addrinfo** tail, int family,
+                                int socktype, struct sockaddr* addr, socklen_t addrlen) {
     int protocol = 0;
     if (socktype == SOCK_DGRAM) {
         protocol = IPPROTO_UDP;
@@ -102,7 +102,7 @@ static void _getaddrinfo_append(struct addrinfo** head, struct addrinfo** tail, 
     }
     struct addrinfo* new_tail = malloc(sizeof(*new_tail));
     *new_tail = (struct addrinfo){.ai_flags = 0,
-                                  .ai_family = AF_INET,
+                                  .ai_family = family,
                                   .ai_socktype = socktype,
                                   .ai_protocol = protocol,
                                   .ai_addrlen = addrlen,
@@ -125,17 +125,45 @@ static void _getaddrinfo_appendv4(struct addrinfo** head, struct addrinfo** tail
     if (add_tcp) {
         struct sockaddr_in* sai = malloc(sizeof(*sai));
         *sai = (struct sockaddr_in){.sin_family = AF_INET, .sin_port = port, .sin_addr = {s_addr}};
-        _getaddrinfo_append(head, tail, SOCK_STREAM, (struct sockaddr*)sai, sizeof(*sai));
+        _getaddrinfo_append(head, tail, AF_INET, SOCK_STREAM, (struct sockaddr*)sai, sizeof(*sai));
     }
     if (add_udp) {
         struct sockaddr_in* sai = malloc(sizeof(*sai));
         *sai = (struct sockaddr_in){.sin_family = AF_INET, .sin_port = port, .sin_addr = {s_addr}};
-        _getaddrinfo_append(head, tail, SOCK_DGRAM, (struct sockaddr*)sai, sizeof(*sai));
+        _getaddrinfo_append(head, tail, AF_INET, SOCK_DGRAM, (struct sockaddr*)sai, sizeof(*sai));
     }
     if (add_raw) {
         struct sockaddr_in* sai = malloc(sizeof(*sai));
         *sai = (struct sockaddr_in){.sin_family = AF_INET, .sin_port = port, .sin_addr = {s_addr}};
-        _getaddrinfo_append(head, tail, SOCK_RAW, (struct sockaddr*)sai, sizeof(*sai));
+        _getaddrinfo_append(head, tail, AF_INET, SOCK_RAW, (struct sockaddr*)sai, sizeof(*sai));
+    }
+}
+
+// IPv6 wrapper for _getaddrinfo_append. Appends an entry for the address and
+// port for each requested socket type.
+static void _getaddrinfo_appendv6(struct addrinfo** head, struct addrinfo** tail, bool add_tcp,
+                                  bool add_udp, bool add_raw, const struct in6_addr* addr6,
+                                  in_port_t port) {
+    if (add_tcp) {
+        struct sockaddr_in6* sai = malloc(sizeof(*sai));
+        *sai = (struct sockaddr_in6){
+            .sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
+        _getaddrinfo_append(head, tail, AF_INET6, SOCK_STREAM, (struct sockaddr*)sai,
+                            sizeof(*sai));
+    }
+    if (add_udp) {
+        struct sockaddr_in6* sai = malloc(sizeof(*sai));
+        *sai = (struct sockaddr_in6){
+            .sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
+        _getaddrinfo_append(head, tail, AF_INET6, SOCK_DGRAM, (struct sockaddr*)sai,
+                            sizeof(*sai));
+    }
+    if (add_raw) {
+        struct sockaddr_in6* sai = malloc(sizeof(*sai));
+        *sai = (struct sockaddr_in6){
+            .sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
+        _getaddrinfo_append(head, tail, AF_INET6, SOCK_RAW, (struct sockaddr*)sai,
+                            sizeof(*sai));
     }
 }
 
@@ -378,19 +406,36 @@ int shimc_api_getaddrinfo(const char* node, const char* service, const struct ad
     }
 
     // "`node` specifies either a numerical network address..."
-    if (add_ipv6) {
-        // TODO: try parsing as IPv6
+    struct in6_addr addr6;
+    const bool parsed_ipv6 = inet_pton(AF_INET6, node, &addr6) == 1;
+    if (parsed_ipv6 && add_ipv6) {
+        _getaddrinfo_appendv6(res, &tail, add_tcp, add_udp, add_raw, &addr6, port);
     }
-    if (add_ipv4) {
-        uint32_t addr;
-        if (inet_pton(AF_INET, node, &addr) == 1) {
+    uint32_t addr;
+    const bool parsed_ipv4 = inet_pton(AF_INET, node, &addr) == 1;
+    if (parsed_ipv4) {
+        if (add_ipv4) {
             _getaddrinfo_appendv4(res, &tail, add_tcp, add_udp, add_raw, addr, port);
+        } else if (hints->ai_family == AF_INET6 && (hints->ai_flags & AI_V4MAPPED)) {
+            struct in6_addr mapped_addr = {
+                .s6_addr =
+                    {
+                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        0x00, 0x00, 0xff, 0xff,
+                    },
+            };
+            memcpy(&mapped_addr.s6_addr[12], &addr, sizeof(addr));
+            _getaddrinfo_appendv6(
+                res, &tail, add_tcp, add_udp, add_raw, &mapped_addr, port);
         }
     }
     // If we successfully parsed as a numeric address, there's no need to
     // continue on to doing name-based lookups.
     if (*res != NULL) {
         return 0;
+    }
+    if (parsed_ipv4 || parsed_ipv6) {
+        return EAI_ADDRFAMILY;
     }
     // "If  hints.ai_flags  contains the  AI_NUMERICHOST  flag,  then  node
     // must be a numerical network address."

--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -146,24 +146,21 @@ static void _getaddrinfo_appendv6(struct addrinfo** head, struct addrinfo** tail
                                   in_port_t port) {
     if (add_tcp) {
         struct sockaddr_in6* sai = malloc(sizeof(*sai));
-        *sai = (struct sockaddr_in6){
-            .sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
-        _getaddrinfo_append(head, tail, AF_INET6, SOCK_STREAM, (struct sockaddr*)sai,
-                            sizeof(*sai));
+        *sai =
+            (struct sockaddr_in6){.sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
+        _getaddrinfo_append(head, tail, AF_INET6, SOCK_STREAM, (struct sockaddr*)sai, sizeof(*sai));
     }
     if (add_udp) {
         struct sockaddr_in6* sai = malloc(sizeof(*sai));
-        *sai = (struct sockaddr_in6){
-            .sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
-        _getaddrinfo_append(head, tail, AF_INET6, SOCK_DGRAM, (struct sockaddr*)sai,
-                            sizeof(*sai));
+        *sai =
+            (struct sockaddr_in6){.sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
+        _getaddrinfo_append(head, tail, AF_INET6, SOCK_DGRAM, (struct sockaddr*)sai, sizeof(*sai));
     }
     if (add_raw) {
         struct sockaddr_in6* sai = malloc(sizeof(*sai));
-        *sai = (struct sockaddr_in6){
-            .sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
-        _getaddrinfo_append(head, tail, AF_INET6, SOCK_RAW, (struct sockaddr*)sai,
-                            sizeof(*sai));
+        *sai =
+            (struct sockaddr_in6){.sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
+        _getaddrinfo_append(head, tail, AF_INET6, SOCK_RAW, (struct sockaddr*)sai, sizeof(*sai));
     }
 }
 
@@ -287,7 +284,7 @@ static bool _shim_api_hostname_to_addr_ipv4(const char* node, uint32_t* addr) {
 }
 
 int shimc_api_getaddrinfo(const char* node, const char* service, const struct addrinfo* hints,
-                         struct addrinfo** res) {
+                          struct addrinfo** res) {
     // Quoted text is from the man page.
 
     // "Either node or service, but not both, may be NULL."

--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -88,8 +88,9 @@ static int _getaddrinfo_service(in_port_t* port, const char* service,
 // Creates an `addrinfo` pointing to `addr`, and adds it to the linked list
 // specified by `head` and `tail`. An empty list can be passed in by setting
 // `*head` and `*tail` to NULL.
-static void _getaddrinfo_append(struct addrinfo** head, struct addrinfo** tail, int family,
-                                int socktype, struct sockaddr* addr, socklen_t addrlen) {
+static void _getaddrinfo_append(struct addrinfo** head, struct addrinfo** tail, int ai_flags,
+                                int family, int socktype, struct sockaddr* addr,
+                                socklen_t addrlen) {
     int protocol = 0;
     if (socktype == SOCK_DGRAM) {
         protocol = IPPROTO_UDP;
@@ -101,7 +102,7 @@ static void _getaddrinfo_append(struct addrinfo** head, struct addrinfo** tail, 
         protocol = 0;
     }
     struct addrinfo* new_tail = malloc(sizeof(*new_tail));
-    *new_tail = (struct addrinfo){.ai_flags = 0,
+    *new_tail = (struct addrinfo){.ai_flags = ai_flags,
                                   .ai_family = family,
                                   .ai_socktype = socktype,
                                   .ai_protocol = protocol,
@@ -125,17 +126,19 @@ static void _getaddrinfo_appendv4(struct addrinfo** head, struct addrinfo** tail
     if (add_tcp) {
         struct sockaddr_in* sai = malloc(sizeof(*sai));
         *sai = (struct sockaddr_in){.sin_family = AF_INET, .sin_port = port, .sin_addr = {s_addr}};
-        _getaddrinfo_append(head, tail, AF_INET, SOCK_STREAM, (struct sockaddr*)sai, sizeof(*sai));
+        _getaddrinfo_append(
+            head, tail, 0, AF_INET, SOCK_STREAM, (struct sockaddr*)sai, sizeof(*sai));
     }
     if (add_udp) {
         struct sockaddr_in* sai = malloc(sizeof(*sai));
         *sai = (struct sockaddr_in){.sin_family = AF_INET, .sin_port = port, .sin_addr = {s_addr}};
-        _getaddrinfo_append(head, tail, AF_INET, SOCK_DGRAM, (struct sockaddr*)sai, sizeof(*sai));
+        _getaddrinfo_append(
+            head, tail, 0, AF_INET, SOCK_DGRAM, (struct sockaddr*)sai, sizeof(*sai));
     }
     if (add_raw) {
         struct sockaddr_in* sai = malloc(sizeof(*sai));
         *sai = (struct sockaddr_in){.sin_family = AF_INET, .sin_port = port, .sin_addr = {s_addr}};
-        _getaddrinfo_append(head, tail, AF_INET, SOCK_RAW, (struct sockaddr*)sai, sizeof(*sai));
+        _getaddrinfo_append(head, tail, 0, AF_INET, SOCK_RAW, (struct sockaddr*)sai, sizeof(*sai));
     }
 }
 
@@ -143,24 +146,27 @@ static void _getaddrinfo_appendv4(struct addrinfo** head, struct addrinfo** tail
 // port for each requested socket type.
 static void _getaddrinfo_appendv6(struct addrinfo** head, struct addrinfo** tail, bool add_tcp,
                                   bool add_udp, bool add_raw, const struct in6_addr* addr6,
-                                  in_port_t port) {
+                                  in_port_t port, int ai_flags) {
     if (add_tcp) {
         struct sockaddr_in6* sai = malloc(sizeof(*sai));
         *sai =
             (struct sockaddr_in6){.sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
-        _getaddrinfo_append(head, tail, AF_INET6, SOCK_STREAM, (struct sockaddr*)sai, sizeof(*sai));
+        _getaddrinfo_append(
+            head, tail, ai_flags, AF_INET6, SOCK_STREAM, (struct sockaddr*)sai, sizeof(*sai));
     }
     if (add_udp) {
         struct sockaddr_in6* sai = malloc(sizeof(*sai));
         *sai =
             (struct sockaddr_in6){.sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
-        _getaddrinfo_append(head, tail, AF_INET6, SOCK_DGRAM, (struct sockaddr*)sai, sizeof(*sai));
+        _getaddrinfo_append(
+            head, tail, ai_flags, AF_INET6, SOCK_DGRAM, (struct sockaddr*)sai, sizeof(*sai));
     }
     if (add_raw) {
         struct sockaddr_in6* sai = malloc(sizeof(*sai));
         *sai =
             (struct sockaddr_in6){.sin6_family = AF_INET6, .sin6_port = port, .sin6_addr = *addr6};
-        _getaddrinfo_append(head, tail, AF_INET6, SOCK_RAW, (struct sockaddr*)sai, sizeof(*sai));
+        _getaddrinfo_append(
+            head, tail, ai_flags, AF_INET6, SOCK_RAW, (struct sockaddr*)sai, sizeof(*sai));
     }
 }
 
@@ -423,7 +429,7 @@ int shimc_api_getaddrinfo(const char* node, const char* service, const struct ad
     struct in6_addr addr6;
     const bool parsed_ipv6 = check_ipv6_numeric && inet_pton(AF_INET6, node, &addr6) == 1;
     if (parsed_ipv6 && add_ipv6) {
-        _getaddrinfo_appendv6(res, &tail, add_tcp, add_udp, add_raw, &addr6, port);
+        _getaddrinfo_appendv6(res, &tail, add_tcp, add_udp, add_raw, &addr6, port, 0);
     }
     uint32_t addr;
     const bool parsed_ipv4 = check_ipv4_numeric && inet_pton(AF_INET, node, &addr) == 1;
@@ -432,7 +438,8 @@ int shimc_api_getaddrinfo(const char* node, const char* service, const struct ad
             _getaddrinfo_appendv4(res, &tail, add_tcp, add_udp, add_raw, addr, port);
         } else if (hints->ai_family == AF_INET6 && (hints->ai_flags & AI_V4MAPPED)) {
             struct in6_addr mapped_addr = _getaddrinfo_make_v4mapped_addr(addr);
-            _getaddrinfo_appendv6(res, &tail, add_tcp, add_udp, add_raw, &mapped_addr, port);
+            _getaddrinfo_appendv6(
+                res, &tail, add_tcp, add_udp, add_raw, &mapped_addr, port, AI_V4MAPPED);
         }
     }
     // If we successfully parsed as a numeric address, there's no need to

--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -420,19 +420,13 @@ int shimc_api_getaddrinfo(const char* node, const char* service, const struct ad
     }
 
     // "`node` specifies either a numerical network address..."
-    // Parse both families when needed so we can distinguish a wrong-family
-    // numeric address (EAI_ADDRFAMILY) from a nonnumeric string
-    // (EAI_NONAME with AI_NUMERICHOST).
-    const bool check_ipv6_numeric = add_ipv6 || hints->ai_family == AF_INET;
-    const bool check_ipv4_numeric = add_ipv4 || hints->ai_family == AF_INET6;
-
     struct in6_addr addr6;
-    const bool parsed_ipv6 = check_ipv6_numeric && inet_pton(AF_INET6, node, &addr6) == 1;
+    const bool parsed_ipv6 = inet_pton(AF_INET6, node, &addr6) == 1;
     if (parsed_ipv6 && add_ipv6) {
         _getaddrinfo_appendv6(res, &tail, add_tcp, add_udp, add_raw, &addr6, port, 0);
     }
     uint32_t addr;
-    const bool parsed_ipv4 = check_ipv4_numeric && inet_pton(AF_INET, node, &addr) == 1;
+    const bool parsed_ipv4 = inet_pton(AF_INET, node, &addr) == 1;
     if (parsed_ipv4) {
         if (add_ipv4) {
             _getaddrinfo_appendv4(res, &tail, add_tcp, add_udp, add_raw, addr, port);

--- a/src/lib/shim/shim_api_addrinfo.c
+++ b/src/lib/shim/shim_api_addrinfo.c
@@ -382,6 +382,14 @@ int shimc_api_getaddrinfo(const char* node, const char* service, const struct ad
         // TODO: try parsing as IPv6
     }
     if (add_ipv4) {
+        // Shadow doesn't support IPv6 sockets, but some applications still
+        // probe the IPv6 loopback address during startup. Treat "::1" as the
+        // IPv4 loopback so they keep working in Shadow's IPv4-only model.
+        if (strcmp(node, "::1") == 0) {
+            _getaddrinfo_appendv4(
+                res, &tail, add_tcp, add_udp, add_raw, htonl(INADDR_LOOPBACK), port);
+        }
+
         uint32_t addr;
         if (inet_pton(AF_INET, node, &addr) == 1) {
             _getaddrinfo_appendv4(res, &tail, add_tcp, add_udp, add_raw, addr, port);

--- a/src/test/resolver/test_getaddrinfo.c
+++ b/src/test/resolver/test_getaddrinfo.c
@@ -273,6 +273,20 @@ void test_numeric_host() {
     assert_addrinfo_equals(res, &expected_addrinfo);
     freeaddrinfo(res);
 
+    // Shadow currently models loopback with IPv4 only. Numeric IPv6 loopback
+    // lookups should still succeed so applications that probe "::1" during
+    // startup don't abort.
+    hints = (struct addrinfo){.ai_socktype = SOCK_STREAM};
+    assert_getaddrinfo_rv_equals(getaddrinfo("::1", NULL, &hints, &res), 0);
+    if (running_in_shadow()) {
+        g_assert_nonnull(res);
+        g_assert_cmpint(res->ai_family, ==, AF_INET);
+        const struct sockaddr_in* addr_in = (const struct sockaddr_in*)res->ai_addr;
+        g_assert_nonnull(addr_in);
+        g_assert_cmpuint(ntohl(addr_in->sin_addr.s_addr), ==, INADDR_LOOPBACK);
+    }
+    freeaddrinfo(res);
+
     // Error on nonnumeric node with AI_NUMERICHOST
     hints = (struct addrinfo){.ai_flags = AI_NUMERICHOST};
     assert_getaddrinfo_rv_equals(

--- a/src/test/resolver/test_getaddrinfo.c
+++ b/src/test/resolver/test_getaddrinfo.c
@@ -302,6 +302,31 @@ void test_numeric_host() {
     hints = (struct addrinfo){.ai_family = AF_INET, .ai_socktype = SOCK_STREAM};
     assert_getaddrinfo_rv_equals(getaddrinfo("::1", NULL, &hints, &res), EAI_ADDRFAMILY);
 
+    // Likewise, a numeric IPv4 literal should fail when only IPv6 results are
+    // allowed and AI_V4MAPPED is not set.
+    hints = (struct addrinfo){.ai_family = AF_INET6, .ai_socktype = SOCK_STREAM};
+    assert_getaddrinfo_rv_equals(getaddrinfo("127.0.0.1", NULL, &hints, &res), EAI_ADDRFAMILY);
+
+    // With AI_V4MAPPED, the same IPv4 literal should be returned as an
+    // IPv4-mapped IPv6 address.
+    hints = (struct addrinfo){
+        .ai_family = AF_INET6, .ai_socktype = SOCK_STREAM, .ai_flags = AI_V4MAPPED};
+    assert_getaddrinfo_rv_equals(getaddrinfo("127.0.0.1", NULL, &hints, &res), 0);
+    struct in6_addr mapped_addr6;
+    g_assert_cmpint(inet_pton(AF_INET6, "::ffff:127.0.0.1", &mapped_addr6), ==, 1);
+    const struct sockaddr_in6 expected_mapped_sockaddr_in6 = {
+        .sin6_family = AF_INET6, .sin6_addr = mapped_addr6};
+    struct addrinfo expected_mapped_addrinfo6 = {
+        .ai_flags = AI_V4MAPPED,
+        .ai_family = AF_INET6,
+        .ai_socktype = SOCK_STREAM,
+        .ai_protocol = IPPROTO_TCP,
+        .ai_addrlen = sizeof(expected_mapped_sockaddr_in6),
+        .ai_addr = (struct sockaddr*)&expected_mapped_sockaddr_in6,
+    };
+    assert_addrinfo_equals(res, &expected_mapped_addrinfo6);
+    freeaddrinfo(res);
+
     // Error on nonnumeric node with AI_NUMERICHOST
     hints = (struct addrinfo){.ai_flags = AI_NUMERICHOST};
     assert_getaddrinfo_rv_equals(

--- a/src/test/resolver/test_getaddrinfo.c
+++ b/src/test/resolver/test_getaddrinfo.c
@@ -78,16 +78,15 @@ int addrinfo_count(struct addrinfo* res) {
 }
 
 const char* sockaddr_in_string(const struct sockaddr* addr) {
-    static char ip[20] = {0};
-    static char ip_and_port[30] = {0};
-    // INET6 unhandled
+    static char ip[INET6_ADDRSTRLEN] = {0};
+    static char ip_and_port[80] = {0};
     if (addr->sa_family == AF_INET) {
         const struct sockaddr_in* addr_in = (const struct sockaddr_in*)addr;
-        inet_ntop(AF_INET, &addr_in->sin_addr, ip, 20);
+        inet_ntop(AF_INET, &addr_in->sin_addr, ip, sizeof(ip));
         sprintf(ip_and_port, "%s:%d", ip, ntohs(addr_in->sin_port));
     } else if (addr->sa_family == AF_INET6) {
         const struct sockaddr_in6* addr_in6 = (const struct sockaddr_in6*)addr;
-        inet_ntop(AF_INET6, &addr_in6->sin6_addr, ip, 20);
+        inet_ntop(AF_INET6, &addr_in6->sin6_addr, ip, sizeof(ip));
         sprintf(ip_and_port, "%s:%d", ip, ntohs(addr_in6->sin6_port));
     } else {
         sprintf(ip_and_port, "<Unknown addr family %d>", addr->sa_family);
@@ -120,11 +119,17 @@ bool sockaddr_equals(const struct sockaddr* lhs, const struct sockaddr* rhs) {
         return false;
     if (lhs->sa_family != rhs->sa_family)
         return false;
-    // INET6 unhandled
-    g_assert(lhs->sa_family == AF_INET);
-    const struct sockaddr_in* lhs_in = (const struct sockaddr_in*)lhs;
-    const struct sockaddr_in* rhs_in = (const struct sockaddr_in*)rhs;
-    return !memcmp(lhs_in, rhs_in, sizeof(*lhs_in));
+    if (lhs->sa_family == AF_INET) {
+        const struct sockaddr_in* lhs_in = (const struct sockaddr_in*)lhs;
+        const struct sockaddr_in* rhs_in = (const struct sockaddr_in*)rhs;
+        return !memcmp(lhs_in, rhs_in, sizeof(*lhs_in));
+    }
+    if (lhs->sa_family == AF_INET6) {
+        const struct sockaddr_in6* lhs_in6 = (const struct sockaddr_in6*)lhs;
+        const struct sockaddr_in6* rhs_in6 = (const struct sockaddr_in6*)rhs;
+        return !memcmp(lhs_in6, rhs_in6, sizeof(*lhs_in6));
+    }
+    g_assert_not_reached();
 }
 
 bool addrinfo_equals(const struct addrinfo* lhs, const struct addrinfo* rhs) {
@@ -272,6 +277,30 @@ void test_numeric_host() {
     assert_getaddrinfo_rv_equals(getaddrinfo("1.2.3.4", NULL, &hints, &res), 0);
     assert_addrinfo_equals(res, &expected_addrinfo);
     freeaddrinfo(res);
+
+    // Numeric IPv6 loopback should resolve as IPv6, matching Linux behavior
+    // even though Shadow doesn't support IPv6 sockets.
+    hints = (struct addrinfo){.ai_socktype = SOCK_STREAM};
+    assert_getaddrinfo_rv_equals(getaddrinfo("::1", NULL, &hints, &res), 0);
+    struct in6_addr addr6;
+    g_assert_cmpint(inet_pton(AF_INET6, "::1", &addr6), ==, 1);
+    const struct sockaddr_in6 expected_sockaddr_in6 = {
+        .sin6_family = AF_INET6, .sin6_addr = addr6};
+    struct addrinfo expected_addrinfo6 = {
+        .ai_flags = 0,
+        .ai_family = AF_INET6,
+        .ai_socktype = SOCK_STREAM,
+        .ai_protocol = IPPROTO_TCP,
+        .ai_addrlen = sizeof(expected_sockaddr_in6),
+        .ai_addr = (struct sockaddr*)&expected_sockaddr_in6,
+    };
+    assert_addrinfo_equals(res, &expected_addrinfo6);
+    freeaddrinfo(res);
+
+    // Linux reports an address-family mismatch for a numeric IPv6 literal when
+    // asked for IPv4 only.
+    hints = (struct addrinfo){.ai_family = AF_INET, .ai_socktype = SOCK_STREAM};
+    assert_getaddrinfo_rv_equals(getaddrinfo("::1", NULL, &hints, &res), EAI_ADDRFAMILY);
 
     // Error on nonnumeric node with AI_NUMERICHOST
     hints = (struct addrinfo){.ai_flags = AI_NUMERICHOST};


### PR DESCRIPTION
I'm trying to run `bitcoind` (regtest) in shadow. This PR fixes one of the issues preventing it from running there.

Bitcoin Core's [LookupHost("::1", false)](https://github.com/bitcoin/bitcoin/blob/v31.0/src/httpserver.cpp#L152) goes through WrappedGetAddrInfo() and [calls getaddrinfo("::1")](https://github.com/bitcoin/bitcoin/blob/v31.0/src/netbase.cpp#L69). Shadow used to return `gaierror(-2, "Name or service not known")` for this, now it return the loopback.

Added a regression test: new subtest in `test_numeric_host`.