### PR TITLE
prctl: emulate parent death signals

### DIFF
--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -475,8 +475,7 @@ impl Host {
             return;
         }
 
-        // Reparent children, and collect IDs of children that are dead.
-        let mut orphaned_zombie_pids: Vec<ProcessId> = self
+        let child_pids: Vec<_> = self
             .processes
             .borrow()
             .iter()
@@ -486,20 +485,46 @@ impl Host {
                     // Not a child of the current process
                     return None;
                 }
-                process.set_parent_id(ProcessId::INIT);
-                let Some(z) = process.borrow_as_zombie() else {
-                    // Not a zombie
-                    return None;
-                };
-                if z.reaper(self).is_some() {
-                    // Not an orphan
-                    None
-                } else {
-                    // Is a zombie orphan child
-                    Some(*other_pid)
-                }
+                Some(*other_pid)
             })
             .collect();
+
+        // Reparent children, and collect IDs of children that are dead. Deliver
+        // parent-death signals before reparenting so the old parent PID is still
+        // reported in the siginfo payload. Since Shadow tracks parentage at the
+        // process level, this models parent-process death rather than the more
+        // specific parent-thread behavior Linux implements.
+        let mut orphaned_zombie_pids: Vec<ProcessId> = Vec::new();
+        for child_pid in child_pids {
+            let parent_death_signal = {
+                let Some(processrc) = self.process_borrow(child_pid) else {
+                    continue;
+                };
+                let process = processrc.borrow(&self.root);
+                process.parent_death_signal()
+            };
+
+            if let Some(signal) = parent_death_signal {
+                let siginfo = siginfo_t::new_for_kill(signal, pid.into(), 0);
+                let Some(processrc) = self.process_borrow(child_pid) else {
+                    continue;
+                };
+                let process = processrc.borrow(&self.root);
+                process.signal(self, None, &siginfo);
+            }
+
+            let is_zombie = {
+                let Some(processrc) = self.process_borrow(child_pid) else {
+                    continue;
+                };
+                let process = processrc.borrow(&self.root);
+                process.set_parent_id(ProcessId::INIT);
+                process.borrow_as_zombie().is_some()
+            };
+            if is_zombie {
+                orphaned_zombie_pids.push(child_pid);
+            }
+        }
 
         // Process we ran is a zombie; is it also an orphan?
         debug_assert!(died);

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -154,6 +154,10 @@ struct Common {
     // Signal to send to parent on death.
     exit_signal: Option<Signal>,
 
+    // Signal to send to this process when its parent dies, as configured via
+    // `prctl(PR_SET_PDEATHSIG)`.
+    parent_death_signal: Cell<Option<Signal>>,
+
     // unique id of the program that this process should run
     name: CString,
 
@@ -626,6 +630,7 @@ impl RunnableProcess {
             group_id: Cell::new(process_group_id),
             session_id: Cell::new(session_id),
             exit_signal,
+            parent_death_signal: Cell::new(None),
             rlimits: self.common.rlimits,
         };
 
@@ -1118,6 +1123,7 @@ impl Process {
             // Exit signal is moot; since parent is INIT there will never
             // be a valid target for it.
             exit_signal: None,
+            parent_death_signal: Cell::new(None),
             rlimits,
         };
         Ok(RootedRc::new(
@@ -1734,6 +1740,16 @@ impl Process {
     /// Signal that will be sent to parent process on exit. Typically `Some(SIGCHLD)`.
     pub fn exit_signal(&self) -> Option<Signal> {
         self.common().exit_signal
+    }
+
+    /// Signal that will be sent to this process when its parent exits.
+    pub fn parent_death_signal(&self) -> Option<Signal> {
+        self.common().parent_death_signal.get()
+    }
+
+    /// Set the signal that should be sent to this process when its parent exits.
+    pub fn set_parent_death_signal(&self, signal: Option<Signal>) {
+        self.common().parent_death_signal.set(signal);
     }
 
     pub fn current_working_dir(&self) -> impl Deref<Target = CString> + '_ {

--- a/src/main/host/syscall/handler/prctl.rs
+++ b/src/main/host/syscall/handler/prctl.rs
@@ -1,6 +1,7 @@
 use linux_api::errno::Errno;
 use linux_api::prctl::{ArchPrctlOp, PrctlOp};
 use linux_api::sched::SuidDump;
+use linux_api::signal::Signal;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
@@ -78,13 +79,25 @@ impl SyscallHandler {
             // effect.
             | PrctlOp::PR_SET_TIMERSLACK
             // Wouldn't actually hurt correctness, but could significantly hurt performance.
-            | PrctlOp::PR_SET_SPECULATION_CTRL
-            // We use this signal to ensure managed processes die when Shadow does. Allowing the
-            // process to override it could end up allowing orphaned managed processes to live on
-            // after shadow exits.
-            | PrctlOp::PR_SET_PDEATHSIG => {
+            | PrctlOp::PR_SET_SPECULATION_CTRL => {
                 log::warn!("Not allowing unimplemented prctl {option}");
                 Err(Errno::EINVAL.into())
+            }
+            PrctlOp::PR_SET_PDEATHSIG => {
+                let signal = if arg2 == 0 {
+                    None
+                } else {
+                    let signal = i32::try_from(arg2).or(Err(Errno::EINVAL))?;
+                    Some(Signal::try_from(signal).or(Err(Errno::EINVAL))?)
+                };
+                ctx.objs.process.set_parent_death_signal(signal);
+                Ok(0)
+            }
+            PrctlOp::PR_GET_PDEATHSIG => {
+                let out_ptr = ForeignPtr::from(arg2).cast::<std::ffi::c_int>();
+                let signal = Signal::as_raw(ctx.objs.process.parent_death_signal());
+                ctx.objs.process.memory_borrow_mut().write(out_ptr, &signal)?;
+                Ok(0)
             }
             PrctlOp::PR_GET_TID_ADDRESS => {
                 let out_ptr = ForeignPtr::from(arg2)

--- a/src/test/prctl/test_prctl.rs
+++ b/src/test/prctl/test_prctl.rs
@@ -1,6 +1,57 @@
 use linux_api::prctl::ArchPrctlOp;
+use nix::poll::{poll, PollFd, PollFlags};
+use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal as NixSignal};
+use rustix::fd::AsRawFd;
+use rustix::io::{read, write};
+use rustix::pipe::pipe;
+use std::sync::atomic::{AtomicI32, Ordering};
 use test_utils::TestEnvironment as TestEnv;
 use test_utils::{assert_with_errno, set};
+
+static PARENT_DEATH_SIGNAL_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
+static PARENT_DEATH_SIGNAL_NUMBER: AtomicI32 = AtomicI32::new(0);
+static PARENT_DEATH_SIGNAL_SENDER: AtomicI32 = AtomicI32::new(0);
+
+extern "C" fn parent_death_signal_handler(
+    signal: libc::c_int,
+    info: *mut libc::siginfo_t,
+    _ctx: *mut libc::c_void,
+) {
+    PARENT_DEATH_SIGNAL_NUMBER.store(signal, Ordering::SeqCst);
+
+    let sender = if info.is_null() {
+        0
+    } else {
+        unsafe { (*info).si_pid() }
+    };
+    PARENT_DEATH_SIGNAL_SENDER.store(sender, Ordering::SeqCst);
+
+    let fd = PARENT_DEATH_SIGNAL_WRITE_FD.load(Ordering::SeqCst);
+    if fd >= 0 {
+        let byte = [1u8];
+        let _ = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
+    }
+}
+
+fn wait_for_parent_death_signal(fd: libc::c_int) -> Result<(), String> {
+    let mut poll_fds = [PollFd::new(fd, PollFlags::POLLIN)];
+
+    loop {
+        match poll(&mut poll_fds, 2000) {
+            Ok(0) => return Err("Timed out waiting for parent-death signal".into()),
+            Ok(_) => {
+                let events = poll_fds[0].revents().unwrap_or(PollFlags::empty());
+                if events.contains(PollFlags::POLLIN) {
+                    return Ok(());
+                }
+
+                return Err(format!("Unexpected poll events while waiting for signal: {events:?}"));
+            }
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(err) => return Err(format!("poll failed while waiting for signal: {err}")),
+        }
+    }
+}
 
 fn main() -> Result<(), String> {
     // should we restrict the tests we run?
@@ -38,6 +89,16 @@ fn get_tests() -> Vec<test_utils::ShadowTest<(), String>> {
         test_utils::ShadowTest::new(
             "test_tid_addr",
             test_tid_addr,
+            set![TestEnv::Libc, TestEnv::Shadow],
+        ),
+        test_utils::ShadowTest::new(
+            "test_parent_death_signal",
+            test_parent_death_signal,
+            set![TestEnv::Libc, TestEnv::Shadow],
+        ),
+        test_utils::ShadowTest::new(
+            "test_parent_death_signal_delivery",
+            test_parent_death_signal_delivery,
             set![TestEnv::Libc, TestEnv::Shadow],
         ),
         test_utils::ShadowTest::new("test_name", test_name, set![TestEnv::Libc, TestEnv::Shadow]),
@@ -87,6 +148,113 @@ fn test_tid_addr() -> Result<(), String> {
         // `black_box` aren't enough)
         println!("{}", unsafe { *addr });
     }
+
+    Ok(())
+}
+
+fn test_parent_death_signal() -> Result<(), String> {
+    let mut signal = -1;
+
+    assert_with_errno!(unsafe { libc::prctl(libc::PR_GET_PDEATHSIG, &mut signal) } == 0);
+    assert_eq!(signal, 0);
+
+    assert_with_errno!(unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) } == 0);
+    assert_with_errno!(unsafe { libc::prctl(libc::PR_GET_PDEATHSIG, &mut signal) } == 0);
+    assert_eq!(signal, libc::SIGTERM);
+
+    assert_with_errno!(unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, 0) } == 0);
+    assert_with_errno!(unsafe { libc::prctl(libc::PR_GET_PDEATHSIG, &mut signal) } == 0);
+    assert_eq!(signal, 0);
+
+    Ok(())
+}
+
+fn test_parent_death_signal_delivery() -> Result<(), String> {
+    let (ready_reader, ready_writer) = pipe().unwrap();
+    let (result_reader, result_writer) = pipe().unwrap();
+
+    let supervisor_pid = unsafe { libc::fork() };
+    assert_with_errno!(supervisor_pid >= 0);
+
+    if supervisor_pid == 0 {
+        let worker_pid = unsafe { libc::fork() };
+        if worker_pid < 0 {
+            unsafe { libc::_exit(10) };
+        }
+
+        if worker_pid == 0 {
+            let expected_parent_pid = unsafe { libc::getppid() };
+            let (signal_reader, signal_writer) = pipe().unwrap();
+            PARENT_DEATH_SIGNAL_WRITE_FD.store(signal_writer.as_raw_fd(), Ordering::SeqCst);
+            PARENT_DEATH_SIGNAL_NUMBER.store(0, Ordering::SeqCst);
+            PARENT_DEATH_SIGNAL_SENDER.store(0, Ordering::SeqCst);
+
+            let action = SigAction::new(
+                SigHandler::SigAction(parent_death_signal_handler),
+                SaFlags::SA_SIGINFO,
+                SigSet::empty(),
+            );
+            assert!(unsafe { nix::sys::signal::sigaction(NixSignal::SIGUSR1, &action) }.is_ok());
+
+            assert_eq!(unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGUSR1) }, 0);
+
+            let mut configured_signal = -1;
+            assert_eq!(
+                unsafe { libc::prctl(libc::PR_GET_PDEATHSIG, &mut configured_signal) },
+                0
+            );
+            assert_eq!(configured_signal, libc::SIGUSR1);
+
+            assert_eq!(write(&ready_writer, &[1]), Ok(1));
+            drop(ready_writer);
+
+            let status = match wait_for_parent_death_signal(signal_reader.as_raw_fd()) {
+                Ok(()) => {
+                    let mut byte = [0];
+                    let read_result = read(&signal_reader, &mut byte);
+                    if read_result == Ok(1)
+                        && PARENT_DEATH_SIGNAL_NUMBER.load(Ordering::SeqCst) == libc::SIGUSR1
+                        && PARENT_DEATH_SIGNAL_SENDER.load(Ordering::SeqCst) == expected_parent_pid
+                    {
+                        0
+                    } else {
+                        1
+                    }
+                }
+                Err(err) => {
+                    eprintln!("{err}");
+                    1
+                }
+            };
+
+            PARENT_DEATH_SIGNAL_WRITE_FD.store(-1, Ordering::SeqCst);
+
+            let _ = write(&result_writer, &[status]);
+            unsafe { libc::_exit(status.into()) };
+        }
+
+        drop(ready_writer);
+        drop(result_writer);
+
+        let mut ready = [0];
+        match read(&ready_reader, &mut ready) {
+            Ok(1) if ready[0] == 1 => unsafe { libc::_exit(0) },
+            _ => unsafe { libc::_exit(11) },
+        }
+    }
+
+    drop(ready_reader);
+    drop(ready_writer);
+    drop(result_writer);
+
+    let mut wait_status = 0;
+    assert_with_errno!(unsafe { libc::waitpid(supervisor_pid, &mut wait_status, 0) } == supervisor_pid);
+    assert!(libc::WIFEXITED(wait_status));
+    assert_eq!(libc::WEXITSTATUS(wait_status), 0);
+
+    let mut result = [255];
+    assert_eq!(read(&result_reader, &mut result), Ok(1));
+    assert_eq!(result[0], 0);
 
     Ok(())
 }

--- a/src/test/prctl/test_prctl.rs
+++ b/src/test/prctl/test_prctl.rs
@@ -1,5 +1,5 @@
 use linux_api::prctl::ArchPrctlOp;
-use nix::poll::{poll, PollFd, PollFlags};
+use nix::poll::{PollFd, PollFlags, poll};
 use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal as NixSignal};
 use rustix::fd::AsRawFd;
 use rustix::io::{read, write};
@@ -45,7 +45,9 @@ fn wait_for_parent_death_signal(fd: libc::c_int) -> Result<(), String> {
                     return Ok(());
                 }
 
-                return Err(format!("Unexpected poll events while waiting for signal: {events:?}"));
+                return Err(format!(
+                    "Unexpected poll events while waiting for signal: {events:?}"
+                ));
             }
             Err(nix::errno::Errno::EINTR) => continue,
             Err(err) => return Err(format!("poll failed while waiting for signal: {err}")),
@@ -196,7 +198,10 @@ fn test_parent_death_signal_delivery() -> Result<(), String> {
             );
             assert!(unsafe { nix::sys::signal::sigaction(NixSignal::SIGUSR1, &action) }.is_ok());
 
-            assert_eq!(unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGUSR1) }, 0);
+            assert_eq!(
+                unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGUSR1) },
+                0
+            );
 
             let mut configured_signal = -1;
             assert_eq!(
@@ -248,7 +253,9 @@ fn test_parent_death_signal_delivery() -> Result<(), String> {
     drop(result_writer);
 
     let mut wait_status = 0;
-    assert_with_errno!(unsafe { libc::waitpid(supervisor_pid, &mut wait_status, 0) } == supervisor_pid);
+    assert_with_errno!(
+        unsafe { libc::waitpid(supervisor_pid, &mut wait_status, 0) } == supervisor_pid
+    );
     assert!(libc::WIFEXITED(wait_status));
     assert_eq!(libc::WEXITSTATUS(wait_status), 0);
 


### PR DESCRIPTION
Handle PR_SET_PDEATHSIG and PR_GET_PDEATHSIG in Shadow instead of rejecting them. Store the configured signal in emulated process state so managed prctl calls no longer depend on the host kernel's parent-death signal setting.

When a parent process exits, deliver the configured signal to each child before reparenting it to INIT. This preserves the old parent PID in the generated siginfo payload while keeping the emulation separate from the shim's native PDEATHSIG used for cleanup.

Track children by pid while delivering parent-death signals so the exit path can signal each child before reparenting it without holding temporary child process references across the traversal.

The delivery model is intentionally process-granular: Shadow tracks parentage per process, so this approximates Linux's parent-thread semantics closely enough for process supervisors without claiming exact thread-level behavior. Add regression tests that cover set/get/clear of the parent-death signal and delivery to a blocked child with the correct si_pid.

This is another patch needed for PostgreSQL to work properly in Shadow. What we saw before that patch:

  - PostgreSQL startup failed with
    `FATAL: could not request parent death signal: Invalid argument`
  - Shadow logged
    `Not allowing unimplemented prctl PR_SET_PDEATHSIG`

After adding the patch, that blocker went away and Postgres could start, assuming the other Postgres-specific fixes were also in place.