### PR TITLE
linux-api: Expose scheduler and rseq constants and types

### DIFF
--- a/src/lib/linux-api/bindings-wrapper.h
+++ b/src/lib/linux-api/bindings-wrapper.h
@@ -18,6 +18,7 @@
 #include <linux/rseq.h>
 #include <linux/rtnetlink.h>
 #include <linux/sched.h>
+#include <linux/sched/types.h>
 #include <linux/signal.h>
 #include <linux/sockios.h>
 #include <linux/stat.h>

--- a/src/lib/linux-api/gen-kernel-bindings.sh
+++ b/src/lib/linux-api/gen-kernel-bindings.sh
@@ -135,6 +135,7 @@ bindgen_flags+=("--allowlist-type=sched_attr")
 
 # rseq types
 bindgen_flags+=("--allowlist-type=rseq")
+bindgen_flags+=("--allowlist-type=rseq_flags")
 
 # in.h types
 bindgen_flags+=("--allowlist-type=sockaddr_in")

--- a/src/lib/linux-api/gen-kernel-bindings.sh
+++ b/src/lib/linux-api/gen-kernel-bindings.sh
@@ -131,6 +131,7 @@ bindgen_flags+=("--allowlist-type=__kernel_old_itimerval")
 
 # Sched types
 bindgen_flags+=("--allowlist-type=clone_args")
+bindgen_flags+=("--allowlist-type=sched_attr")
 
 # rseq types
 bindgen_flags+=("--allowlist-type=rseq")

--- a/src/lib/linux-api/src/bindings.rs
+++ b/src/lib/linux-api/src/bindings.rs
@@ -2482,6 +2482,9 @@ const _: () = {
     ["Offset of field: linux_rlimit64::rlim_max"]
         [::core::mem::offset_of!(linux_rlimit64, rlim_max) - 8usize];
 };
+pub const LINUX_rseq_flags_RSEQ_FLAG_UNREGISTER: linux_rseq_flags = 1;
+pub const LINUX_rseq_flags_RSEQ_FLAG_SLICE_EXT_DEFAULT_ON: linux_rseq_flags = 2;
+pub type linux_rseq_flags = ::core::ffi::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct linux_rseq_slice_ctrl {

--- a/src/lib/linux-api/src/bindings.rs
+++ b/src/lib/linux-api/src/bindings.rs
@@ -1178,6 +1178,8 @@ pub const LINUX_SCHED_FLAG_UTIL_CLAMP_MAX: u32 = 64;
 pub const LINUX_SCHED_FLAG_KEEP_ALL: u32 = 24;
 pub const LINUX_SCHED_FLAG_UTIL_CLAMP: u32 = 96;
 pub const LINUX_SCHED_FLAG_ALL: u32 = 127;
+pub const LINUX_SCHED_ATTR_SIZE_VER0: u32 = 48;
+pub const LINUX_SCHED_ATTR_SIZE_VER1: u32 = 56;
 pub const LINUX_NSIG: u32 = 32;
 pub const LINUX_SIGHUP: u32 = 1;
 pub const LINUX_SIGINT: u32 = 2;
@@ -2092,6 +2094,7 @@ pub const LINUX_AF_XDP: u32 = 44;
 pub const LINUX_AF_MCTP: u32 = 45;
 pub type linux___u8 = ::core::ffi::c_uchar;
 pub type linux___u16 = ::core::ffi::c_ushort;
+pub type linux___s32 = ::core::ffi::c_int;
 pub type linux___u32 = ::core::ffi::c_uint;
 pub type linux___u64 = ::core::ffi::c_ulonglong;
 #[repr(C)]
@@ -3528,6 +3531,45 @@ const _: () = {
         [::core::mem::offset_of!(linux_clone_args, set_tid_size) - 72usize];
     ["Offset of field: linux_clone_args::cgroup"]
         [::core::mem::offset_of!(linux_clone_args, cgroup) - 80usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct linux_sched_attr {
+    pub size: linux___u32,
+    pub sched_policy: linux___u32,
+    pub sched_flags: linux___u64,
+    pub sched_nice: linux___s32,
+    pub sched_priority: linux___u32,
+    pub sched_runtime: linux___u64,
+    pub sched_deadline: linux___u64,
+    pub sched_period: linux___u64,
+    pub sched_util_min: linux___u32,
+    pub sched_util_max: linux___u32,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of linux_sched_attr"][::core::mem::size_of::<linux_sched_attr>() - 56usize];
+    ["Alignment of linux_sched_attr"][::core::mem::align_of::<linux_sched_attr>() - 8usize];
+    ["Offset of field: linux_sched_attr::size"]
+        [::core::mem::offset_of!(linux_sched_attr, size) - 0usize];
+    ["Offset of field: linux_sched_attr::sched_policy"]
+        [::core::mem::offset_of!(linux_sched_attr, sched_policy) - 4usize];
+    ["Offset of field: linux_sched_attr::sched_flags"]
+        [::core::mem::offset_of!(linux_sched_attr, sched_flags) - 8usize];
+    ["Offset of field: linux_sched_attr::sched_nice"]
+        [::core::mem::offset_of!(linux_sched_attr, sched_nice) - 16usize];
+    ["Offset of field: linux_sched_attr::sched_priority"]
+        [::core::mem::offset_of!(linux_sched_attr, sched_priority) - 20usize];
+    ["Offset of field: linux_sched_attr::sched_runtime"]
+        [::core::mem::offset_of!(linux_sched_attr, sched_runtime) - 24usize];
+    ["Offset of field: linux_sched_attr::sched_deadline"]
+        [::core::mem::offset_of!(linux_sched_attr, sched_deadline) - 32usize];
+    ["Offset of field: linux_sched_attr::sched_period"]
+        [::core::mem::offset_of!(linux_sched_attr, sched_period) - 40usize];
+    ["Offset of field: linux_sched_attr::sched_util_min"]
+        [::core::mem::offset_of!(linux_sched_attr, sched_util_min) - 48usize];
+    ["Offset of field: linux_sched_attr::sched_util_max"]
+        [::core::mem::offset_of!(linux_sched_attr, sched_util_max) - 52usize];
 };
 pub type linux_sigset_t = ::core::ffi::c_ulong;
 pub type linux___signalfn_t =

--- a/src/lib/linux-api/src/rseq.rs
+++ b/src/lib/linux-api/src/rseq.rs
@@ -1,5 +1,14 @@
-use crate::bindings;
+use crate::{bindings, const_conversions};
 
 pub use bindings::linux_rseq;
 #[allow(non_camel_case_types)]
 pub type rseq = linux_rseq;
+
+bitflags::bitflags! {
+    #[allow(non_camel_case_types)]
+    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+    pub struct rseq_flags: i32 {
+        const RSEQ_FLAG_UNREGISTER = const_conversions::i32_from_u32(bindings::LINUX_rseq_flags_RSEQ_FLAG_UNREGISTER);
+        const RSEQ_FLAG_SLICE_EXT_DEFAULT_ON = const_conversions::i32_from_u32(bindings::LINUX_rseq_flags_RSEQ_FLAG_SLICE_EXT_DEFAULT_ON);
+    }
+}

--- a/src/lib/linux-api/src/sched.rs
+++ b/src/lib/linux-api/src/sched.rs
@@ -36,6 +36,11 @@ bitflags::bitflags! {
     }
 }
 
+/// This is the ABI-stable kernel version of `struct sched_param`, as for
+/// syscall `sched_getparam`.
+#[allow(non_camel_case_types)]
+pub type sched_attr = bindings::linux_sched_attr;
+
 bitflags::bitflags! {
     /// The flags passed to the `clone` and `clone3` syscalls.
     /// While `clone` is documented as taking an i32 parameter for flags,

--- a/src/lib/linux-api/src/sched.rs
+++ b/src/lib/linux-api/src/sched.rs
@@ -1,10 +1,40 @@
 use linux_syscall::{Result as LinuxSyscallResult, Result64};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::errno::Errno;
 use crate::ldt::linux_user_desc;
 use crate::posix_types::{Pid, kernel_pid_t};
 use crate::signal::Signal;
 use crate::{bindings, const_conversions};
+
+#[allow(non_camel_case_types)]
+#[repr(i32)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+pub enum Sched {
+    SCHED_NORMAL = const_conversions::i32_from_u32(bindings::LINUX_SCHED_NORMAL),
+    SCHED_FIFO = const_conversions::i32_from_u32(bindings::LINUX_SCHED_FIFO),
+    SCHED_RR = const_conversions::i32_from_u32(bindings::LINUX_SCHED_RR),
+    SCHED_BATCH = const_conversions::i32_from_u32(bindings::LINUX_SCHED_BATCH),
+    SCHED_IDLE = const_conversions::i32_from_u32(bindings::LINUX_SCHED_IDLE),
+    SCHED_DEADLINE = const_conversions::i32_from_u32(bindings::LINUX_SCHED_DEADLINE),
+    SCHED_EXT = const_conversions::i32_from_u32(bindings::LINUX_SCHED_EXT),
+}
+
+pub const SCHED_RESET_ON_FORK: i32 =
+    const_conversions::i32_from_u32(bindings::LINUX_SCHED_RESET_ON_FORK);
+
+bitflags::bitflags! {
+    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+    pub struct SchedFlags: i32 {
+        const SCHED_FLAG_RESET_ON_FORK = const_conversions::i32_from_u32(bindings::LINUX_SCHED_FLAG_RESET_ON_FORK);
+        const SCHED_FLAG_RECLAIM = const_conversions::i32_from_u32(bindings::LINUX_SCHED_FLAG_RECLAIM);
+        const SCHED_FLAG_DL_OVERRUN = const_conversions::i32_from_u32(bindings::LINUX_SCHED_FLAG_DL_OVERRUN);
+        const SCHED_FLAG_KEEP_POLICY = const_conversions::i32_from_u32(bindings::LINUX_SCHED_FLAG_KEEP_POLICY);
+        const SCHED_FLAG_KEEP_PARAMS = const_conversions::i32_from_u32(bindings::LINUX_SCHED_FLAG_KEEP_PARAMS);
+        const SCHED_FLAG_UTIL_CLAMP_MIN = const_conversions::i32_from_u32(bindings::LINUX_SCHED_FLAG_UTIL_CLAMP_MIN);
+        const SCHED_FLAG_UTIL_CLAMP_MAX = const_conversions::i32_from_u32(bindings::LINUX_SCHED_FLAG_UTIL_CLAMP_MAX);
+    }
+}
 
 bitflags::bitflags! {
     /// The flags passed to the `clone` and `clone3` syscalls.

--- a/src/main/host/syscall/handler/sched.rs
+++ b/src/main/host/syscall/handler/sched.rs
@@ -1,8 +1,9 @@
 use std::mem::MaybeUninit;
 
+use bitflags::Flags;
 use linux_api::errno::Errno;
 use linux_api::posix_types::kernel_pid_t;
-use linux_api::rseq::rseq;
+use linux_api::rseq::{rseq, rseq_flags};
 use log::warn;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
@@ -13,8 +14,6 @@ use crate::host::thread::ThreadId;
 
 // We always report that the thread is running on CPU 0, Node 0
 const CURRENT_CPU: u32 = 0;
-
-const RSEQ_FLAG_UNREGISTER: i32 = 1;
 
 impl SyscallHandler {
     log_syscall!(
@@ -123,11 +122,14 @@ impl SyscallHandler {
         let rseq_len = rseq_len.try_into().unwrap();
         let rseq_len = std::cmp::min(rseq_len, std::mem::size_of::<rseq>());
 
-        if flags & (!RSEQ_FLAG_UNREGISTER) != 0 {
-            warn!("Unrecognized rseq flags: {flags}");
+        let flags = rseq_flags::from_bits_retain(flags);
+        let unknown_flags = flags.unknown_bits();
+
+        if unknown_flags != 0 {
+            warn!("Unrecognized rseq flags: 0x{unknown_flags:x} in {flags:?}");
             return Err(Errno::EINVAL);
         }
-        if flags & RSEQ_FLAG_UNREGISTER != 0 {
+        if flags.contains(rseq_flags::RSEQ_FLAG_UNREGISTER) {
             // TODO:
             // * Validate that an rseq was previously registered
             // * Validate that `sig` matches registration


### PR DESCRIPTION
To facilitate https://github.com/shadow/shadow/pull/3744
