### PR TITLE
epoll: avoid oneshot test race

### DIFF
--- a/src/test/epoll/test_epoll_edge.rs
+++ b/src/test/epoll/test_epoll_edge.rs
@@ -161,12 +161,16 @@ fn test_threads_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
         )?;
 
         let timeout = Duration::from_millis(100);
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
 
-        let threads = [
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
-        ];
+        let threads: [std::thread::JoinHandle<()>; 3] = std::array::from_fn(|_| {
+            let result_tx = result_tx.clone();
+            std::thread::spawn(move || {
+                let result = do_epoll_wait(epollfd, timeout, /* do_read= */ false);
+                result_tx.send(result).unwrap();
+            })
+        });
+        drop(result_tx);
 
         // Wait for readers to block.
         std::thread::sleep(timeout / 3);
@@ -174,11 +178,24 @@ fn test_threads_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
         // Make the read-end readable.
         unistd::write(writefd, &[0])?;
 
-        // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 3);
+        // Wait for the first edge to be consumed, then drain the byte before
+        // generating the next edge. Otherwise the second write can happen
+        // while the fd is still readable and fail to create another wakeup.
+        let first_result = result_rx.recv().unwrap();
+        unistd::read(readfd, &mut [0])?;
+
+        // Make the read-end readable again.
         unistd::write(writefd, &[0])?;
 
-        let mut results = threads.map(|t| t.join().unwrap());
+        let mut results = [
+            first_result,
+            result_rx.recv().unwrap(),
+            result_rx.recv().unwrap(),
+        ];
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
 
         // Two of the threads should have gotten an event, but we don't know which one.
         // Sort results by number of events received.
@@ -257,7 +274,7 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
 
         drop(write_requested_tx);
         thread.join().unwrap()?;
-        let results = vec![results0, results1, results2];
+        let results = [results0, results1, results2];
 
         // The first wait should have received the event
         ensure_ord!(results[0].epoll_res, ==, Ok(1));

--- a/src/test/epoll/test_epoll_edge.rs
+++ b/src/test/epoll/test_epoll_edge.rs
@@ -215,37 +215,35 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
         )?;
 
         let timeout = Duration::from_millis(100);
-        let (wait_started_tx, wait_started_rx) = std::sync::mpsc::channel();
-        let (wait_finished_tx, wait_finished_rx) = std::sync::mpsc::channel();
+        let (write_requested_tx, write_requested_rx) = std::sync::mpsc::channel();
+        let (write_finished_tx, write_finished_rx) = std::sync::mpsc::channel();
 
         let thread = std::thread::spawn(move || {
-            let wait_once = || {
-                wait_started_tx.send(()).unwrap();
-                let res = do_epoll_wait(epollfd, timeout, /* do_read= */ false);
-                wait_finished_tx.send(()).unwrap();
-                res
-            };
-
-            vec![wait_once(), wait_once(), wait_once()]
+            while let Ok(()) = write_requested_rx.recv() {
+                unistd::write(writefd, &[0])?;
+                write_finished_tx.send(()).unwrap();
+            }
+            Ok::<(), anyhow::Error>(())
         });
 
-        // Coordinate each phase explicitly so that the second wait has already
-        // timed out before we rearm the oneshot registration. Using fixed
-        // sleeps here is racy under scheduler delays.
-        wait_started_rx.recv().unwrap();
+        // Keep the waits on this thread and let a helper thread perform only
+        // the writes. In this test, each wait has the same expected result
+        // whether the corresponding write happens just before or during the
+        // wait, and the rearm still happens strictly after the second wait.
+        let request_write = || -> anyhow::Result<()> {
+            write_requested_tx.send(()).unwrap();
+            write_finished_rx.recv().unwrap();
+            Ok(())
+        };
 
         // Make the read-end readable.
-        unistd::write(writefd, &[0])?;
-        wait_finished_rx.recv().unwrap();
+        request_write()?;
+        let results0 = do_epoll_wait(epollfd, timeout, /* do_read= */ false);
 
         // Wait again and make the read-end readable again.
-        wait_started_rx.recv().unwrap();
-        unistd::write(writefd, &[0])?;
+        request_write()?;
+        let results1 = do_epoll_wait(epollfd, timeout, /* do_read= */ false);
 
-        // Wait for the second wait to time out.
-        wait_finished_rx.recv().unwrap();
-
-        wait_started_rx.recv().unwrap();
         epoll::epoll_ctl(
             epollfd,
             epoll::EpollOp::EpollCtlMod,
@@ -254,9 +252,12 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
         )?;
 
         // Make the read-end readable.
-        unistd::write(writefd, &[0])?;
+        request_write()?;
+        let results2 = do_epoll_wait(epollfd, timeout, /* do_read= */ false);
 
-        let results = thread.join().unwrap();
+        drop(write_requested_tx);
+        thread.join().unwrap()?;
+        let results = vec![results0, results1, results2];
 
         // The first wait should have received the event
         ensure_ord!(results[0].epoll_res, ==, Ok(1));

--- a/src/test/epoll/test_epoll_edge.rs
+++ b/src/test/epoll/test_epoll_edge.rs
@@ -226,11 +226,7 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
                 res
             };
 
-            vec![
-                wait_once(),
-                wait_once(),
-                wait_once(),
-            ]
+            vec![wait_once(), wait_once(), wait_once()]
         });
 
         // Coordinate each phase explicitly so that the second wait has already

--- a/src/test/epoll/test_epoll_edge.rs
+++ b/src/test/epoll/test_epoll_edge.rs
@@ -215,28 +215,41 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
         )?;
 
         let timeout = Duration::from_millis(100);
+        let (wait_started_tx, wait_started_rx) = std::sync::mpsc::channel();
+        let (wait_finished_tx, wait_finished_rx) = std::sync::mpsc::channel();
 
         let thread = std::thread::spawn(move || {
+            let wait_once = || {
+                wait_started_tx.send(()).unwrap();
+                let res = do_epoll_wait(epollfd, timeout, /* do_read= */ false);
+                wait_finished_tx.send(()).unwrap();
+                res
+            };
+
             vec![
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
+                wait_once(),
+                wait_once(),
+                wait_once(),
             ]
         });
 
-        // Wait for readers to block.
-        std::thread::sleep(timeout / 3);
+        // Coordinate each phase explicitly so that the second wait has already
+        // timed out before we rearm the oneshot registration. Using fixed
+        // sleeps here is racy under scheduler delays.
+        wait_started_rx.recv().unwrap();
 
         // Make the read-end readable.
         unistd::write(writefd, &[0])?;
+        wait_finished_rx.recv().unwrap();
 
         // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 3);
+        wait_started_rx.recv().unwrap();
         unistd::write(writefd, &[0])?;
 
         // Wait for the second wait to time out.
-        std::thread::sleep(timeout);
+        wait_finished_rx.recv().unwrap();
 
+        wait_started_rx.recv().unwrap();
         epoll::epoll_ctl(
             epollfd,
             epoll::EpollOp::EpollCtlMod,


### PR DESCRIPTION
Replace the sleep-based sequencing in `test_oneshot_multi_write` with explicit synchronization between the waiter thread and the writer thread.

The old test assumed the second epoll_wait had already timed out before the main thread rearmed the EPOLLONESHOT registration. Under scheduler delay that assumption can fail: the second wait may still be blocked when EPOLL_CTL_MOD rearms the interest and the following write arrives, causing the second wait to observe an event instead of timing out. This matches the CI failure in `epoll-edge-rs-linux` on the unix-dgram case.

Coordinate each phase explicitly so that the second wait has definitely finished before the rearm, and the third wait is the one that observes the post-rearm event. This removes the timing race without changing the behavior being tested.

---

This fixes the flake that happened here: https://github.com/shadow/shadow/actions/runs/24945895909/job/73230158110?pr=3745

To repro the flake reliably, use this patch:
```diff
diff --git a/src/test/epoll/test_epoll_edge.rs b/src/test/epoll/test_epoll_edge.rs
index c245a55c1..b9797e65a 100644
--- a/src/test/epoll/test_epoll_edge.rs
+++ b/src/test/epoll/test_epoll_edge.rs
@@ -219,7 +219,13 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
         let thread = std::thread::spawn(move || {
             vec![
                 do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
+                // Control-only delay to reproduce the race where the second
+                // wait is still blocked when the main thread rearms the
+                // oneshot registration and performs the final write.
+                {
+                    std::thread::sleep(timeout);
+                    do_epoll_wait(epollfd, timeout, /* do_read= */ false)
+                },
                 do_epoll_wait(epollfd, timeout, /* do_read= */ false),
             ]
         });

```