### PR TITLE
Reorganize the edge-triggered epoll tests to try to reduce timing-related flakiness

### DIFF
--- a/src/test/epoll/test_epoll_edge.rs
+++ b/src/test/epoll/test_epoll_edge.rs
@@ -65,28 +65,37 @@ fn test_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow::Result
 
         let timeout = Duration::from_millis(200);
 
-        let thread = std::thread::spawn(move || {
-            vec![
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                // The last one is supposed to timeout.
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-            ]
-        });
+        // Results from the epoll waits.
+        let mut results = Vec::new();
 
         ////// First epoll wait.
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait for the epoll wait to block and make the read-end readable.
         std::thread::sleep(timeout / 3);
         unistd::write(writefd, &[0])?;
 
+        results.push(thread.join().unwrap());
+
         ////// Second epoll wait.
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait again and make the read-end readable again.
         std::thread::sleep(timeout / 3);
         unistd::write(writefd, &[0])?;
 
-        let results = thread.join().unwrap();
+        results.push(thread.join().unwrap());
+
+        ////// Third epoll wait (should time out).
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
+
+        results.push(thread.join().unwrap());
 
         ////// Check results.
 
@@ -119,27 +128,30 @@ fn test_write_then_partial_read(readfd: libc::c_int, writefd: libc::c_int) -> an
 
         let timeout = Duration::from_millis(200);
 
-        let thread = std::thread::spawn(move || {
-            vec![
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                // The second one is supposed to timeout.
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-            ]
-        });
+        // Results from the epoll waits.
+        let mut results = Vec::new();
 
         ////// First epoll wait.
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait for the epoll wait to block and make the read-end readable.
         std::thread::sleep(timeout / 3);
         unistd::write(writefd, &[0, 0])?;
 
+        results.push(thread.join().unwrap());
+
         ////// Second epoll wait (should time out).
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait and read some, but not all, from the buffer.
         std::thread::sleep(timeout / 3);
         unistd::read(readfd, &mut [0])?;
 
-        let results = thread.join().unwrap();
+        results.push(thread.join().unwrap());
 
         ////// Check results.
 
@@ -224,21 +236,24 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
 
         let timeout = Duration::from_millis(200);
 
-        let thread = std::thread::spawn(move || {
-            vec![
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-            ]
-        });
+        // Results from the epoll waits.
+        let mut results = Vec::new();
 
         ////// First epoll wait.
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait for the epoll wait to block and make the read-end readable.
         std::thread::sleep(timeout / 3);
         unistd::write(writefd, &[0])?;
 
+        results.push(thread.join().unwrap());
+
         ////// Second epoll wait (should time out).
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait again and make the read-end readable again.
         std::thread::sleep(timeout / 3);
@@ -247,7 +262,15 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
         // Wait for the second wait to time out.
         std::thread::sleep(timeout);
 
+        results.push(thread.join().unwrap());
+
         ////// Third epoll wait.
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
+
+        // Wait for the epoll wait to block.
+        std::thread::sleep(timeout / 5);
 
         // Rearm the edge-triggered epoll.
         epoll::epoll_ctl(
@@ -260,7 +283,7 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
         // Make the read-end readable.
         unistd::write(writefd, &[0])?;
 
-        let results = thread.join().unwrap();
+        results.push(thread.join().unwrap());
 
         ////// Check results.
 
@@ -294,35 +317,48 @@ fn test_eventfd_multi_write() -> anyhow::Result<()> {
 
         let timeout = Duration::from_millis(200);
 
-        let thread = std::thread::spawn(move || {
-            vec![
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                // The last one is supposed to timeout.
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-            ]
-        });
+        // Results from the epoll waits.
+        let mut results = Vec::new();
 
         ////// First epoll wait.
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait for the epoll wait to block and make the read-end readable.
         std::thread::sleep(timeout / 4);
         unistd::write(efd, &1u64.to_le_bytes())?;
 
+        results.push(thread.join().unwrap());
+
         ////// Second epoll wait.
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait again and make the read-end readable again.
         std::thread::sleep(timeout / 4);
         unistd::write(efd, &1u64.to_le_bytes())?;
 
+        results.push(thread.join().unwrap());
+
         ////// Third epoll wait.
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait again and make the read-end readable again, but with zero value this time.
         std::thread::sleep(timeout / 4);
         unistd::write(efd, &0u64.to_le_bytes())?;
 
-        let results = thread.join().unwrap();
+        results.push(thread.join().unwrap());
+
+        ////// Fourth epoll wait (should time out).
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
+
+        results.push(thread.join().unwrap());
 
         ////// Check results.
 
@@ -378,28 +414,37 @@ fn test_netlink_multi_write() -> anyhow::Result<()> {
 
         let timeout = Duration::from_millis(200);
 
-        let thread = std::thread::spawn(move || {
-            vec![
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                // The last one is supposed to timeout.
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-            ]
-        });
+        // Results from the epoll waits.
+        let mut results = Vec::new();
 
         ////// First epoll wait.
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait for the epoll wait to block and make the read-end readable.
         std::thread::sleep(timeout / 3);
         unistd::write(fd, buffer.as_slice())?;
 
+        results.push(thread.join().unwrap());
+
         ////// Second epoll wait.
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait again and make the read-end readable again.
         std::thread::sleep(timeout / 3);
         unistd::write(fd, buffer.as_slice())?;
 
-        let results = thread.join().unwrap();
+        results.push(thread.join().unwrap());
+
+        ////// Third epoll wait (should time out).
+
+        let thread =
+            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
+
+        results.push(thread.join().unwrap());
 
         ////// Check results.
 

--- a/src/test/epoll/test_epoll_edge.rs
+++ b/src/test/epoll/test_epoll_edge.rs
@@ -74,7 +74,7 @@ fn test_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow::Result
             std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait for the epoll wait to block and make the read-end readable.
-        std::thread::sleep(timeout / 3);
+        std::thread::sleep(timeout / 5);
         unistd::write(writefd, &[0])?;
 
         results.push(thread.join().unwrap());
@@ -85,7 +85,7 @@ fn test_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow::Result
             std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 3);
+        std::thread::sleep(timeout / 5);
         unistd::write(writefd, &[0])?;
 
         results.push(thread.join().unwrap());
@@ -137,7 +137,7 @@ fn test_write_then_partial_read(readfd: libc::c_int, writefd: libc::c_int) -> an
             std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait for the epoll wait to block and make the read-end readable.
-        std::thread::sleep(timeout / 3);
+        std::thread::sleep(timeout / 5);
         unistd::write(writefd, &[0, 0])?;
 
         results.push(thread.join().unwrap());
@@ -148,7 +148,7 @@ fn test_write_then_partial_read(readfd: libc::c_int, writefd: libc::c_int) -> an
             std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait and read some, but not all, from the buffer.
-        std::thread::sleep(timeout / 3);
+        std::thread::sleep(timeout / 5);
         unistd::read(readfd, &mut [0])?;
 
         results.push(thread.join().unwrap());
@@ -189,13 +189,13 @@ fn test_threads_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
         ];
 
         // Wait for readers to block.
-        std::thread::sleep(timeout / 3);
+        std::thread::sleep(timeout / 5);
 
         // Make the read-end readable.
         unistd::write(writefd, &[0])?;
 
         // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 3);
+        std::thread::sleep(timeout / 10);
         unistd::write(writefd, &[0])?;
 
         let mut results = threads.map(|t| t.join().unwrap());
@@ -245,7 +245,7 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
             std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait for the epoll wait to block and make the read-end readable.
-        std::thread::sleep(timeout / 3);
+        std::thread::sleep(timeout / 5);
         unistd::write(writefd, &[0])?;
 
         results.push(thread.join().unwrap());
@@ -256,7 +256,7 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
             std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 3);
+        std::thread::sleep(timeout / 5);
         unistd::write(writefd, &[0])?;
 
         // Wait for the second wait to time out.
@@ -326,7 +326,7 @@ fn test_eventfd_multi_write() -> anyhow::Result<()> {
             std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait for the epoll wait to block and make the read-end readable.
-        std::thread::sleep(timeout / 4);
+        std::thread::sleep(timeout / 5);
         unistd::write(efd, &1u64.to_le_bytes())?;
 
         results.push(thread.join().unwrap());
@@ -337,7 +337,7 @@ fn test_eventfd_multi_write() -> anyhow::Result<()> {
             std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 4);
+        std::thread::sleep(timeout / 5);
         unistd::write(efd, &1u64.to_le_bytes())?;
 
         results.push(thread.join().unwrap());
@@ -348,7 +348,7 @@ fn test_eventfd_multi_write() -> anyhow::Result<()> {
             std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait again and make the read-end readable again, but with zero value this time.
-        std::thread::sleep(timeout / 4);
+        std::thread::sleep(timeout / 5);
         unistd::write(efd, &0u64.to_le_bytes())?;
 
         results.push(thread.join().unwrap());
@@ -423,7 +423,7 @@ fn test_netlink_multi_write() -> anyhow::Result<()> {
             std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait for the epoll wait to block and make the read-end readable.
-        std::thread::sleep(timeout / 3);
+        std::thread::sleep(timeout / 5);
         unistd::write(fd, buffer.as_slice())?;
 
         results.push(thread.join().unwrap());
@@ -434,7 +434,7 @@ fn test_netlink_multi_write() -> anyhow::Result<()> {
             std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false));
 
         // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 3);
+        std::thread::sleep(timeout / 5);
         unistd::write(fd, buffer.as_slice())?;
 
         results.push(thread.join().unwrap());

--- a/src/test/epoll/test_epoll_edge.rs
+++ b/src/test/epoll/test_epoll_edge.rs
@@ -74,17 +74,21 @@ fn test_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow::Result
             ]
         });
 
-        // Wait for readers to block.
-        std::thread::sleep(timeout / 3);
+        ////// First epoll wait.
 
-        // Make the read-end readable.
+        // Wait for the epoll wait to block and make the read-end readable.
+        std::thread::sleep(timeout / 3);
         unistd::write(writefd, &[0])?;
+
+        ////// Second epoll wait.
 
         // Wait again and make the read-end readable again.
         std::thread::sleep(timeout / 3);
         unistd::write(writefd, &[0])?;
 
         let results = thread.join().unwrap();
+
+        ////// Check results.
 
         // The first two waits should have received the event
         for res in &results[..2] {
@@ -123,17 +127,21 @@ fn test_write_then_partial_read(readfd: libc::c_int, writefd: libc::c_int) -> an
             ]
         });
 
-        // Wait for readers to block.
-        std::thread::sleep(timeout / 3);
+        ////// First epoll wait.
 
-        // Make the read-end readable.
+        // Wait for the epoll wait to block and make the read-end readable.
+        std::thread::sleep(timeout / 3);
         unistd::write(writefd, &[0, 0])?;
+
+        ////// Second epoll wait (should time out).
 
         // Wait and read some, but not all, from the buffer.
         std::thread::sleep(timeout / 3);
         unistd::read(readfd, &mut [0])?;
 
         let results = thread.join().unwrap();
+
+        ////// Check results.
 
         // The first wait should have received the event
         ensure_ord!(results[0].epoll_res, ==, Ok(1));
@@ -224,11 +232,13 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
             ]
         });
 
-        // Wait for readers to block.
-        std::thread::sleep(timeout / 3);
+        ////// First epoll wait.
 
-        // Make the read-end readable.
+        // Wait for the epoll wait to block and make the read-end readable.
+        std::thread::sleep(timeout / 3);
         unistd::write(writefd, &[0])?;
+
+        ////// Second epoll wait (should time out).
 
         // Wait again and make the read-end readable again.
         std::thread::sleep(timeout / 3);
@@ -237,6 +247,9 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
         // Wait for the second wait to time out.
         std::thread::sleep(timeout);
 
+        ////// Third epoll wait.
+
+        // Rearm the edge-triggered epoll.
         epoll::epoll_ctl(
             epollfd,
             epoll::EpollOp::EpollCtlMod,
@@ -248,6 +261,8 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
         unistd::write(writefd, &[0])?;
 
         let results = thread.join().unwrap();
+
+        ////// Check results.
 
         // The first wait should have received the event
         ensure_ord!(results[0].epoll_res, ==, Ok(1));
@@ -289,21 +304,27 @@ fn test_eventfd_multi_write() -> anyhow::Result<()> {
             ]
         });
 
-        // Wait for readers to block.
-        std::thread::sleep(timeout / 4);
+        ////// First epoll wait.
 
-        // Make the read-end readable.
+        // Wait for the epoll wait to block and make the read-end readable.
+        std::thread::sleep(timeout / 4);
         unistd::write(efd, &1u64.to_le_bytes())?;
+
+        ////// Second epoll wait.
 
         // Wait again and make the read-end readable again.
         std::thread::sleep(timeout / 4);
         unistd::write(efd, &1u64.to_le_bytes())?;
+
+        ////// Third epoll wait.
 
         // Wait again and make the read-end readable again, but with zero value this time.
         std::thread::sleep(timeout / 4);
         unistd::write(efd, &0u64.to_le_bytes())?;
 
         let results = thread.join().unwrap();
+
+        ////// Check results.
 
         // The first three waits should have received the event
         for res in &results[..3] {
@@ -366,17 +387,21 @@ fn test_netlink_multi_write() -> anyhow::Result<()> {
             ]
         });
 
-        // Wait for readers to block.
-        std::thread::sleep(timeout / 3);
+        ////// First epoll wait.
 
-        // Make the read-end readable.
+        // Wait for the epoll wait to block and make the read-end readable.
+        std::thread::sleep(timeout / 3);
         unistd::write(fd, buffer.as_slice())?;
+
+        ////// Second epoll wait.
 
         // Wait again and make the read-end readable again.
         std::thread::sleep(timeout / 3);
         unistd::write(fd, buffer.as_slice())?;
 
         let results = thread.join().unwrap();
+
+        ////// Check results.
 
         // The first two waits should have received the event
         for res in &results[..2] {


### PR DESCRIPTION
Part of #3410.

We've been having issues with these tests running slowly and exceeding their expected duration in CI. I think what exacerbates the situation is that for tests running two parallel threads, we don't have any synchronization between the two threads after each epoll wait. So the timing of the threads gradually becomes more out-of-sync over time.

This commit launches each epoll wait in a new thread so that the epoll wait in one thread and the sleep in the other thread have a common reference point.

We could have alternatively used some synchronization primitive to synchronize the threads, but I think it's better to rely on the thread start/stop synchronization instead of introducing futex operations to the test.

There's still a race between the epoll waits in one thread and the writes in the other thread. This also shortens the sleeps in all tests to hopefully reduce how often things approach the timeout.