### PR TITLE
Extend and modularize shadow-exec

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,8 +43,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v6
         with:
-          # Oldest python version supported by shadowtools package
-          python-version: '3.8'
+          # Oldest python version supported by shadowtools package.
+          # See shadowtools/pyproject.toml, `requires-python`
+          python-version: '3.9'
       # Last bumped 2024-12-02
       - run: pip install mypy==1.11.2
       # Type annotations of dependencies

--- a/shadowtools/README.md
+++ b/shadowtools/README.md
@@ -6,16 +6,18 @@ This is a python package containing tools for working with the [shadow] simulato
 
 [shadow]: <https://shadow.github.io/>
 
-It currently contains two modules:
+It currently contains the modules:
 
 * `shadowtools.config` - `TypedDict`s defining shadow's configuration file format.
   These are meant to facilitate dynamic generation of shadow config files
   from python code.
 
-* `shadowtools.shadow_exec` - Streamlines running a single command in a
-  single-host shadow simulation.
+* `shadowtools.shadow_exec` - Tools for running shadow simulations.
 
-See the respective modules for further documentation and examples.
+And the CLI script:
+
+* `shadow-exec` - Streamlines running a single command in a single-host shadow
+  simulation.
 
 ## Installation
 

--- a/shadowtools/src/shadowtools/shadow_exec.py
+++ b/shadowtools/src/shadowtools/shadow_exec.py
@@ -23,6 +23,7 @@ import argparse
 import glob
 import re
 import enum
+import os
 import subprocess
 import shlex
 import shutil
@@ -105,8 +106,8 @@ def _make_controller_host(args: Iterable[str]) -> scfg.Host:
         # Change back to host working dir
         cd {shlex.quote(str(Path('.').resolve()))}
 
-        # Run specified command, merging stderr to stdout
-        exec {shlex.join(args)} 2>&1
+        # Run specified command
+        exec {shlex.join(args)}
         """)
     return scfg.Host(
         network_node_id=0,
@@ -131,8 +132,8 @@ def _run_shadow_watching_process(
     shadow_config_path: Path,
     shadow_args: Iterable[str] = (),
     stdout: BinaryIO = sys.stdout.buffer,
-    stderr: TextIO = sys.stderr,
-) -> int:
+    stderr: BinaryIO = sys.stderr.buffer,
+) -> None:
     """Run shadow, forwarding the stdout of one simulated process to `stdout`
 
     watch_host: Name of the host inside the shadow sim to watch.
@@ -149,9 +150,8 @@ def _run_shadow_watching_process(
         # It wouldn't be *terribly* hard to support this, but not today.
         # Naively allowing this override would break our stdout pass-through
         # below.
-        print(
+        raise Exception(
             f"ERROR: Overriding shadow's --data-directory currently unsupported.",
-            file=stderr,
         )
     shadow_stdout_path = dstdir.joinpath("shadow.stdout")
     shadow_stderr_path = dstdir.joinpath("shadow.stderr")
@@ -167,28 +167,49 @@ def _run_shadow_watching_process(
             stderr=shadow_stderr_file,
         )
         simulated_stdout_file = None
+        simulated_stderr_file = None
         shadow_exited = False
         while True:
             processed_data = False
 
-            # Try opening the simulated process's stdout if we haven't
-            # successfully done so yet.
+            # Try opening the simulated process's stdout and stderr if we
+            # haven't successfully done so yet.
             if simulated_stdout_file is None:
                 simulated_stdout_file = _try_open_glob(
                     host_dir, f"*.{watch_pid}.stdout"
                 )
+            if simulated_stderr_file is None:
+                simulated_stderr_file = _try_open_glob(
+                    host_dir, f"*.{watch_pid}.stderr"
+                )
 
-            # Pump data from sim stdout to our stdout
-            data = None
-            if simulated_stdout_file is not None:
-                # Fairly arbitrary, but might as well avoid excessive memory
-                # usage here.
-                bufsize = 1_000_000
-                data = simulated_stdout_file.read(bufsize)
-            while data:
-                processed_data = True
-                count = stdout.write(data)
-                data = data[count:]
+            # Pump data from sim stdout and stderr to our stdout and stderr.
+            # TODO: maybe this could be simplified using shutil.copyfileobj?
+            for src, dest in [
+                (simulated_stdout_file, stdout),
+                (simulated_stderr_file, stderr),
+            ]:
+                data = None
+                if src is not None:
+                    # Fairly arbitrary, but impose *some* limit to avoid
+                    # excessive buffering.
+                    bufsize = 1_000_000
+                    data = src.read(bufsize)
+                if data:
+                    processed_data = True
+                    while data:
+                        count = dest.write(data)
+                        data = data[count:]
+                else:
+                    # Flush when there's currently no data available to read.
+                    # Flushing makes output more responsive for interactive
+                    # usage, but potentially intermingles stdout and stderr
+                    # output, e.g. if they're both ultimately going to a
+                    # console.  Only flushing when there's no more data tries to
+                    # at least ensure we do it on reasonable boundaries. e.g. if
+                    # the target program line-buffers its output, then this will
+                    # *tend* to flush only at line boundaries.
+                    dest.flush()
 
             if not processed_data and shadow_exited:
                 # Done
@@ -197,8 +218,6 @@ def _run_shadow_watching_process(
             if not processed_data:
                 # No data ready to handle right now.
 
-                # Flush anything we've pumped so far.
-                stdout.flush()
                 try:
                     # Wait a bit for shadow to exit.
                     # We want this to be long enough to avoid burning CPU
@@ -214,13 +233,14 @@ def _run_shadow_watching_process(
                     # shadow didn't exit. Loop to see if there's more data to
                     # process.
                     pass
+    stdout.flush()
+    stderr.flush()
     # if shadow failed, dump its stderr
     if shadow_ps.returncode:
-        shadow_stderr = shadow_stderr_path.read_text()
-        while shadow_stderr:
-            count = stderr.write(textwrap.indent(shadow_stderr, "shadow: "))
-            shadow_stderr = shadow_stderr[count:]
-    return shadow_ps.returncode
+        raise Exception(
+            f"shadow exited with code {shadow_ps.returncode}. stderr:\n"
+            + shadow_stderr_path.read_text()
+        )
 
 
 def _main(
@@ -228,11 +248,11 @@ def _main(
     args: Iterable[str],
     preserve: PreserveChoice = PreserveChoice.NEVER,
     temp_dir: Optional[Path] = None,
-    stdout: BinaryIO = sys.stdout.buffer,
+    stdout: TextIO = sys.stdout,
     stderr: TextIO = sys.stderr,
     shadow_bin: Path = Path("shadow"),
     shadow_args: Iterable[str] = (),
-) -> int:
+) -> None:
     """
     Run a program under shadow.
 
@@ -255,27 +275,37 @@ def _main(
     config_path = tmpdir.joinpath("shadow.yaml")
     config_path.write_text(yaml.safe_dump(config))
 
-    shadow_stdout_path = tmpdir.joinpath("shadow.stdout")
-    shadow_stderr_path = tmpdir.joinpath("shadow.stderr")
-    shadow_rc = _run_shadow_watching_process(
-        watch_host=hostname,
-        watch_pid=1000,
-        dstdir=tmpdir,
-        shadow_bin=shadow_bin,
-        shadow_config_path=config_path,
-        shadow_args=shadow_args,
-        stdout=stdout,
-        stderr=stderr,
-    )
-    # clean up temp files
-    if preserve == PreserveChoice.ALWAYS or (
-        preserve == PreserveChoice.ON_ERROR and shadow_rc
-    ):
-        print(f"{progname}: Preserving tmpdir {tmpdir}", file=stderr)
-    else:
-        shutil.rmtree(tmpdir)
+    # Flush before handing the underlying buffers over
+    stdout.flush()
+    stderr.flush()
 
-    return shadow_rc
+    error = False
+    try:
+        _run_shadow_watching_process(
+            watch_host=hostname,
+            watch_pid=1000,
+            dstdir=tmpdir,
+            shadow_bin=shadow_bin,
+            shadow_config_path=config_path,
+            shadow_args=shadow_args,
+            stdout=stdout.buffer,
+            stderr=stderr.buffer,
+        )
+    except Exception:
+        error = True
+        raise
+    finally:
+        # Ensure all raw data written into the buffers are flushed
+        stdout.flush()
+        stderr.flush()
+
+        # clean up temp files
+        if preserve == PreserveChoice.ALWAYS or (
+            preserve == PreserveChoice.ON_ERROR and error
+        ):
+            print(f"{progname}: Preserving tmpdir {tmpdir}", file=stderr)
+        else:
+            shutil.rmtree(tmpdir)
 
 
 def __main__() -> None:
@@ -331,7 +361,7 @@ def __main__() -> None:
     )
     parser.add_argument("args", nargs="+", help="command and arguments to execute")
     res = parser.parse_args()
-    rv = _main(
+    _main(
         progname=PROGNAME,
         args=res.args,
         # parser should have enforced a valid value here
@@ -340,7 +370,6 @@ def __main__() -> None:
         temp_dir=res.temp_dir,
         shadow_args=shlex.split(res.shadow_args),
     )
-    sys.exit(rv)
 
 
 if __name__ == "__main__":

--- a/shadowtools/src/shadowtools/shadow_exec.py
+++ b/shadowtools/src/shadowtools/shadow_exec.py
@@ -155,7 +155,7 @@ def run_shadow_watching_process(
         # Naively allowing this override would break our stdout pass-through
         # below.
         raise Exception(
-            f"ERROR: Overriding shadow's --data-directory currently unsupported.",
+            f"Overriding shadow's --data-directory currently unsupported.",
         )
     shadow_stdout_path = dstdir.joinpath("shadow.stdout")
     shadow_stderr_path = dstdir.joinpath("shadow.stderr")

--- a/shadowtools/src/shadowtools/shadow_exec.py
+++ b/shadowtools/src/shadowtools/shadow_exec.py
@@ -33,7 +33,7 @@ import textwrap
 import yaml
 
 from pathlib import Path
-from typing import TextIO, BinaryIO, Final, Optional, List, Iterable
+from typing import TextIO, BinaryIO, Final, Optional, List, Iterable, Dict
 
 import shadowtools.config as scfg
 
@@ -98,7 +98,7 @@ def _make_base_config() -> scfg.Config:
     )
 
 
-def _make_controller_host(args: Iterable[str]) -> scfg.Host:
+def _make_controller_host(args: Iterable[str], environ: Dict[str, str]) -> scfg.Host:
     """Generate a shadow host configuration to run the command in `args`"""
     wrapper_script = textwrap.dedent(f"""
         set -eu
@@ -118,6 +118,7 @@ def _make_controller_host(args: Iterable[str]) -> scfg.Host:
                     "-c",
                     wrapper_script,
                 ],
+                environment=environ,
             )
         ],
     )
@@ -246,6 +247,7 @@ def _run_shadow_watching_process(
 def _main(
     progname: str,
     args: Iterable[str],
+    environ: Dict[str, str],
     preserve: PreserveChoice = PreserveChoice.NEVER,
     temp_dir: Optional[Path] = None,
     stdout: TextIO = sys.stdout,
@@ -270,7 +272,7 @@ def _main(
 
     config = _make_base_config()
     hostname = "host"
-    config["hosts"][hostname] = _make_controller_host(args)
+    config["hosts"][hostname] = _make_controller_host(args, environ)
 
     config_path = tmpdir.joinpath("shadow.yaml")
     config_path.write_text(yaml.safe_dump(config))
@@ -349,6 +351,11 @@ def __main__() -> None:
         type=Path,
         help="shadow binary basename or path",
     )
+    parser.add_argument(
+        "--ignore-env",
+        action=argparse.BooleanOptionalAction,
+        help=("Don't pass current environment variables through to simulated process"),
+    )
     # We take a single shell-encoded string here and split it instead of taking
     # multiple strings, because otherwise argparse will try to interpret tokens
     # starting with - as a new option for itself.
@@ -361,9 +368,11 @@ def __main__() -> None:
     )
     parser.add_argument("args", nargs="+", help="command and arguments to execute")
     res = parser.parse_args()
+    environ = {} if res.ignore_env else dict(os.environ)
     _main(
         progname=PROGNAME,
         args=res.args,
+        environ=environ,
         # parser should have enforced a valid value here
         preserve=PreserveChoice[res.preserve.upper().translate({ord("-"): "_"})],
         shadow_bin=res.shadow_bin,

--- a/shadowtools/src/shadowtools/shadow_exec.py
+++ b/shadowtools/src/shadowtools/shadow_exec.py
@@ -20,6 +20,7 @@ Sat Jan  1 00:16:40 GMT 2000
 """
 
 import argparse
+import glob
 import re
 import enum
 import subprocess
@@ -42,45 +43,12 @@ class PreserveChoice(enum.Enum):
     ON_ERROR = enum.auto()
 
 
-def _main(
-    progname: str,
-    args: Iterable[str],
-    preserve: PreserveChoice = PreserveChoice.NEVER,
-    temp_dir: Optional[Path] = None,
-    stdout: BinaryIO = sys.stdout.buffer,
-    stderr: TextIO = sys.stderr,
-    shadow_bin: Path = Path("shadow"),
-    shadow_args: Iterable[str] = (),
-) -> int:
+def _make_base_config() -> scfg.Config:
+    """Generate a simple shadow configuration, suitable for one-off ad-hoc simulations.
+
+    Does *not* include any hosts, which must be added separately.
     """
-    Run a program under shadow.
-
-    args:
-    progname -- String prefix to use for output originating from this function.
-    args -- List of arguments of program to be run under shadow.
-    preserve -- Whether to save the temporary directory containing the raw
-                simulation config and results.
-    stdout -- Destination for the simulated program's merged stdout and stderr.
-    stderr -- Destination for other "meta" output.
-    shadow_bin -- Shadow binary basename or path.
-    """
-
-    tmpdir = Path(tempfile.mkdtemp(prefix=f"{progname}-", dir=temp_dir))
-
-    wrapper_script = textwrap.dedent(
-        f"""
-        set -euo pipefail
-
-        # Change back to host working dir
-        cd {shlex.quote(str(Path('.').resolve()))}
-
-        # Run specified command, merging stderr to stdout
-        exec {shlex.join(args)} 2>&1
-        """
-    )
-
-    data_dir = tmpdir.joinpath("shadow.data")
-    config = scfg.Config(
+    return scfg.Config(
         general=scfg.General(
             # It'd be nice to set a higher stop-time here, but some simulations
             # (chutney) take a long time to fast-forward empty time after all
@@ -91,7 +59,6 @@ def _main(
             log_level="warning",
             heartbeat_interval=None,
             progress=False,
-            data_directory=str(data_dir),
         ),
         experimental=scfg.Experimental(
             # For the sort of small simulations this tool is meant for, cpu
@@ -100,24 +67,58 @@ def _main(
             use_cpu_pinning=False,
         ),
         network=scfg.Network(graph=scfg.Graph(type="1_gbit_switch")),
-        hosts={
-            "host": scfg.Host(
-                network_node_id=0,
-                processes=[
-                    scfg.Process(
-                        path="bash",
-                        args=[
-                            "-c",
-                            wrapper_script,
-                        ],
-                    )
+        hosts={},
+    )
+
+
+def _make_controller_host(args: Iterable[str]) -> scfg.Host:
+    """Generate a shadow host configuration to run the command in `args`"""
+    wrapper_script = textwrap.dedent(f"""
+        set -euo pipefail
+
+        # Change back to host working dir
+        cd {shlex.quote(str(Path('.').resolve()))}
+
+        # Run specified command, merging stderr to stdout
+        exec {shlex.join(args)} 2>&1
+        """)
+    return scfg.Host(
+        network_node_id=0,
+        processes=[
+            scfg.Process(
+                path="bash",
+                args=[
+                    "-c",
+                    wrapper_script,
                 ],
             )
-        },
+        ],
     )
-    config_path = tmpdir.joinpath("shadow.yaml")
-    config_path.write_text(yaml.safe_dump(config))
 
+
+def _run_shadow_watching_process(
+    *,
+    watch_host: str,
+    watch_pid: int,
+    dstdir: Path,
+    shadow_bin: Path = Path("shadow"),
+    shadow_config_path: Path,
+    shadow_args: Iterable[str] = (),
+    stdout: BinaryIO = sys.stdout.buffer,
+    stderr: TextIO = sys.stderr,
+) -> int:
+    """Run shadow, forwarding the stdout of one simulated process to `stdout`
+
+    watch_host: Name of the host inside the shadow sim to watch.
+    watch_pid: pid of the process on watch_host to watch.
+    dstdir: directory in which to put output files.
+    shadow_bin: path to the shadow executable.
+    shadow_config_path: path to the shadow config file.
+    shadow_args: additional command-line arguments to pass to shadow.
+    stdout: where to write the watched process's stdout.
+    stderr: where to write the watched process's stderr.
+    """
+    data_dir = dstdir.joinpath("shadow.data")
     if any((re.match(r"^--data-directory(=|$)|^-d", s) for s in shadow_args)):
         # It wouldn't be *terribly* hard to support this, but not today.
         # Naively allowing this override would break our stdout pass-through
@@ -126,14 +127,16 @@ def _main(
             f"ERROR: Overriding shadow's --data-directory currently unsupported.",
             file=stderr,
         )
-        sys.exit(1)
-    shadow_stdout_path = tmpdir.joinpath("shadow.stdout")
-    shadow_stderr_path = tmpdir.joinpath("shadow.stderr")
+    shadow_stdout_path = dstdir.joinpath("shadow.stdout")
+    shadow_stderr_path = dstdir.joinpath("shadow.stderr")
+    host_dir = data_dir.joinpath("hosts", watch_host)
     with shadow_stdout_path.open("w") as shadow_stdout_file, shadow_stderr_path.open(
         "w"
     ) as shadow_stderr_file:
         shadow_ps = subprocess.Popen(
-            [str(shadow_bin)] + list(shadow_args) + ["--", str(config_path)],
+            [str(shadow_bin)]
+            + list(shadow_args)
+            + [f"--data-directory={data_dir}", "--", str(shadow_config_path)],
             stdout=shadow_stdout_file,
             stderr=shadow_stderr_file,
         )
@@ -144,14 +147,14 @@ def _main(
 
             # Try opening the simulated process's stdout if we haven't
             # successfully done so yet.
-            if simulated_stdout_file is None:
-                try:
-                    simulated_stdout_file = open(
-                        str(data_dir.joinpath("hosts/host/bash.1000.stdout")), "rb"
+            if simulated_stdout_file is None and (
+                stdout_paths := glob.glob(f"*.{watch_pid}.stdout", root_dir=host_dir)
+            ):
+                if len(stdout_paths) != 1:
+                    raise Exception(
+                        f"Unexpectedly more than 1 matching path: {stdout_paths}"
                     )
-                except FileNotFoundError:
-                    # Not created yet, presumably
-                    pass
+                simulated_stdout_file = host_dir.joinpath(stdout_paths[0]).open("rb")
 
             # Pump data from sim stdout to our stdout
             data = None
@@ -195,16 +198,62 @@ def _main(
         while shadow_stderr:
             count = stderr.write(textwrap.indent(shadow_stderr, "shadow: "))
             shadow_stderr = shadow_stderr[count:]
+    return shadow_ps.returncode
 
+
+def _main(
+    progname: str,
+    args: Iterable[str],
+    preserve: PreserveChoice = PreserveChoice.NEVER,
+    temp_dir: Optional[Path] = None,
+    stdout: BinaryIO = sys.stdout.buffer,
+    stderr: TextIO = sys.stderr,
+    shadow_bin: Path = Path("shadow"),
+    shadow_args: Iterable[str] = (),
+) -> int:
+    """
+    Run a program under shadow.
+
+    args:
+    progname -- String prefix to use for output originating from this function.
+    args -- List of arguments of program to be run under shadow.
+    preserve -- Whether to save the temporary directory containing the raw
+                simulation config and results.
+    stdout -- Destination for the simulated program's merged stdout and stderr.
+    stderr -- Destination for other "meta" output.
+    shadow_bin -- Shadow binary basename or path.
+    """
+
+    tmpdir = Path(tempfile.mkdtemp(prefix=f"{progname}-", dir=temp_dir))
+
+    config = _make_base_config()
+    hostname = "host"
+    config["hosts"][hostname] = _make_controller_host(args)
+
+    config_path = tmpdir.joinpath("shadow.yaml")
+    config_path.write_text(yaml.safe_dump(config))
+
+    shadow_stdout_path = tmpdir.joinpath("shadow.stdout")
+    shadow_stderr_path = tmpdir.joinpath("shadow.stderr")
+    shadow_rc = _run_shadow_watching_process(
+        watch_host=hostname,
+        watch_pid=1000,
+        dstdir=tmpdir,
+        shadow_bin=shadow_bin,
+        shadow_config_path=config_path,
+        shadow_args=shadow_args,
+        stdout=stdout,
+        stderr=stderr,
+    )
     # clean up temp files
     if preserve == PreserveChoice.ALWAYS or (
-        preserve == PreserveChoice.ON_ERROR and shadow_ps.returncode
+        preserve == PreserveChoice.ON_ERROR and shadow_rc
     ):
         print(f"{progname}: Preserving tmpdir {tmpdir}", file=stderr)
     else:
         shutil.rmtree(tmpdir)
 
-    return shadow_ps.returncode
+    return shadow_rc
 
 
 def __main__() -> None:
@@ -214,15 +263,13 @@ def __main__() -> None:
 
     parser = argparse.ArgumentParser(
         prog=PROGNAME,
-        description=textwrap.dedent(
-            f"""
+        description=textwrap.dedent(f"""
             Executes the command `args` inside a single-host shadow simulation.
 
             Examples:
               {PROGNAME} date
               {PROGNAME} -- bash -c 'date; sleep 100; date'
-            """
-        ),
+            """),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(

--- a/shadowtools/src/shadowtools/shadow_exec.py
+++ b/shadowtools/src/shadowtools/shadow_exec.py
@@ -43,6 +43,32 @@ class PreserveChoice(enum.Enum):
     ON_ERROR = enum.auto()
 
 
+def _glob_with_root_dir(pattern: str, root_dir: Path) -> List[str]:
+    """Wrapper around glob.glob, backporting root_dir param.
+
+    glob.glob added the root_dir parameter in python 3.10. When we stop
+    supporting python 3.10 we can replace calls to this function with
+    `glob.glob(pattern, root_dir=root_dir)`.
+    """
+    prefix = str(root_dir).removesuffix(os.sep) + os.sep
+    rooted_pattern = prefix + pattern
+    return [s.removeprefix(prefix) for s in glob.glob(rooted_pattern)]
+
+
+def _try_open_glob(root_dir: Path, pattern: str) -> Optional[BinaryIO]:
+    """Open and return a file matching `pattern` in `root_dir`, if one exists.
+
+    Raises an exception if there are multiple matches."""
+    matches = _glob_with_root_dir(pattern, root_dir)
+    if len(matches) == 0:
+        return None
+    if len(matches) != 1:
+        raise Exception(
+            f"Unexpectedly more than 1 match at {root_dir}/{pattern}: {matches}"
+        )
+    return root_dir.joinpath(matches[0]).open("rb")
+
+
 def _make_base_config() -> scfg.Config:
     """Generate a simple shadow configuration, suitable for one-off ad-hoc simulations.
 
@@ -147,14 +173,10 @@ def _run_shadow_watching_process(
 
             # Try opening the simulated process's stdout if we haven't
             # successfully done so yet.
-            if simulated_stdout_file is None and (
-                stdout_paths := glob.glob(f"*.{watch_pid}.stdout", root_dir=host_dir)
-            ):
-                if len(stdout_paths) != 1:
-                    raise Exception(
-                        f"Unexpectedly more than 1 matching path: {stdout_paths}"
-                    )
-                simulated_stdout_file = host_dir.joinpath(stdout_paths[0]).open("rb")
+            if simulated_stdout_file is None:
+                simulated_stdout_file = _try_open_glob(
+                    host_dir, f"*.{watch_pid}.stdout"
+                )
 
             # Pump data from sim stdout to our stdout
             data = None

--- a/shadowtools/src/shadowtools/shadow_exec.py
+++ b/shadowtools/src/shadowtools/shadow_exec.py
@@ -20,6 +20,7 @@ Sat Jan  1 00:16:40 GMT 2000
 """
 
 import argparse
+import fnmatch
 import glob
 import re
 import enum
@@ -33,7 +34,7 @@ import textwrap
 import yaml
 
 from pathlib import Path
-from typing import TextIO, BinaryIO, Final, Optional, List, Iterable, Dict
+from typing import TextIO, BinaryIO, Final, Optional, List, Iterable, Dict, Literal
 
 import shadowtools.config as scfg
 
@@ -44,23 +45,32 @@ class PreserveChoice(enum.Enum):
     ON_ERROR = enum.auto()
 
 
-def _glob_with_root_dir(pattern: str, root_dir: Path) -> List[str]:
-    """Wrapper around glob.glob, backporting root_dir param.
+def _glob(pattern: str, root_dir: Path, include_hidden: Literal[True]) -> List[str]:
+    """Reimplementation of glob.glob, backporting root_dir and include_hidden.
 
-    glob.glob added the root_dir parameter in python 3.10. When we stop
-    supporting python 3.10 we can replace calls to this function with
-    `glob.glob(pattern, root_dir=root_dir)`.
+    glob.glob added the root_dir parameter in python 3.10. For simplicity, we
+    *require* it here.
+
+    glob.glob added the include_hidden parameter in python 3.11. For simplicity
+    we require it to be True here.
+
+    When our minimum version is >= 3.11 we can replace calls to this function with
+    `glob.glob(pattern, root_dir=root_dir, include_hidden=True)`.
     """
-    prefix = str(root_dir).removesuffix(os.sep) + os.sep
-    rooted_pattern = prefix + pattern
-    return [s.removeprefix(prefix) for s in glob.glob(rooted_pattern)]
+    try:
+        paths = os.listdir(root_dir)
+    except FileNotFoundError:
+        # root_dir doesn't exist. glob.glob behavior is to return empty.
+        return []
+    return [path for path in paths if fnmatch.fnmatchcase(path, pattern)]
 
 
 def _try_open_glob(root_dir: Path, pattern: str) -> Optional[BinaryIO]:
     """Open and return a file matching `pattern` in `root_dir`, if one exists.
 
     Raises an exception if there are multiple matches."""
-    matches = _glob_with_root_dir(pattern, root_dir)
+    # TODO: call glob.glob when our minimum python is >= 3.11.
+    matches = _glob(pattern, root_dir=root_dir, include_hidden=True)
     if len(matches) == 0:
         return None
     if len(matches) != 1:

--- a/shadowtools/src/shadowtools/shadow_exec.py
+++ b/shadowtools/src/shadowtools/shadow_exec.py
@@ -124,10 +124,9 @@ def _make_controller_host(args: Iterable[str], environ: Dict[str, str]) -> scfg.
     )
 
 
-def _run_shadow_watching_process(
+def run_shadow_watching_process(
     *,
     watch_host: str,
-    watch_pid: int,
     dstdir: Path,
     shadow_bin: Path = Path("shadow"),
     shadow_config_path: Path,
@@ -135,10 +134,14 @@ def _run_shadow_watching_process(
     stdout: BinaryIO = sys.stdout.buffer,
     stderr: BinaryIO = sys.stderr.buffer,
 ) -> None:
-    """Run shadow, forwarding the stdout of one simulated process to `stdout`
+    """Run shadow, forwarding the output of one simulated process.
+
+    The simulated process's simulated stdout and stderr are continuously
+    forwarded to `stdout` and `stderr`.
 
     watch_host: Name of the host inside the shadow sim to watch.
-    watch_pid: pid of the process on watch_host to watch.
+      There should be exactly one "root" process configured for this host.
+      (But that process is allowed to launch additional processes).
     dstdir: directory in which to put output files.
     shadow_bin: path to the shadow executable.
     shadow_config_path: path to the shadow config file.
@@ -172,6 +175,11 @@ def _run_shadow_watching_process(
         shadow_exited = False
         while True:
             processed_data = False
+
+            # We use the shadow implementation detail that pid's start from
+            # 1000. To avoid exposing that detail to the caller, this function
+            # currently only supports simulated hosts with 1 root process.
+            watch_pid = 1000
 
             # Try opening the simulated process's stdout and stderr if we
             # haven't successfully done so yet.
@@ -283,9 +291,8 @@ def _main(
 
     error = False
     try:
-        _run_shadow_watching_process(
+        run_shadow_watching_process(
             watch_host=hostname,
-            watch_pid=1000,
             dstdir=tmpdir,
             shadow_bin=shadow_bin,
             shadow_config_path=config_path,

--- a/shadowtools/src/shadowtools/shadow_exec.py
+++ b/shadowtools/src/shadowtools/shadow_exec.py
@@ -101,7 +101,7 @@ def _make_base_config() -> scfg.Config:
 def _make_controller_host(args: Iterable[str]) -> scfg.Host:
     """Generate a shadow host configuration to run the command in `args`"""
     wrapper_script = textwrap.dedent(f"""
-        set -euo pipefail
+        set -eu
 
         # Change back to host working dir
         cd {shlex.quote(str(Path('.').resolve()))}
@@ -113,7 +113,7 @@ def _make_controller_host(args: Iterable[str]) -> scfg.Host:
         network_node_id=0,
         processes=[
             scfg.Process(
-                path="bash",
+                path="sh",
                 args=[
                     "-c",
                     wrapper_script,


### PR DESCRIPTION
Primarily this is to decouple shadow-exec's functionality of creating simple ad-hoc simulations, from its functionality for running simulations while streaming stdout and stderr of a simulated process. This allows the latter to be used for more complex, multihost, simulations where there is a single client or "control" process (#3671) that has most of the useful output.
