### PR TITLE
emulate posix record locks

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2125,6 +2125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2558,7 @@ dependencies = [
  "rand_chacha 0.10.0",
  "rand_core 0.10.1",
  "rand_xoshiro",
+ "rangemap",
  "rayon",
  "regex",
  "rustix 0.38.44",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1738,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -1748,10 +1748,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -2642,6 +2643,7 @@ dependencies = [
  "linux-api",
  "neli",
  "nix 0.26.4",
+ "num_enum",
  "once_cell",
  "rand 0.9.2",
  "rustix 0.38.44",

--- a/src/lib/linux-api/src/fcntl.rs
+++ b/src/lib/linux-api/src/fcntl.rs
@@ -73,6 +73,9 @@ pub enum FcntlCommand {
     F_SETDELEG = bindings::LINUX_F_SETDELEG,
 }
 
+pub use bindings::linux_flock as flock;
+unsafe impl shadow_pod::Pod for flock {}
+
 /// Owner, as used with [`FcntlCommand::F_SETOWN_EX`] and [`FcntlCommand::F_GETOWN_EX`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u32)]
@@ -93,6 +96,17 @@ pub enum FcntlLeaseType {
     F_UNLCK = bindings::LINUX_F_UNLCK,
     F_EXLCK = bindings::LINUX_F_EXLCK,
     F_SHLCK = bindings::LINUX_F_SHLCK,
+}
+
+/// Lock type, as found in `flock::l_type`, used with e.g.
+/// [`FcntlCommand::F_SETLK`] and [`FcntlCommand::F_OFD_SETLK`]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(i16)]
+#[allow(non_camel_case_types)]
+pub enum FlockType {
+    F_RDLCK = const_conversions::i16_from_u32(bindings::LINUX_F_RDLCK),
+    F_WRLCK = const_conversions::i16_from_u32(bindings::LINUX_F_WRLCK),
+    F_UNLCK = const_conversions::i16_from_u32(bindings::LINUX_F_UNLCK),
 }
 
 /// Seal type, as used with [`FcntlCommand::F_ADD_SEALS`] and [`FcntlCommand::F_GET_SEALS`].

--- a/src/lib/linux-api/src/fcntl.rs
+++ b/src/lib/linux-api/src/fcntl.rs
@@ -76,6 +76,16 @@ pub enum FcntlCommand {
 pub use bindings::linux_flock as flock;
 unsafe impl shadow_pod::Pod for flock {}
 
+// Valid values for `flock::l_whence`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(i16)]
+#[allow(non_camel_case_types)]
+pub enum FlockWhence {
+    SEEK_SET = const_conversions::i16_from_u32(bindings::LINUX_SEEK_SET),
+    SEEK_CUR = const_conversions::i16_from_u32(bindings::LINUX_SEEK_CUR),
+    SEEK_END = const_conversions::i16_from_u32(bindings::LINUX_SEEK_END),
+}
+
 /// Owner, as used with [`FcntlCommand::F_SETOWN_EX`] and [`FcntlCommand::F_GETOWN_EX`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u32)]

--- a/src/lib/linux-api/src/lib.rs
+++ b/src/lib/linux-api/src/lib.rs
@@ -121,4 +121,9 @@ mod const_conversions {
 
         val as u16
     }
+
+    pub const fn i16_from_u32(val: u32) -> i16 {
+        assert!(val <= (i16::MAX as u32));
+        val as i16
+    }
 }

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -67,6 +67,7 @@ vsprintf = { git = "https://github.com/shadow/vsprintf", rev = "fa9a307e3043a972
 which = "8.0.0"
 bytemuck = "1.25.0"
 rustix = { version = "0.38.44", features = ["event", "mm", "pipe"] }
+rangemap = "1.7.1"
 
 [features]
 perf_timers = []

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -4,7 +4,7 @@ use log::*;
 use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::syscall_types::SyscallReg;
 
-use crate::host::descriptor::Descriptor;
+use crate::host::descriptor::{Descriptor, DropPosixRecordLocks};
 use crate::host::host::Host;
 use crate::utility::ObjectCounter;
 use crate::utility::callback_queue::CallbackQueue;
@@ -239,10 +239,11 @@ impl Default for DescriptorTable {
 }
 
 impl ExplicitDrop for DescriptorTable {
-    type ExplicitDropParam<'p> = &'p Host;
+    type ExplicitDropParam<'p> = (&'p Host, DropPosixRecordLocks);
     type ExplicitDropResult = ();
 
-    fn explicit_drop<'p>(mut self, host: Self::ExplicitDropParam<'p>) {
+    fn explicit_drop<'p>(mut self, param: Self::ExplicitDropParam<'p>) {
+        let (host, drop_posix_record_locks) = param;
         // Drop all descriptors using a callback queue.
         //
         // Doing this explicitly instead of letting `DescriptorTable`'s `Drop`
@@ -252,7 +253,7 @@ impl ExplicitDrop for DescriptorTable {
         let descriptors = self.remove_all();
         CallbackQueue::queue_and_run_with_legacy(|cb_queue| {
             for desc in descriptors {
-                desc.close(host, cb_queue);
+                desc.close(host, drop_posix_record_locks, cb_queue);
             }
         });
     }

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -2,23 +2,23 @@
 
 use std::sync::Arc;
 
-use atomic_refcell::AtomicRefCell;
-use linux_api::errno::Errno;
-use linux_api::fcntl::{DescriptorFlags, OFlag};
-use linux_api::ioctls::IoctlRequest;
-use shadow_shim_helper_rs::syscall_types::ForeignPtr;
-
-use crate::core::worker;
 use crate::cshadow as c;
 use crate::host::descriptor::listener::{StateListenHandle, StateListenerFilter};
 use crate::host::descriptor::socket::{Socket, SocketRef, SocketRefMut};
+use crate::host::fcntl_lock_table::FileId;
 use crate::host::host::Host;
 use crate::host::memory_manager::MemoryManager;
+use crate::host::process::ProcessId;
 use crate::host::syscall::io::IoVec;
 use crate::host::syscall::types::{SyscallError, SyscallResult};
 use crate::utility::callback_queue::CallbackQueue;
 use crate::utility::{HostTreePointer, IsSend, IsSync, ObjectCounter};
+use atomic_refcell::AtomicRefCell;
+use linux_api::errno::Errno;
+use linux_api::fcntl::{DescriptorFlags, OFlag};
+use linux_api::ioctls::IoctlRequest;
 use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
+use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 pub mod descriptor_table;
 pub mod epoll;
@@ -44,6 +44,19 @@ bitflags::bitflags! {
         const DIRECT = OFlag::O_DIRECT.bits();
         const NOATIME = OFlag::O_NOATIME.bits();
     }
+}
+
+/// For functions that involve closing descriptors; specifies for which
+/// `ProcessId` posix record locks ought to be freed, if any.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum DropPosixRecordLocks {
+    // Indicates to *not* drop posix record locks as part of closing a
+    // descriptor.  This should only be used for "non-user-visible" closes; e.g.
+    // we end up internally cloning and dropping descriptors as part of our fork
+    // and exec implementations.
+    False,
+    // Includes associated ProcessId for which to drop locks.
+    ForPid(ProcessId),
 }
 
 impl FileStatus {
@@ -517,12 +530,37 @@ impl Descriptor {
         self.file.take().unwrap()
     }
 
-    /// Close the descriptor. The `host` option is a legacy option for legacy file.
+    fn drop_posix_record_locks(&self, host: &Host, pid: ProcessId) {
+        let owner = super::fcntl_lock_table::LockOwner::Process(pid);
+        let stat = match self.file().stat() {
+            Ok(s) => s,
+            Err(e) => {
+                log::debug!("Couldn't stat file to drop record locks: {e:?}");
+                return;
+            }
+        };
+        let fid = FileId::from(&stat);
+        host.fcntl_lock_table_borrow_mut().remove_owner(fid, &owner);
+    }
+
+    /// Close the descriptor.
+    // Caller needs to tell us which PID to drop posix record locks for, if any.
+    // We can't store the "owning" PID in the `Descriptor`, nor the
+    // `DescriptorTable`, since both can be shared across multiple processes
+    // (e.g. after `clone` with `CLONE_FILES` and without `CLONE_THREAD`).
+    //
+    // We use the Host reference both for closing legacy files, and for
+    // accessing the record-lock table.
     pub fn close(
         self,
         host: &Host,
+        drop_posix_record_locks: DropPosixRecordLocks,
         cb_queue: &mut CallbackQueue,
     ) -> Option<Result<(), SyscallError>> {
+        match drop_posix_record_locks {
+            DropPosixRecordLocks::False => (),
+            DropPosixRecordLocks::ForPid(pid) => self.drop_posix_record_locks(host, pid),
+        }
         self.into_file().close(host, cb_queue)
     }
 
@@ -592,12 +630,12 @@ impl Drop for Descriptor {
 }
 
 impl ExplicitDrop for Descriptor {
-    type ExplicitDropParam<'p> = (&'p Host, &'p mut CallbackQueue);
+    type ExplicitDropParam<'p> = (&'p Host, DropPosixRecordLocks, &'p mut CallbackQueue);
     type ExplicitDropResult = Option<Result<(), SyscallError>>;
 
     fn explicit_drop<'p>(self, param: Self::ExplicitDropParam<'p>) -> Self::ExplicitDropResult {
-        let (host, cb_queue) = param;
-        self.close(host, cb_queue)
+        let (host, drop_posix_record_locks, cb_queue) = param;
+        self.close(host, drop_posix_record_locks, cb_queue)
     }
 }
 
@@ -687,11 +725,16 @@ impl LegacyFileCounter {
 
     /// Should drop `self` immediately after calling this.
     fn close_helper(&mut self, host: &Host) {
+        // Always take out the `file` object, so that our `Drop` impl knows this object
+        // was closed properly.
+        let Some(file) = self.file.take() else {
+            warn_and_debug_panic!("Tried to close missing file");
+            #[allow(unreachable_code)]
+            return;
+        };
         // this isn't subject to race conditions since we should never access descriptors
         // from multiple threads at the same time
-        if Arc::<()>::strong_count(&self.open_count) == 1
-            && let Some(file) = self.file.take()
-        {
+        if Arc::<()>::strong_count(&self.open_count) == 1 {
             unsafe { c::legacyfile_close(file.ptr(), host) }
         }
     }
@@ -713,7 +756,20 @@ impl LegacyFileCounter {
 
 impl std::ops::Drop for LegacyFileCounter {
     fn drop(&mut self) {
-        worker::Worker::with_active_host(|host| self.close_helper(host)).unwrap();
+        if self.file.is_some() {
+            warn_and_debug_panic!("Dropped LegacyFileCounter without explicitly closing");
+            #[allow(unreachable_code)]
+            crate::core::worker::Worker::with_active_host(|host| self.close_helper(host)).unwrap();
+        }
+    }
+}
+
+impl ExplicitDrop for LegacyFileCounter {
+    type ExplicitDropParam<'p> = &'p Host;
+    type ExplicitDropResult = ();
+
+    fn explicit_drop<'p>(mut self, host: Self::ExplicitDropParam<'p>) -> Self::ExplicitDropResult {
+        self.close_helper(host);
     }
 }
 

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -701,6 +701,14 @@ impl LegacyFileCounter {
     pub fn close(mut self, host: &Host) {
         self.close_helper(host);
     }
+
+    pub fn mode(&self) -> FileMode {
+        let raw_flags = unsafe { c::legacyfile_getFlags(self.ptr()) };
+        let oflags = OFlag::from_bits_retain(raw_flags);
+        let (mode, _other_flags) =
+            FileMode::from_o_flags(oflags).expect("Invalid flags for open file");
+        mode
+    }
 }
 
 impl std::ops::Drop for LegacyFileCounter {
@@ -747,6 +755,13 @@ impl CompatFile {
         match self {
             CompatFile::New(open_file) => open_file.inner_file().borrow().stat(),
             CompatFile::Legacy(legacy_file_counter) => Ok(legacy_file_counter.stat()?),
+        }
+    }
+
+    pub fn mode(&self) -> FileMode {
+        match self {
+            CompatFile::New(open_file) => open_file.inner_file().borrow().mode(),
+            CompatFile::Legacy(legacy_file_counter) => legacy_file_counter.mode(),
         }
     }
 }

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -405,7 +405,12 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
         file->type = FILE_TYPE_REGULAR;
     }
 
-    int originalFlags = flags;
+    // store original flags in superclass, LegacyDescriptor.
+    // (Primarily so that rust code operating on a LegacyDescriptor
+    // can work out whether the file is readable and/or writable).
+    // TODO: track updates to status flags. Tentatively fixed in pending
+    // <https://github.com/shadow/shadow/pull/3782>.
+    legacyfile_setFlags(&file->super, flags);
 
     // move any flags that shadow handles from 'flags' to 'shadowFlags'
     file->shadowFlags = flags & SHADOW_FLAG_MASK;

--- a/src/main/host/fcntl_lock_table.rs
+++ b/src/main/host/fcntl_lock_table.rs
@@ -1,0 +1,404 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Range,
+};
+
+use linux_api::fcntl::FlockType;
+use rangemap::RangeMap;
+
+use crate::host::process::ProcessId;
+
+/// Error returned by a lock operation.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum LockError {
+    // lock couldn't be taken, because it's held by another owner.
+    ConflictingLock,
+}
+
+/// Owner of a record lock.
+// Intentionally not `Copy`; see TODO below.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum LockOwner {
+    /// For "process-associated" (posix) locks, as created via `fcntl` operation
+    /// `F_SETLK`.
+    // TODO: We might want to make the owner be the *descriptor table* to
+    // more-closely align with the (undocumented? unintentional?) Linux
+    // semantics for processes that shares a descriptor table. See
+    // <https://github.com/shadow/shadow/issues/3783>
+    Process(ProcessId),
+    // TODO: add enumerator for "open file description" locks, as created via
+    // `fcntl` operation `F_OFD_SETLK`. We might want this to involve some sort
+    // of pointer (e.g. Weak) to the file description. To support that, we don't
+    // make this type `Copy`.
+}
+
+/// Internal representation of a record lock.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum FcntlLock {
+    // Write-lock; one owner.
+    Write(LockOwner),
+    // Read-lock; multiple owners.
+    // Important to use a sorted set here, so that an "arbitrary" conflicting
+    // lock returned via a.g. `F_GETLK` is deterministic.
+    Read(BTreeSet<LockOwner>),
+}
+
+impl FcntlLock {
+    fn new(requester: &LockOwner, flock_type: FlockType) -> Option<FcntlLock> {
+        match flock_type {
+            FlockType::F_UNLCK => None,
+            FlockType::F_RDLCK => Some(FcntlLock::Read(BTreeSet::from_iter([requester.clone()]))),
+            FlockType::F_WRLCK => Some(FcntlLock::Write(requester.clone())),
+        }
+    }
+
+    fn access(&self) -> FlockType {
+        match self {
+            FcntlLock::Write(_) => FlockType::F_WRLCK,
+            FcntlLock::Read(_) => FlockType::F_RDLCK,
+        }
+    }
+
+    fn owners_contains(&self, o: &LockOwner) -> bool {
+        match self {
+            FcntlLock::Write(write_owner) => write_owner == o,
+            FcntlLock::Read(read_owners) => read_owners.contains(o),
+        }
+    }
+
+    /// Return the result of updating this lock with the given request, if possible.
+    /// Otherwise returns an error that describes one of the conflicting locks.
+    ///
+    /// Use `requested_type=FlockType::F_UNLCK` to unlock.
+    ///
+    /// Returns:
+    /// * `Ok(None)` when the result is "no lock"; i.e. when
+    ///   `requested_type` is `F_UNLCK`, and `requester` is the only owner of
+    ///   `self`.
+    /// * `Ok(Some(x))`, where x is the result of a successful update.
+    /// * `Err(x)`, where x is one of the current owners of a conflicting lock.
+    pub fn with_request_applied(
+        &self,
+        requester: &LockOwner,
+        requested_type: FlockType,
+    ) -> Result<Option<Self>, LockOwner> {
+        match self {
+            FcntlLock::Write(current_owner) => {
+                if current_owner == requester {
+                    // requester is already the exclusive owner.
+                    // Give them whatever they want.
+                    Ok(Self::new(requester, requested_type))
+                } else if requested_type == FlockType::F_UNLCK {
+                    // requester is releasing, but isn't an owner of this lock.
+                    // Return this lock unchanged.
+                    Ok(Some(self.clone()))
+                } else {
+                    // Conflict with current owner.
+                    Err(current_owner.clone())
+                }
+            }
+            FcntlLock::Read(current_owners) => {
+                match requested_type {
+                    FlockType::F_RDLCK => {
+                        // Add requester to the set of read-lock owners
+                        let mut s = current_owners.clone();
+                        s.insert(requester.clone());
+                        Ok(Some(FcntlLock::Read(s)))
+                    }
+                    FlockType::F_WRLCK => {
+                        match current_owners.iter().find(|o| o != &requester) {
+                            Some(conflicting_owner) => {
+                                // requesting a write lock, but a different owner
+                                // is holding a read lock.
+                                Err(conflicting_owner.clone())
+                            }
+                            None => {
+                                // requesting a write lock, and requester is the sole holder
+                                // of a read lock. Upgrade it to a write lock.
+                                Ok(FcntlLock::new(requester, FlockType::F_WRLCK))
+                            }
+                        }
+                    }
+                    FlockType::F_UNLCK => {
+                        // Requesting to unlock, and there's a read-lock.
+                        // Remove requester from set of read-lock owners.
+                        let new_owners = BTreeSet::from_iter(
+                            current_owners.iter().filter(|x| x != &requester).cloned(),
+                        );
+                        if new_owners.is_empty() {
+                            // No owners left -> unlocked.
+                            Ok(None)
+                        } else {
+                            Ok(Some(FcntlLock::Read(new_owners)))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Stable identifier for a file, which we use to look up record locks.
+/// Remains valid as long as the file has links in the file system and/or there
+/// are open file descriptors to the file.
+//
+// We implement this using device+inode, as returned by `fstat`.
+//
+// According to
+// [posix](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/sys_stat.h.html):
+//
+//   A file identity is uniquely determined by the combination of st_dev and
+//   st_ino. At any given time in a system, distinct files shall have distinct
+//   file identities; hard links to the same file shall have the same file
+//   identity. Over time, these file identities can be reused for different files.
+//   For example, the st_ino value can be reused after the last link to a file is
+//   unlinked and the space occupied by the file has been freed, and the st_dev
+//   value associated with a file system can be reused if that file system is
+//   detached ("unmounted") and another is attached ("mounted").
+//
+// While the posix definition doesn't seem to clearly specify whether an inode
+// number can be reused when there are no more links in the file system, but the
+// file is still open, my understanding is that at least in Linux, files aren't
+// destroyed and their inode numbers made available for reuse until it is no
+// longer open by anyone. e.g.
+// [unlink(2)](https://man7.org/linux/man-pages/man2/unlink.2.html):
+//
+//   If the name was the last link to a file but any processes still
+//   have the file open, the file will remain in existence until the
+//   last file descriptor referring to it is closed.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct FileId {
+    device: u64,
+    inode: u64,
+}
+
+impl From<&linux_api::stat::stat> for FileId {
+    fn from(value: &linux_api::stat::stat) -> Self {
+        FileId {
+            device: value.lst_dev,
+            inode: value.lst_ino,
+        }
+    }
+}
+
+impl From<&libc::stat> for FileId {
+    fn from(value: &libc::stat) -> Self {
+        FileId {
+            device: value.st_dev,
+            inode: value.st_ino,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FcntlLockTableForOneFile {
+    locks: RangeMap<usize, FcntlLock>,
+    // Will need something here to track sleepers
+}
+
+impl FcntlLockTableForOneFile {
+    fn new() -> Self {
+        Self {
+            locks: Default::default(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.locks.is_empty()
+    }
+
+    /// Apply the requested lock to the given range. Similar semantics as
+    /// `fcntl` operations like `F_SETLK`.
+    ///
+    /// Returns an error if an incompatible lock exists.
+    pub fn set_lock(
+        &mut self,
+        requested_range: Range<usize>,
+        requester: &LockOwner,
+        requested_type: FlockType,
+    ) -> Result<(), LockError> {
+        // Process overlapping locks, collecting what the updated locks will look like.
+        let mut updated_results = Vec::<(Range<usize>, FcntlLock)>::new();
+        for (lock_range, lock) in self.locks.overlapping(&requested_range) {
+            match lock.with_request_applied(requester, requested_type) {
+                Ok(Some(updated_lock)) => {
+                    // Record the updated lock.
+                    let start = std::cmp::max(lock_range.start, requested_range.start);
+                    let end = std::cmp::min(lock_range.end, requested_range.end);
+                    updated_results.push((start..end, updated_lock));
+                }
+                Ok(None) => {
+                    // Result is no-lock. No need to record anything; we'll clear this below.
+                }
+                Err(_) => {
+                    // Conflicting lock; can't update.
+                    return Err(LockError::ConflictingLock);
+                }
+            }
+        }
+
+        // Set the whole range based on the requested lock.
+        match FcntlLock::new(requester, requested_type) {
+            Some(l) => {
+                self.locks.insert(requested_range.clone(), l);
+            }
+            None => {
+                self.locks.remove(requested_range.clone());
+            }
+        }
+
+        // Insert the updated locks, potentially overwriting what we just wrote
+        // into the whole range.
+        for (updated_range, updated_lock) in updated_results {
+            self.locks.insert(updated_range, updated_lock);
+        }
+
+        Ok(())
+    }
+
+    /// Return one of the locks that would conflict with the requested lock, if
+    /// any. The return range is *uncoalesced*, meaning that if a conflicting read lock
+    /// is returned, the bounds have not been expanded to include adjancent read locks
+    /// that also have the returned owner.
+    ///
+    /// Intended for `fcntl` operations like `F_GETLK`, but result is the raw
+    /// internal lock, if any.
+    fn get_uncoalesced_conflicting_lock(
+        &self,
+        requested_range: Range<usize>,
+        requester: &LockOwner,
+        requested_type: FlockType,
+    ) -> Option<(LockOwner, Range<usize>, FlockType)> {
+        for (lock_range, lock) in self.locks.overlapping(&requested_range) {
+            match lock.with_request_applied(requester, requested_type) {
+                Ok(_) => (), // No conflict,
+                Err(o) => return Some((o, lock_range.clone(), lock.access())),
+            }
+        }
+        None
+    }
+
+    /// Return one of the locks that would conflict with the requested lock, if
+    /// any. Intended for `fcntl` operations like `F_GETLK`.
+    ///
+    /// The returned range is coalesced for the returned owner: it includes all adjacent
+    /// range over which the owner has the returned access, even if parts of the range
+    /// have different ownership sets. (Reproducing the behavior of `F_GETLK` on Linux).
+    pub fn get_coalesced_conflicting_lock(
+        &self,
+        requested_range: Range<usize>,
+        requester: &LockOwner,
+        requested_type: FlockType,
+    ) -> Option<(LockOwner, Range<usize>, FlockType)> {
+        let (conflicting_owner, mut conflicting_range, conflicting_access) =
+            self.get_uncoalesced_conflicting_lock(requested_range, requester, requested_type)?;
+
+        let can_coalesce = |other_lock: &FcntlLock| -> bool {
+            other_lock.access() == conflicting_access
+                && other_lock.owners_contains(&conflicting_owner)
+        };
+
+        // Coalesce backwards
+        while let Some(x) = conflicting_range.start.checked_sub(1) {
+            let Some((prev_range, prev_lock)) = self.locks.get_key_value(&x) else {
+                break;
+            };
+            if !(can_coalesce(prev_lock)) {
+                break;
+            }
+            conflicting_range.start = prev_range.start
+        }
+
+        // Coalesce forwards
+        while let Some((next_range, next_lock)) = self.locks.get_key_value(&conflicting_range.end) {
+            if !(can_coalesce(next_lock)) {
+                break;
+            }
+            debug_assert_eq!(conflicting_range.end, next_range.start);
+            conflicting_range.end = next_range.end
+        }
+
+        Some((conflicting_owner, conflicting_range, conflicting_access))
+    }
+}
+
+/// All record locks for a Host.
+#[derive(Debug)]
+pub struct FcntlLockTable {
+    /// locks by FileId.
+    locks: BTreeMap<FileId, FcntlLockTableForOneFile>,
+}
+
+impl FcntlLockTable {
+    pub fn new() -> Self {
+        Self {
+            locks: BTreeMap::new(),
+        }
+    }
+
+    pub fn set_lock(
+        &mut self,
+        file_id: FileId,
+        requested_range: Range<usize>,
+        requested_owner: &LockOwner,
+        requested_access: FlockType,
+    ) -> Result<(), LockError> {
+        let file_locks = self
+            .locks
+            .entry(file_id)
+            .or_insert_with(FcntlLockTableForOneFile::new);
+        let res = file_locks.set_lock(requested_range.clone(), requested_owner, requested_access);
+        if res.is_err() {
+            log::debug!(
+                "failed to lock {file_id:?}.{requested_range:?}.{requested_owner:?}.{requested_access:?}"
+            );
+        }
+        if file_locks.is_empty() {
+            self.locks.remove(&file_id);
+        }
+        res
+    }
+
+    /// Return one of the locks that would conflict with the requested lock, if
+    /// any. Intended for `fcntl` operations like `F_GETLK`.
+    pub fn get_coalesced_conflicting_lock(
+        &self,
+        file_id: FileId,
+        requested_range: Range<usize>,
+        requested_owner: &LockOwner,
+        requested_access: FlockType,
+    ) -> Option<(LockOwner, Range<usize>, FlockType)> {
+        let file_locks = self.locks.get(&file_id)?;
+        let start = requested_range.start;
+        let end = requested_range.end;
+        let res = file_locks.get_coalesced_conflicting_lock(
+            requested_range,
+            requested_owner,
+            requested_access,
+        );
+        log::trace!(
+            "get_coalesced_conflicting_lock({file_locks:?}, {file_id:?}, {start}..{end}, {requested_owner:?}, {requested_access:?} -> {res:?})"
+        );
+        res
+    }
+
+    /// Drop all of the given owner's locks on the given file.
+    pub fn remove_owner(&mut self, file_id: FileId, requested_owner: &LockOwner) {
+        // F_UNLCK operation removes the specified owner where applicable for
+        // any part of the range, and has no effect for parts of the range where
+        // the owner doesn't hold a lock.
+        self.set_lock(
+            file_id,
+            usize::MIN..usize::MAX,
+            requested_owner,
+            FlockType::F_UNLCK,
+        )
+        .expect("F_UNLCK should always succeed");
+    }
+}
+
+impl Default for FcntlLockTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -1008,6 +1008,7 @@ impl Drop for Host {
         assert!(self.shim_shmem_lock.borrow().is_none());
     }
 }
+
 mod export {
     use std::{os::raw::c_char, time::Duration};
 

--- a/src/main/host/host.rs
+++ b/src/main/host/host.rs
@@ -38,6 +38,7 @@ use crate::core::worker::Worker;
 use crate::cshadow;
 use crate::host::descriptor::socket::abstract_unix_ns::AbstractUnixNamespace;
 use crate::host::descriptor::socket::inet::InetSocket;
+use crate::host::fcntl_lock_table::FcntlLockTable;
 use crate::host::futex_table::FutexTable;
 use crate::host::network::interface::{FifoPacketPriority, NetworkInterface, PcapOptions};
 use crate::host::network::namespace::NetworkNamespace;
@@ -130,6 +131,9 @@ pub struct Host {
 
     // map address to futex objects
     futex_table: RefCell<FutexTable>,
+
+    // track fcntl locks
+    fcntl_lock_table: RefCell<FcntlLockTable>,
 
     #[cfg(feature = "perf_timers")]
     execution_timer: RefCell<PerfTimer>,
@@ -293,6 +297,7 @@ impl Host {
             relay_inet_in: Arc::new(relay_inet_in),
             relay_loopback: Arc::new(relay_loopback),
             futex_table: RefCell::new(FutexTable::new()),
+            fcntl_lock_table: RefCell::new(FcntlLockTable::new()),
             random,
             shim_shmem,
             shim_shmem_lock: RefCell::new(None),
@@ -634,6 +639,16 @@ impl Host {
     #[track_caller]
     pub fn futextable_borrow_mut(&self) -> impl DerefMut<Target = FutexTable> + '_ {
         self.futex_table.borrow_mut()
+    }
+
+    #[track_caller]
+    pub fn fcntl_lock_table_borrow(&self) -> impl Deref<Target = FcntlLockTable> + '_ {
+        self.fcntl_lock_table.borrow()
+    }
+
+    #[track_caller]
+    pub fn fcntl_lock_table_borrow_mut(&self) -> impl DerefMut<Target = FcntlLockTable> + '_ {
+        self.fcntl_lock_table.borrow_mut()
     }
 
     #[allow(non_snake_case)]
@@ -993,7 +1008,6 @@ impl Drop for Host {
         assert!(self.shim_shmem_lock.borrow().is_none());
     }
 }
-
 mod export {
     use std::{os::raw::c_char, time::Duration};
 

--- a/src/main/host/mod.rs
+++ b/src/main/host/mod.rs
@@ -7,6 +7,7 @@
 pub mod context;
 pub mod cpu;
 pub mod descriptor;
+pub mod fcntl_lock_table;
 pub mod futex_table;
 #[allow(clippy::module_inception)]
 pub mod host;

--- a/src/main/host/syscall/handler/clone.rs
+++ b/src/main/host/syscall/handler/clone.rs
@@ -9,6 +9,7 @@ use shadow_shim_helper_rs::rootedcell::rc::RootedRc;
 use shadow_shim_helper_rs::rootedcell::refcell::RootedRefCell;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
+use crate::host::descriptor::DropPosixRecordLocks;
 use crate::host::descriptor::descriptor_table::DescriptorTable;
 use crate::host::process::ProcessId;
 use crate::host::thread::Thread;
@@ -115,7 +116,11 @@ impl SyscallHandler {
             RootedRc::new(root, RootedRefCell::new(root, table))
         };
         let desc_table = ExplicitDropper::new(desc_table, |desc_table| {
-            desc_table.explicit_drop_recursive(ctx.objs.host.root(), ctx.objs.host);
+            // If we drop the table through this object, it means the clone
+            // failed, and we *don't* drop any posix record locks. (Particularly not the current
+            // process's locks).
+            let d = DropPosixRecordLocks::False;
+            desc_table.explicit_drop_recursive(ctx.objs.host.root(), (ctx.objs.host, d));
         });
         handled_flags.insert(CloneFlags::CLONE_FILES);
 

--- a/src/main/host/syscall/handler/clone.rs
+++ b/src/main/host/syscall/handler/clone.rs
@@ -26,6 +26,9 @@ impl SyscallHandler {
         ctid: ForeignPtr<kernel_pid_t>,
         newtls: u64,
     ) -> Result<kernel_pid_t, Errno> {
+        trace!(
+            "flags:{flags:?} exit_signal:{exit_signal:?} child_stack:{child_stack:?} ptid:{ptid:?} ctid:{ctid:?} newtls:{newtls:?}"
+        );
         // We use this for a consistency check to validate that we've inspected
         // and emulated all of the provided flags.
         let mut handled_flags = CloneFlags::empty();

--- a/src/main/host/syscall/handler/close_range.rs
+++ b/src/main/host/syscall/handler/close_range.rs
@@ -2,7 +2,7 @@ use linux_api::close_range::CloseRangeFlags;
 use linux_api::errno::Errno;
 use linux_api::fcntl::DescriptorFlags;
 
-use crate::host::descriptor::descriptor_table;
+use crate::host::descriptor::{DropPosixRecordLocks, descriptor_table};
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
 use crate::utility::callback_queue::CallbackQueue;
 
@@ -72,7 +72,8 @@ impl SyscallHandler {
                 for desc in descriptors {
                     // close_range(2):
                     // > Errors closing a given file descriptor are currently ignored.
-                    let _ = desc.close(ctx.objs.host, cb_queue);
+                    let drop_locks = DropPosixRecordLocks::ForPid(ctx.objs.process.id());
+                    let _ = desc.close(ctx.objs.host, drop_locks, cb_queue);
                 }
             });
         }

--- a/src/main/host/syscall/handler/fcntl.c
+++ b/src/main/host/syscall/handler/fcntl.c
@@ -55,6 +55,12 @@ static int _syscallhandler_fcntlHelper(SyscallHandler* sys, RegularFile* file, i
         }
 
         case F_GETLK:
+        case F_SETLK:
+        case F_SETLKW:
+        {
+            utility_panic("fcntl command %ld should have already been handled in the rust fcntl handler", command);
+            break;
+        }
 #ifdef F_OFD_GETLK
         case F_OFD_GETLK:
 #endif
@@ -74,11 +80,9 @@ static int _syscallhandler_fcntlHelper(SyscallHandler* sys, RegularFile* file, i
         }
 #endif
 
-        case F_SETLK:
 #ifdef F_OFD_SETLK
         case F_OFD_SETLK:
 #endif
-        case F_SETLKW:
 #ifdef F_OFD_SETLKW
         case F_OFD_SETLKW:
 #endif

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -1,12 +1,118 @@
+use std::ops::Range;
+
 use linux_api::errno::Errno;
-use linux_api::fcntl::{DescriptorFlags, FcntlCommand, OFlag};
+use linux_api::fcntl::{DescriptorFlags, FcntlCommand, FlockType, FlockWhence, OFlag, flock};
+use linux_api::unistd::LSeekWhence;
 use log::debug;
+use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::cshadow;
-use crate::host::descriptor::{CompatFile, File, FileStatus};
+use crate::host::descriptor::{CompatFile, File, FileMode, FileStatus};
+use crate::host::fcntl_lock_table::{self, FileId, LockError, LockOwner};
+use crate::host::process::Process;
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
 use crate::host::syscall::type_formatting::SyscallNonDeterministicArg;
 use crate::host::syscall::types::SyscallError;
+
+#[derive(Debug, Clone)]
+struct CommonFlockParams {
+    file_id: fcntl_lock_table::FileId,
+    // TODO: make this `std::range::Range` instead of `std::ops::Range` go get `Copy`,
+    // once we've updated to Rust 1.96.
+    range: Range<usize>,
+    owner: LockOwner,
+    access: FlockType,
+}
+
+/// Common code for interpreting `flock`
+fn flock_params(
+    file: &CompatFile,
+    process: &Process,
+    flock: &linux_api::fcntl::flock,
+) -> Result<CommonFlockParams, SyscallError> {
+    let requested_access = FlockType::try_from(flock.l_type).map_err(|_| Errno::EINVAL)?;
+    let access_compat = match requested_access {
+        FlockType::F_RDLCK => file.mode().contains(FileMode::READ),
+        FlockType::F_WRLCK => file.mode().contains(FileMode::WRITE),
+        FlockType::F_UNLCK => true,
+    };
+    if !access_compat {
+        log::debug!(
+            "requested access {requested_access:?} incompatible with file mode {:?}",
+            file.mode()
+        );
+        return Err(Errno::EBADF.into());
+    }
+    let file_id = FileId::from(&file.stat()?);
+    let whence = FlockWhence::try_from(flock.l_whence).map_err(|_| Errno::EINVAL)?;
+    let origin = match whence {
+        FlockWhence::SEEK_SET => 0,
+        FlockWhence::SEEK_CUR => file.lseek(0, LSeekWhence::SEEK_CUR)?,
+        FlockWhence::SEEK_END => file.stat()?.lst_size,
+    };
+    let Some(signed_start) = origin.checked_add(flock.l_start) else {
+        return Err(Errno::EINVAL.into());
+    };
+    let (start, open_end) = if flock.l_len == 0 {
+        // fcntl(2): Specifying 0 for l_len has the special meaning: lock all
+        // bytes starting at the location specified by l_whence and l_start
+        // through to the end of file, no matter how large the file grows.
+        let start = usize::try_from(signed_start).map_err(|_| Errno::EINVAL)?;
+        (start, FLOCK_LENGTH_0_OPEN_END)
+    } else if flock.l_len < 0 {
+        // fcntl(2): if l_len is negative, the interval described by lock
+        // covers bytes l_start+l_len  up  to  and  including  l_start-1.
+        let start = signed_start
+            .checked_add(flock.l_len)
+            .ok_or(Errno::EINVAL)
+            .and_then(|x| usize::try_from(x).map_err(|_| Errno::EINVAL))?;
+        let open_end = usize::try_from(signed_start).map_err(|_| Errno::EINVAL)?;
+        (start, open_end)
+    } else {
+        let start = usize::try_from(signed_start).map_err(|_| Errno::EINVAL)?;
+        // We know length is positive.
+        let len =
+            usize::try_from(flock.l_len).expect("Negative length should have been caught earlier");
+        let Some(open_end) = start.checked_add(len) else {
+            return Err(Errno::EOVERFLOW.into());
+        };
+        if open_end > FLOCK_MAX_VISIBLE_RANGE_OPEN_END {
+            return Err(Errno::EOVERFLOW.into());
+        }
+        (start, open_end)
+    };
+    if open_end <= start {
+        return Err(Errno::EINVAL.into());
+    }
+    let requested_owner = LockOwner::Process(process.id());
+    Ok(CommonFlockParams {
+        file_id,
+        range: start..open_end,
+        owner: requested_owner,
+        access: requested_access,
+    })
+}
+
+// Linux returns an overflow error when the calculated (open) end is greater
+// than i64::MAX + 1, so that's the maximum user-visible range-end we permit.
+//
+// Internally we use values greater than this, having special meaning (see
+// FLOCK_LENGTH_0_OPEN_END, below).
+const FLOCK_MAX_VISIBLE_RANGE_OPEN_END: usize = (i64::MAX as usize) + 1;
+/// fcntl(2): Specifying 0 for l_len has the special meaning: lock all bytes
+/// starting at the location specified by l_whence and l_start through to the
+/// end of file, no matter how large the file grows.
+///
+/// We need to "round-trip" this behavior - returning a length of 0 in `F_GETLK`
+/// for a lock that was set with length 0.
+///
+/// We do this by internally mapping length 0 locks to end at usize::MAX,
+/// which is beyond the end that can be specified otherwise
+/// (FLOCK_MAX_VISIBLE_RANGE_OPEN_END).
+const FLOCK_LENGTH_0_OPEN_END: usize = usize::MAX;
+const _: () = const {
+    assert!(FLOCK_LENGTH_0_OPEN_END > FLOCK_MAX_VISIBLE_RANGE_OPEN_END);
+};
 
 impl SyscallHandler {
     log_syscall!(
@@ -39,11 +145,81 @@ impl SyscallHandler {
         };
 
         Ok(match cmd {
-            FcntlCommand::F_SETLK
-            | FcntlCommand::F_SETLKW
-            | FcntlCommand::F_OFD_SETLKW
-            | FcntlCommand::F_GETLK
-            | FcntlCommand::F_OFD_GETLK => {
+            FcntlCommand::F_SETLK | FcntlCommand::F_SETLKW => {
+                let flock_ptr = ForeignPtr::<()>::from(arg).cast::<flock>();
+                let flock = ctx.objs.process.memory_borrow().read(flock_ptr)?;
+                let file = desc.file();
+                let params = flock_params(file, ctx.objs.process, &flock)?;
+                let mut lock_table = ctx.objs.host.fcntl_lock_table_borrow_mut();
+                let res = lock_table.set_lock(
+                    params.file_id,
+                    params.range.clone(),
+                    &params.owner,
+                    params.access,
+                );
+                log::trace!("setlk[w] {params:?} -> {res:?}");
+                if let Err(e) = res {
+                    match e {
+                        LockError::ConflictingLock => {
+                            let errno = Errno::EACCES;
+                            if cmd == FcntlCommand::F_SETLKW {
+                                // TODO: block instead of returning an error.
+                                // <https://github.com/shadow/shadow/issues/3784>
+                                log::warn!(
+                                    "SETLKW({params:?}) should block, but blocking is unimplemented. Returning {errno:?}"
+                                );
+                            }
+                            return Err(errno.into());
+                        }
+                    }
+                }
+                0i64
+            }
+            FcntlCommand::F_GETLK => {
+                let flock_ptr = ForeignPtr::<()>::from(arg).cast::<flock>();
+                let flock = ctx.objs.process.memory_borrow().read(flock_ptr)?;
+                let file = desc.file();
+                let params = flock_params(file, ctx.objs.process, &flock)?;
+                let lock_table = ctx.objs.host.fcntl_lock_table_borrow();
+                let out_flock = match lock_table.get_coalesced_conflicting_lock(
+                    params.file_id,
+                    params.range.clone(),
+                    &params.owner,
+                    params.access,
+                ) {
+                    Some((conflict_owner, conflict_range, conflict_access)) => {
+                        let start = i64::try_from(conflict_range.start).unwrap_or_else(|_err| {
+                            panic!("Current lock range {conflict_range:?} start is out of range")
+                        });
+                        // length > i64::MAX is represented as 0.
+                        // Primarily this happens when the lock is *set* with
+                        // length 0 (see FLOCK_LENGTH_0_OPEN_END), but Linux
+                        // also uses 0 to represent the length of a coalesced
+                        // lock whose length doesn't fit in an i64.
+                        let length = i64::try_from(conflict_range.len()).unwrap_or(0);
+                        flock {
+                            l_type: conflict_access.into(),
+                            l_whence: FlockWhence::SEEK_SET.into(),
+                            l_start: start,
+                            l_len: length,
+                            l_pid: match conflict_owner {
+                                LockOwner::Process(process_id) => process_id.into(),
+                            },
+                        }
+                    }
+                    None => flock {
+                        l_type: FlockType::F_UNLCK.into(),
+                        ..flock
+                    },
+                };
+                ctx.objs
+                    .process
+                    .memory_borrow_mut()
+                    .write(flock_ptr, &out_flock)?;
+                log::trace!("getlk {params:?} -> {out_flock:?}");
+                0i64
+            }
+            FcntlCommand::F_OFD_SETLK | FcntlCommand::F_OFD_SETLKW | FcntlCommand::F_OFD_GETLK => {
                 match desc.file() {
                     CompatFile::New(_) => {
                         warn_once_then_debug!("fcntl({cmd:?}) unimplemented for {:?}", desc.file());

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -13,7 +13,9 @@ use crate::host::descriptor::socket::inet::udp::UdpSocket;
 use crate::host::descriptor::socket::netlink::{NetlinkFamily, NetlinkSocket, NetlinkSocketType};
 use crate::host::descriptor::socket::unix::{UnixSocket, UnixSocketType};
 use crate::host::descriptor::socket::{RecvmsgArgs, RecvmsgReturn, SendmsgArgs, Socket};
-use crate::host::descriptor::{CompatFile, Descriptor, File, FileState, FileStatus, OpenFile};
+use crate::host::descriptor::{
+    CompatFile, Descriptor, DropPosixRecordLocks, File, FileState, FileStatus, OpenFile,
+};
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
 use crate::host::syscall::io::{self, IoVec};
 use crate::host::syscall::type_formatting::{SyscallBufferArg, SyscallSockAddrArg};
@@ -992,14 +994,22 @@ impl SyscallHandler {
         match write_res {
             Ok(_) => Ok(()),
             Err(e) => {
+                // Don't bother trying to drop locks. We couldn't have created
+                // any via these descriptors, and there can't exist any others
+                // to that point to the same underlying file description.
+                let dont_drop_locks = DropPosixRecordLocks::False;
                 CallbackQueue::queue_and_run_with_legacy(|cb_queue| {
                     // ignore any errors when closing
-                    dt.deregister_descriptor(fd_1)
-                        .unwrap()
-                        .close(ctx.objs.host, cb_queue);
-                    dt.deregister_descriptor(fd_2)
-                        .unwrap()
-                        .close(ctx.objs.host, cb_queue);
+                    dt.deregister_descriptor(fd_1).unwrap().close(
+                        ctx.objs.host,
+                        dont_drop_locks,
+                        cb_queue,
+                    );
+                    dt.deregister_descriptor(fd_2).unwrap().close(
+                        ctx.objs.host,
+                        dont_drop_locks,
+                        cb_queue,
+                    );
                 });
                 Err(e.into())
             }

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -16,9 +16,10 @@ use crate::core::work::task::TaskRef;
 use crate::core::worker::Worker;
 use crate::cshadow as c;
 use crate::host::descriptor::descriptor_table::DescriptorHandle;
-use crate::host::descriptor::pipe;
 use crate::host::descriptor::shared_buf::SharedBuf;
-use crate::host::descriptor::{CompatFile, Descriptor, File, FileMode, FileStatus, OpenFile};
+use crate::host::descriptor::{
+    CompatFile, Descriptor, DropPosixRecordLocks, File, FileMode, FileStatus, OpenFile, pipe,
+};
 use crate::host::process::{Process, ProcessId};
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
 use crate::host::syscall::io::{IoVec, read_cstring_vec};
@@ -50,8 +51,11 @@ impl SyscallHandler {
 
         // if there are still valid descriptors to the open file, close() will do nothing
         // and return None
-        CallbackQueue::queue_and_run_with_legacy(|cb_queue| desc.close(ctx.objs.host, cb_queue))
-            .unwrap_or(Ok(()))
+        let drop_locks = DropPosixRecordLocks::ForPid(ctx.objs.process.id());
+        CallbackQueue::queue_and_run_with_legacy(|cb_queue| {
+            desc.close(ctx.objs.host, drop_locks, cb_queue)
+        })
+        .unwrap_or(Ok(()))
     }
 
     log_syscall!(
@@ -105,10 +109,11 @@ impl SyscallHandler {
 
         // close the replaced descriptor
         if let Some(replaced_desc) = replaced_desc {
+            let drop_locks = DropPosixRecordLocks::ForPid(ctx.objs.process.id());
             // from 'man 2 dup2': "If newfd was open, any errors that would have been reported at
             // close(2) time are lost"
             CallbackQueue::queue_and_run_with_legacy(|cb_queue| {
-                replaced_desc.close(ctx.objs.host, cb_queue)
+                replaced_desc.close(ctx.objs.host, drop_locks, cb_queue)
             });
         }
 
@@ -167,10 +172,11 @@ impl SyscallHandler {
 
         // close the replaced descriptor
         if let Some(replaced_desc) = replaced_desc {
+            let drop_locks = DropPosixRecordLocks::ForPid(ctx.objs.process.id());
             // from 'man 2 dup3': "If newfd was open, any errors that would have been reported at
             // close(2) time are lost"
             CallbackQueue::queue_and_run_with_legacy(|cb_queue| {
-                replaced_desc.close(ctx.objs.host, cb_queue)
+                replaced_desc.close(ctx.objs.host, drop_locks, cb_queue)
             });
         }
 
@@ -519,14 +525,21 @@ impl SyscallHandler {
         match write_res {
             Ok(_) => Ok(()),
             Err(e) => {
+                // Behave as if descriptor was never created. (Though such locks shouldn't exist
+                // for this descriptor type anyway).
+                let dont_drop_locks = DropPosixRecordLocks::False;
                 CallbackQueue::queue_and_run_with_legacy(|cb_queue| {
                     // ignore any errors when closing
-                    dt.deregister_descriptor(read_fd)
-                        .unwrap()
-                        .close(ctx.objs.host, cb_queue);
-                    dt.deregister_descriptor(write_fd)
-                        .unwrap()
-                        .close(ctx.objs.host, cb_queue);
+                    dt.deregister_descriptor(read_fd).unwrap().close(
+                        ctx.objs.host,
+                        dont_drop_locks,
+                        cb_queue,
+                    );
+                    dt.deregister_descriptor(write_fd).unwrap().close(
+                        ctx.objs.host,
+                        dont_drop_locks,
+                        cb_queue,
+                    );
                 });
                 Err(e.into())
             }

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -24,6 +24,7 @@ use super::host::Host;
 use super::managed_thread::{self, ManagedThread};
 use super::process::{Process, ProcessId};
 use crate::cshadow as c;
+use crate::host::descriptor::DropPosixRecordLocks;
 use crate::host::syscall::condition::{SyscallConditionRef, SyscallConditionRefMut};
 use crate::host::syscall::handler::SyscallHandler;
 use crate::utility::callback_queue::CallbackQueue;
@@ -130,7 +131,11 @@ impl Thread {
             // Descriptor table is unshared
             let desc_table_rc = self.desc_table.take().unwrap();
             let mut desc_table = DescriptorTable::clone(&desc_table_rc.borrow(host.root()));
-            desc_table_rc.explicit_drop_recursive(host.root(), host);
+            // Don't inadvertently drop locks as part of this bookkeeping.
+            // In particular, fcntl(2): "Record locks are ... are preserved
+            // across an execve(2)".
+            let dont_drop_locks = DropPosixRecordLocks::False;
+            desc_table_rc.explicit_drop_recursive(host.root(), (host, dont_drop_locks));
 
             // Any descriptors with CLOEXEC are closed.
             let to_close: Vec<DescriptorHandle> = desc_table
@@ -146,11 +151,12 @@ impl Thread {
 
             CallbackQueue::queue_and_run_with_legacy(|q| {
                 for handle in to_close {
+                    let drop_locks = DropPosixRecordLocks::ForPid(self.process_id());
                     log::trace!("Unregistering FD_CLOEXEC descriptor {handle:?}");
                     if let Some(Err(e)) = desc_table
                         .deregister_descriptor(handle)
                         .unwrap()
-                        .close(host, q)
+                        .close(host, drop_locks, q)
                     {
                         log::debug!("Error closing {handle:?}: {e:?}");
                     };
@@ -612,7 +618,11 @@ impl ExplicitDrop for Thread {
 
     fn explicit_drop<'p>(mut self, host: Self::ExplicitDropParam<'p>) {
         if let Some(table) = self.desc_table.take() {
-            table.explicit_drop_recursive(host.root(), host);
+            // If this is the last reference to the given table, do drop posix
+            // record locks. Typically this should only be the case if this is
+            // the last thread in the process.
+            let drop_locks = DropPosixRecordLocks::ForPid(self.process_id());
+            table.explicit_drop_recursive(host.root(), (host, drop_locks));
         }
     }
 }

--- a/src/test/Cargo.toml
+++ b/src/test/Cargo.toml
@@ -271,3 +271,4 @@ vasi-sync = { path = "../lib/vasi-sync" }
 static_assertions = "1.1.0"
 tempfile = "3.27.0"
 tor-llcrypto = "0.41.0"
+num_enum = "0.7.6"

--- a/src/test/clone/test_fork.rs
+++ b/src/test/clone/test_fork.rs
@@ -40,6 +40,15 @@ fn fork_via_clone_syscall() -> Result<CloneResult, Errno> {
     }
 }
 
+fn fork_via_clone3_syscall() -> Result<CloneResult, Errno> {
+    let clone_args = linux_api::sched::clone_args {
+        flags: CloneFlags::empty().bits(),
+        exit_signal: u64::try_from(Signal::SIGCHLD.as_i32()).unwrap(),
+        ..shadow_pod::zeroed()
+    };
+    unsafe { linux_api::sched::clone3(&clone_args) }
+}
+
 fn fork_via_fork_syscall() -> Result<CloneResult, Errno> {
     unsafe { linux_api::sched::fork() }
 }
@@ -1311,10 +1320,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut tests: Vec<test_utils::ShadowTest<(), anyhow::Error>> = Vec::new();
 
     #[allow(clippy::type_complexity)]
-    let fork_fns: [(&str, Arc<dyn Fn() -> Result<CloneResult, Errno>>); 3] = [
+    let fork_fns: [(&str, Arc<dyn Fn() -> Result<CloneResult, Errno>>); _] = [
         (
             stringify!(fork_via_clone_syscall),
             Arc::new(fork_via_clone_syscall),
+        ),
+        (
+            stringify!(fork_via_clone3_syscall),
+            Arc::new(fork_via_clone3_syscall),
         ),
         (
             stringify!(fork_via_fork_syscall),

--- a/src/test/file_locks/file-locks.yaml
+++ b/src/test/file_locks/file-locks.yaml
@@ -9,3 +9,5 @@ hosts:
     processes:
     - path: ../../target/debug/test_file_locks
       args: --shadow-passing
+      environment:
+        RUST_BACKTRACE: "1"

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -182,6 +182,68 @@ fn test_contested_pid_locks() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn test_contested_zero_len_pid_locks() -> anyhow::Result<()> {
+    let file = tempfile::tempfile().unwrap();
+    let mut child = ForkedChild::new(handle_lock_request)?;
+
+    // fcntl(2):
+    // "Specifying 0 for l_len has the special meaning: > lock all bytes
+    // starting at the location specified by l_whence and l_start through to the
+    // end of file, no matter how large the file grows."
+    let zerolen_flock = libc::flock {
+        l_type: libc::F_WRLCK.try_into().unwrap(),
+        l_whence: libc::SEEK_SET.try_into().unwrap(),
+        l_start: 100,
+        l_len: 0,
+        l_pid: 0,
+    };
+    let res = child
+        .send_recv(&SerializedLockRequest {
+            fd: file.as_raw_fd(),
+            cmd: libc::F_SETLK,
+            flock: zerolen_flock,
+        })
+        .unwrap();
+    ensure_ord!(res.rv, ==, 0);
+    ensure_ord!(res.flock, ==, zerolen_flock);
+
+    // first 100 bytes should still be available to lock
+    let begin_flock = libc::flock {
+        l_type: libc::F_WRLCK.try_into().unwrap(),
+        l_whence: libc::SEEK_SET.try_into().unwrap(),
+        l_start: 0,
+        l_len: 100,
+        l_pid: 0,
+    };
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_GETLK, &begin_flock)?.l_type, ==, i16::try_from(libc::F_UNLCK).unwrap());
+
+    // next byte should conflict with child's lock
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_GETLK, &libc::flock{
+        l_type: libc::F_WRLCK.try_into().unwrap(),
+        l_whence: libc::SEEK_SET.try_into().unwrap(),
+        l_start: 100,
+        l_len: 1,
+        l_pid: 0,
+    })?, ==, libc::flock{
+        l_pid: child.pid(),
+        ..zerolen_flock}
+    );
+
+    // last byte should conflict with child's lock
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_GETLK, &libc::flock{
+        l_type: libc::F_WRLCK.try_into().unwrap(),
+        l_whence: libc::SEEK_SET.try_into().unwrap(),
+        l_start: i64::MAX,
+        l_len: 1,
+        l_pid: 0,
+    })?, ==, libc::flock{
+        l_pid: child.pid(),
+        ..zerolen_flock}
+    );
+
+    Ok(())
+}
+
 fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
     // Open file before forking, so that child also has the descriptor.
     let file = tempfile::tempfile().unwrap();
@@ -524,6 +586,12 @@ fn main() -> anyhow::Result<()> {
             "contested-pid-locks",
             test_contested_pid_locks,
             // TODO: <https://github.com/shadow/shadow/issues/2258>
+            no_shadow_envs.clone(),
+        ),
+        // TODO: <https://github.com/shadow/shadow/issues/2258>
+        ShadowTest::new(
+            "contested-zero-len-pid-locks",
+            test_contested_zero_len_pid_locks,
             no_shadow_envs.clone(),
         ),
         ShadowTest::new(

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -1,7 +1,37 @@
 use anyhow::ensure;
 use linux_api::errno::Errno;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::os::fd::AsRawFd;
 use test_utils::{ForkedChild, ShadowTest, TestEnvironment, ensure_ord, set};
+
+// fcntl commands that set (or clear) a range lock, and that should behave
+// identically when the requested lock is uncontested.
+#[allow(non_camel_case_types)]
+#[repr(i32)]
+#[derive(Copy, Clone, Debug, IntoPrimitive, TryFromPrimitive)]
+enum FcntlPosixSetlkUncontestedCommand {
+    F_SETLK = libc::F_SETLK,
+    F_SETLKW = libc::F_SETLKW,
+}
+
+// fcntl commands whose third argument is a pointer to `libc::flock`.
+#[allow(non_camel_case_types)]
+#[repr(i32)]
+#[derive(Copy, Clone, Debug, IntoPrimitive, TryFromPrimitive)]
+enum FcntlFlockCommand {
+    F_SETLK = libc::F_SETLK,
+    F_SETLKW = libc::F_SETLKW,
+    F_GETLK = libc::F_GETLK,
+    F_OFD_SETLK = libc::F_OFD_SETLK,
+    F_OFD_SETLKW = libc::F_OFD_SETLKW,
+    F_OFD_GETLK = libc::F_OFD_GETLK,
+}
+
+impl From<FcntlPosixSetlkUncontestedCommand> for FcntlFlockCommand {
+    fn from(value: FcntlPosixSetlkUncontestedCommand) -> Self {
+        Self::try_from(i32::from(value)).unwrap()
+    }
+}
 
 /// safer, convenient wrapper around fcntl for lock operations.
 ///
@@ -9,24 +39,16 @@ use test_utils::{ForkedChild, ShadowTest, TestEnvironment, ensure_ord, set};
 /// version that uses them instead of its own.
 fn fcntl_lock(
     raw_fd: libc::c_int,
-    cmd: libc::c_int,
+    cmd: FcntlFlockCommand,
     flock: &libc::flock,
 ) -> Result<libc::flock, Errno> {
-    assert!(
-        [libc::F_SETLK, libc::F_SETLKW, libc::F_GETLK].contains(&cmd),
-        "Unhandled command"
-    );
     let mut res = *flock;
-    Errno::result_from_libc_errno(-1, unsafe { libc::fcntl(raw_fd, cmd, &mut res) })?;
+    Errno::result_from_libc_errno(-1, unsafe { libc::fcntl(raw_fd, cmd.into(), &mut res) })?;
     Ok(res)
 }
 
 /// test taking uncontested locks, using either F_SETLK or F_SETLKW.
-fn test_uncontested_pid_locks(cmd: libc::c_int) -> anyhow::Result<()> {
-    assert!(
-        [libc::F_SETLK, libc::F_SETLKW].contains(&cmd),
-        "Unhandled command"
-    );
+fn test_uncontested_pid_locks(cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow::Result<()> {
     let file = tempfile::tempfile().unwrap();
 
     let rd_flock = libc::flock {
@@ -39,21 +61,21 @@ fn test_uncontested_pid_locks(cmd: libc::c_int) -> anyhow::Result<()> {
 
     // Taking a read lock succeeds. (Doesn't matter that the file is empty; non-existent ranges can be locked).
     // flock struct should be unmodified.
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd, &rd_flock)?, ==, rd_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &rd_flock)?, ==, rd_flock);
 
     // Taking a read lock where we already have one still succeeds.
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd, &rd_flock)?, ==, rd_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &rd_flock)?, ==, rd_flock);
 
     // Upgrading a read lock to a write lock succeeds.
     let wr_flock = libc::flock {
         l_type: libc::F_WRLCK.try_into().unwrap(),
         ..rd_flock
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd, &wr_flock)?, ==, wr_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &wr_flock)?, ==, wr_flock);
 
     // GETLK, when there is no conflicting lock (which is the case when we own the only existing lock)...
     {
-        let mut res_flock = fcntl_lock(file.as_raw_fd(), libc::F_GETLK, &rd_flock)?;
+        let mut res_flock = fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_GETLK, &rd_flock)?;
         // ... should set l_type to F_UNLCK
         ensure_ord!(res_flock.l_type, ==, i16::try_from(libc::F_UNLCK).unwrap());
         // ... and leave other fields unchanged.
@@ -66,20 +88,20 @@ fn test_uncontested_pid_locks(cmd: libc::c_int) -> anyhow::Result<()> {
         l_type: libc::F_UNLCK.try_into().unwrap(),
         ..rd_flock
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd, &unlck)?, ==, unlck);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &unlck)?, ==, unlck);
     // should still succeed with nothing holding the lock.
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd, &unlck)?, ==, unlck);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &unlck)?, ==, unlck);
 
     let named_file = tempfile::NamedTempFile::new().unwrap();
     let read_only_file = std::fs::File::open(named_file.path()).unwrap();
 
     // We can take a read lock from a read-only descriptor.
     Errno::result_from_libc_errno(-1, unsafe {
-        libc::fcntl(read_only_file.as_raw_fd(), cmd, &rd_flock)
+        libc::fcntl(read_only_file.as_raw_fd(), cmd.into(), &rd_flock)
     })?;
 
     // We *cannot* take a write lock from a read-only descriptor.
-    ensure_ord!(Errno::result_from_libc_errno(-1, unsafe { libc::fcntl(read_only_file.as_raw_fd(), cmd, &wr_flock)}), ==, Err(Errno::EBADF));
+    ensure_ord!(Errno::result_from_libc_errno(-1, unsafe { libc::fcntl(read_only_file.as_raw_fd(), cmd.into(), &wr_flock)}), ==, Err(Errno::EBADF));
 
     Ok(())
 }
@@ -139,13 +161,13 @@ fn test_contested_pid_locks() -> anyhow::Result<()> {
         l_len: 100,
         l_pid: 0,
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &rd_flock)?, ==, rd_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &rd_flock)?, ==, rd_flock);
 
     // Child should be able to take the same read lock.
     ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: libc::F_SETLK,
+            cmd: FcntlFlockCommand::F_SETLK.into(),
             flock: rd_flock,
         })
         .unwrap().to_result()?, ==, rd_flock);
@@ -158,14 +180,14 @@ fn test_contested_pid_locks() -> anyhow::Result<()> {
     };
 
     // GETLK should tell us about the child's conflicting lock.
-    let res = fcntl_lock(file.as_raw_fd(), libc::F_GETLK, &wr_flock);
+    let res = fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_GETLK, &wr_flock);
     ensure_ord!(res, ==, Ok(libc::flock {
         l_pid: child.pid(),
         ..rd_flock
     }));
 
     // Trying to take the lock anyway should fail.
-    let res = fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &wr_flock);
+    let res = fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &wr_flock);
     ensure!(
         res == Err(Errno::EACCES) || res == Err(Errno::EAGAIN),
         "Expected EACCES or EGAIN, got {res:?}"
@@ -179,13 +201,13 @@ fn test_contested_pid_locks() -> anyhow::Result<()> {
     ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: libc::F_SETLK,
+            cmd: FcntlFlockCommand::F_SETLK.into(),
             flock: unlck_flock,
         })
         .unwrap().to_result()?, ==, unlck_flock);
 
     // We should now be free to upgrade to a write lock.
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &wr_flock), ==, Ok(wr_flock));
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &wr_flock), ==, Ok(wr_flock));
 
     Ok(())
 }
@@ -208,7 +230,7 @@ fn test_contested_zero_len_pid_locks() -> anyhow::Result<()> {
     ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: libc::F_SETLK,
+            cmd: FcntlFlockCommand::F_SETLK.into(),
             flock: zerolen_flock,
         })
         .unwrap().to_result()?, ==, zerolen_flock);
@@ -221,10 +243,10 @@ fn test_contested_zero_len_pid_locks() -> anyhow::Result<()> {
         l_len: 100,
         l_pid: 0,
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_GETLK, &begin_flock)?.l_type, ==, i16::try_from(libc::F_UNLCK).unwrap());
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_GETLK, &begin_flock)?.l_type, ==, i16::try_from(libc::F_UNLCK).unwrap());
 
     // next byte should conflict with child's lock
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_GETLK, &libc::flock{
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_GETLK, &libc::flock{
         l_type: libc::F_WRLCK.try_into().unwrap(),
         l_whence: libc::SEEK_SET.try_into().unwrap(),
         l_start: 100,
@@ -236,7 +258,7 @@ fn test_contested_zero_len_pid_locks() -> anyhow::Result<()> {
     );
 
     // last byte should conflict with child's lock
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_GETLK, &libc::flock{
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_GETLK, &libc::flock{
         l_type: libc::F_WRLCK.try_into().unwrap(),
         l_whence: libc::SEEK_SET.try_into().unwrap(),
         l_start: i64::MAX,
@@ -264,20 +286,20 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
         l_len: 100,
         l_pid: 0,
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &wr100_flock)?, ==, wr100_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &wr100_flock)?, ==, wr100_flock);
 
     // Lock next 100 bytes
     let wr_next_100_flock = libc::flock {
         l_start: wr100_flock.l_start + wr100_flock.l_len,
         ..wr100_flock
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &wr_next_100_flock)?, ==, wr_next_100_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &wr_next_100_flock)?, ==, wr_next_100_flock);
 
     // Child querying any part of the locked region should see a coalesced lock.
     ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: libc::F_GETLK,
+            cmd: FcntlFlockCommand::F_GETLK.into(),
             flock: wr100_flock,
         })
         .unwrap().to_result()?, ==, libc::flock {
@@ -292,14 +314,14 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
         l_start: wr100_flock.l_len / 2,
         ..wr100_flock
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &unlock_middle_flock)?, ==, unlock_middle_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &unlock_middle_flock)?, ==, unlock_middle_flock);
 
     // Querying byte 0 should return a conflicting lock extending to the
     // beginning of where we unlocked.
     ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: libc::F_GETLK,
+            cmd: FcntlFlockCommand::F_GETLK.into(),
             flock: libc::flock {
                 l_type: libc::F_WRLCK.try_into().unwrap(),
                 l_whence: libc::SEEK_SET.try_into().unwrap(),
@@ -325,7 +347,7 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
     ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: libc::F_GETLK,
+            cmd: FcntlFlockCommand::F_GETLK.into(),
             flock: query_flock,
         })
         .unwrap().to_result()?, ==, libc::flock {
@@ -338,7 +360,7 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
     ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: libc::F_GETLK,
+            cmd: FcntlFlockCommand::F_GETLK.into(),
             flock: libc::flock {
                 l_type: libc::F_WRLCK.try_into().unwrap(),
                 l_whence: libc::SEEK_SET.try_into().unwrap(),
@@ -373,7 +395,7 @@ fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
     child1
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: libc::F_SETLK,
+            cmd: FcntlFlockCommand::F_SETLK.into(),
             flock: child1_flock,
         })?
         .to_result()?;
@@ -390,7 +412,7 @@ fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
     child2
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: libc::F_SETLK,
+            cmd: FcntlFlockCommand::F_SETLK.into(),
             flock: child2_flock,
         })?
         .to_result()?;
@@ -400,7 +422,7 @@ fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
     // can't return just the first, unshared, part of the child1 lock).
     ensure_ord!(fcntl_lock(
         file.as_raw_fd(),
-        libc::F_GETLK,
+        FcntlFlockCommand::F_GETLK,
         &libc::flock {
             l_type: libc::F_WRLCK.try_into()?,
             l_whence: libc::SEEK_SET.try_into()?,
@@ -417,7 +439,7 @@ fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
     // locks covering that byte.
     let res = fcntl_lock(
         file.as_raw_fd(),
-        libc::F_GETLK,
+        FcntlFlockCommand::F_GETLK,
         &libc::flock {
             l_type: libc::F_WRLCK.try_into()?,
             l_whence: libc::SEEK_SET.try_into()?,
@@ -432,7 +454,7 @@ fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
     // describing the whole range covered by that lock)
     ensure_ord!(fcntl_lock(
         file.as_raw_fd(),
-        libc::F_GETLK,
+        FcntlFlockCommand::F_GETLK,
         &libc::flock {
             l_type: libc::F_WRLCK.try_into()?,
             l_whence: libc::SEEK_SET.try_into()?,
@@ -459,33 +481,33 @@ fn test_unlock_pid_locks_edge_cases() -> anyhow::Result<()> {
         l_len: 100,
         l_pid: 0,
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &wr_flock)?, ==,wr_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &wr_flock)?, ==,wr_flock);
 
     // Unlocking the locked range should work.
     let unlk_flock = libc::flock {
         l_type: libc::F_UNLCK.try_into()?,
         ..wr_flock
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &unlk_flock)?, ==,unlk_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &unlk_flock)?, ==,unlk_flock);
 
     // Unlocking a range where there are no locks should still work.
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &unlk_flock)?, ==,unlk_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &unlk_flock)?, ==,unlk_flock);
 
     // Take a write lock in a child process
     let mut child = ForkedChild::new(handle_lock_request)?;
     child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: libc::F_SETLK,
+            cmd: FcntlFlockCommand::F_SETLK.into(),
             flock: wr_flock,
         })?
         .to_result()?;
 
     // Unlocking a range where we don't have a lock *and othes do*, should still succeed.
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &unlk_flock)?, ==,unlk_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &unlk_flock)?, ==,unlk_flock);
 
     // The child lock should still be there, of course.
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_GETLK, &wr_flock)?, ==, libc::flock {
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_GETLK, &wr_flock)?, ==, libc::flock {
         l_pid: child.pid(),
         ..wr_flock
     });
@@ -517,14 +539,14 @@ fn test_block_on_pid_locks() -> anyhow::Result<()> {
     let sleep_duration = std::time::Duration::from_secs(1);
 
     let mut child = ForkedChild::<u8, u8>::new(|cmd| match *cmd {
-        LOCK => match fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &flock) {
+        LOCK => match fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &flock) {
             Ok(_) => OK,
             Err(_) => ERR,
         },
         UNLOCK => {
             match fcntl_lock(
                 file.as_raw_fd(),
-                libc::F_SETLK,
+                FcntlFlockCommand::F_SETLK,
                 &libc::flock {
                     l_type: libc::F_UNLCK.try_into().unwrap(),
                     ..flock
@@ -553,7 +575,7 @@ fn test_block_on_pid_locks() -> anyhow::Result<()> {
 
     // Try to take the lock ourselves, using F_SETLKW to block.
     // This should block until after the child wakes up and unlocks.
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLKW, &flock), ==, Ok(flock));
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLKW, &flock), ==, Ok(flock));
 
     let t1 = std::time::Instant::now();
 
@@ -579,17 +601,19 @@ fn main() -> anyhow::Result<()> {
     let summarize = std::env::args().any(|x| x == "--summarize");
     let all_envs = set![TestEnvironment::Libc, TestEnvironment::Shadow];
     let no_shadow_envs = set![TestEnvironment::Libc];
-    let mut tests: Vec<test_utils::ShadowTest<(), anyhow::Error>> = vec![
-        ShadowTest::new(
-            "uncontested-pid-locks SETLK",
-            || test_uncontested_pid_locks(libc::F_SETLK),
+    let posix_uncontested_setlk_commands = [
+        FcntlPosixSetlkUncontestedCommand::F_SETLK,
+        FcntlPosixSetlkUncontestedCommand::F_SETLKW,
+    ];
+    let mut tests: Vec<test_utils::ShadowTest<(), anyhow::Error>> = Vec::new();
+    for cmd in posix_uncontested_setlk_commands {
+        tests.push(ShadowTest::new(
+            &format!("uncontested-pid-locks {cmd:?}"),
+            move || test_uncontested_pid_locks(cmd),
             all_envs.clone(),
-        ),
-        ShadowTest::new(
-            "uncontested-pid-locks SETLKW",
-            || test_uncontested_pid_locks(libc::F_SETLKW),
-            all_envs.clone(),
-        ),
+        ));
+    }
+    tests.extend([
         ShadowTest::new(
             "contested-pid-locks",
             test_contested_pid_locks,
@@ -626,7 +650,7 @@ fn main() -> anyhow::Result<()> {
             // TODO: <https://github.com/shadow/shadow/issues/2258>
             no_shadow_envs.clone(),
         ),
-    ];
+    ]);
     if filter_shadow_passing {
         tests.retain(|x| x.passing(TestEnvironment::Shadow));
     }

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -3,7 +3,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::{
     io::{Seek as _, SeekFrom, Write as _},
     ops::Neg as _,
-    os::fd::AsRawFd,
+    os::fd::{AsRawFd, IntoRawFd as _},
 };
 use test_utils::{ForkedChild, ShadowTest, TestEnvironment, ensure_in, ensure_ord, set};
 
@@ -244,6 +244,220 @@ fn test_contested_pid_locks(cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow::R
         let out_flock = fcntl_lock(file.as_raw_fd(), cmd.into(), &wr_flock)?;
         // output flock should be unmodified.
         ensure_ord!(out_flock, ==, wr_flock);
+    }
+
+    Ok(())
+}
+
+fn test_pid_locks_shared_descriptor_table(
+    setlk_cmd: FcntlPosixSetlkUncontestedCommand,
+) -> anyhow::Result<()> {
+    let file = tempfile::tempfile().unwrap();
+
+    // A file object would be confused by what we're doing here;
+    // convert to a raw file descriptor.
+    //
+    // We'll close this descriptor in the child with the share descriptor table
+    // as part of testing.
+    let raw_file_fd_to_close = file.into_raw_fd();
+    // We'll keep this one open throughout and use it for other operations.
+    let raw_file_fd = unsafe { libc::dup(raw_file_fd_to_close) };
+
+    // The lock we'll take and check.
+    let flock = libc::flock {
+        l_type: libc::F_WRLCK.try_into().unwrap(),
+        l_whence: libc::SEEK_SET.try_into().unwrap(),
+        l_start: 0,
+        l_len: 100,
+        l_pid: 0,
+    };
+
+    // Take this lock ourselves.
+    fcntl_lock(raw_file_fd_to_close, setlk_cmd.into(), &flock)?;
+
+    // We'll use this, conventionally forked, child to check the status of the lock.
+    let mut getlk_child = ForkedChild::new(handle_lock_request)?;
+
+    // commands we'll send the child:
+    // close `raw_file_fd_to_close`; return 0 or errno.
+    const CMD_CLOSE: i32 = 0;
+    // take the lock using `raw_file_fd`; return 0 or errno.
+    const CMD_SETLOCK: i32 = 1;
+    // query the lock using `raw_file_fd`; return l_pid (owning pid) or negated errno.
+    const CMD_GETLOCK: i32 = 2;
+
+    // Create a child process with a shared descriptor table (CLONE_FILES).
+    let mut clone_files_child = {
+        let child_fn = |cmd: &i32| -> i32 {
+            match *cmd {
+                CMD_CLOSE => {
+                    // close the file.
+                    let rv = unsafe { libc::close(raw_file_fd_to_close) };
+                    if rv == 0 {
+                        0
+                    } else {
+                        unsafe { *libc::__errno_location() }
+                    }
+                }
+                CMD_SETLOCK => match fcntl_lock(raw_file_fd, setlk_cmd.into(), &flock) {
+                    Ok(_) => 0,
+                    Err(e) => i32::from(e),
+                },
+                CMD_GETLOCK => match fcntl_lock(raw_file_fd, FcntlFlockCommand::F_GETLK, &flock) {
+                    Ok(fl) => fl.l_pid,
+                    Err(e) => e.to_negated_i32(),
+                },
+                _other => -1,
+            }
+        };
+        unsafe { ForkedChild::new_with_clone_files(child_fn) }?
+    };
+
+    // Regular child should still see the lock as held by us, and have our PID
+    // associated with it.
+    {
+        let res = getlk_child
+            .send_recv(&SerializedLockRequest {
+                fd: raw_file_fd,
+                cmd: FcntlFlockCommand::F_GETLK.into(),
+                flock,
+            })?
+            .to_result()?;
+        ensure_ord!(res.l_pid, ==, i32::try_from(std::process::id()).unwrap());
+    }
+
+    // clone_files_child sees the lock as take-able.
+    // This implies that despite the lock having our pid associated with it
+    // above, the shared *descriptor table* is the true owner of the lock, not
+    // the process.
+    {
+        let res = clone_files_child.send_recv(&CMD_GETLOCK)?;
+        ensure_ord!(res, ==, 0);
+    }
+
+    // Tell clone_files_child to close `raw_file_fd_to_close`.
+    {
+        let res = clone_files_child.send_recv(&CMD_CLOSE)?;
+        ensure_ord!(res, ==, 0);
+    }
+
+    // We should have now lost the lock.
+    {
+        let res = getlk_child
+            .send_recv(&SerializedLockRequest {
+                fd: raw_file_fd,
+                cmd: FcntlFlockCommand::F_GETLK.into(),
+                flock,
+            })?
+            .to_result()?;
+        ensure_ord!(res.l_type, ==, i16::try_from(libc::F_UNLCK).unwrap());
+        ensure_ord!(res.l_pid, ==, 0);
+    }
+
+    // Tell clone_files_child to lock the file again, using `raw_files_fd`.
+    {
+        let res = clone_files_child.send_recv(&CMD_SETLOCK)?;
+        ensure_ord!(res, ==, 0);
+    }
+
+    // regular child should see clone_files_child as the owner of the lock.
+    // i.e. the pid associated with the lock is the one that actually did the
+    // lock operation, not the one that originally created the file descriptor
+    // and file descriptor table)
+    {
+        let res = getlk_child
+            .send_recv(&SerializedLockRequest {
+                fd: raw_file_fd,
+                cmd: FcntlFlockCommand::F_GETLK.into(),
+                flock,
+            })?
+            .to_result()?;
+        ensure_ord!(res.l_type, ==, i16::try_from(libc::F_WRLCK).unwrap());
+        ensure_ord!(res.l_pid, ==, clone_files_child.pid());
+    }
+
+    // we should be able to take a lock that contained within clone_files_child's
+    // lock, since our shared descriptor table is the owner.
+    let contained_flock = libc::flock {
+        l_type: libc::F_WRLCK.try_into().unwrap(),
+        l_whence: libc::SEEK_SET.try_into().unwrap(),
+        l_start: 0,
+        l_len: 1,
+        l_pid: 0,
+    };
+    // operation succeeds since we have the same owner, and ...
+    fcntl_lock(raw_file_fd, setlk_cmd.into(), &contained_flock)?;
+
+    // the pid label doesn't change. it still appears as a single lock owned by
+    // the `clone_files_child`.
+    {
+        let res = getlk_child
+            .send_recv(&SerializedLockRequest {
+                fd: raw_file_fd,
+                cmd: FcntlFlockCommand::F_GETLK.into(),
+                flock: contained_flock,
+            })?
+            .to_result()?;
+        ensure_ord!(res, ==, libc::flock {
+            l_pid: clone_files_child.pid(),
+            ..flock
+        });
+    }
+
+    // if we take a lock that *overlaps* with the clone_files_child's lock ...
+    let overlapping_flock = libc::flock {
+        l_type: libc::F_WRLCK.try_into().unwrap(),
+        l_whence: libc::SEEK_SET.try_into().unwrap(),
+        l_start: 50,
+        l_len: 100,
+        l_pid: 0,
+    };
+    fcntl_lock(raw_file_fd, setlk_cmd.into(), &overlapping_flock)?;
+
+    // the whole locked region is locked. The existing lock, with
+    // clone_files_child's pid label, gets expanded to include the new region.
+    // (i.e. the new region doesn't get our pid label).
+    {
+        let res = getlk_child
+            .send_recv(&SerializedLockRequest {
+                fd: raw_file_fd,
+                cmd: FcntlFlockCommand::F_GETLK.into(),
+                flock: libc::flock {
+                    l_len: 1,
+                    ..overlapping_flock
+                },
+            })?
+            .to_result()?;
+        ensure_ord!(res, ==, libc::flock {
+            l_start: 0,
+            l_len: 150,
+            l_pid: clone_files_child.pid(),
+            ..overlapping_flock
+        });
+    }
+
+    // taking a completely distinct lock:
+    let distinct_flock = libc::flock {
+        l_type: libc::F_WRLCK.try_into().unwrap(),
+        l_whence: libc::SEEK_SET.try_into().unwrap(),
+        l_start: 300,
+        l_len: 100,
+        l_pid: 0,
+    };
+    fcntl_lock(raw_file_fd, setlk_cmd.into(), &distinct_flock)?;
+    // here the new lock does get *our* pid label.
+    {
+        let res = getlk_child
+            .send_recv(&SerializedLockRequest {
+                fd: raw_file_fd,
+                cmd: FcntlFlockCommand::F_GETLK.into(),
+                flock: distinct_flock,
+            })?
+            .to_result()?;
+        ensure_ord!(res, ==, libc::flock {
+            l_pid: std::process::id().try_into().unwrap(),
+            ..distinct_flock
+        });
     }
 
     Ok(())
@@ -1264,6 +1478,12 @@ fn main() -> anyhow::Result<()> {
                 &format!("uncontested-pid-locks {cmd:?}"),
                 move || test_uncontested_pid_locks(cmd),
                 all_envs.clone(),
+            ),
+            ShadowTest::new(
+                &format!("pid-locks-shared-descriptor-table {cmd:?}"),
+                move || test_pid_locks_shared_descriptor_table(cmd),
+                // <https://github.com/shadow/shadow/issues/3783>
+                no_shadow_envs.clone(),
             ),
             ShadowTest::new(
                 &format!("pid-lock-seek-end {cmd:?}"),

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -102,19 +102,22 @@ struct SerializedLockResponse {
 }
 unsafe impl shadow_pod::Pod for SerializedLockResponse {}
 
+/// Perform the operation specified by `req`.
+fn handle_lock_request(req: &SerializedLockRequest) -> SerializedLockResponse {
+    let mut flock = req.flock;
+    let rv = unsafe { libc::fcntl(req.fd, req.cmd, &mut flock) };
+    SerializedLockResponse {
+        rv,
+        flock,
+        errno: unsafe { *libc::__errno_location() },
+    }
+}
+
 fn test_contested_pid_locks() -> anyhow::Result<()> {
     // Open file before forking, so that child also has the descriptor.
     let file = tempfile::tempfile().unwrap();
 
-    let mut child = ForkedChild::<SerializedLockRequest, SerializedLockResponse>::new(|req| {
-        let mut flock = req.flock;
-        let rv = unsafe { libc::fcntl(req.fd, req.cmd, &mut flock) };
-        SerializedLockResponse {
-            rv,
-            flock,
-            errno: unsafe { *libc::__errno_location() },
-        }
-    })?;
+    let mut child = ForkedChild::new(handle_lock_request)?;
 
     // Take a read lock
     let rd_flock = libc::flock {
@@ -183,15 +186,7 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
     // Open file before forking, so that child also has the descriptor.
     let file = tempfile::tempfile().unwrap();
 
-    let mut child = ForkedChild::<SerializedLockRequest, SerializedLockResponse>::new(|req| {
-        let mut flock = req.flock;
-        let rv = unsafe { libc::fcntl(req.fd, req.cmd, &mut flock) };
-        SerializedLockResponse {
-            rv,
-            flock,
-            errno: unsafe { *libc::__errno_location() },
-        }
-    })?;
+    let mut child = ForkedChild::new(handle_lock_request)?;
 
     // Lock first 100 bytes
     let wr100_flock = libc::flock {

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -381,7 +381,7 @@ fn test_coalesce_and_split_pid_locks(cmd: FcntlPosixSetlkUncontestedCommand) -> 
     Ok(())
 }
 
-fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
+fn test_overlapping_pid_locks(cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow::Result<()> {
     // Open file before forking, so that child also has the descriptor.
     let file = tempfile::tempfile()?;
 
@@ -397,7 +397,7 @@ fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
     child1
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: FcntlFlockCommand::F_SETLK.into(),
+            cmd: cmd.into(),
             flock: child1_flock,
         })?
         .to_result()?;
@@ -414,7 +414,7 @@ fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
     child2
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: FcntlFlockCommand::F_SETLK.into(),
+            cmd: cmd.into(),
             flock: child2_flock,
         })?
         .to_result()?;
@@ -635,18 +635,18 @@ fn main() -> anyhow::Result<()> {
                 // TODO: <https://github.com/shadow/shadow/issues/2258>
                 no_shadow_envs.clone(),
             ),
+            ShadowTest::new(
+                &format!("overlapping-pid-locks {cmd:?}"),
+                move || test_overlapping_pid_locks(cmd),
+                // TODO: <https://github.com/shadow/shadow/issues/2258>
+                no_shadow_envs.clone(),
+            ),
         ]);
     }
     tests.extend([
         ShadowTest::new(
             "block-on-pid-locks",
             test_block_on_pid_locks,
-            // TODO: <https://github.com/shadow/shadow/issues/2258>
-            no_shadow_envs.clone(),
-        ),
-        ShadowTest::new(
-            "query-overlapping-pid-locks",
-            test_query_overlapping_pid_locks,
             // TODO: <https://github.com/shadow/shadow/issues/2258>
             no_shadow_envs.clone(),
         ),

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -283,6 +283,71 @@ fn test_pid_lock_overflow(cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow::Res
     Ok(())
 }
 
+fn test_pid_lock_max_range(cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow::Result<()> {
+    let file = tempfile::tempfile().unwrap();
+
+    // lock 0..i64::MAX
+    fcntl_lock(
+        file.as_raw_fd(),
+        cmd.into(),
+        &libc::flock {
+            l_type: libc::F_WRLCK.try_into().unwrap(),
+            l_whence: libc::SEEK_SET.try_into().unwrap(),
+            l_start: 0,
+            l_len: i64::MAX,
+            l_pid: 0,
+        },
+    )?;
+
+    // We can lock one more byte beyond that (see overflow test above),
+    // such that the coalesced lock has length i64::MAX+1.
+    fcntl_lock(
+        file.as_raw_fd(),
+        cmd.into(),
+        &libc::flock {
+            l_type: libc::F_WRLCK.try_into().unwrap(),
+            l_whence: libc::SEEK_SET.try_into().unwrap(),
+            l_start: i64::MAX,
+            l_len: 1,
+            l_pid: 0,
+        },
+    )?;
+
+    // Get the coalesced conflicting lock.
+    let mut child = ForkedChild::new(handle_lock_request)?;
+    let conflict_flock = {
+        // The child should successfully release the lock.
+        child
+            .send_recv(&SerializedLockRequest {
+                fd: file.as_raw_fd(),
+                cmd: FcntlFlockCommand::F_GETLK.into(),
+                flock: libc::flock {
+                    l_type: libc::F_WRLCK.try_into().unwrap(),
+                    l_whence: libc::SEEK_SET.try_into().unwrap(),
+                    l_start: 0,
+                    l_len: 1,
+                    l_pid: 0,
+                },
+            })?
+            .to_result()?
+    };
+
+    {
+        let expected = libc::flock {
+            l_type: libc::F_WRLCK.try_into().unwrap(),
+            l_whence: libc::SEEK_SET.try_into().unwrap(),
+            l_start: 0,
+            // effective length of the coalesced lock is i64::MAX+1. This gets
+            // mapped back to length=0.
+            l_len: 0,
+            l_pid: std::process::id().try_into().unwrap(),
+        };
+        ensure_ord!(conflict_flock, ==, expected);
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 enum CloseDescriptor {
     Original,
@@ -1259,6 +1324,11 @@ fn main() -> anyhow::Result<()> {
             ShadowTest::new(
                 &format!("pid-lock-overflow {cmd:?}"),
                 move || test_pid_lock_overflow(cmd),
+                all_envs.clone(),
+            ),
+            ShadowTest::new(
+                &format!("pid-lock-max-range {cmd:?}"),
+                move || test_pid_lock_max_range(cmd),
                 all_envs.clone(),
             ),
         ]);

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -274,7 +274,7 @@ fn test_zero_len_pid_locks(cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow::Re
     Ok(())
 }
 
-fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
+fn test_coalesce_and_split_pid_locks(cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow::Result<()> {
     // Open file before forking, so that child also has the descriptor.
     let file = tempfile::tempfile().unwrap();
 
@@ -288,14 +288,14 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
         l_len: 100,
         l_pid: 0,
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &wr100_flock)?, ==, wr100_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &wr100_flock)?, ==, wr100_flock);
 
     // Lock next 100 bytes
     let wr_next_100_flock = libc::flock {
         l_start: wr100_flock.l_start + wr100_flock.l_len,
         ..wr100_flock
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &wr_next_100_flock)?, ==, wr_next_100_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &wr_next_100_flock)?, ==, wr_next_100_flock);
 
     // Child querying any part of the locked region should see a coalesced lock.
     ensure_ord!(child
@@ -316,7 +316,7 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
         l_start: wr100_flock.l_len / 2,
         ..wr100_flock
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &unlock_middle_flock)?, ==, unlock_middle_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &unlock_middle_flock)?, ==, unlock_middle_flock);
 
     // Querying byte 0 should return a conflicting lock extending to the
     // beginning of where we unlocked.
@@ -629,15 +629,15 @@ fn main() -> anyhow::Result<()> {
                 // TODO: <https://github.com/shadow/shadow/issues/2258>
                 no_shadow_envs.clone(),
             ),
+            ShadowTest::new(
+                &format!("coalesce-and-split-pid-locks {cmd:?}"),
+                move || test_coalesce_and_split_pid_locks(cmd),
+                // TODO: <https://github.com/shadow/shadow/issues/2258>
+                no_shadow_envs.clone(),
+            ),
         ]);
     }
     tests.extend([
-        ShadowTest::new(
-            "coalese-and-split-pid-locks",
-            test_coalesce_and_split_pid_locks,
-            // TODO: <https://github.com/shadow/shadow/issues/2258>
-            no_shadow_envs.clone(),
-        ),
         ShadowTest::new(
             "block-on-pid-locks",
             test_block_on_pid_locks,

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -1203,54 +1203,47 @@ fn main() -> anyhow::Result<()> {
             ShadowTest::new(
                 &format!("pid-lock-seek-end {cmd:?}"),
                 move || test_pid_lock_seek_end(cmd),
-                // TODO: <https://github.com/shadow/shadow/issues/2258>
-                no_shadow_envs.clone(),
+                all_envs.clone(),
             ),
             ShadowTest::new(
                 &format!("pid-lock-seek-cur {cmd:?}"),
                 move || test_pid_lock_seek_cur(cmd),
-                // TODO: <https://github.com/shadow/shadow/issues/2258>
-                no_shadow_envs.clone(),
+                all_envs.clone(),
             ),
             ShadowTest::new(
                 &format!("zero-len-pid-locks {cmd:?}"),
                 move || test_zero_len_pid_locks(cmd),
-                // TODO: <https://github.com/shadow/shadow/issues/2258>
-                no_shadow_envs.clone(),
+                all_envs.clone(),
             ),
             ShadowTest::new(
                 &format!("negative-len-pid-locks {cmd:?}"),
                 move || test_negative_len_pid_locks(cmd),
-                no_shadow_envs.clone(),
+                all_envs.clone(),
             ),
             ShadowTest::new(
                 &format!("contested-pid-locks {cmd:?}"),
                 move || test_contested_pid_locks(cmd),
-                // TODO: <https://github.com/shadow/shadow/issues/2258>
-                no_shadow_envs.clone(),
+                all_envs.clone(),
             ),
             ShadowTest::new(
                 &format!("pid-owner_exits {cmd:?}"),
                 move || test_pid_owner_exits(cmd),
-                no_shadow_envs.clone(),
+                all_envs.clone(),
             ),
             ShadowTest::new(
                 &format!("pid-lock-threads {cmd:?}"),
                 move || test_pid_lock_threads(cmd),
-                // TODO: <https://github.com/shadow/shadow/issues/2258>
-                no_shadow_envs.clone(),
+                all_envs.clone(),
             ),
             ShadowTest::new(
                 &format!("coalesce-and-split-pid-locks {cmd:?}"),
                 move || test_coalesce_and_split_pid_locks(cmd),
-                // TODO: <https://github.com/shadow/shadow/issues/2258>
-                no_shadow_envs.clone(),
+                all_envs.clone(),
             ),
             ShadowTest::new(
                 &format!("overlapping-pid-locks {cmd:?}"),
                 move || test_overlapping_pid_locks(cmd),
-                // TODO: <https://github.com/shadow/shadow/issues/2258>
-                no_shadow_envs.clone(),
+                all_envs.clone(),
             ),
             ShadowTest::new(
                 &format!("block-on-pid-locks {cmd:?}"),
@@ -1261,8 +1254,7 @@ fn main() -> anyhow::Result<()> {
             ShadowTest::new(
                 &format!("unlock-pid-locks-edge-cases {cmd:?}"),
                 move || test_unlock_pid_locks_edge_cases(cmd),
-                // TODO: <https://github.com/shadow/shadow/issues/2258>
-                no_shadow_envs.clone(),
+                all_envs.clone(),
             ),
             ShadowTest::new(
                 &format!("pid-lock-overflow {cmd:?}"),
@@ -1276,8 +1268,7 @@ fn main() -> anyhow::Result<()> {
             tests.extend([ShadowTest::new(
                 &format!("pid-owner-closes-descriptor {cmd:?} {close_descriptor:?}"),
                 move || test_pid_owner_closes_descriptor(cmd, close_descriptor),
-                // TODO: <https://github.com/shadow/shadow/issues/2258>
-                no_shadow_envs.clone(),
+                all_envs.clone(),
             )])
         }
     }

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -297,6 +297,93 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
+    // Open file before forking, so that child also has the descriptor.
+    let file = tempfile::tempfile()?;
+
+    // child1 takes a reader lock of bytes 0..100
+    let child1_flock = libc::flock {
+        l_type: libc::F_RDLCK.try_into().unwrap(),
+        l_whence: libc::SEEK_SET.try_into().unwrap(),
+        l_start: 0,
+        l_len: 100,
+        l_pid: 0,
+    };
+    let mut child1 = ForkedChild::new(handle_lock_request)?;
+    child1.send_recv(&SerializedLockRequest {
+        fd: file.as_raw_fd(),
+        cmd: libc::F_SETLK,
+        flock: child1_flock,
+    })?;
+
+    // child2 takes an overlapping reader lock of bytes 25..50
+    let child2_flock = libc::flock {
+        l_type: libc::F_RDLCK.try_into()?,
+        l_whence: libc::SEEK_SET.try_into()?,
+        l_start: 25,
+        l_len: 25,
+        l_pid: 0,
+    };
+    let mut child2 = ForkedChild::new(handle_lock_request)?;
+    child2.send_recv(&SerializedLockRequest {
+        fd: file.as_raw_fd(),
+        cmd: libc::F_SETLK,
+        flock: child2_flock,
+    })?;
+
+    // querying the first byte of the child1 lock should describe the *whole*
+    // child1 lock, even though some of the lock's range is shared. (e.g. it
+    // can't return just the first, unshared, part of the child1 lock).
+    ensure_ord!(fcntl_lock(
+        file.as_raw_fd(),
+        libc::F_GETLK,
+        &libc::flock {
+            l_type: libc::F_WRLCK.try_into()?,
+            l_whence: libc::SEEK_SET.try_into()?,
+            l_start: child1_flock.l_start,
+            l_len: 1,
+            l_pid: 0,
+        },
+    )?, ==, libc::flock{
+        l_pid: child1.pid(),
+        ..child1_flock
+    });
+
+    // querying the first byte of the child2 lock can return *either* of the two
+    // locks covering that byte.
+    let res = fcntl_lock(
+        file.as_raw_fd(),
+        libc::F_GETLK,
+        &libc::flock {
+            l_type: libc::F_WRLCK.try_into()?,
+            l_whence: libc::SEEK_SET.try_into()?,
+            l_start: child2_flock.l_start,
+            l_len: 1,
+            l_pid: 0,
+        },
+    )?;
+    ensure!([child1.pid(), child2.pid()].contains(&res.l_pid));
+
+    // querying the last byte of the child1 lock should return that one (again
+    // describing the whole range covered by that lock)
+    ensure_ord!(fcntl_lock(
+        file.as_raw_fd(),
+        libc::F_GETLK,
+        &libc::flock {
+            l_type: libc::F_WRLCK.try_into()?,
+            l_whence: libc::SEEK_SET.try_into()?,
+            l_start: child1_flock.l_start + child1_flock.l_len - 1,
+            l_len: 1,
+            l_pid: 0,
+        },
+    )?, ==, libc::flock{
+        l_pid: child1.pid(),
+        ..child1_flock
+    });
+
+    Ok(())
+}
+
 fn test_block_on_pid_locks() -> anyhow::Result<()> {
     // Open file before forking, so that child also has the descriptor.
     let file = tempfile::tempfile().unwrap();
@@ -409,6 +496,12 @@ fn main() -> anyhow::Result<()> {
         ShadowTest::new(
             "block-on-pid-locks",
             test_block_on_pid_locks,
+            // TODO: <https://github.com/shadow/shadow/issues/2258>
+            no_shadow_envs.clone(),
+        ),
+        ShadowTest::new(
+            "query-overlapping-pid-locks",
+            test_query_overlapping_pid_locks,
             // TODO: <https://github.com/shadow/shadow/issues/2258>
             no_shadow_envs.clone(),
         ),

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -517,7 +517,7 @@ fn test_unlock_pid_locks_edge_cases() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn test_block_on_pid_locks() -> anyhow::Result<()> {
+fn test_block_on_pid_locks(setlk_cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow::Result<()> {
     // Open file before forking, so that child also has the descriptor.
     let file = tempfile::tempfile().unwrap();
 
@@ -541,14 +541,14 @@ fn test_block_on_pid_locks() -> anyhow::Result<()> {
     let sleep_duration = std::time::Duration::from_secs(1);
 
     let mut child = ForkedChild::<u8, u8>::new(|cmd| match *cmd {
-        LOCK => match fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &flock) {
+        LOCK => match fcntl_lock(file.as_raw_fd(), setlk_cmd.into(), &flock) {
             Ok(_) => OK,
             Err(_) => ERR,
         },
         UNLOCK => {
             match fcntl_lock(
                 file.as_raw_fd(),
-                FcntlFlockCommand::F_SETLK,
+                setlk_cmd.into(),
                 &libc::flock {
                     l_type: libc::F_UNLCK.try_into().unwrap(),
                     ..flock
@@ -641,22 +641,20 @@ fn main() -> anyhow::Result<()> {
                 // TODO: <https://github.com/shadow/shadow/issues/2258>
                 no_shadow_envs.clone(),
             ),
+            ShadowTest::new(
+                &format!("block-on-pid-locks {cmd:?}"),
+                move || test_block_on_pid_locks(cmd),
+                // TODO: <https://github.com/shadow/shadow/issues/2258>
+                no_shadow_envs.clone(),
+            ),
         ]);
     }
-    tests.extend([
-        ShadowTest::new(
-            "block-on-pid-locks",
-            test_block_on_pid_locks,
-            // TODO: <https://github.com/shadow/shadow/issues/2258>
-            no_shadow_envs.clone(),
-        ),
-        ShadowTest::new(
-            "unlock-pid-locks-edge-cases",
-            test_unlock_pid_locks_edge_cases,
-            // TODO: <https://github.com/shadow/shadow/issues/2258>
-            no_shadow_envs.clone(),
-        ),
-    ]);
+    tests.extend([ShadowTest::new(
+        "unlock-pid-locks-edge-cases",
+        test_unlock_pid_locks_edge_cases,
+        // TODO: <https://github.com/shadow/shadow/issues/2258>
+        no_shadow_envs.clone(),
+    )]);
     if filter_shadow_passing {
         tests.retain(|x| x.passing(TestEnvironment::Shadow));
     }

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -212,7 +212,8 @@ fn test_contested_pid_locks() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn test_contested_zero_len_pid_locks() -> anyhow::Result<()> {
+/// Tests setting a lock with `l_len=0` using `cmd`. Queries are done with F_GETLK.
+fn test_zero_len_pid_locks(cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow::Result<()> {
     let file = tempfile::tempfile().unwrap();
     let mut child = ForkedChild::new(handle_lock_request)?;
 
@@ -230,7 +231,7 @@ fn test_contested_zero_len_pid_locks() -> anyhow::Result<()> {
     ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: FcntlFlockCommand::F_SETLK.into(),
+            cmd: cmd.into(),
             flock: zerolen_flock,
         })
         .unwrap().to_result()?, ==, zerolen_flock);
@@ -606,24 +607,28 @@ fn main() -> anyhow::Result<()> {
         FcntlPosixSetlkUncontestedCommand::F_SETLKW,
     ];
     let mut tests: Vec<test_utils::ShadowTest<(), anyhow::Error>> = Vec::new();
+    // We test both F_SETLK and F_SETLKW in cases where we expect the operation
+    // to immediately succeed, in which case they should behave identically.
     for cmd in posix_uncontested_setlk_commands {
-        tests.push(ShadowTest::new(
-            &format!("uncontested-pid-locks {cmd:?}"),
-            move || test_uncontested_pid_locks(cmd),
-            all_envs.clone(),
-        ));
+        tests.extend([
+            ShadowTest::new(
+                &format!("uncontested-pid-locks {cmd:?}"),
+                move || test_uncontested_pid_locks(cmd),
+                all_envs.clone(),
+            ),
+            ShadowTest::new(
+                &format!("zero-len-pid-locks {cmd:?}"),
+                move || test_zero_len_pid_locks(cmd),
+                // TODO: <https://github.com/shadow/shadow/issues/2258>
+                no_shadow_envs.clone(),
+            ),
+        ]);
     }
     tests.extend([
         ShadowTest::new(
             "contested-pid-locks",
             test_contested_pid_locks,
             // TODO: <https://github.com/shadow/shadow/issues/2258>
-            no_shadow_envs.clone(),
-        ),
-        // TODO: <https://github.com/shadow/shadow/issues/2258>
-        ShadowTest::new(
-            "contested-zero-len-pid-locks",
-            test_contested_zero_len_pid_locks,
             no_shadow_envs.clone(),
         ),
         ShadowTest::new(

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -472,7 +472,7 @@ fn test_overlapping_pid_locks(cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow:
     Ok(())
 }
 
-fn test_unlock_pid_locks_edge_cases() -> anyhow::Result<()> {
+fn test_unlock_pid_locks_edge_cases(cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow::Result<()> {
     let file = tempfile::tempfile()?;
 
     // Lock a range
@@ -483,30 +483,30 @@ fn test_unlock_pid_locks_edge_cases() -> anyhow::Result<()> {
         l_len: 100,
         l_pid: 0,
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &wr_flock)?, ==,wr_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &wr_flock)?, ==,wr_flock);
 
     // Unlocking the locked range should work.
     let unlk_flock = libc::flock {
         l_type: libc::F_UNLCK.try_into()?,
         ..wr_flock
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &unlk_flock)?, ==,unlk_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &unlk_flock)?, ==,unlk_flock);
 
     // Unlocking a range where there are no locks should still work.
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &unlk_flock)?, ==,unlk_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &unlk_flock)?, ==,unlk_flock);
 
     // Take a write lock in a child process
     let mut child = ForkedChild::new(handle_lock_request)?;
     child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: FcntlFlockCommand::F_SETLK.into(),
+            cmd: cmd.into(),
             flock: wr_flock,
         })?
         .to_result()?;
 
     // Unlocking a range where we don't have a lock *and othes do*, should still succeed.
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &unlk_flock)?, ==,unlk_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &unlk_flock)?, ==,unlk_flock);
 
     // The child lock should still be there, of course.
     ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_GETLK, &wr_flock)?, ==, libc::flock {
@@ -647,14 +647,14 @@ fn main() -> anyhow::Result<()> {
                 // TODO: <https://github.com/shadow/shadow/issues/2258>
                 no_shadow_envs.clone(),
             ),
+            ShadowTest::new(
+                &format!("unlock-pid-locks-edge-cases {cmd:?}"),
+                move || test_unlock_pid_locks_edge_cases(cmd),
+                // TODO: <https://github.com/shadow/shadow/issues/2258>
+                no_shadow_envs.clone(),
+            ),
         ]);
     }
-    tests.extend([ShadowTest::new(
-        "unlock-pid-locks-edge-cases",
-        test_unlock_pid_locks_edge_cases,
-        // TODO: <https://github.com/shadow/shadow/issues/2258>
-        no_shadow_envs.clone(),
-    )]);
     if filter_shadow_passing {
         tests.retain(|x| x.passing(TestEnvironment::Shadow));
     }

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -147,7 +147,7 @@ fn handle_lock_request(req: &SerializedLockRequest) -> SerializedLockResponse {
     }
 }
 
-fn test_contested_pid_locks() -> anyhow::Result<()> {
+fn test_contested_pid_locks(cmd: FcntlPosixSetlkUncontestedCommand) -> anyhow::Result<()> {
     // Open file before forking, so that child also has the descriptor.
     let file = tempfile::tempfile().unwrap();
 
@@ -161,13 +161,13 @@ fn test_contested_pid_locks() -> anyhow::Result<()> {
         l_len: 100,
         l_pid: 0,
     };
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &rd_flock)?, ==, rd_flock);
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &rd_flock)?, ==, rd_flock);
 
     // Child should be able to take the same read lock.
     ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: FcntlFlockCommand::F_SETLK.into(),
+            cmd: cmd.into(),
             flock: rd_flock,
         })
         .unwrap().to_result()?, ==, rd_flock);
@@ -187,6 +187,7 @@ fn test_contested_pid_locks() -> anyhow::Result<()> {
     }));
 
     // Trying to take the lock anyway should fail.
+    // (We only test F_SETLK here rather than `cmd`; blocking behavior with F_SETLKW is in another test).
     let res = fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &wr_flock);
     ensure!(
         res == Err(Errno::EACCES) || res == Err(Errno::EAGAIN),
@@ -201,13 +202,13 @@ fn test_contested_pid_locks() -> anyhow::Result<()> {
     ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
-            cmd: FcntlFlockCommand::F_SETLK.into(),
+            cmd: cmd.into(),
             flock: unlck_flock,
         })
         .unwrap().to_result()?, ==, unlck_flock);
 
     // We should now be free to upgrade to a write lock.
-    ensure_ord!(fcntl_lock(file.as_raw_fd(), FcntlFlockCommand::F_SETLK, &wr_flock), ==, Ok(wr_flock));
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), cmd.into(), &wr_flock), ==, Ok(wr_flock));
 
     Ok(())
 }
@@ -622,15 +623,15 @@ fn main() -> anyhow::Result<()> {
                 // TODO: <https://github.com/shadow/shadow/issues/2258>
                 no_shadow_envs.clone(),
             ),
+            ShadowTest::new(
+                &format!("contested-pid-locks {cmd:?}"),
+                move || test_contested_pid_locks(cmd),
+                // TODO: <https://github.com/shadow/shadow/issues/2258>
+                no_shadow_envs.clone(),
+            ),
         ]);
     }
     tests.extend([
-        ShadowTest::new(
-            "contested-pid-locks",
-            test_contested_pid_locks,
-            // TODO: <https://github.com/shadow/shadow/issues/2258>
-            no_shadow_envs.clone(),
-        ),
         ShadowTest::new(
             "coalese-and-split-pid-locks",
             test_coalesce_and_split_pid_locks,

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -384,6 +384,45 @@ fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn test_unlock_pid_locks_edge_cases() -> anyhow::Result<()> {
+    let file = tempfile::tempfile()?;
+
+    // Lock a range
+    let wr_flock = libc::flock {
+        l_type: libc::F_WRLCK.try_into()?,
+        l_whence: libc::SEEK_SET.try_into()?,
+        l_start: 0,
+        l_len: 100,
+        l_pid: 0,
+    };
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &wr_flock)?, ==,wr_flock);
+
+    // Unlocking the locked range should work.
+    let unlk_flock = libc::flock {
+        l_type: libc::F_UNLCK.try_into()?,
+        ..wr_flock
+    };
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &unlk_flock)?, ==,unlk_flock);
+
+    // Unlocking a range where there are no locks should still work.
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &unlk_flock)?, ==,unlk_flock);
+
+    // Take a write lock in a child process
+    let mut child = ForkedChild::new(handle_lock_request)?;
+    ensure_ord!(child.send_recv(&SerializedLockRequest { fd: file.as_raw_fd(), cmd: libc::F_SETLK, flock: wr_flock })?.rv, ==, 0);
+
+    // Unlocking a range where we don't have a lock *and othes do*, should still succeed.
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &unlk_flock)?, ==,unlk_flock);
+
+    // The child lock should still be there, of course.
+    ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_GETLK, &wr_flock)?, ==, libc::flock {
+        l_pid: child.pid(),
+        ..wr_flock
+    });
+
+    Ok(())
+}
+
 fn test_block_on_pid_locks() -> anyhow::Result<()> {
     // Open file before forking, so that child also has the descriptor.
     let file = tempfile::tempfile().unwrap();
@@ -502,6 +541,12 @@ fn main() -> anyhow::Result<()> {
         ShadowTest::new(
             "query-overlapping-pid-locks",
             test_query_overlapping_pid_locks,
+            // TODO: <https://github.com/shadow/shadow/issues/2258>
+            no_shadow_envs.clone(),
+        ),
+        ShadowTest::new(
+            "unlock-pid-locks-edge-cases",
+            test_unlock_pid_locks_edge_cases,
             // TODO: <https://github.com/shadow/shadow/issues/2258>
             no_shadow_envs.clone(),
         ),

--- a/src/test/file_locks/test_file_locks.rs
+++ b/src/test/file_locks/test_file_locks.rs
@@ -102,6 +102,18 @@ struct SerializedLockResponse {
 }
 unsafe impl shadow_pod::Pod for SerializedLockResponse {}
 
+impl SerializedLockResponse {
+    fn to_result(self) -> Result<libc::flock, Errno> {
+        if self.rv == -1 {
+            return Err(Errno::from_libc_errnum(self.errno).expect("Bad errno"));
+        }
+        if self.rv != 0 {
+            panic!("Unexpected rv: {}", self.rv);
+        }
+        Ok(self.flock)
+    }
+}
+
 /// Perform the operation specified by `req`.
 fn handle_lock_request(req: &SerializedLockRequest) -> SerializedLockResponse {
     let mut flock = req.flock;
@@ -130,15 +142,13 @@ fn test_contested_pid_locks() -> anyhow::Result<()> {
     ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &rd_flock)?, ==, rd_flock);
 
     // Child should be able to take the same read lock.
-    let res = child
+    ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
             cmd: libc::F_SETLK,
             flock: rd_flock,
         })
-        .unwrap();
-    ensure_ord!(res.rv, ==, 0);
-    ensure_ord!(res.flock, ==, rd_flock);
+        .unwrap().to_result()?, ==, rd_flock);
 
     // We should *not* be able to upgrade to a write lock, since the child now
     // has a read lock.
@@ -166,15 +176,13 @@ fn test_contested_pid_locks() -> anyhow::Result<()> {
         l_type: libc::F_UNLCK.try_into().unwrap(),
         ..rd_flock
     };
-    let res = child
+    ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
             cmd: libc::F_SETLK,
             flock: unlck_flock,
         })
-        .unwrap();
-    ensure_ord!(res.rv, ==, 0);
-    ensure_ord!(res.flock, ==, unlck_flock);
+        .unwrap().to_result()?, ==, unlck_flock);
 
     // We should now be free to upgrade to a write lock.
     ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &wr_flock), ==, Ok(wr_flock));
@@ -197,15 +205,13 @@ fn test_contested_zero_len_pid_locks() -> anyhow::Result<()> {
         l_len: 0,
         l_pid: 0,
     };
-    let res = child
+    ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
             cmd: libc::F_SETLK,
             flock: zerolen_flock,
         })
-        .unwrap();
-    ensure_ord!(res.rv, ==, 0);
-    ensure_ord!(res.flock, ==, zerolen_flock);
+        .unwrap().to_result()?, ==, zerolen_flock);
 
     // first 100 bytes should still be available to lock
     let begin_flock = libc::flock {
@@ -268,15 +274,13 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
     ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &wr_next_100_flock)?, ==, wr_next_100_flock);
 
     // Child querying any part of the locked region should see a coalesced lock.
-    let res = child
+    ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
             cmd: libc::F_GETLK,
             flock: wr100_flock,
         })
-        .unwrap();
-    ensure_ord!(res.rv, ==, 0);
-    ensure_ord!(res.flock, ==, libc::flock {
+        .unwrap().to_result()?, ==, libc::flock {
         l_len: wr100_flock.l_len*2,
         l_pid: std::process::id().try_into().unwrap(),
         ..wr100_flock
@@ -292,7 +296,7 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
 
     // Querying byte 0 should return a conflicting lock extending to the
     // beginning of where we unlocked.
-    let res = child
+    ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
             cmd: libc::F_GETLK,
@@ -304,9 +308,7 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
                 l_pid: 0,
             },
         })
-        .unwrap();
-    ensure_ord!(res.rv, ==, 0);
-    ensure_ord!(res.flock, ==, libc::flock {
+        .unwrap().to_result()?, ==, libc::flock {
         l_len: unlock_middle_flock.l_start,
         l_pid: std::process::id().try_into().unwrap(),
         ..wr100_flock
@@ -320,22 +322,20 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
         l_len: 1,
         l_pid: 0,
     };
-    let res = child
+    ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
             cmd: libc::F_GETLK,
             flock: query_flock,
         })
-        .unwrap();
-    ensure_ord!(res.rv, ==, 0);
-    ensure_ord!(res.flock, ==, libc::flock {
+        .unwrap().to_result()?, ==, libc::flock {
         l_type: libc::F_UNLCK.try_into().unwrap(),
         ..query_flock
     });
 
     // Querying first byte after the locked region should return a conflicting lock extending to the
     // end of the still-locked region.
-    let res = child
+    ensure_ord!(child
         .send_recv(&SerializedLockRequest {
             fd: file.as_raw_fd(),
             cmd: libc::F_GETLK,
@@ -347,9 +347,7 @@ fn test_coalesce_and_split_pid_locks() -> anyhow::Result<()> {
                 l_pid: 0,
             },
         })
-        .unwrap();
-    ensure_ord!(res.rv, ==, 0);
-    ensure_ord!(res.flock, ==, libc::flock {
+        .unwrap().to_result()?, ==, libc::flock {
         l_start: unlock_middle_flock.l_start+unlock_middle_flock.l_len,
         l_len: wr_next_100_flock.l_len/2,
         l_pid: std::process::id().try_into().unwrap(),
@@ -372,11 +370,13 @@ fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
         l_pid: 0,
     };
     let mut child1 = ForkedChild::new(handle_lock_request)?;
-    child1.send_recv(&SerializedLockRequest {
-        fd: file.as_raw_fd(),
-        cmd: libc::F_SETLK,
-        flock: child1_flock,
-    })?;
+    child1
+        .send_recv(&SerializedLockRequest {
+            fd: file.as_raw_fd(),
+            cmd: libc::F_SETLK,
+            flock: child1_flock,
+        })?
+        .to_result()?;
 
     // child2 takes an overlapping reader lock of bytes 25..50
     let child2_flock = libc::flock {
@@ -387,11 +387,13 @@ fn test_query_overlapping_pid_locks() -> anyhow::Result<()> {
         l_pid: 0,
     };
     let mut child2 = ForkedChild::new(handle_lock_request)?;
-    child2.send_recv(&SerializedLockRequest {
-        fd: file.as_raw_fd(),
-        cmd: libc::F_SETLK,
-        flock: child2_flock,
-    })?;
+    child2
+        .send_recv(&SerializedLockRequest {
+            fd: file.as_raw_fd(),
+            cmd: libc::F_SETLK,
+            flock: child2_flock,
+        })?
+        .to_result()?;
 
     // querying the first byte of the child1 lock should describe the *whole*
     // child1 lock, even though some of the lock's range is shared. (e.g. it
@@ -471,7 +473,13 @@ fn test_unlock_pid_locks_edge_cases() -> anyhow::Result<()> {
 
     // Take a write lock in a child process
     let mut child = ForkedChild::new(handle_lock_request)?;
-    ensure_ord!(child.send_recv(&SerializedLockRequest { fd: file.as_raw_fd(), cmd: libc::F_SETLK, flock: wr_flock })?.rv, ==, 0);
+    child
+        .send_recv(&SerializedLockRequest {
+            fd: file.as_raw_fd(),
+            cmd: libc::F_SETLK,
+            flock: wr_flock,
+        })?
+        .to_result()?;
 
     // Unlocking a range where we don't have a lock *and othes do*, should still succeed.
     ensure_ord!(fcntl_lock(file.as_raw_fd(), libc::F_SETLK, &unlk_flock)?, ==,unlk_flock);

--- a/src/test/test_utils.rs
+++ b/src/test/test_utils.rs
@@ -8,10 +8,12 @@
 use std::collections::HashSet;
 use std::io::{PipeReader, PipeWriter, Write};
 use std::marker::PhantomData;
+use std::os::fd::IntoRawFd as _;
 use std::sync::mpsc;
 use std::time::{Duration, SystemTime};
 use std::{fmt, thread};
 
+use linux_api::sched::{CloneFlags, CloneResult, clone_args};
 use nix::poll::PollFlags;
 use nix::sys::signal;
 use nix::sys::time::TimeVal;
@@ -689,7 +691,7 @@ where
 // TODO: It'd be nice to wrap a generic `Write` object instead, but this is
 // tricky to do in a sound way when T may have undefined padding bytes.
 pub struct TypedWriter<W, T> {
-    fd: W,
+    writer: W,
     _t: PhantomData<T>,
 }
 impl<W, T> TypedWriter<W, T>
@@ -697,16 +699,16 @@ where
     T: shadow_pod::Pod,
     W: std::os::fd::AsRawFd,
 {
-    fn new(fd: W) -> Self {
+    fn new(writer: W) -> Self {
         Self {
-            fd,
+            writer,
             _t: PhantomData,
         }
     }
 
     /// Send `val`
     pub fn send(&mut self, val: &T) -> Result<(), std::io::Error> {
-        self.fd.write_pod(val)
+        self.writer.write_pod(val)
     }
 }
 
@@ -769,22 +771,37 @@ where
     ResponseType: shadow_pod::Pod,
 {
     /// Create a forked child process that used `f` as its handler function.
-    pub fn new<FnType>(mut f: FnType) -> Result<Self, std::io::Error>
+    ///
+    /// Safety:
+    ///
+    /// Various `clone_args` can break all sort of soundness assumptions.
+    unsafe fn new_with_clone_args<FnType>(
+        clone_args: &clone_args,
+        mut f: FnType,
+    ) -> Result<Self, std::io::Error>
     where
         FnType: FnMut(&RequestType) -> ResponseType,
     {
+        let clone_flags = CloneFlags::from_bits(clone_args.flags).unwrap();
         let (mut cmd_reader, cmd_writer) = typed_pipe::<RequestType>()?;
         let (res_reader, mut res_writer) = typed_pipe::<ResponseType>()?;
-        let fork_res = unsafe { libc::fork() };
-        let pid = match fork_res.cmp(&0) {
-            std::cmp::Ordering::Equal => {
+        let clone_res = unsafe { linux_api::sched::clone3(clone_args) };
+        let pid = match clone_res {
+            Ok(CloneResult::CallerIsChild) => {
                 // Child will run in a loop, processing requests.
                 let child_closure = || {
-                    // Close our cmd writer, to ensure we get EOF when the parent closes their copy,
-                    // which happens implicitly when the ForkedChild is dropped.
-                    drop(cmd_writer);
-                    // Close our response reader while we're at it, though not strictly necessary.
-                    drop(res_reader);
+                    if clone_flags.contains(CloneFlags::CLONE_FILES) {
+                        // We share a descriptor table with the parent. *do not* close the parent's
+                        // ends of the pipes.
+                        let _ = cmd_writer.writer.into_raw_fd();
+                        let _ = res_reader.reader.into_raw_fd();
+                    } else {
+                        // Close our cmd writer, to ensure we get EOF when the parent closes their copy,
+                        // which happens implicitly when the ForkedChild is dropped.
+                        drop(cmd_writer);
+                        // Close our response reader while we're at it, though not strictly necessary.
+                        drop(res_reader);
+                    }
                     while let Some(cmd) = cmd_reader.recv().expect("Couldn't read from parent") {
                         let res = f(&cmd);
                         res_writer.send(&res).expect("Couldn't send to parent");
@@ -806,14 +823,72 @@ where
                     libc::_exit(if res.is_ok() { 0 } else { 1 });
                 }
             }
-            std::cmp::Ordering::Greater => fork_res,
-            std::cmp::Ordering::Less => return Err(std::io::Error::last_os_error()),
+            Ok(CloneResult::CallerIsParent(pid)) => pid,
+            Err(e) => return Err(std::io::Error::from_raw_os_error(e.into())),
         };
+        if clone_flags.contains(CloneFlags::CLONE_FILES) {
+            // We share a descriptor table with the child. *do not* close the child's
+            // ends of the pipes.
+            let _ = cmd_reader.reader.into_raw_fd();
+            let _ = res_writer.writer.into_raw_fd();
+        }
         Ok(Self {
-            pid,
+            pid: pid.as_raw_nonzero().get(),
             cmd_writer: Some(cmd_writer),
             res_reader,
         })
+    }
+
+    /// Create a child process that shares its descriptor table with the parent
+    /// with the CLONE_FILES flag.
+    ///
+    /// # Safety
+    ///
+    /// TLDR: avoid manipulating shared file descriptors using Rust code that
+    /// has safety requirements around the state of those descriptors.
+    ///
+    /// The spawned child process shares a descriptor table with its parent,
+    /// similarly as if it were a thread. Unlike a thread, though, the child
+    /// process does *not* share a virtual address space, meaning that even if
+    /// we used `Send` and `Sync` requirements here, tools like
+    /// `std::sync::Mutex` that might otherwise make such sharing safe won't
+    /// work as expected.
+    ///
+    /// For example, `std::fs::File` is an "owned file descriptor", with a
+    /// safety requirement that it is open for the lifetime of the object.
+    /// <https://doc.rust-lang.org/stable/std/os/fd/trait.FromRawFd.html#tymethod.from_raw_fd>.
+    /// Sharing such an object between the parent and the child, and dropping
+    /// the object in one of them (closing the file), would violate the safety
+    /// property in the other. Even if we required that the function object is
+    /// `Send` and `Sync`, the type system would allow calling code to share an
+    /// `Arc<Mutex<Option<File>>>`, but at runtime calling
+    /// `lock().unwrap().take()` on one of the objects would close the
+    /// descriptor for both processes without actually doing any in-memory
+    /// synchronization, resulting in a safety violation.
+    pub unsafe fn new_with_clone_files<FnType>(f: FnType) -> Result<Self, std::io::Error>
+    where
+        FnType: FnMut(&RequestType) -> ResponseType + Send + Sync,
+    {
+        // equivalent to `fork`
+        let clone_args = clone_args {
+            flags: CloneFlags::CLONE_FILES.bits(),
+            exit_signal: libc::SIGCHLD.try_into().unwrap(),
+            ..shadow_pod::zeroed()
+        };
+        unsafe { Self::new_with_clone_args(&clone_args, f) }
+    }
+
+    /// Create a forked child process that used `f` as its handler function.
+    pub fn new<FnType>(f: FnType) -> Result<Self, std::io::Error>
+    where
+        FnType: FnMut(&RequestType) -> ResponseType,
+    {
+        // equivalent to `fork`
+        let clone_args = clone_args {
+            exit_signal: libc::SIGCHLD.try_into().unwrap(),
+            ..shadow_pod::zeroed()
+        };
+        unsafe { Self::new_with_clone_args(&clone_args, f) }
     }
 
     /// Send a value to the child process.

--- a/src/test/test_utils.rs
+++ b/src/test/test_utils.rs
@@ -719,7 +719,7 @@ where
 /// The child exits when this object is dropped.
 pub struct ForkedChild<RequestType, ResponseType> {
     pid: libc::c_int,
-    cmd_writer: TypedWriter<PipeWriter, RequestType>,
+    cmd_writer: Option<TypedWriter<PipeWriter, RequestType>>,
     res_reader: TypedReader<PipeReader, ResponseType>,
 }
 
@@ -771,14 +771,14 @@ where
         };
         Ok(Self {
             pid,
-            cmd_writer,
+            cmd_writer: Some(cmd_writer),
             res_reader,
         })
     }
 
     /// Send a value to the child process.
     pub fn send(&mut self, req: &RequestType) -> Result<(), std::io::Error> {
-        self.cmd_writer.send(req)
+        self.cmd_writer.as_mut().unwrap().send(req)
     }
 
     /// Receive a value from the child process.
@@ -802,5 +802,22 @@ where
     /// pid of the child process.
     pub fn pid(&self) -> i32 {
         self.pid
+    }
+}
+
+impl<RequestType, ResponseType> Drop for ForkedChild<RequestType, ResponseType> {
+    fn drop(&mut self) {
+        // Take the command writer, which closes the underlying file and signals child to exit.
+        assert!(self.cmd_writer.take().is_some());
+        let pid = rustix::process::Pid::from_raw(self.pid).expect("corrupted pid");
+        let waitopts = rustix::process::WaitOptions::empty();
+        let res = rustix::process::waitpid(Some(pid), waitopts)
+            .expect("failed to wait for child {pid:?}")
+            .expect("missing exit status for child {pid:?}");
+        assert_eq!(
+            res.exit_status(),
+            Some(0),
+            "Unexpected child {pid:?} exit status: {res:?}"
+        );
     }
 }


### PR DESCRIPTION
Implements most of posix record locks (#2258).

`F_SETLKW` doesn't yet implement blocking. Instead, if the lock can't be taken immediately, it returns `EACCES` as for `F_SETLK` and logs a warning. It's probably not that much more work to add it, but I'll leave it for a future PR since this is already quite big.

This should cover the functionality used by `sqlite`.