### PR TITLE
Some syscall logger improvements, and new "long" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ MAJOR changes (breaking):
 
 MINOR changes (backwards-compatible):
 
-*
+* Added a "long" option for the `experimental.strace_logging_mode` configuration option.
 
 PATCH changes (bugfixes):
 

--- a/docs/shadow_config_spec.md
+++ b/docs/shadow_config_spec.md
@@ -437,7 +437,7 @@ Initial size of the socket's send buffer.
 #### `experimental.strace_logging_mode`
 
 Default: "off"  
-Type: "off" OR "standard" OR "deterministic"
+Type: "off" OR "standard" OR "deterministic" OR "long"
 
 Log the syscalls for each process to individual "strace" files.
 

--- a/src/main/core/configuration.rs
+++ b/src/main/core/configuration.rs
@@ -210,6 +210,7 @@ impl ConfigOptions {
         match self.experimental.strace_logging_mode.as_ref().unwrap() {
             StraceLoggingMode::Standard => Some(FmtOptions::Standard),
             StraceLoggingMode::Deterministic => Some(FmtOptions::Deterministic),
+            StraceLoggingMode::Long => Some(FmtOptions::Long),
             StraceLoggingMode::Off => None,
         }
     }
@@ -1175,6 +1176,7 @@ pub enum StraceLoggingMode {
     Off,
     Standard,
     Deterministic,
+    Long,
 }
 
 impl FromStr for StraceLoggingMode {

--- a/src/main/host/syscall/formatter.rs
+++ b/src/main/host/syscall/formatter.rs
@@ -16,6 +16,7 @@ use crate::host::thread::ThreadId;
 pub enum FmtOptions {
     Standard,
     Deterministic,
+    Long,
 }
 
 // this type is required until we no longer need to access the format options from C
@@ -25,6 +26,7 @@ pub enum StraceFmtMode {
     Off,
     Standard,
     Deterministic,
+    Long,
 }
 
 impl From<StraceFmtMode> for Option<FmtOptions> {
@@ -33,6 +35,7 @@ impl From<StraceFmtMode> for Option<FmtOptions> {
             StraceFmtMode::Off => None,
             StraceFmtMode::Standard => Some(FmtOptions::Standard),
             StraceFmtMode::Deterministic => Some(FmtOptions::Deterministic),
+            StraceFmtMode::Long => Some(FmtOptions::Long),
         }
     }
 }
@@ -43,6 +46,7 @@ impl From<Option<FmtOptions>> for StraceFmtMode {
             None => StraceFmtMode::Off,
             Some(FmtOptions::Standard) => StraceFmtMode::Standard,
             Some(FmtOptions::Deterministic) => StraceFmtMode::Deterministic,
+            Some(FmtOptions::Long) => StraceFmtMode::Long,
         }
     }
 }

--- a/src/main/host/syscall/handler/epoll.rs
+++ b/src/main/host/syscall/handler/epoll.rs
@@ -14,6 +14,7 @@ use crate::host::descriptor::epoll::Epoll;
 use crate::host::descriptor::{CompatFile, Descriptor, File, FileState, OpenFile};
 use crate::host::memory_manager::MemoryManager;
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
+use crate::host::syscall::type_formatting::SyscallArrayArg;
 use crate::host::syscall::types::{ForeignArrayPtr, SyscallError};
 use crate::utility::callback_queue::CallbackQueue;
 
@@ -194,7 +195,7 @@ impl SyscallHandler {
         epoll_wait,
         /* rv */ std::ffi::c_int,
         /* epfd */ std::ffi::c_int,
-        /* events */ *const std::ffi::c_void,
+        /* events */ SyscallArrayArg</* max_events */ 2, linux_api::epoll::epoll_event>,
         /* max_events */ std::ffi::c_int,
         /* timeout */ std::ffi::c_int,
     );
@@ -214,7 +215,7 @@ impl SyscallHandler {
         epoll_pwait,
         /* rv */ std::ffi::c_int,
         /* epfd */ std::ffi::c_int,
-        /* events */ *const std::ffi::c_void,
+        /* events */ SyscallArrayArg</* max_events */ 2, linux_api::epoll::epoll_event>,
         /* max_events */ std::ffi::c_int,
         /* timeout */ std::ffi::c_int,
         /* sigmask */ *const std::ffi::c_void,
@@ -246,7 +247,7 @@ impl SyscallHandler {
         epoll_pwait2,
         /* rv */ std::ffi::c_int,
         /* epfd */ std::ffi::c_int,
-        /* events */ *const std::ffi::c_void,
+        /* events */ SyscallArrayArg</* max_events */ 2, linux_api::epoll::epoll_event>,
         /* max_events */ std::ffi::c_int,
         /* timeout */ *const std::ffi::c_void,
         /* sigmask */ *const std::ffi::c_void,

--- a/src/main/host/syscall/handler/shadow.rs
+++ b/src/main/host/syscall/handler/shadow.rs
@@ -3,7 +3,7 @@ use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
 use crate::core::worker::Worker;
 use crate::host::syscall::handler::{SyscallContext, SyscallHandler};
-use crate::host::syscall::type_formatting::{SyscallSockAddrArg, SyscallStringArg};
+use crate::host::syscall::type_formatting::{SyscallBufferArg, SyscallSockAddrArg};
 use crate::host::syscall::types::ForeignArrayPtr;
 use crate::utility::case_insensitive_eq;
 
@@ -33,9 +33,9 @@ impl SyscallHandler {
     log_syscall!(
         shadow_hostname_to_addr_ipv4,
         /* rv */ std::ffi::c_int,
-        /* name_ptr */ SyscallStringArg,
+        /* name_ptr */ SyscallBufferArg</* name_len */ 1>,
         /* name_len */ u64,
-        /* addr_ptr */ SyscallSockAddrArg<3>,
+        /* addr_ptr */ SyscallSockAddrArg</* addr_len */ 3>,
         /* addr_len */ u64,
     );
     pub fn shadow_hostname_to_addr_ipv4(

--- a/src/main/host/syscall/type_formatting.rs
+++ b/src/main/host/syscall/type_formatting.rs
@@ -335,6 +335,70 @@ fn fmt_string(
     }
 }
 
+fn fmt_array<'a, T>(
+    f: &mut std::fmt::Formatter<'_>,
+    ptr: ForeignPtr<T>,
+    len: usize,
+    args: [shadow_shim_helper_rs::syscall_types::SyscallReg; 6],
+    options: FmtOptions,
+    mem: &'a MemoryManager,
+) -> std::fmt::Result
+where
+    SyscallVal<'a, *const T>: SyscallDisplay,
+{
+    // How many bytes we want to show.
+    // We try not to exceed this, but there may be some edge cases which do.
+    const DISPLAY_LEN: usize = 100;
+
+    // Separator for items.
+    const SEPARATOR: &str = ", ";
+
+    if options == FmtOptions::Deterministic {
+        return write!(f, "<pointer>");
+    }
+
+    let mut s = String::with_capacity(DISPLAY_LEN);
+
+    s.push('[');
+
+    let mut num_items_displayed = 0;
+
+    for idx in 0..len {
+        // We reuse the same code for displaying a `*const T` here, since an array is essentially a
+        // pointer to the first item. So we make a fake register value containing the pointer with
+        // the required offset.
+        //
+        // TODO: This is a little awkward since `deref_pointer_impl!()` prints the pointer address
+        // for each item. Ideally we'd want to print only one pointer address for the start of the
+        // array.
+        let fake_reg = ptr.add(idx).into();
+        let syscall_val: SyscallVal<'_, *const T> = SyscallVal::new(fake_reg, args, options, mem);
+
+        let item_str = format!("{syscall_val}");
+
+        let maybe_separator = if idx != 0 { SEPARATOR } else { "" };
+
+        // current string length + separator length + item length + closing ']' length
+        if s.len() + maybe_separator.len() + item_str.len() + 1 > DISPLAY_LEN {
+            // not enough room, so stop
+            break;
+        }
+
+        // we have enough room, so add the item
+        s.push_str(maybe_separator);
+        s.push_str(&item_str);
+
+        num_items_displayed += 1;
+    }
+
+    if len > num_items_displayed {
+        // we may exceed DISPLAY_LEN here, but it's not worth worrying about that
+        write!(f, "{s}, ...]")
+    } else {
+        write!(f, "{s}]")
+    }
+}
+
 /// Format a plugin's `libc::msghdr`. Any pointers contained in the `libc::msghdr` must be pointers
 /// within the plugin's memory space.
 fn fmt_msghdr(
@@ -409,6 +473,34 @@ impl SyscallDisplay for SyscallVal<'_, SyscallStringArg> {
     ) -> std::fmt::Result {
         let ptr = self.reg.into();
         fmt_string(f, ptr, None, mem)
+    }
+}
+
+/// Displays an array with a length that is specified by another syscall argument.
+///
+/// For an array of bytes (like a string or buffer),
+/// typically prefer [`SyscallBufferArg`].
+pub struct SyscallArrayArg<const LEN_INDEX: usize, T>
+where
+    for<'a> SyscallVal<'a, *const T>: SyscallDisplay,
+{
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<const LEN_INDEX: usize, T> SyscallDisplay for SyscallVal<'_, SyscallArrayArg<LEN_INDEX, T>>
+where
+    for<'a> SyscallVal<'a, *const T>: SyscallDisplay,
+{
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        options: FmtOptions,
+        mem: &MemoryManager,
+    ) -> std::fmt::Result {
+        let ptr: ForeignPtr<T> = self.reg.into();
+        let len: libc::size_t = self.args[LEN_INDEX].into();
+        let args = self.args;
+        fmt_array::<T>(f, ptr, len, args, options, mem)
     }
 }
 

--- a/src/main/host/syscall/type_formatting.rs
+++ b/src/main/host/syscall/type_formatting.rs
@@ -127,9 +127,9 @@ macro_rules! deref_pointer_impl {
             ) -> std::fmt::Result {
                 let ptr = ForeignPtr::<$type>::from(self.reg);
                 match (options, mem.memory_ref(ForeignArrayPtr::new(ptr, 1))) {
-                    (FmtOptions::Standard, Ok(vals)) => write!(f, "{:?} ({:p})", &(*vals)[0], ptr),
+                    (FmtOptions::Standard | FmtOptions::Long, Ok(vals)) => write!(f, "{:?} ({:p})", &(*vals)[0], ptr),
                     // if we couldn't read the memory, just show the pointer instead
-                    (FmtOptions::Standard, Err(_)) => fmt_ptr_with_suffix(f, ptr, "<invalid-read>"),
+                    (FmtOptions::Standard | FmtOptions::Long, Err(_)) => fmt_ptr_with_suffix(f, ptr, "<invalid-read>"),
                     (FmtOptions::Deterministic, _) => write!(f, "<pointer>"),
                 }
             }
@@ -154,7 +154,7 @@ macro_rules! safe_pointer_impl {
             ) -> std::fmt::Result {
                 let ptr = ForeignPtr::<()>::from(self.reg);
                 match options {
-                    FmtOptions::Standard => write!(f, "{ptr:p}"),
+                    FmtOptions::Standard | FmtOptions::Long => write!(f, "{ptr:p}"),
                     FmtOptions::Deterministic => write!(f, "<pointer>"),
                 }
             }
@@ -179,9 +179,9 @@ macro_rules! deref_array_impl {
             ) -> std::fmt::Result {
                 let ptr = ForeignPtr::<$type>::from(self.reg);
                 match (options, mem.memory_ref(ForeignArrayPtr::new(ptr, K))) {
-                    (FmtOptions::Standard, Ok(vals)) => write!(f, "{:?} ({:p})", &(*vals), ptr),
+                    (FmtOptions::Standard | FmtOptions::Long, Ok(vals)) => write!(f, "{:?} ({:p})", &(*vals), ptr),
                     // if we couldn't read the memory, just show the pointer instead
-                    (FmtOptions::Standard, Err(_)) => fmt_ptr_with_suffix(f, ptr, "<invalid-read>"),
+                    (FmtOptions::Standard | FmtOptions::Long, Err(_)) => fmt_ptr_with_suffix(f, ptr, "<invalid-read>"),
                     (FmtOptions::Deterministic, _) => write!(f, "<pointer>"),
                 }
             }
@@ -244,7 +244,11 @@ fn fmt_buffer(
     options: FmtOptions,
     mem: &MemoryManager,
 ) -> std::fmt::Result {
-    const DISPLAY_LEN: usize = 40;
+    let display_len = if options == FmtOptions::Long {
+        2000
+    } else {
+        40
+    };
 
     if options == FmtOptions::Deterministic {
         return write!(f, "<pointer>");
@@ -256,7 +260,7 @@ fn fmt_buffer(
         Err(_) => return fmt_ptr_with_suffix(f, ptr, "<invalid-addr>"),
     };
 
-    let mut s = String::with_capacity(DISPLAY_LEN);
+    let mut s = String::with_capacity(display_len);
 
     // the number of plugin mem bytes used; num_bytes <= s.len()
     let mut num_plugin_bytes = 0;
@@ -264,7 +268,7 @@ fn fmt_buffer(
     for c in mem_ref.iter() {
         let escaped = std::ascii::escape_default(*c);
 
-        if s.len() + escaped.len() > DISPLAY_LEN {
+        if s.len() + escaped.len() > display_len {
             break;
         }
 
@@ -349,7 +353,11 @@ where
 {
     // How many bytes we want to show.
     // We try not to exceed this, but there may be some edge cases which do.
-    const DISPLAY_LEN: usize = 100;
+    let display_len = if options == FmtOptions::Long {
+        2000
+    } else {
+        100
+    };
 
     // Separator for items.
     const SEPARATOR: &str = ", ";
@@ -358,7 +366,7 @@ where
         return write!(f, "<pointer>");
     }
 
-    let mut s = String::with_capacity(DISPLAY_LEN);
+    let mut s = String::with_capacity(display_len);
 
     s.push('[');
 
@@ -380,7 +388,7 @@ where
         let maybe_separator = if idx != 0 { SEPARATOR } else { "" };
 
         // current string length + separator length + item length + closing ']' length
-        if s.len() + maybe_separator.len() + item_str.len() + 1 > DISPLAY_LEN {
+        if s.len() + maybe_separator.len() + item_str.len() + 1 > display_len {
             // not enough room, so stop
             break;
         }
@@ -393,7 +401,7 @@ where
     }
 
     if len > num_items_displayed {
-        // we may exceed DISPLAY_LEN here, but it's not worth worrying about that
+        // we may exceed `display_len` here, but it's not worth worrying about that
         write!(f, "{s}, ...]")
     } else {
         write!(f, "{s}]")

--- a/src/main/host/syscall/type_formatting.rs
+++ b/src/main/host/syscall/type_formatting.rs
@@ -251,6 +251,9 @@ fn fmt_buffer(
     };
 
     if options == FmtOptions::Deterministic {
+        // The pointer address may be non-deterministic,
+        // and we don't know how many bytes were written to the buffer (see #3694)
+        // so the buffer may have some non-deterministic bytes.
         return write!(f, "<pointer>");
     }
 
@@ -363,6 +366,9 @@ where
     const SEPARATOR: &str = ", ";
 
     if options == FmtOptions::Deterministic {
+        // The pointer address may be non-deterministic,
+        // and we don't know how many bytes were written to the array (see #3694)
+        // so the array may have some non-deterministic bytes.
         return write!(f, "<pointer>");
     }
 

--- a/src/main/host/syscall/type_formatting.rs
+++ b/src/main/host/syscall/type_formatting.rs
@@ -205,6 +205,7 @@ deref_pointer_impl!(linux_api::time::timespec);
 deref_pointer_impl!(linux_api::time::kernel_timespec);
 deref_pointer_impl!(linux_api::time::kernel_old_timeval);
 deref_pointer_impl!(linux_api::time::kernel_old_itimerval);
+deref_pointer_impl!(linux_api::epoll::epoll_event);
 
 deref_array_impl!(i8, i16, i32, i64, isize);
 deref_array_impl!(u8, u16, u32, u64, usize);


### PR DESCRIPTION
1. This adds a `SyscallArrayArg` for displaying arrays of values, which is used for `epoll_wait()` (and related epoll calls).

    Before:

    ```text
    00:00:00.050000000 [tid 1001] epoll_wait(5, 0x7f1cb8000ea0, 10, 100) = 1
    ```

    After:

    ```text
    00:00:00.050000000 [tid 1001] epoll_wait(5, [linux_epoll_event { events: 1, data: 0 } (0x7f5be8000ea0), ...], 10, 100) = 1
    ```

2. This also switches `shadow_hostname_to_addr_ipv4()` from using `SyscallStringArg` to `SyscallBufferArg`.

    This doesn't change the output in the typical case. But if the syscall was called without a null terminated string, the logger could try to access memory outside the given limit in `name_len`.

3. This also adds a new "long" option for `experimental.strace_logging_mode`. If set, shadow doesn't as aggressively truncate values.

    Before:

    ```text
    00:00:01.160000000 [tid 1000] write(1, "Testing test_zero_len_buf <sys_method=To"..., 79) = 79
    ```

    After (with option set):

    ```text
    00:00:01.160000000 [tid 1000] write(1, "Testing test_zero_len_buf <sys_method=ToFrom, init_method=Inet, sock_type=1>...", 79) = 79
    ```