### PR TITLE
Improve "explicit drop" API and usage

### DIFF
--- a/src/lib/shadow-shim-helper-rs/src/explicit_drop.rs
+++ b/src/lib/shadow-shim-helper-rs/src/explicit_drop.rs
@@ -9,9 +9,9 @@
 /// dropped. One workaround is for a type to also implement `Drop`, and have
 /// that implementation validate that `ExplicitDrop::explicit_drop` was called.
 pub trait ExplicitDrop {
-    type ExplicitDropParam;
+    type ExplicitDropParam<'p>;
     type ExplicitDropResult;
-    fn explicit_drop(self, param: &Self::ExplicitDropParam) -> Self::ExplicitDropResult;
+    fn explicit_drop<'p>(self, param: Self::ExplicitDropParam<'p>) -> Self::ExplicitDropResult;
 }
 
 /// Wrapper that uses a provided function to drop the inner value.

--- a/src/lib/shadow-shim-helper-rs/src/rootedcell/rc.rs
+++ b/src/lib/shadow-shim-helper-rs/src/rootedcell/rc.rs
@@ -227,10 +227,10 @@ impl<T> RootedRc<T> {
 
     /// Drops `self`, and if `self` was the last strong reference, call
     /// `ExplicitDrop::explicit_drop` on the internal value.
-    pub fn explicit_drop_recursive(
+    pub fn explicit_drop_recursive<'p>(
         self,
         root: &Root,
-        param: &T::ExplicitDropParam,
+        param: T::ExplicitDropParam<'p>,
     ) -> Option<T::ExplicitDropResult>
     where
         T: ExplicitDrop,
@@ -240,14 +240,14 @@ impl<T> RootedRc<T> {
 }
 
 impl<T> ExplicitDrop for RootedRc<T> {
-    type ExplicitDropParam = Root;
+    type ExplicitDropParam<'p> = &'p Root;
 
     type ExplicitDropResult = ();
 
     /// If T itself implements `ExplicitDrop`, consider
     /// `RootedRc::explicit_drop_recursive` instead to call it when dropping the
     /// last strong reference.
-    fn explicit_drop(self, root: &Self::ExplicitDropParam) -> Self::ExplicitDropResult {
+    fn explicit_drop<'p>(self, root: Self::ExplicitDropParam<'p>) -> Self::ExplicitDropResult {
         self.common.safely_drop(root, RefType::Strong);
     }
 }
@@ -413,10 +413,13 @@ mod test_rooted_rc {
         // to safely drop the inner `RootedRc` when dropping a `RootedRc<MyOuter>`.
         struct MyOuter(RootedRc<()>);
         impl ExplicitDrop for MyOuter {
-            type ExplicitDropParam = Root;
+            type ExplicitDropParam<'p> = &'p Root;
             type ExplicitDropResult = ();
 
-            fn explicit_drop(self, root: &Self::ExplicitDropParam) -> Self::ExplicitDropResult {
+            fn explicit_drop<'p>(
+                self,
+                root: Self::ExplicitDropParam<'p>,
+            ) -> Self::ExplicitDropResult {
                 self.0.explicit_drop(root);
             }
         }
@@ -462,12 +465,12 @@ impl<T> RootedRcWeak<T> {
 }
 
 impl<T> ExplicitDrop for RootedRcWeak<T> {
-    type ExplicitDropParam = Root;
+    type ExplicitDropParam<'p> = &'p Root;
 
     type ExplicitDropResult = ();
 
     #[inline]
-    fn explicit_drop(self, root: &Self::ExplicitDropParam) -> Self::ExplicitDropResult {
+    fn explicit_drop<'p>(self, root: Self::ExplicitDropParam<'p>) -> Self::ExplicitDropResult {
         let val = self.common.safely_drop(root, RefType::Weak);
         // Since this isn't a strong reference, this can't be the *last* strong
         // reference, so the value should never be returned.

--- a/src/lib/shadow-shim-helper-rs/src/rootedcell/refcell.rs
+++ b/src/lib/shadow-shim-helper-rs/src/rootedcell/refcell.rs
@@ -84,10 +84,10 @@ impl<T> ExplicitDrop for RootedRefCell<T>
 where
     T: ExplicitDrop,
 {
-    type ExplicitDropParam = <T as ExplicitDrop>::ExplicitDropParam;
+    type ExplicitDropParam<'p> = <T as ExplicitDrop>::ExplicitDropParam<'p>;
     type ExplicitDropResult = <T as ExplicitDrop>::ExplicitDropResult;
 
-    fn explicit_drop(self, param: &Self::ExplicitDropParam) -> Self::ExplicitDropResult {
+    fn explicit_drop<'p>(self, param: Self::ExplicitDropParam<'p>) -> Self::ExplicitDropResult {
         self.val.into_inner().explicit_drop(param)
     }
 }

--- a/src/main/core/worker.rs
+++ b/src/main/core/worker.rs
@@ -454,7 +454,7 @@ impl Worker {
 
             // while we handle this okay, this probably indicates an issue somewhere else in the
             // code so panic only in debug builds
-            debug_panic!("Trying to add syscall counts when there is no worker");
+            warn_and_debug_panic!("Trying to add syscall counts when there is no worker");
         });
     }
 

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -191,10 +191,13 @@ impl DescriptorTable {
 
     /// Remove and return all descriptors.
     pub fn remove_all(&mut self) -> impl Iterator<Item = Descriptor> {
-        // reset the descriptor table
-        let old_self = std::mem::take(self);
+        // reset `self` to default state.
+        let mut old_self = std::mem::take(self);
+        // take the descriptors out of the table, so that our `Drop` check
+        // doesn't think we forgot to close them.
+        let old_descriptors = std::mem::take(&mut old_self.descriptors);
         // return the old descriptors
-        old_self.descriptors.into_values()
+        old_descriptors.into_values()
     }
 
     /// Remove and return all descriptors in the range. If you want to remove all descriptors, you
@@ -252,6 +255,14 @@ impl ExplicitDrop for DescriptorTable {
                 desc.close(host, cb_queue);
             }
         });
+    }
+}
+
+impl Drop for DescriptorTable {
+    fn drop(&mut self) {
+        if !self.descriptors.is_empty() {
+            debug_panic!("Dropped DescriptorTable without closing (or taking) descriptors");
+        }
     }
 }
 

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -236,10 +236,10 @@ impl Default for DescriptorTable {
 }
 
 impl ExplicitDrop for DescriptorTable {
-    type ExplicitDropParam = Host;
+    type ExplicitDropParam<'p> = &'p Host;
     type ExplicitDropResult = ();
 
-    fn explicit_drop(mut self, host: &Host) {
+    fn explicit_drop<'p>(mut self, host: Self::ExplicitDropParam<'p>) {
         // Drop all descriptors using a callback queue.
         //
         // Doing this explicitly instead of letting `DescriptorTable`'s `Drop`

--- a/src/main/host/descriptor/descriptor_table.rs
+++ b/src/main/host/descriptor/descriptor_table.rs
@@ -261,7 +261,9 @@ impl ExplicitDrop for DescriptorTable {
 impl Drop for DescriptorTable {
     fn drop(&mut self) {
         if !self.descriptors.is_empty() {
-            debug_panic!("Dropped DescriptorTable without closing (or taking) descriptors");
+            warn_and_debug_panic!(
+                "Dropped DescriptorTable without closing (or taking) descriptors"
+            );
         }
     }
 }

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -17,6 +17,7 @@ use crate::host::syscall::io::IoVec;
 use crate::host::syscall::types::{SyscallError, SyscallResult};
 use crate::utility::callback_queue::CallbackQueue;
 use crate::utility::{HostTreePointer, IsSend, IsSync, ObjectCounter};
+use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 
 pub mod descriptor_table;
 pub mod epoll;
@@ -475,7 +476,9 @@ impl std::ops::Drop for OpenFileInner {
 #[derive(Debug, Clone)]
 pub struct Descriptor {
     /// The file that this descriptor points to.
-    file: CompatFile,
+    // `Option` wrapper so that our `Drop` implementation can ensure that the
+    // file was closed or removed before drop.
+    file: Option<CompatFile>,
     /// Descriptor flags.
     flags: DescriptorFlags,
     _counter: ObjectCounter,
@@ -488,14 +491,14 @@ impl IsSync for Descriptor {}
 impl Descriptor {
     pub fn new(file: CompatFile) -> Self {
         Self {
-            file,
+            file: Some(file),
             flags: DescriptorFlags::empty(),
             _counter: ObjectCounter::new("Descriptor"),
         }
     }
 
     pub fn file(&self) -> &CompatFile {
-        &self.file
+        self.file.as_ref().unwrap()
     }
 
     pub fn flags(&self) -> DescriptorFlags {
@@ -506,8 +509,8 @@ impl Descriptor {
         self.flags = flags;
     }
 
-    pub fn into_file(self) -> CompatFile {
-        self.file
+    pub fn into_file(mut self) -> CompatFile {
+        self.file.take().unwrap()
     }
 
     /// Close the descriptor. The `host` option is a legacy option for legacy file.
@@ -516,7 +519,7 @@ impl Descriptor {
         host: &Host,
         cb_queue: &mut CallbackQueue,
     ) -> Option<Result<(), SyscallError>> {
-        self.file.close(host, cb_queue)
+        self.into_file().close(host, cb_queue)
     }
 
     /// Duplicate the descriptor, with both descriptors pointing to the same `OpenFile`. In
@@ -573,6 +576,24 @@ impl Descriptor {
         assert!(remaining.is_empty());
         descriptor.set_flags(descriptor_flags);
         descriptor
+    }
+}
+
+impl Drop for Descriptor {
+    fn drop(&mut self) {
+        if self.file.is_some() {
+            debug_panic!("Dropped descriptor without closing");
+        }
+    }
+}
+
+impl ExplicitDrop for Descriptor {
+    type ExplicitDropParam<'p> = (&'p Host, &'p mut CallbackQueue);
+    type ExplicitDropResult = Option<Result<(), SyscallError>>;
+
+    fn explicit_drop<'p>(self, param: Self::ExplicitDropParam<'p>) -> Self::ExplicitDropResult {
+        let (host, cb_queue) = param;
+        self.close(host, cb_queue)
     }
 }
 

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -404,12 +404,12 @@ impl OpenFile {
 
             if file.state().contains(FileState::CLOSED) {
                 // panic if debug assertions are enabled
-                debug_panic!("Creating an `OpenFile` object for a closed file");
+                warn_and_debug_panic!("Creating an `OpenFile` object for a closed file");
             }
 
             if file.has_open_file() {
                 // panic if debug assertions are enabled
-                debug_panic!(
+                warn_and_debug_panic!(
                     "Creating an `OpenFile` object for a file that already has an `OpenFile` object"
                 );
             }
@@ -582,7 +582,7 @@ impl Descriptor {
 impl Drop for Descriptor {
     fn drop(&mut self) {
         if self.file.is_some() {
-            debug_panic!("Dropped descriptor without closing");
+            warn_and_debug_panic!("Dropped descriptor without closing");
         }
     }
 }

--- a/src/main/host/descriptor/shared_buf.rs
+++ b/src/main/host/descriptor/shared_buf.rs
@@ -243,7 +243,7 @@ impl Drop for SharedBuf {
         // listeners waiting for `NO_READERS` or `NO_WRITERS` status changes will never be notified
         if self.num_readers != 0 || self.num_writers != 0 {
             // panic in debug builds since the backtrace will be helpful for debugging
-            debug_panic!(
+            warn_and_debug_panic!(
                 "Dropping SharedBuf while it still has {} readers and {} writers.",
                 self.num_readers,
                 self.num_writers,
@@ -297,7 +297,7 @@ impl Drop for ReaderHandle {
         }
 
         // panic in debug builds since the backtrace will be helpful for debugging
-        debug_panic!(
+        warn_and_debug_panic!(
             "Dropping ReaderHandle without returning it to SharedBuf. \
              This likely indicates a bug in Shadow."
         );
@@ -312,7 +312,7 @@ impl Drop for WriterHandle {
         }
 
         // panic in debug builds since the backtrace will be helpful for debugging
-        debug_panic!(
+        warn_and_debug_panic!(
             "Dropping WriterHandle without returning it to SharedBuf. \
              This likely indicates a bug in Shadow."
         );

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -1997,7 +1997,7 @@ impl UnixSocketCommon {
             );
 
             // panic in debug builds since the backtrace will be helpful for debugging
-            debug_panic!("When closing a unix socket, the CLOSED flag was not set");
+            warn_and_debug_panic!("When closing a unix socket, the CLOSED flag was not set");
         }
 
         Ok(())

--- a/src/main/host/network/interface.rs
+++ b/src/main/host/network/interface.rs
@@ -130,7 +130,7 @@ impl NetworkInterface {
             entry.insert(socket.clone());
         } else {
             // TODO: Return an error if the association fails.
-            debug_panic!("Entry is unexpectedly occupied");
+            warn_and_debug_panic!("Entry is unexpectedly occupied");
         }
     }
 

--- a/src/main/host/network/namespace.rs
+++ b/src/main/host/network/namespace.rs
@@ -259,7 +259,7 @@ impl NetworkNamespace {
 impl std::ops::Drop for NetworkNamespace {
     fn drop(&mut self) {
         if !self.has_run_cleanup.get() && !std::thread::panicking() {
-            debug_panic!("Dropped the network namespace before it has been cleaned up");
+            warn_and_debug_panic!("Dropped the network namespace before it has been cleaned up");
         }
     }
 }

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -1054,7 +1054,7 @@ impl Process {
         )?;
         let native_pid = mthread.native_pid();
         let main_thread =
-            Thread::wrap_mthread(host, mthread, desc_table, process_id, main_thread_id).unwrap();
+            Thread::wrap_mthread(host, mthread, desc_table, process_id, main_thread_id);
 
         debug!("process '{plugin_name:?}' started");
 

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -687,10 +687,10 @@ impl RunnableProcess {
 }
 
 impl ExplicitDrop for RunnableProcess {
-    type ExplicitDropParam = Host;
+    type ExplicitDropParam<'p> = &'p Host;
     type ExplicitDropResult = ();
 
-    fn explicit_drop(mut self, host: &Self::ExplicitDropParam) -> Self::ExplicitDropResult {
+    fn explicit_drop<'p>(mut self, host: Self::ExplicitDropParam<'p>) -> Self::ExplicitDropResult {
         let threads = std::mem::take(self.threads.get_mut());
         for thread in threads.into_values() {
             thread.explicit_drop_recursive(host.root(), host);
@@ -869,10 +869,10 @@ impl ProcessState {
 }
 
 impl ExplicitDrop for ProcessState {
-    type ExplicitDropParam = Host;
+    type ExplicitDropParam<'p> = &'p Host;
     type ExplicitDropResult = ();
 
-    fn explicit_drop(self, host: &Self::ExplicitDropParam) -> Self::ExplicitDropResult {
+    fn explicit_drop<'p>(self, host: Self::ExplicitDropParam<'p>) -> Self::ExplicitDropResult {
         match self {
             ProcessState::Runnable(r) => r.explicit_drop(host),
             ProcessState::Zombie(_) => (),
@@ -1874,10 +1874,10 @@ impl Drop for Process {
 }
 
 impl ExplicitDrop for Process {
-    type ExplicitDropParam = Host;
+    type ExplicitDropParam<'p> = &'p Host;
     type ExplicitDropResult = ();
 
-    fn explicit_drop(mut self, host: &Self::ExplicitDropParam) -> Self::ExplicitDropResult {
+    fn explicit_drop<'p>(mut self, host: Self::ExplicitDropParam<'p>) -> Self::ExplicitDropResult {
         // Should normally only be dropped in the zombie state.
         debug_assert!(self.as_zombie().is_some() || std::thread::panicking());
 

--- a/src/main/host/process.rs
+++ b/src/main/host/process.rs
@@ -767,7 +767,7 @@ impl ZombieProcess {
 
         let Some(parent_runnable) = parent.as_runnable() else {
             trace!("Not notifying parent of exit: {parent_pid:?} not running");
-            debug_panic!("Non-running parent process shouldn't be possible.");
+            warn_and_debug_panic!("Non-running parent process shouldn't be possible.");
             #[allow(unreachable_code)]
             {
                 return;

--- a/src/main/host/syscall/handler/clone.rs
+++ b/src/main/host/syscall/handler/clone.rs
@@ -221,7 +221,7 @@ impl SyscallHandler {
             desc_table.into_value(),
             child_pid,
             child_tid,
-        )?;
+        );
 
         let childrc = ExplicitDropper::new(
             RootedRc::new(

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -471,8 +471,8 @@ impl Thread {
         desc_table: RootedRc<RootedRefCell<DescriptorTable>>,
         pid: ProcessId,
         tid: ThreadId,
-    ) -> Result<Thread, Errno> {
-        let child = Self {
+    ) -> Thread {
+        Self {
             mthread: RefCell::new(mthread),
             syscallhandler: RootedRefCell::new(
                 host.root(),
@@ -502,8 +502,7 @@ impl Thread {
             )),
             desc_table: Some(desc_table),
             _counter: ObjectCounter::new("Thread"),
-        };
-        Ok(child)
+        }
     }
 
     /// Shared memory for this thread.

--- a/src/main/host/thread.rs
+++ b/src/main/host/thread.rs
@@ -608,10 +608,10 @@ impl Drop for Thread {
 }
 
 impl ExplicitDrop for Thread {
-    type ExplicitDropParam = Host;
+    type ExplicitDropParam<'p> = &'p Host;
     type ExplicitDropResult = ();
 
-    fn explicit_drop(mut self, host: &Host) {
+    fn explicit_drop<'p>(mut self, host: Self::ExplicitDropParam<'p>) {
         if let Some(table) = self.desc_table.take() {
             table.explicit_drop_recursive(host.root(), host);
         }

--- a/src/main/utility/callback_queue.rs
+++ b/src/main/utility/callback_queue.rs
@@ -98,7 +98,7 @@ impl Drop for CallbackQueue {
 
         if !self.is_empty() {
             // panic in debug builds since the backtrace will be helpful for debugging
-            debug_panic!("Dropping EventQueue while it still has events pending.");
+            warn_and_debug_panic!("Dropping EventQueue while it still has events pending.");
         }
     }
 }

--- a/src/main/utility/macros.rs
+++ b/src/main/utility/macros.rs
@@ -1,5 +1,5 @@
 /// Log a warning, and if a debug build then panic.
-macro_rules! debug_panic {
+macro_rules! warn_and_debug_panic {
     ($($x:tt)+) => {
         log::warn!($($x)+);
         #[cfg(debug_assertions)]
@@ -308,15 +308,15 @@ mod tests {
     #[test]
     #[cfg(debug_assertions)]
     #[should_panic]
-    fn debug_panic_macro() {
-        debug_panic!("Hello {}", "World");
+    fn warn_and_debug_panic_macro() {
+        warn_and_debug_panic!("Hello {}", "World");
     }
 
     // will *not* panic in release mode
     #[test]
     #[cfg(not(debug_assertions))]
-    fn debug_panic_macro() {
-        debug_panic!("Hello {}", "World");
+    fn warn_and_debug_panic_macro() {
+        warn_and_debug_panic!("Hello {}", "World");
     }
 
     #[test]


### PR DESCRIPTION
Broken out of WIP #3774, which is progress on #2258

* Generalize the `ExplicitDrop` trait to have a lifetime parameter, instead of `ExplicitDrop::explicit_drop` taking a reference to `ExplicitDropParam` with an implicit lifetime. This is necessary to allow `ExplicitDropParam` to internally include lifetimes, which is used in #3774.
* Detect if `Descriptor`s and `DescriptorTable`s are dropped without explicitly closing. (This becomes more important in #3774, where we release fcntl record locks as part of the descriptor-close process)