### PR TITLE
shadow-exec: dump shadow config as json to avoid ambiguities

### DIFF
--- a/shadowtools/src/shadowtools/shadow_exec.py
+++ b/shadowtools/src/shadowtools/shadow_exec.py
@@ -31,7 +31,7 @@ import shutil
 import sys
 import tempfile
 import textwrap
-import yaml
+import json
 
 from pathlib import Path
 from typing import TextIO, BinaryIO, Final, Optional, List, Iterable, Dict, Literal
@@ -293,7 +293,20 @@ def _main(
     config["hosts"][hostname] = _make_controller_host(args, environ)
 
     config_path = tmpdir.joinpath("shadow.yaml")
-    config_path.write_text(yaml.safe_dump(config))
+    # Encoding as yaml using pyyaml leads to ambiguities; since yaml is a superset
+    # of json, we use the json encoder instead.
+    #
+    # In particular pyyaml encodes to the yaml 1.1 spec
+    # <https://github.com/yaml/pyyaml/issues/486>, while shadow's serde_yaml
+    # appears to decode by the yaml 1.2 spec
+    # <https://github.com/yaml/yaml-serde/issues/14>.
+    # The main problem we've seen is that the pyyaml encoder doesn't quote
+    # some strings that, by the yaml 1.2 spec, are then interpreted as floats
+    # <https://github.com/yaml/pyyaml/issues/393>.
+    #
+    # If we ever switch back to a yaml encoder here, consider one that can
+    # encode to the 1.2 spec (like py-yaml12).
+    config_path.write_text(json.dumps(config, indent=4, sort_keys=True))
 
     # Flush before handing the underlying buffers over
     stdout.flush()

--- a/shadowtools/tests/test_shadow_exec.py
+++ b/shadowtools/tests/test_shadow_exec.py
@@ -103,3 +103,32 @@ class TestShadowExecCLI(unittest.TestCase):
             text=True,
         )
         self.assertNotEqual(res1, res2)
+
+    def test_floaty_env(self) -> None:
+        # check that shadow-exec can pass through an environment variable that
+        # happens to look like a float.  we've had problems before where our
+        # encoder doesn't quote the output, and shadow's decoder interprets the
+        # output as a float and rejects the config file.
+        env_name = "FLOATY_ENV_VAR"
+        env_value = "123e10"
+        env = dict(os.environ) | {env_name: env_value}
+        res = subprocess.check_output(
+            [
+                "python3",
+                "-m",
+                "shadowtools.shadow_exec",
+                f"--shadow-bin={SHADOW_BIN}",
+                "--preserve=on-error",
+                "--no-ignore-env",
+                "--",
+                "bash",
+                "-c",
+                f"echo ${env_name}",
+            ],
+            env=env,
+            text=True,
+        )
+        self.assertEqual(
+            res.strip(),
+            env_value,
+        )


### PR DESCRIPTION
In particular, the pyyaml encoder doesn't quote strings that it thinks unambiguously look like strings. shadow's yaml decoder sometimes disagrees here, causing it to reject output from the pyyaml encoder.

IIUC the particular here is a difference between yaml 1.1 and 1.2 spec https://github.com/yaml/pyyaml/issues/393, where pyyaml follows 1.1 <https://github.com/yaml/pyyaml/issues/486> and thinks a string only looks like a float if it has a `+` after the `e`, so feels free to emit a string like `1e6` without quoting, but shadow's decoder presumably uses yaml 1.2 and interprets such a string as a float. https://github.com/yaml/pyyaml/issues/393

Rather than continuing to try to iron those out, json is probably a better output format for a config file that is machine-generated and machine-consumed. Since json is by design a subset of yaml, this is still valid yaml. The json output should be less prone to ambiguities in shadow's yaml decoder.