### PR TITLE
Clean up oflag handling

### DIFF
--- a/src/lib/linux-api/src/fcntl.rs
+++ b/src/lib/linux-api/src/fcntl.rs
@@ -31,6 +31,94 @@ bitflags::bitflags! {
     }
 }
 
+impl OFlag {
+    pub fn access_mode_flags(&self) -> AccessModeOFlag {
+        AccessModeOFlag::from_bits_truncate(self.bits())
+    }
+
+    pub fn file_creation_flags(&self) -> FileCreationOFlag {
+        FileCreationOFlag::from_bits_truncate(self.bits())
+    }
+
+    pub fn file_status_flags(&self) -> FileStatusOFlag {
+        FileStatusOFlag::from_bits_truncate(self.bits())
+    }
+
+    /// Split into access-mode, creation, and status flags.
+    pub fn partition(&self) -> (AccessModeOFlag, FileCreationOFlag, FileStatusOFlag) {
+        (
+            self.access_mode_flags(),
+            self.file_creation_flags(),
+            self.file_status_flags(),
+        )
+    }
+}
+
+impl From<AccessModeOFlag> for OFlag {
+    fn from(value: AccessModeOFlag) -> Self {
+        Self::from_bits(value.bits()).unwrap()
+    }
+}
+
+impl From<FileCreationOFlag> for OFlag {
+    fn from(value: FileCreationOFlag) -> Self {
+        Self::from_bits(value.bits()).unwrap()
+    }
+}
+
+impl From<FileStatusOFlag> for OFlag {
+    fn from(value: FileStatusOFlag) -> Self {
+        Self::from_bits(value.bits()).unwrap()
+    }
+}
+
+bitflags::bitflags! {
+    /// "Access mode" flags as specified in open(2); Subset of OFlag.
+    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+    pub struct AccessModeOFlag: i32 {
+        const O_RDONLY = OFlag::O_RDONLY.bits();
+        const O_WRONLY = OFlag::O_WRONLY.bits();
+        const O_RDWR = OFlag::O_RDWR.bits();
+    }
+}
+
+bitflags::bitflags! {
+    /// "File creation flags" as specified in open(2). Subset of OFlag.
+    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+    pub struct FileCreationOFlag : i32 {
+        const O_CLOEXEC = OFlag::O_CLOEXEC.bits();
+        const O_CREAT= OFlag::O_CREAT.bits();
+        const O_DIRECTORY= OFlag::O_DIRECTORY.bits();
+        const O_EXCL= OFlag::O_EXCL.bits();
+        const O_NOCTTY= OFlag::O_NOCTTY.bits();
+        const O_NOFOLLOW= OFlag::O_NOFOLLOW.bits();
+        const O_TMPFILE= OFlag::O_TMPFILE.bits();
+        const O_TRUNC= OFlag::O_TRUNC.bits();
+    }
+}
+
+bitflags::bitflags! {
+    /// "File status flags" as specified in open(2), as "all the remaining flags"
+    /// that aren't specified as creation or access flags.
+    ///
+    /// open(2): "The file status flags can be retrieved and (in some cases)
+    /// modified; see fcntl(2) for details."
+    ///
+    /// Subset of OFlag.
+    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+    pub struct FileStatusOFlag: i32 {
+        const O_APPEND= OFlag::O_APPEND.bits();
+        const O_ASYNC= OFlag::O_ASYNC.bits();
+        const O_DIRECT= OFlag::O_DIRECT.bits();
+        const O_NOATIME= OFlag::O_NOATIME.bits();
+        const O_NONBLOCK= OFlag::O_NONBLOCK.bits();
+        const O_DSYNC= OFlag::O_DSYNC.bits();
+        const O_SYNC= OFlag::O_SYNC.bits();
+        const O_LARGEFILE= OFlag::O_LARGEFILE.bits();
+        const O_PATH= OFlag::O_PATH.bits();
+    }
+}
+
 /// fcntl commands, as used with `fcntl`.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u32)]
@@ -183,5 +271,37 @@ bitflags::bitflags! {
         const AT_EMPTY_PATH = const_conversions::i32_from_u32(bindings::LINUX_AT_EMPTY_PATH);
         const AT_SYMLINK_NOFOLLOW = const_conversions::i32_from_u32(bindings::LINUX_AT_SYMLINK_NOFOLLOW);
         const AT_EXECVE_CHECK = const_conversions::i32_from_u32(bindings::LINUX_AT_EXECVE_CHECK);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_partition_oflags() {
+        let all_o_flags = OFlag::all();
+        let (access_mode, creation, status) = all_o_flags.partition();
+
+        // all defined bits should be set in partitions.
+        assert_eq!(access_mode, AccessModeOFlag::all());
+        assert_eq!(creation, FileCreationOFlag::all());
+        assert_eq!(status, FileStatusOFlag::all());
+
+        // convert back to OFlag.
+        let access_mode = OFlag::from(access_mode);
+        let creation = OFlag::from(creation);
+        let status = OFlag::from(status);
+
+        // they should all be mutually exclusive.
+        assert_eq!(access_mode & creation, OFlag::empty());
+        assert_eq!(access_mode & status, OFlag::empty());
+        assert_eq!(creation & status, OFlag::empty());
+
+        // together they should cover all of the OFlag bits.
+        assert_eq!(
+            OFlag::all() - (access_mode | creation | status),
+            OFlag::empty()
+        );
     }
 }

--- a/src/lib/linux-api/src/fcntl.rs
+++ b/src/lib/linux-api/src/fcntl.rs
@@ -128,6 +128,19 @@ bitflags::bitflags! {
     }
 }
 
+impl FileStatusOFlag {
+    pub fn as_o_flags(&self) -> OFlag {
+        OFlag::from_bits(self.bits()).unwrap()
+    }
+
+    /// Returns a tuple of the `FileStatus` and any remaining flags.
+    pub fn from_o_flags(flags: OFlag) -> (Self, OFlag) {
+        let status = Self::from_bits_truncate(flags.bits());
+        let remaining = flags.bits() & !status.bits();
+        (status, OFlag::from_bits(remaining).unwrap())
+    }
+}
+
 /// fcntl commands, as used with `fcntl`.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u32)]

--- a/src/lib/linux-api/src/fcntl.rs
+++ b/src/lib/linux-api/src/fcntl.rs
@@ -2,6 +2,15 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{bindings, const_conversions};
 
+// open(2): The Linux header file <asm/fcntl.h> doesn't define O_ASYNC; the
+// (BSD-derived) FASYNC synonym is defined instead.
+//
+// We define with the LINUX_ prefix for C usage, and as a u32 for consistency
+// with the other c-bindgen output. We use a literal integer here instead of
+// setting directly to LINUX_FASYNC so that cbindgen can handle it.
+pub const LINUX_O_ASYNC: u32 = 0x2000;
+const _: () = const { assert!(LINUX_O_ASYNC == bindings::LINUX_FASYNC) };
+
 bitflags::bitflags! {
     /// Open flags, as used e.g. with `open`.
     #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
@@ -27,7 +36,7 @@ bitflags::bitflags! {
         const O_PATH = const_conversions::i32_from_u32(bindings::LINUX_O_PATH);
         const O_TMPFILE = const_conversions::i32_from_u32(bindings::LINUX_O_TMPFILE);
         const O_NDELAY = const_conversions::i32_from_u32(bindings::LINUX_O_NDELAY);
-        const O_ASYNC = const_conversions::i32_from_u32(bindings::LINUX_FASYNC);
+        const O_ASYNC = const_conversions::i32_from_u32(LINUX_O_ASYNC);
     }
 }
 

--- a/src/lib/linux-api/src/fcntl.rs
+++ b/src/lib/linux-api/src/fcntl.rs
@@ -305,3 +305,29 @@ mod test {
         );
     }
 }
+
+mod export {
+    /// "file creation" "oflags", as per `open(2)`.
+    // TODO: export as a plain constant, if/when cbindgen handles evaluation of
+    // const functions.
+    #[unsafe(no_mangle)]
+    pub extern "C-unwind" fn linux_file_creation_oflags() -> core::ffi::c_int {
+        super::FileCreationOFlag::all().bits()
+    }
+
+    /// "access mode" "oflags", as per `open(2)`.
+    // TODO: export as a plain constant, if/when cbindgen handles evaluation of
+    // const functions.
+    #[unsafe(no_mangle)]
+    pub extern "C-unwind" fn linux_access_mode_oflags() -> core::ffi::c_int {
+        super::AccessModeOFlag::all().bits()
+    }
+
+    /// "file status" "oflags", as per `open(2)`.
+    // TODO: export as a plain constant, if/when cbindgen handles evaluation of
+    // const functions.
+    #[unsafe(no_mangle)]
+    pub extern "C-unwind" fn linux_file_status_oflags() -> core::ffi::c_int {
+        super::FileStatusOFlag::all().bits()
+    }
+}

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -279,19 +279,16 @@ void legacyfile_removeListener(LegacyFile* descriptor, StatusListener* listener)
 
 gint legacyfile_getFlags(LegacyFile* descriptor) {
     MAGIC_ASSERT(descriptor);
-    return descriptor->flags;
+    MAGIC_ASSERT(descriptor->funcTable);
+    utility_alwaysAssert(descriptor->funcTable->get_flags != NULL);
+    return descriptor->funcTable->get_flags(descriptor);
 }
 
 void legacyfile_setFlags(LegacyFile* descriptor, gint flags) {
     MAGIC_ASSERT(descriptor);
-    int creation_flags = flags & linux_file_creation_oflags();
-    if (creation_flags) {
-        warning("Caller included creation flags 0x%x, which they should have removed and handled "
-                "separately",
-                creation_flags);
-    }
-    utility_debugAssert(!creation_flags);
-    descriptor->flags = flags;
+    MAGIC_ASSERT(descriptor->funcTable);
+    utility_alwaysAssert(descriptor->funcTable->set_flags != NULL);
+    descriptor->funcTable->set_flags(descriptor, flags);
 }
 
 bool legacyfile_supportsSaRestart(LegacyFile* legacyDesc) {

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -284,10 +284,13 @@ gint legacyfile_getFlags(LegacyFile* descriptor) {
 
 void legacyfile_setFlags(LegacyFile* descriptor, gint flags) {
     MAGIC_ASSERT(descriptor);
-    if (flags & O_CLOEXEC) {
-        warning("Adding CLOEXEC to legacy file when it should "
-                "have been added to the descriptor");
+    int creation_flags = flags & linux_file_creation_oflags();
+    if (creation_flags) {
+        warning("Caller included creation flags 0x%x, which they should have removed and handled "
+                "separately",
+                creation_flags);
     }
+    utility_debugAssert(!creation_flags);
     descriptor->flags = flags;
 }
 

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -277,18 +277,36 @@ void legacyfile_removeListener(LegacyFile* descriptor, StatusListener* listener)
     eventsource_removeLegacyListener(descriptor->event_source, listener);
 }
 
-gint legacyfile_getFlags(LegacyFile* descriptor) {
+gint legacyfile_getAccessModeFlags(LegacyFile* descriptor) {
     MAGIC_ASSERT(descriptor);
-    MAGIC_ASSERT(descriptor->funcTable);
-    utility_alwaysAssert(descriptor->funcTable->get_flags != NULL);
-    return descriptor->funcTable->get_flags(descriptor);
+    return descriptor->accessAndCreationFlags & linux_access_mode_oflags();
 }
 
-void legacyfile_setFlags(LegacyFile* descriptor, gint flags) {
+gint legacyfile_getFileStatusFlags(LegacyFile* descriptor) {
     MAGIC_ASSERT(descriptor);
     MAGIC_ASSERT(descriptor->funcTable);
-    utility_alwaysAssert(descriptor->funcTable->set_flags != NULL);
-    descriptor->funcTable->set_flags(descriptor, flags);
+    utility_alwaysAssert(descriptor->funcTable->get_status_flags != NULL);
+    return descriptor->funcTable->get_status_flags(descriptor);
+}
+
+void legacyfile_setFileStatusFlags(LegacyFile* descriptor, gint flags) {
+    MAGIC_ASSERT(descriptor);
+    MAGIC_ASSERT(descriptor->funcTable);
+    utility_alwaysAssert(descriptor->funcTable->set_status_flags != NULL);
+    descriptor->funcTable->set_status_flags(descriptor, flags);
+}
+
+void legacyfile_setAccessAndCreationFlags(LegacyFile* descriptor, gint flags) {
+    MAGIC_ASSERT(descriptor);
+    if (descriptor->accessAndCreationFlags) {
+        panic("Overwriting accesss and creation flags, which should be immutable");
+    }
+    int mask = linux_access_mode_oflags() | linux_file_creation_oflags();
+    int unhandled = flags & ~mask;
+    if (unhandled) {
+        panic("Caller gave us unahndled flags 0x%x", unhandled);
+    }
+    descriptor->accessAndCreationFlags = flags;
 }
 
 bool legacyfile_supportsSaRestart(LegacyFile* legacyDesc) {

--- a/src/main/host/descriptor/descriptor.c
+++ b/src/main/host/descriptor/descriptor.c
@@ -291,20 +291,6 @@ void legacyfile_setFlags(LegacyFile* descriptor, gint flags) {
     descriptor->flags = flags;
 }
 
-void legacyfile_addFlags(LegacyFile* descriptor, gint flags) {
-    MAGIC_ASSERT(descriptor);
-    if (flags & O_CLOEXEC) {
-        warning("Adding CLOEXEC to legacy file when it should "
-                "have been added to the descriptor");
-    }
-    descriptor->flags |= flags;
-}
-
-void legacyfile_removeFlags(LegacyFile* descriptor, gint flags) {
-    MAGIC_ASSERT(descriptor);
-    descriptor->flags &= ~flags;
-}
-
 bool legacyfile_supportsSaRestart(LegacyFile* legacyDesc) {
     switch (legacyDesc->type) {
         case DT_TCPSOCKET:

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -36,7 +36,9 @@ const RootedRefCell_StateEventSource* legacyfile_getEventSource(LegacyFile* desc
 
 LegacyFileType legacyfile_getType(LegacyFile* descriptor);
 
+/* Get the "access" and "file status" oflags. See open(2). */
 gint legacyfile_getFlags(LegacyFile* descriptor);
+/* Set the "access" and "file status" oflags. See open(2). */
 void legacyfile_setFlags(LegacyFile* descriptor, gint flags);
 
 /*

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -38,8 +38,6 @@ LegacyFileType legacyfile_getType(LegacyFile* descriptor);
 
 gint legacyfile_getFlags(LegacyFile* descriptor);
 void legacyfile_setFlags(LegacyFile* descriptor, gint flags);
-void legacyfile_addFlags(LegacyFile* descriptor, gint flags);
-void legacyfile_removeFlags(LegacyFile* descriptor, gint flags);
 
 /*
  * One of the main functions of the descriptor is to track its poll status,

--- a/src/main/host/descriptor/descriptor.h
+++ b/src/main/host/descriptor/descriptor.h
@@ -36,10 +36,19 @@ const RootedRefCell_StateEventSource* legacyfile_getEventSource(LegacyFile* desc
 
 LegacyFileType legacyfile_getType(LegacyFile* descriptor);
 
-/* Get the "access" and "file status" oflags. See open(2). */
-gint legacyfile_getFlags(LegacyFile* descriptor);
-/* Set the "access" and "file status" oflags. See open(2). */
-void legacyfile_setFlags(LegacyFile* descriptor, gint flags);
+/* Get the "access mode" oflags. See open(2). */
+gint legacyfile_getAccessModeFlags(LegacyFile* descriptor);
+
+/* Get the "file status" oflags. See open(2). */
+gint legacyfile_getFileStatusFlags(LegacyFile* descriptor);
+/* Set the "file status" oflags. See open(2). */
+void legacyfile_setFileStatusFlags(LegacyFile* descriptor, gint flags);
+
+/* Should be called exactly once, generally by the constructor of the specific file type.
+ * Ideally we'd make these a parameter to `legacyfile_init` instead, but that'd take
+ * more significantly more refactoring.
+ */
+void legacyfile_setAccessAndCreationFlags(LegacyFile* descriptor, gint flags);
 
 /*
  * One of the main functions of the descriptor is to track its poll status,

--- a/src/main/host/descriptor/descriptor_types.h
+++ b/src/main/host/descriptor/descriptor_types.h
@@ -53,6 +53,9 @@ struct _LegacyFile {
     RootedRefCell_StateEventSource* event_source;
     int refCountStrong;
     int refCountWeak;
+    // access-mode and status "oflags" (*not* file creation flags) as provided
+    // to `open(2)`, and retrieved with fcntl F_GETFL.
+    // TODO: this probably ought be pushed down into concrete implementations.
     int flags;
     // Since this structure is shared with Rust, we should always include the magic struct
     // member so that the struct is always the same size regardless of compile-time options.

--- a/src/main/host/descriptor/descriptor_types.h
+++ b/src/main/host/descriptor/descriptor_types.h
@@ -26,9 +26,9 @@ typedef struct _LegacyFileFunctionTable LegacyFileFunctionTable;
 /* required functions */
 
 /* Set "file status" oflags */
-typedef void (*LegacyFileSetFlags)(LegacyFile* descriptor, int flags);
+typedef void (*LegacyFileSetStatusFlags)(LegacyFile* descriptor, int flags);
 /* Get "file status" and "access mode" oflags. */
-typedef int (*LegacyFileGetFlags)(LegacyFile* descriptor);
+typedef int (*LegacyFileGetStatusFlags)(LegacyFile* descriptor);
 typedef int (*LegacyFileFStatFunc)(LegacyFile* descriptor, struct linux_stat* statbuf);
 typedef off_t (*LegacyFileLSeekFunc)(LegacyFile* descriptor, off_t offset, int whence);
 typedef void (*LegacyFileCloseFunc)(LegacyFile* descriptor, const Host* host);
@@ -43,8 +43,8 @@ typedef void (*LegacyFileFreeFunc)(LegacyFile* descriptor);
  * callable functions.
  */
 struct _LegacyFileFunctionTable {
-    LegacyFileSetFlags set_flags;
-    LegacyFileGetFlags get_flags;
+    LegacyFileSetStatusFlags set_status_flags;
+    LegacyFileGetStatusFlags get_status_flags;
     LegacyFileFStatFunc fstat;
     LegacyFileLSeekFunc lseek;
     LegacyFileCloseFunc close;
@@ -60,6 +60,8 @@ struct _LegacyFile {
     RootedRefCell_StateEventSource* event_source;
     int refCountStrong;
     int refCountWeak;
+    // The "access" and "file creation" oflags; immutable after initialization.
+    int accessAndCreationFlags;
     // Since this structure is shared with Rust, we should always include the magic struct
     // member so that the struct is always the same size regardless of compile-time options.
     MAGIC_DECLARE_ALWAYS;

--- a/src/main/host/descriptor/descriptor_types.h
+++ b/src/main/host/descriptor/descriptor_types.h
@@ -24,6 +24,11 @@ typedef struct _LegacyFile LegacyFile;
 typedef struct _LegacyFileFunctionTable LegacyFileFunctionTable;
 
 /* required functions */
+
+/* Set "file status" oflags */
+typedef void (*LegacyFileSetFlags)(LegacyFile* descriptor, int flags);
+/* Get "file status" and "access mode" oflags. */
+typedef int (*LegacyFileGetFlags)(LegacyFile* descriptor);
 typedef int (*LegacyFileFStatFunc)(LegacyFile* descriptor, struct linux_stat* statbuf);
 typedef off_t (*LegacyFileLSeekFunc)(LegacyFile* descriptor, off_t offset, int whence);
 typedef void (*LegacyFileCloseFunc)(LegacyFile* descriptor, const Host* host);
@@ -38,6 +43,8 @@ typedef void (*LegacyFileFreeFunc)(LegacyFile* descriptor);
  * callable functions.
  */
 struct _LegacyFileFunctionTable {
+    LegacyFileSetFlags set_flags;
+    LegacyFileGetFlags get_flags;
     LegacyFileFStatFunc fstat;
     LegacyFileLSeekFunc lseek;
     LegacyFileCloseFunc close;
@@ -53,10 +60,6 @@ struct _LegacyFile {
     RootedRefCell_StateEventSource* event_source;
     int refCountStrong;
     int refCountWeak;
-    // access-mode and status "oflags" (*not* file creation flags) as provided
-    // to `open(2)`, and retrieved with fcntl F_GETFL.
-    // TODO: this probably ought be pushed down into concrete implementations.
-    int flags;
     // Since this structure is shared with Rust, we should always include the magic struct
     // member so that the struct is always the same size regardless of compile-time options.
     MAGIC_DECLARE_ALWAYS;

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -113,8 +113,8 @@ struct _Epoll {
     /* A counter for sorting watches, for guaranteeing determinism when reporting events. */
     uint64_t watch_id_counter;
 
-    /* access and status flags, as returned via fcntl F_GETFL */
-    int accessAndStatusFlags;
+    /* status flags, as documented in open(2) */
+    int statusFlags;
 
     MAGIC_DECLARE;
 };
@@ -325,30 +325,30 @@ static void _epoll_close(LegacyFile* descriptor, const Host* host) {
     epoll_clearWatchListeners(epoll);
 }
 
-void epoll_set_flags(Epoll* epoll, int flags) {
+void epoll_set_status_flags(Epoll* epoll, int flags) {
     MAGIC_ASSERT(epoll);
-    epoll->accessAndStatusFlags = flags & (linux_access_mode_oflags() | linux_file_status_oflags());
+    epoll->statusFlags = flags & linux_file_status_oflags();
 }
 
-static void _epoll_set_flags(LegacyFile* descriptor, int flags) {
+static void _epoll_set_status_flags(LegacyFile* descriptor, int flags) {
     Epoll* epoll = _epoll_fromLegacyFile(descriptor);
-    epoll_set_flags(epoll, flags);
+    epoll_set_status_flags(epoll, flags);
 }
 
-int epoll_get_flags(Epoll* epoll) {
+int epoll_get_status_flags(Epoll* epoll) {
     MAGIC_ASSERT(epoll);
-    return epoll->accessAndStatusFlags;
+    return epoll->statusFlags;
 }
 
-static int _epoll_get_flags(LegacyFile* descriptor) {
+static int _epoll_get_status_flags(LegacyFile* descriptor) {
     Epoll* epoll = _epoll_fromLegacyFile(descriptor);
-    return epoll_get_flags(epoll);
+    return epoll_get_status_flags(epoll);
 }
 
 LegacyFileFunctionTable epollFunctions = {.close = _epoll_close,
                                           .cleanup = NULL,
-                                          .set_flags = _epoll_set_flags,
-                                          .get_flags = _epoll_get_flags,
+                                          .set_status_flags = _epoll_set_status_flags,
+                                          .get_status_flags = _epoll_get_status_flags,
                                           .free = _epoll_free,
                                           MAGIC_INITIALIZER};
 

--- a/src/main/host/descriptor/epoll.c
+++ b/src/main/host/descriptor/epoll.c
@@ -113,6 +113,9 @@ struct _Epoll {
     /* A counter for sorting watches, for guaranteeing determinism when reporting events. */
     uint64_t watch_id_counter;
 
+    /* access and status flags, as returned via fcntl F_GETFL */
+    int accessAndStatusFlags;
+
     MAGIC_DECLARE;
 };
 
@@ -322,8 +325,32 @@ static void _epoll_close(LegacyFile* descriptor, const Host* host) {
     epoll_clearWatchListeners(epoll);
 }
 
-LegacyFileFunctionTable epollFunctions = {
-    .close = _epoll_close, .cleanup = NULL, .free = _epoll_free, MAGIC_INITIALIZER};
+void epoll_set_flags(Epoll* epoll, int flags) {
+    MAGIC_ASSERT(epoll);
+    epoll->accessAndStatusFlags = flags & (linux_access_mode_oflags() | linux_file_status_oflags());
+}
+
+static void _epoll_set_flags(LegacyFile* descriptor, int flags) {
+    Epoll* epoll = _epoll_fromLegacyFile(descriptor);
+    epoll_set_flags(epoll, flags);
+}
+
+int epoll_get_flags(Epoll* epoll) {
+    MAGIC_ASSERT(epoll);
+    return epoll->accessAndStatusFlags;
+}
+
+static int _epoll_get_flags(LegacyFile* descriptor) {
+    Epoll* epoll = _epoll_fromLegacyFile(descriptor);
+    return epoll_get_flags(epoll);
+}
+
+LegacyFileFunctionTable epollFunctions = {.close = _epoll_close,
+                                          .cleanup = NULL,
+                                          .set_flags = _epoll_set_flags,
+                                          .get_flags = _epoll_get_flags,
+                                          .free = _epoll_free,
+                                          MAGIC_INITIALIZER};
 
 Epoll* epoll_new() {
     Epoll* epoll = g_new0(Epoll, 1);

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -29,23 +29,8 @@ pub mod shared_buf;
 pub mod socket;
 pub mod timerfd;
 
-bitflags::bitflags! {
-    /// These are flags that can potentially be changed from the plugin (analagous to the Linux
-    /// `filp->f_flags` status flags). Not all `O_` flags are valid here. For example file access
-    /// mode flags (ex: `O_RDWR`) are stored elsewhere, and file creation flags (ex: `O_CREAT`)
-    /// are not stored anywhere. Many of these can be represented in different ways, for example:
-    /// `O_NONBLOCK`, `SOCK_NONBLOCK`, `EFD_NONBLOCK`, `GRND_NONBLOCK`, etc, and not all have the
-    /// same value.
-    #[derive(Copy, Clone, Debug)]
-    pub struct FileStatus: i32 {
-        const NONBLOCK = OFlag::O_NONBLOCK.bits();
-        const APPEND = OFlag::O_APPEND.bits();
-        const ASYNC = OFlag::O_ASYNC.bits();
-        const DIRECT = OFlag::O_DIRECT.bits();
-        const NOATIME = OFlag::O_NOATIME.bits();
-    }
-}
-
+// TODO: migrate users to use `FileStatusOFlag` directly.
+pub use linux_api::fcntl::FileStatusOFlag as FileStatus;
 /// For functions that involve closing descriptors; specifies for which
 /// `ProcessId` posix record locks ought to be freed, if any.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -57,19 +42,6 @@ pub enum DropPosixRecordLocks {
     False,
     // Includes associated ProcessId for which to drop locks.
     ForPid(ProcessId),
-}
-
-impl FileStatus {
-    pub fn as_o_flags(&self) -> OFlag {
-        OFlag::from_bits(self.bits()).unwrap()
-    }
-
-    /// Returns a tuple of the `FileStatus` and any remaining flags.
-    pub fn from_o_flags(flags: OFlag) -> (Self, OFlag) {
-        let status = Self::from_bits_truncate(flags.bits());
-        let remaining = flags.bits() & !status.bits();
-        (status, OFlag::from_bits(remaining).unwrap())
-    }
 }
 
 bitflags::bitflags! {

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -15,7 +15,7 @@ use crate::utility::callback_queue::CallbackQueue;
 use crate::utility::{HostTreePointer, IsSend, IsSync, ObjectCounter};
 use atomic_refcell::AtomicRefCell;
 use linux_api::errno::Errno;
-use linux_api::fcntl::{DescriptorFlags, OFlag};
+use linux_api::fcntl::{AccessModeOFlag, DescriptorFlags, OFlag};
 use linux_api::ioctls::IoctlRequest;
 use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
@@ -723,6 +723,19 @@ impl LegacyFileCounter {
         Ok(statbuf)
     }
 
+    pub fn set_status(&self, status: FileStatus) {
+        // legacyfile lumps access and status bits together. fetch
+        // the access bits so that we don't attempt to clobber them.
+        let raw = unsafe { c::legacyfile_getFlags(self.ptr()) };
+        let access = AccessModeOFlag::from_bits_truncate(raw);
+        unsafe { c::legacyfile_setFlags(self.ptr(), access.bits() | status.bits()) }
+    }
+
+    pub fn status(&self) -> FileStatus {
+        let raw = unsafe { c::legacyfile_getFlags(self.ptr()) };
+        FileStatus::from_bits_truncate(raw)
+    }
+
     /// Should drop `self` immediately after calling this.
     fn close_helper(&mut self, host: &Host) {
         // Always take out the `file` object, so that our `Drop` impl knows this object
@@ -818,6 +831,20 @@ impl CompatFile {
         match self {
             CompatFile::New(open_file) => open_file.inner_file().borrow().mode(),
             CompatFile::Legacy(legacy_file_counter) => legacy_file_counter.mode(),
+        }
+    }
+
+    pub fn set_status(&self, status: FileStatus) {
+        match self {
+            CompatFile::New(open_file) => open_file.inner_file().borrow_mut().set_status(status),
+            CompatFile::Legacy(legacy_file_counter) => legacy_file_counter.set_status(status),
+        }
+    }
+
+    pub fn status(&self) -> FileStatus {
+        match self {
+            CompatFile::New(open_file) => open_file.inner_file().borrow().status(),
+            CompatFile::Legacy(legacy_file_counter) => legacy_file_counter.status(),
         }
     }
 }

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -15,7 +15,7 @@ use crate::utility::callback_queue::CallbackQueue;
 use crate::utility::{HostTreePointer, IsSend, IsSync, ObjectCounter};
 use atomic_refcell::AtomicRefCell;
 use linux_api::errno::Errno;
-use linux_api::fcntl::{AccessModeOFlag, DescriptorFlags, OFlag};
+use linux_api::fcntl::{DescriptorFlags, OFlag};
 use linux_api::ioctls::IoctlRequest;
 use shadow_shim_helper_rs::explicit_drop::ExplicitDrop;
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
@@ -696,20 +696,16 @@ impl LegacyFileCounter {
     }
 
     pub fn set_status(&self, status: FileStatus) {
-        // legacyfile lumps access and status bits together. fetch
-        // the access bits so that we don't attempt to clobber them.
-        let raw = unsafe { c::legacyfile_getFlags(self.ptr()) };
-        let access = AccessModeOFlag::from_bits_truncate(raw);
-        unsafe { c::legacyfile_setFlags(self.ptr(), access.bits() | status.bits()) }
+        unsafe { c::legacyfile_setFileStatusFlags(self.ptr(), status.bits()) }
     }
 
     pub fn status(&self) -> FileStatus {
-        let raw = unsafe { c::legacyfile_getFlags(self.ptr()) };
+        let raw = unsafe { c::legacyfile_getFileStatusFlags(self.ptr()) };
         FileStatus::from_bits_truncate(raw)
     }
 
     pub fn mode(&self) -> FileMode {
-        let raw_flags = unsafe { c::legacyfile_getFlags(self.ptr()) };
+        let raw_flags = unsafe { c::legacyfile_getAccessModeFlags(self.ptr()) };
         let oflags = OFlag::from_bits_retain(raw_flags);
         let (mode, _other_flags) =
             FileMode::from_o_flags(oflags).expect("Invalid flags for open file");

--- a/src/main/host/descriptor/mod.rs
+++ b/src/main/host/descriptor/mod.rs
@@ -736,6 +736,14 @@ impl LegacyFileCounter {
         FileStatus::from_bits_truncate(raw)
     }
 
+    pub fn mode(&self) -> FileMode {
+        let raw_flags = unsafe { c::legacyfile_getFlags(self.ptr()) };
+        let oflags = OFlag::from_bits_retain(raw_flags);
+        let (mode, _other_flags) =
+            FileMode::from_o_flags(oflags).expect("Invalid flags for open file");
+        mode
+    }
+
     /// Should drop `self` immediately after calling this.
     fn close_helper(&mut self, host: &Host) {
         // Always take out the `file` object, so that our `Drop` impl knows this object
@@ -756,14 +764,6 @@ impl LegacyFileCounter {
     /// the legacy file as well.
     pub fn close(mut self, host: &Host) {
         self.close_helper(host);
-    }
-
-    pub fn mode(&self) -> FileMode {
-        let raw_flags = unsafe { c::legacyfile_getFlags(self.ptr()) };
-        let oflags = OFlag::from_bits_retain(raw_flags);
-        let (mode, _other_flags) =
-            FileMode::from_o_flags(oflags).expect("Invalid flags for open file");
-        mode
     }
 }
 
@@ -827,13 +827,6 @@ impl CompatFile {
         }
     }
 
-    pub fn mode(&self) -> FileMode {
-        match self {
-            CompatFile::New(open_file) => open_file.inner_file().borrow().mode(),
-            CompatFile::Legacy(legacy_file_counter) => legacy_file_counter.mode(),
-        }
-    }
-
     pub fn set_status(&self, status: FileStatus) {
         match self {
             CompatFile::New(open_file) => open_file.inner_file().borrow_mut().set_status(status),
@@ -845,6 +838,13 @@ impl CompatFile {
         match self {
             CompatFile::New(open_file) => open_file.inner_file().borrow().status(),
             CompatFile::Legacy(legacy_file_counter) => legacy_file_counter.status(),
+        }
+    }
+
+    pub fn mode(&self) -> FileMode {
+        match self {
+            CompatFile::New(open_file) => open_file.inner_file().borrow().mode(),
+            CompatFile::Legacy(legacy_file_counter) => legacy_file_counter.mode(),
         }
     }
 }

--- a/src/main/host/descriptor/pipe.rs
+++ b/src/main/host/descriptor/pipe.rs
@@ -188,10 +188,11 @@ impl Pipe {
             return Err(linux_api::errno::Errno::EPIPE.into());
         }
 
-        if self.write_mode == WriteMode::Packet && !self.status.contains(FileStatus::DIRECT) {
+        if self.write_mode == WriteMode::Packet && !self.status.contains(FileStatus::O_DIRECT) {
             // switch to stream mode immediately, regardless of whether the buffer is empty or not
             self.write_mode = WriteMode::Stream;
-        } else if self.write_mode == WriteMode::Stream && self.status.contains(FileStatus::DIRECT) {
+        } else if self.write_mode == WriteMode::Stream && self.status.contains(FileStatus::O_DIRECT)
+        {
             // in linux, it seems that pipes only switch to packet mode when a new page is added to
             // the buffer, so we simulate that behaviour for when the first page is added (when the
             // buffer is empty)

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -972,6 +972,9 @@ int regularfile_fcntl(RegularFile* file, unsigned long command, void* arg) {
         utility_panic("F_SETFD operates on file descriptor, not file description."
                       " should have been handled in fcntl.rs handler");
     }
+    if (command == F_SETFL || command == F_GETFL) {
+        utility_panic("F_SETFL and F_GETFL should have been handled in fcntl.rs handler");
+    }
 
     int result = fcntl(_regularfile_getOSBackedFD(file), command, arg);
 

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -58,8 +58,6 @@ struct _RegularFile {
             int fd;
             /* The flags used when opening the file; Not the file's current flags. */
             int flagsAtOpen;
-            /* The permission mode the file was opened with. */
-            mode_t modeAtOpen;
             /* The path of the file when it was opened. */
             char* absPathAtOpen;
         } osfile;
@@ -70,8 +68,6 @@ struct _RegularFile {
             char* content;
             /* The flags used when opening the file; Not the file's current flags. */
             int flagsAtOpen;
-            /* The permission mode the file was opened with. */
-            mode_t modeAtOpen;
             /* Callback to (re)-generate contents. */
             _generateInMemoryFileContentCbType generate_contents_cb;
             /* Whether contents should be re-generated on an lseek operation.
@@ -93,15 +89,6 @@ int regularfile_getFlagsAtOpen(RegularFile* file) {
         return file->osfile.flagsAtOpen;
     } else {
         return file->inMemoryFile.flagsAtOpen;
-    }
-}
-
-mode_t regularfile_getModeAtOpen(RegularFile* file) {
-    MAGIC_ASSERT(file);
-    if (file->type != FILE_TYPE_IN_MEMORY) {
-        return file->osfile.modeAtOpen;
-    } else {
-        return file->inMemoryFile.modeAtOpen;
     }
 }
 
@@ -279,7 +266,6 @@ int _regularfile_initRoInMemoryFile(RegularFile* file, int flags, mode_t mode,
     file->inMemoryFile.contentLen = contentLen;
     file->inMemoryFile.content = content;
     file->inMemoryFile.flagsAtOpen = flags;
-    file->inMemoryFile.modeAtOpen = mode;
     file->inMemoryFile.generate_contents_cb = generate_contents_cb;
     file->inMemoryFile.regen_after_lseek = regen_after_lseek;
 
@@ -439,7 +425,6 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
     file->osfile.fd = osfd;
     file->osfile.absPathAtOpen = abspath;
     file->osfile.flagsAtOpen = flags;
-    file->osfile.modeAtOpen = mode;
 
     trace("RegularFile %p opened os-backed file %i at absolute path %s", file,
           _regularfile_getOSBackedFD(file), file->osfile.absPathAtOpen);

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -24,6 +24,7 @@
 #include <syscall.h>
 #include <unistd.h>
 
+#include "descriptor.h"
 #include "lib/logger/logger.h"
 #include "main/core/worker.h"
 #include "main/host/descriptor/descriptor.h"
@@ -47,8 +48,8 @@ struct _RegularFile {
     /* File is a sub-type of a descriptor. */
     LegacyFile super;
     FileType type;
-    /* "access" and "status" oflags */
-    int accessAndStatusFlags;
+    /* "status" oflags, as documented in open(2) */
+    int statusFlags;
     /* Info related to our OS-backed file. */
     union {
         struct {
@@ -104,7 +105,7 @@ static inline bool _fd_isValid(int fd) { return fd >= 0; }
 
 int regularfile_getOSBackedFD(RegularFile* file) { return _regularfile_getOSBackedFD(file); }
 
-// Used internally to set accessAndStatusFlags based on the flags actually
+// Used internally to set statusFlags based on the flags actually
 // set on the native file descriptor.
 static void _regularfile_try_update_flags_from_os(RegularFile* file) {
     MAGIC_ASSERT(file);
@@ -123,12 +124,13 @@ static void _regularfile_try_update_flags_from_os(RegularFile* file) {
         return;
     }
 
-    // fcntl(2) *says* that F_GETFL returns only the access and status flags,
-    // but experimentally some "creation" flags are returned as well.
-    // (e.g. O_DIRECTORY, O_NOFOLLOW).
-    rv &= linux_access_mode_oflags() | linux_file_status_oflags();
-
-    file->accessAndStatusFlags = rv;
+    // fcntl(2) *says* that F_GETFL returns only the access and status flags;
+    // we only want the status flags here.
+    //
+    // Experimentally F_GETFL returns some "creation" flags as well, including
+    // O_NOFOLLOW, which seems to be undocumented, at least in the libc man
+    // pages).
+    file->statusFlags = rv & linux_file_status_oflags();
 }
 
 static void _regularfile_closeHelper(RegularFile* file) {
@@ -267,7 +269,7 @@ int _regularfile_initRoInMemoryFile(RegularFile* file, int flags, mode_t mode,
     utility_alwaysAssert(content != NULL);
 
     file->type = FILE_TYPE_IN_MEMORY;
-    file->accessAndStatusFlags = flags & (linux_access_mode_oflags() | linux_file_status_oflags());
+    file->statusFlags = flags & linux_file_status_oflags();
     file->inMemoryFile.cursor = 0;
     file->inMemoryFile.cursor = 0;
     file->inMemoryFile.contentLen = contentLen;
@@ -309,6 +311,10 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
 
     trace("Attempting to open file with pathname=%s flags=%i mode=%i workingdir=%s", pathname,
           flags, (int)mode, workingDir);
+
+    legacyfile_setAccessAndCreationFlags(
+        &file->super, flags & (linux_access_mode_oflags() | linux_file_creation_oflags()));
+
 #ifdef DEBUG
     if (flags) {
         _regularfile_print_flags(flags);
@@ -324,7 +330,7 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
     /* initialize to the requested access and status, though in some cases this gets overwritten
      * later.
      */
-    file->accessAndStatusFlags = flags & (linux_access_mode_oflags() | linux_file_status_oflags());
+    file->statusFlags = flags & linux_file_status_oflags();
 
     /* Handle special files. */
     if (utility_isRandomPath(abspath)) {
@@ -1554,11 +1560,11 @@ int regularfile_statx(RegularFile* dir, const char* pathname, int flags, unsigne
 }
 #endif
 
-void regularfile_set_flags(RegularFile* file, int flags) {
+void regularfile_set_status_flags(RegularFile* file, int flags) {
     MAGIC_ASSERT(file);
 
-    int mask = linux_access_mode_oflags() | linux_file_status_oflags();
-    file->accessAndStatusFlags = flags & mask;
+    int mask = linux_file_status_oflags();
+    file->statusFlags = flags & mask;
 
     int native_fd = _regularfile_getOSBackedFD(file);
     if (_fd_isValid(native_fd)) {
@@ -1574,27 +1580,27 @@ void regularfile_set_flags(RegularFile* file, int flags) {
     }
 }
 
-static void _regularfile_set_flags(LegacyFile* descriptor, int flags) {
+static void _regularfile_set_status_flags(LegacyFile* descriptor, int flags) {
     RegularFile* file = _regularfile_legacyFileToRegularFile(descriptor);
-    regularfile_set_flags(file, flags);
+    regularfile_set_status_flags(file, flags);
 }
 
-int regularfile_get_flags(RegularFile* file) {
+int regularfile_get_status_flags(RegularFile* file) {
     MAGIC_ASSERT(file);
-    return file->accessAndStatusFlags;
+    return file->statusFlags;
 }
 
-static int _regularfile_get_flags(LegacyFile* descriptor) {
+static int _regularfile_get_status_flags(LegacyFile* descriptor) {
     RegularFile* file = _regularfile_legacyFileToRegularFile(descriptor);
-    return regularfile_get_flags(file);
+    return regularfile_get_status_flags(file);
 }
 
 static LegacyFileFunctionTable _fileFunctions = (LegacyFileFunctionTable){
     .close = _regularfile_close,
     .fstat = _regularfile_fstat,
     .lseek = _regularfile_lseek,
-    .get_flags = _regularfile_get_flags,
-    .set_flags = _regularfile_set_flags,
+    .get_status_flags = _regularfile_get_status_flags,
+    .set_status_flags = _regularfile_set_status_flags,
     .cleanup = NULL,
     .free = _regularfile_free,
 };

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -82,6 +82,11 @@ FileType regularfile_getType(RegularFile* file) {
     return file->type;
 }
 
+LegacyFile* regularfile_getLegacyFile(RegularFile* file) {
+    MAGIC_ASSERT(file);
+    return &file->super;
+}
+
 static inline RegularFile* _regularfile_legacyFileToRegularFile(LegacyFile* desc) {
     utility_debugAssert(legacyfile_getType(desc) == DT_FILE);
     RegularFile* file = (RegularFile*)desc;

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -962,29 +962,12 @@ int regularfile_fcntl(RegularFile* file, unsigned long command, void* arg) {
         return -EBADF;
     }
 
-    if (command == F_SETFD) {
-        intptr_t arg_int = (intptr_t)arg;
-        // if the arg contains FD_CLOEXEC
-        if (arg_int & FD_CLOEXEC) {
-            file->shadowFlags |= O_CLOEXEC;
-        } else {
-            file->shadowFlags &= ~O_CLOEXEC;
-        }
-        // shadow always sets FD_CLOEXEC on the os-backed fd
-        arg_int |= FD_CLOEXEC;
-        arg = (void*)arg_int;
+    if (command == F_SETFD || command == F_GETFD) {
+        utility_panic("F_SETFD operates on file descriptor, not file description."
+                      " should have been handled in fcntl.rs handler");
     }
 
     int result = fcntl(_regularfile_getOSBackedFD(file), command, arg);
-
-    if (result >= 0 && command == F_GETFD) {
-        // if the file should have FD_CLOEXEC
-        if (file->shadowFlags & O_CLOEXEC) {
-            result |= FD_CLOEXEC;
-        } else {
-            result &= ~FD_CLOEXEC;
-        }
-    }
 
     return (result < 0) ? -errno : result;
 }

--- a/src/main/host/descriptor/regular_file.c
+++ b/src/main/host/descriptor/regular_file.c
@@ -33,8 +33,6 @@
 
 #define OSFILE_INVALID -1
 
-const int SHADOW_FLAG_MASK = O_CLOEXEC;
-
 /* Callback to (re)-generate contents of a `FILE_TYPE_IN_MEMORY` file.
  *
  * Should set `contents` to a malloc'd pointer containing the new contents, and
@@ -49,15 +47,12 @@ struct _RegularFile {
     /* File is a sub-type of a descriptor. */
     LegacyFile super;
     FileType type;
-    /* O file flags that we don't pass to the native fd, but instead track within
-     * Shadow and handle manually. A subset of SHADOW_FLAG_MASK. */
-    int shadowFlags;
+    /* "access" and "status" oflags */
+    int accessAndStatusFlags;
     /* Info related to our OS-backed file. */
     union {
         struct {
             int fd;
-            /* The flags used when opening the file; Not the file's current flags. */
-            int flagsAtOpen;
             /* The path of the file when it was opened. */
             char* absPathAtOpen;
         } osfile;
@@ -66,8 +61,6 @@ struct _RegularFile {
             off_t cursor;
             ssize_t contentLen;
             char* content;
-            /* The flags used when opening the file; Not the file's current flags. */
-            int flagsAtOpen;
             /* Callback to (re)-generate contents. */
             _generateInMemoryFileContentCbType generate_contents_cb;
             /* Whether contents should be re-generated on an lseek operation.
@@ -82,20 +75,6 @@ struct _RegularFile {
     };
     MAGIC_DECLARE;
 };
-
-int regularfile_getFlagsAtOpen(RegularFile* file) {
-    MAGIC_ASSERT(file);
-    if (file->type != FILE_TYPE_IN_MEMORY) {
-        return file->osfile.flagsAtOpen;
-    } else {
-        return file->inMemoryFile.flagsAtOpen;
-    }
-}
-
-int regularfile_getShadowFlags(RegularFile* file) {
-    MAGIC_ASSERT(file);
-    return file->shadowFlags;
-}
 
 FileType regularfile_getType(RegularFile* file) {
     MAGIC_ASSERT(file);
@@ -124,6 +103,33 @@ static inline int _regularfile_getOSBackedFD(RegularFile* file) {
 static inline bool _fd_isValid(int fd) { return fd >= 0; }
 
 int regularfile_getOSBackedFD(RegularFile* file) { return _regularfile_getOSBackedFD(file); }
+
+// Used internally to set accessAndStatusFlags based on the flags actually
+// set on the native file descriptor.
+static void _regularfile_try_update_flags_from_os(RegularFile* file) {
+    MAGIC_ASSERT(file);
+
+    int native_fd = _regularfile_getOSBackedFD(file);
+    if (!_fd_isValid(native_fd)) {
+        // Nothing to do.
+        debug("No native fd to update flags from");
+        return;
+    }
+
+    // Update our emulated flags to match what actually got set.
+    int rv = fcntl(native_fd, F_GETFL, 0);
+    if (rv == -1) {
+        warning("Couldn't get native flags for fd %d: %s", native_fd, strerror(errno));
+        return;
+    }
+
+    // fcntl(2) *says* that F_GETFL returns only the access and status flags,
+    // but experimentally some "creation" flags are returned as well.
+    // (e.g. O_DIRECTORY, O_NOFOLLOW).
+    rv &= linux_access_mode_oflags() | linux_file_status_oflags();
+
+    file->accessAndStatusFlags = rv;
+}
 
 static void _regularfile_closeHelper(RegularFile* file) {
     if(file && file->type != FILE_TYPE_IN_MEMORY) {
@@ -261,11 +267,11 @@ int _regularfile_initRoInMemoryFile(RegularFile* file, int flags, mode_t mode,
     utility_alwaysAssert(content != NULL);
 
     file->type = FILE_TYPE_IN_MEMORY;
+    file->accessAndStatusFlags = flags & (linux_access_mode_oflags() | linux_file_status_oflags());
     file->inMemoryFile.cursor = 0;
     file->inMemoryFile.cursor = 0;
     file->inMemoryFile.contentLen = contentLen;
     file->inMemoryFile.content = content;
-    file->inMemoryFile.flagsAtOpen = flags;
     file->inMemoryFile.generate_contents_cb = generate_contents_cb;
     file->inMemoryFile.regen_after_lseek = regen_after_lseek;
 
@@ -314,6 +320,11 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
     char* abspath = _regularfile_getAbsolutePath(dir, pathname, workingDir);
 
     const char* proc_prefix = "/proc/";
+
+    /* initialize to the requested access and status, though in some cases this gets overwritten
+     * later.
+     */
+    file->accessAndStatusFlags = flags & (linux_access_mode_oflags() | linux_file_status_oflags());
 
     /* Handle special files. */
     if (utility_isRandomPath(abspath)) {
@@ -391,24 +402,16 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
         file->type = FILE_TYPE_REGULAR;
     }
 
-    // store original flags in superclass, LegacyDescriptor.
-    // (Primarily so that rust code operating on a LegacyDescriptor
-    // can work out whether the file is readable and/or writable).
-    // TODO: track updates to status flags. Tentatively fixed in pending
-    // <https://github.com/shadow/shadow/pull/3782>.
-    legacyfile_setFlags(&file->super, flags);
-
-    // move any flags that shadow handles from 'flags' to 'shadowFlags'
-    file->shadowFlags = flags & SHADOW_FLAG_MASK;
-    flags &= ~SHADOW_FLAG_MASK;
+    // start from the emulated oflags
+    int native_oflags = flags;
 
     // we should always use O_CLOEXEC for files opened in shadow
-    flags |= O_CLOEXEC;
+    native_oflags |= O_CLOEXEC;
 
     // TODO: we should open the os-backed file in non-blocking mode even if a
     // non-block is not requested, and then properly handle the io by, e.g.,
     // epolling on all such files with a shadow support thread.
-    int osfd = open(abspath, flags, mode);
+    int osfd = open(abspath, native_oflags, mode);
     int errcode = errno;
 
     if (osfd < 0) {
@@ -423,8 +426,11 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
 
     /* Store the create information, which is used if we mmap the file later. */
     file->osfile.fd = osfd;
+    /* TODO: do we still need this? mmap uses a /proc path instead. */
     file->osfile.absPathAtOpen = abspath;
-    file->osfile.flagsAtOpen = flags;
+
+    /* fetch the actual access and status flags that got set. */
+    _regularfile_try_update_flags_from_os(file);
 
     trace("RegularFile %p opened os-backed file %i at absolute path %s", file,
           _regularfile_getOSBackedFD(file), file->osfile.absPathAtOpen);
@@ -1545,10 +1551,47 @@ int regularfile_statx(RegularFile* dir, const char* pathname, int flags, unsigne
 }
 #endif
 
+void regularfile_set_flags(RegularFile* file, int flags) {
+    MAGIC_ASSERT(file);
+
+    int mask = linux_access_mode_oflags() | linux_file_status_oflags();
+    file->accessAndStatusFlags = flags & mask;
+
+    int native_fd = _regularfile_getOSBackedFD(file);
+    if (_fd_isValid(native_fd)) {
+        // Update the native descriptor to match.
+        int rv = fcntl(native_fd, F_SETFL, flags);
+        if (rv == -1) {
+            warning("Couldn't update native flags for fd %d to 0x%x: %s", native_fd, flags,
+                    strerror(errno));
+            return;
+        }
+        // Update our emulated flags to match what actually got set.
+        _regularfile_try_update_flags_from_os(file);
+    }
+}
+
+static void _regularfile_set_flags(LegacyFile* descriptor, int flags) {
+    RegularFile* file = _regularfile_legacyFileToRegularFile(descriptor);
+    regularfile_set_flags(file, flags);
+}
+
+int regularfile_get_flags(RegularFile* file) {
+    MAGIC_ASSERT(file);
+    return file->accessAndStatusFlags;
+}
+
+static int _regularfile_get_flags(LegacyFile* descriptor) {
+    RegularFile* file = _regularfile_legacyFileToRegularFile(descriptor);
+    return regularfile_get_flags(file);
+}
+
 static LegacyFileFunctionTable _fileFunctions = (LegacyFileFunctionTable){
     .close = _regularfile_close,
     .fstat = _regularfile_fstat,
     .lseek = _regularfile_lseek,
+    .get_flags = _regularfile_get_flags,
+    .set_flags = _regularfile_set_flags,
     .cleanup = NULL,
     .free = _regularfile_free,
 };

--- a/src/main/host/descriptor/regular_file.h
+++ b/src/main/host/descriptor/regular_file.h
@@ -67,9 +67,6 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
 /* Returns the flags that were used when opening the file. */
 int regularfile_getFlagsAtOpen(RegularFile* file);
 
-/* Returns the mode that was used when opening the file. */
-mode_t regularfile_getModeAtOpen(RegularFile* file);
-
 /* Get the file flags that shadow handles manually, but not the flags on the
  * linux-backed file. Will be a subset of SHADOW_FLAG_MASK. */
 int regularfile_getShadowFlags(RegularFile* file);

--- a/src/main/host/descriptor/regular_file.h
+++ b/src/main/host/descriptor/regular_file.h
@@ -20,10 +20,6 @@
 #include "main/core/definitions.h"
 #include "main/host/syscall/kernel_types.h"
 
-/* Mask of all O file flags that we don't pass to the native fd, but instead
- * track within Shadow and handle manually. */
-extern const int SHADOW_FLAG_MASK;
-
 /* Opaque type representing a file-backed file descriptor. */
 typedef struct _RegularFile RegularFile;
 
@@ -63,13 +59,6 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
 // ************************
 // Accessors
 // ************************
-
-/* Returns the flags that were used when opening the file. */
-int regularfile_getFlagsAtOpen(RegularFile* file);
-
-/* Get the file flags that shadow handles manually, but not the flags on the
- * linux-backed file. Will be a subset of SHADOW_FLAG_MASK. */
-int regularfile_getShadowFlags(RegularFile* file);
 
 /* Get the type of file. */
 FileType regularfile_getType(RegularFile* file);
@@ -119,6 +108,8 @@ int regularfile_getdents64(RegularFile* file, struct linux_dirent64* dirp, unsig
 int regularfile_ioctl(RegularFile* file, unsigned long request, void* arg);
 int regularfile_fcntl(RegularFile* file, unsigned long command, void* arg);
 int regularfile_poll(RegularFile* file, struct pollfd* pfd);
+int regularfile_get_flags(RegularFile* file);
+void regularfile_set_flags(RegularFile* file, int flags);
 
 // ******************************************
 // Operations where the dir RegularFile* may be null

--- a/src/main/host/descriptor/regular_file.h
+++ b/src/main/host/descriptor/regular_file.h
@@ -18,6 +18,7 @@
 
 #include "lib/linux-api/linux-api.h"
 #include "main/core/definitions.h"
+#include "main/host/descriptor/descriptor_types.h"
 #include "main/host/syscall/kernel_types.h"
 
 /* Opaque type representing a file-backed file descriptor. */
@@ -62,6 +63,9 @@ int regularfile_openat(RegularFile* file, RegularFile* dir, const char* pathname
 
 /* Get the type of file. */
 FileType regularfile_getType(RegularFile* file);
+
+/* Get a "superclass" pointer to the LegacyFile */
+LegacyFile* regularfile_getLegacyFile(RegularFile* file);
 
 /* Returns the linux-backed fd that shadow uses to perform the file operations.  */
 int regularfile_getOSBackedFD(RegularFile* file);

--- a/src/main/host/descriptor/regular_file.h
+++ b/src/main/host/descriptor/regular_file.h
@@ -108,8 +108,8 @@ int regularfile_getdents64(RegularFile* file, struct linux_dirent64* dirp, unsig
 int regularfile_ioctl(RegularFile* file, unsigned long request, void* arg);
 int regularfile_fcntl(RegularFile* file, unsigned long command, void* arg);
 int regularfile_poll(RegularFile* file, struct pollfd* pfd);
-int regularfile_get_flags(RegularFile* file);
-void regularfile_set_flags(RegularFile* file, int flags);
+int regularfile_get_status_flags(RegularFile* file);
+void regularfile_set_status_flags(RegularFile* file, int flags);
 
 // ******************************************
 // Operations where the dir RegularFile* may be null

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -94,7 +94,30 @@ gssize legacysocket_receiveUserData(LegacySocket* socket, const Thread* thread,
     return socket->vtable->receive(socket, thread, buffer, nBytes, ip, port);
 }
 
+void legacysocket_set_flags(LegacySocket* socket, int flags) {
+    MAGIC_ASSERT(socket);
+    socket->accessAndStatusFlags =
+        flags & (linux_access_mode_oflags() | linux_file_status_oflags());
+}
+
+static void _legacysocket_set_flags(LegacyFile* descriptor, int flags) {
+    LegacySocket* socket = _legacysocket_fromLegacyFile(descriptor);
+    legacysocket_set_flags(socket, flags);
+}
+
+int legacysocket_get_flags(LegacySocket* socket) {
+    MAGIC_ASSERT(socket);
+    return socket->accessAndStatusFlags;
+}
+
+static int _legacysocket_get_flags(LegacyFile* descriptor) {
+    LegacySocket* socket = _legacysocket_fromLegacyFile(descriptor);
+    return legacysocket_get_flags(socket);
+}
+
 LegacyFileFunctionTable socket_functions = {.close = _legacysocket_close,
+                                            .get_flags = _legacysocket_get_flags,
+                                            .set_flags = _legacysocket_set_flags,
                                             .cleanup = _legacysocket_cleanup,
                                             .free = _legacysocket_free,
                                             MAGIC_INITIALIZER};

--- a/src/main/host/descriptor/socket.c
+++ b/src/main/host/descriptor/socket.c
@@ -94,30 +94,29 @@ gssize legacysocket_receiveUserData(LegacySocket* socket, const Thread* thread,
     return socket->vtable->receive(socket, thread, buffer, nBytes, ip, port);
 }
 
-void legacysocket_set_flags(LegacySocket* socket, int flags) {
+void legacysocket_set_status_flags(LegacySocket* socket, int flags) {
     MAGIC_ASSERT(socket);
-    socket->accessAndStatusFlags =
-        flags & (linux_access_mode_oflags() | linux_file_status_oflags());
+    socket->statusFlags = flags & linux_file_status_oflags();
 }
 
-static void _legacysocket_set_flags(LegacyFile* descriptor, int flags) {
+static void _legacysocket_set_status_flags(LegacyFile* descriptor, int flags) {
     LegacySocket* socket = _legacysocket_fromLegacyFile(descriptor);
-    legacysocket_set_flags(socket, flags);
+    legacysocket_set_status_flags(socket, flags);
 }
 
-int legacysocket_get_flags(LegacySocket* socket) {
+int legacysocket_get_status_flags(LegacySocket* socket) {
     MAGIC_ASSERT(socket);
-    return socket->accessAndStatusFlags;
+    return socket->statusFlags;
 }
 
-static int _legacysocket_get_flags(LegacyFile* descriptor) {
+static int _legacysocket_get_status_flags(LegacyFile* descriptor) {
     LegacySocket* socket = _legacysocket_fromLegacyFile(descriptor);
-    return legacysocket_get_flags(socket);
+    return legacysocket_get_status_flags(socket);
 }
 
 LegacyFileFunctionTable socket_functions = {.close = _legacysocket_close,
-                                            .get_flags = _legacysocket_get_flags,
-                                            .set_flags = _legacysocket_set_flags,
+                                            .get_status_flags = _legacysocket_get_status_flags,
+                                            .set_status_flags = _legacysocket_set_status_flags,
                                             .cleanup = _legacysocket_cleanup,
                                             .free = _legacysocket_free,
                                             MAGIC_INITIALIZER};

--- a/src/main/host/descriptor/socket.h
+++ b/src/main/host/descriptor/socket.h
@@ -57,8 +57,8 @@ struct _LegacySocket {
     SocketFunctionTable* vtable;
 
     enum SocketFlags flags;
-    /* access and status flags, as returned by fcntl F_GETFL */
-    int accessAndStatusFlags;
+    /* status flags, as documented in open(2) */
+    int statusFlags;
     ProtocolType protocol;
 
     in_addr_t peerIP;

--- a/src/main/host/descriptor/socket.h
+++ b/src/main/host/descriptor/socket.h
@@ -57,6 +57,8 @@ struct _LegacySocket {
     SocketFunctionTable* vtable;
 
     enum SocketFlags flags;
+    /* access and status flags, as returned by fcntl F_GETFL */
+    int accessAndStatusFlags;
     ProtocolType protocol;
 
     in_addr_t peerIP;

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -99,7 +99,7 @@ impl LegacyTcpSocket {
     }
 
     pub fn status(&self) -> FileStatus {
-        let o_flags = unsafe { c::legacyfile_getFlags(self.as_legacy_file()) };
+        let o_flags = unsafe { c::legacyfile_getFileStatusFlags(self.as_legacy_file()) };
         let o_flags =
             linux_api::fcntl::OFlag::from_bits(o_flags).expect("Not a valid OFlag: {o_flags:?}");
         let (status, extra_flags) = FileStatus::from_o_flags(o_flags);
@@ -112,7 +112,7 @@ impl LegacyTcpSocket {
 
     pub fn set_status(&mut self, status: FileStatus) {
         let o_flags = status.as_o_flags().bits();
-        unsafe { c::legacyfile_setFlags(self.as_legacy_file(), o_flags) };
+        unsafe { c::legacyfile_setFileStatusFlags(self.as_legacy_file(), o_flags) };
     }
 
     pub fn mode(&self) -> FileMode {

--- a/src/main/host/descriptor/socket/inet/legacy_tcp.rs
+++ b/src/main/host/descriptor/socket/inet/legacy_tcp.rs
@@ -359,7 +359,7 @@ impl LegacyTcpSocket {
             return Err(Errno::EINVAL.into());
         };
 
-        if socket_ref.status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::O_NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 
@@ -470,7 +470,7 @@ impl LegacyTcpSocket {
             return Err(Errno::EINVAL.into());
         };
 
-        if socket_ref.status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::O_NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 
@@ -853,7 +853,7 @@ impl LegacyTcpSocket {
             Ok(())
         };
 
-        if !socket_ref.status().contains(FileStatus::NONBLOCK) {
+        if !socket_ref.status().contains(FileStatus::O_NONBLOCK) {
             // this is a blocking connect call
             if errcode == Err(Errno::EINPROGRESS) {
                 // This is the first time we ever called connect, and so we need to wait for the

--- a/src/main/host/descriptor/socket/inet/tcp.rs
+++ b/src/main/host/descriptor/socket/inet/tcp.rs
@@ -413,7 +413,7 @@ impl TcpSocket {
             return Err(Errno::EINVAL.into());
         };
 
-        if socket_ref.status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::O_NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 
@@ -471,7 +471,7 @@ impl TcpSocket {
             return Err(Errno::EINVAL.into());
         };
 
-        if socket_ref.status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::O_NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 
@@ -719,7 +719,7 @@ impl TcpSocket {
         // return the result
         socket_ref.connect_result_is_pending = true;
 
-        if socket_ref.status.contains(FileStatus::NONBLOCK) {
+        if socket_ref.status.contains(FileStatus::O_NONBLOCK) {
             Err(Errno::EINPROGRESS.into())
         } else {
             let err = SyscallError::new_blocked_on_file(

--- a/src/main/host/descriptor/socket/inet/udp.rs
+++ b/src/main/host/descriptor/socket/inet/udp.rs
@@ -354,7 +354,7 @@ impl UdpSocket {
             },
         };
 
-        if socket_ref.status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::O_NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 
@@ -495,7 +495,7 @@ impl UdpSocket {
             return Err(Errno::EINVAL.into());
         };
 
-        if socket_ref.status().contains(FileStatus::NONBLOCK) {
+        if socket_ref.status().contains(FileStatus::O_NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 

--- a/src/main/host/descriptor/socket/netlink.rs
+++ b/src/main/host/descriptor/socket/netlink.rs
@@ -1142,7 +1142,7 @@ impl NetlinkSocketCommon {
             return Err(Errno::EINVAL.into());
         }
 
-        if self.status.contains(FileStatus::NONBLOCK) {
+        if self.status.contains(FileStatus::O_NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 
@@ -1218,7 +1218,7 @@ impl NetlinkSocketCommon {
             return Err(Errno::EINVAL.into());
         }
 
-        if self.status.contains(FileStatus::NONBLOCK) {
+        if self.status.contains(FileStatus::O_NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 

--- a/src/main/host/descriptor/socket/unix.rs
+++ b/src/main/host/descriptor/socket/unix.rs
@@ -1179,7 +1179,7 @@ impl Protocol for ConnOrientedInitial {
                 return (self.into(), Err(Errno::ECONNREFUSED.into()));
             }
             Err(IncomingConnError::QueueFull) => {
-                if common.status.contains(FileStatus::NONBLOCK) {
+                if common.status.contains(FileStatus::O_NONBLOCK) {
                     return (self.into(), Err(Errno::EWOULDBLOCK.into()));
                 }
 
@@ -2135,7 +2135,7 @@ impl UnixSocketCommon {
             return Err(Errno::EINVAL.into());
         }
 
-        if self.status.contains(FileStatus::NONBLOCK) {
+        if self.status.contains(FileStatus::O_NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 
@@ -2245,7 +2245,7 @@ impl UnixSocketCommon {
             return Err(Errno::EINVAL.into());
         }
 
-        if self.status.contains(FileStatus::NONBLOCK) {
+        if self.status.contains(FileStatus::O_NONBLOCK) {
             flags.insert(MsgFlags::MSG_DONTWAIT);
         }
 

--- a/src/main/host/syscall/handler/eventfd.rs
+++ b/src/main/host/syscall/handler/eventfd.rs
@@ -58,7 +58,7 @@ impl SyscallHandler {
         let mut semaphore_mode = false;
 
         if flags.contains(EfdFlags::EFD_NONBLOCK) {
-            file_flags.insert(FileStatus::NONBLOCK);
+            file_flags.insert(FileStatus::O_NONBLOCK);
         }
 
         if flags.contains(EfdFlags::EFD_CLOEXEC) {

--- a/src/main/host/syscall/handler/fcntl.c
+++ b/src/main/host/syscall/handler/fcntl.c
@@ -193,14 +193,6 @@ SyscallReturn syscallhandler_fcntl(SyscallHandler* sys, const SyscallArgs* args)
     } else {
         /* TODO: add additional support for important operations. */
         switch (command) {
-            case F_GETFL: {
-                result = legacyfile_getFlags(desc);
-                break;
-            }
-            case F_SETFL: {
-                legacyfile_setFlags(desc, argReg.as_i64);
-                break;
-            }
             default: {
                 warning("We do not support fcntl command %lu on descriptor %i",
                         command, fd);

--- a/src/main/host/syscall/handler/fcntl.rs
+++ b/src/main/host/syscall/handler/fcntl.rs
@@ -236,32 +236,15 @@ impl SyscallHandler {
                 };
             }
             FcntlCommand::F_GETFL => {
-                let file = match desc.file() {
-                    CompatFile::New(d) => d,
-                    // if it's a legacy file, use the C syscall handler instead
-                    CompatFile::Legacy(_) => {
-                        drop(desc_table);
-                        return legacy_syscall_fn(ctx);
-                    }
-                };
-
-                let file = file.inner_file().borrow();
+                let file = desc.file();
                 // combine the file status and access mode flags
                 let flags = file.status().as_o_flags() | file.mode().as_o_flags();
                 flags.bits().into()
             }
             FcntlCommand::F_SETFL => {
-                let file = match desc.file() {
-                    CompatFile::New(d) => d,
-                    // if it's a legacy file, use the C syscall handler instead
-                    CompatFile::Legacy(_) => {
-                        drop(desc_table);
-                        return legacy_syscall_fn(ctx);
-                    }
-                };
-
                 let status = i32::try_from(arg).or(Err(Errno::EINVAL))?;
                 let mut status = OFlag::from_bits(status).ok_or(Errno::EINVAL)?;
+
                 // remove access mode flags
                 status.remove(OFlag::O_RDONLY | OFlag::O_WRONLY | OFlag::O_RDWR | OFlag::O_PATH);
                 // remove file creation flags
@@ -276,8 +259,7 @@ impl SyscallHandler {
                         | OFlag::O_TRUNC,
                 );
 
-                let mut file = file.inner_file().borrow_mut();
-                let old_flags = file.status().as_o_flags();
+                let old_flags = desc.file().status().as_o_flags();
 
                 // fcntl(2): "On Linux, this command can change only the O_APPEND, O_ASYNC, O_DIRECT,
                 // O_NOATIME, and O_NONBLOCK flags"
@@ -310,7 +292,7 @@ impl SyscallHandler {
                     return Err(Errno::EINVAL.into());
                 }
 
-                file.set_status(status);
+                desc.file().set_status(status);
                 0
             }
             FcntlCommand::F_GETFD => desc.flags().bits().into(),

--- a/src/main/host/syscall/handler/ioctl.rs
+++ b/src/main/host/syscall/handler/ioctl.rs
@@ -76,7 +76,7 @@ impl SyscallHandler {
             let arg = ctx.objs.process.memory_borrow_mut().read(arg_ptr)?;
 
             let mut status = file.status();
-            status.set(FileStatus::NONBLOCK, arg != 0);
+            status.set(FileStatus::O_NONBLOCK, arg != 0);
             file.set_status(status);
 
             return Ok(0.into());

--- a/src/main/host/syscall/handler/mman.rs
+++ b/src/main/host/syscall/handler/mman.rs
@@ -379,7 +379,8 @@ impl SyscallHandler {
         // /proc/<shadow-pid>/fd/<linux-fd> file, which is a symbolic link
         flags -= OFlag::O_NOFOLLOW;
 
-        let mode = unsafe { c::regularfile_getModeAtOpen(file) };
+        // Mode argument to 'open' is a no-op, since we're not creating a file.
+        let mode = 0i32;
 
         // instruct the plugin to open the file at the path we sent
         let (process_ctx, thread) = ctx.split_thread();
@@ -387,7 +388,7 @@ impl SyscallHandler {
             &process_ctx,
             plugin_buffer.ptr().ptr(),
             flags.bits() as i32,
-            mode as i32,
+            mode,
         );
 
         plugin_buffer.free(ctx);

--- a/src/main/host/syscall/handler/mman.rs
+++ b/src/main/host/syscall/handler/mman.rs
@@ -352,7 +352,11 @@ impl SyscallHandler {
         // get the access and status oflags (not creation flags).
         // unclear whether the status flags are actually needed, but they may effect
         // performance (e.g. O_DIRECT).
-        let oflags = OFlag::from_bits_retain(unsafe { c::regularfile_get_flags(file) });
+        let oflags = {
+            let raw_status = unsafe { c::regularfile_get_status_flags(file) };
+            let raw_access = unsafe { c::legacyfile_getAccessModeFlags(file.cast()) };
+            OFlag::from_bits_truncate(raw_status | raw_access)
+        };
         assert_eq!(oflags.file_creation_flags(), FileCreationOFlag::empty());
 
         // Mode argument to 'open' is a no-op, since we're not creating a file.

--- a/src/main/host/syscall/handler/mman.rs
+++ b/src/main/host/syscall/handler/mman.rs
@@ -354,7 +354,8 @@ impl SyscallHandler {
         // performance (e.g. O_DIRECT).
         let oflags = {
             let raw_status = unsafe { c::regularfile_get_status_flags(file) };
-            let raw_access = unsafe { c::legacyfile_getAccessModeFlags(file.cast()) };
+            let lf = unsafe { c::regularfile_getLegacyFile(file) };
+            let raw_access = unsafe { c::legacyfile_getAccessModeFlags(lf) };
             OFlag::from_bits_truncate(raw_status | raw_access)
         };
         assert_eq!(oflags.file_creation_flags(), FileCreationOFlag::empty());

--- a/src/main/host/syscall/handler/mman.rs
+++ b/src/main/host/syscall/handler/mman.rs
@@ -2,7 +2,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 
 use linux_api::errno::Errno;
-use linux_api::fcntl::OFlag;
+use linux_api::fcntl::{FileCreationOFlag, OFlag};
 use linux_api::mman::{MapFlags, ProtFlags};
 use shadow_shim_helper_rs::syscall_types::ForeignPtr;
 
@@ -347,49 +347,21 @@ impl SyscallHandler {
         }
 
         // attempt to open the file in the plugin with the same flags as what the shadow RegularFile
-        // object has
+        // object has.
 
-        // from man 2 open
-        let creation_flags = OFlag::empty()
-            | OFlag::O_CLOEXEC
-            | OFlag::O_CREAT
-            | OFlag::O_DIRECTORY
-            | OFlag::O_EXCL
-            | OFlag::O_NOCTTY
-            | OFlag::O_NOFOLLOW
-            | OFlag::O_TMPFILE
-            | OFlag::O_TRUNC;
-
-        // the flags linux is using
-        let native_flags = OFlag::from_bits_retain(unsafe {
-            libc::fcntl(c::regularfile_getOSBackedFD(file), libc::F_GETFL)
-        });
-
-        // get original flags that were used to open the file
-        let mut flags = OFlag::from_bits_retain(unsafe { c::regularfile_getFlagsAtOpen(file) });
-        // use only the file creation flags, except O_CLOEXEC
-        flags &= creation_flags.difference(OFlag::O_CLOEXEC);
-        // add any file access mode and file status flags that shadow doesn't implement
-        flags |= native_flags.difference(OFlag::from_bits_retain(unsafe { c::SHADOW_FLAG_MASK }));
-        // add any flags that shadow implements
-        flags |= OFlag::from_bits_retain(unsafe { c::regularfile_getShadowFlags(file) });
-        // be careful not to try re-creating or truncating it
-        flags -= OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_TMPFILE | OFlag::O_TRUNC;
-        // don't use O_NOFOLLOW since it will prevent the plugin from opening the
-        // /proc/<shadow-pid>/fd/<linux-fd> file, which is a symbolic link
-        flags -= OFlag::O_NOFOLLOW;
+        // get the access and status oflags (not creation flags).
+        // unclear whether the status flags are actually needed, but they may effect
+        // performance (e.g. O_DIRECT).
+        let oflags = OFlag::from_bits_retain(unsafe { c::regularfile_get_flags(file) });
+        assert_eq!(oflags.file_creation_flags(), FileCreationOFlag::empty());
 
         // Mode argument to 'open' is a no-op, since we're not creating a file.
         let mode = 0i32;
 
         // instruct the plugin to open the file at the path we sent
         let (process_ctx, thread) = ctx.split_thread();
-        let open_result = thread.native_open(
-            &process_ctx,
-            plugin_buffer.ptr().ptr(),
-            flags.bits() as i32,
-            mode,
-        );
+        let open_result =
+            thread.native_open(&process_ctx, plugin_buffer.ptr().ptr(), oflags.bits(), mode);
 
         plugin_buffer.free(ctx);
 

--- a/src/main/host/syscall/handler/socket.rs
+++ b/src/main/host/syscall/handler/socket.rs
@@ -46,7 +46,7 @@ impl SyscallHandler {
         let mut descriptor_flags = DescriptorFlags::empty();
 
         if flags & libc::SOCK_NONBLOCK != 0 {
-            file_flags.insert(FileStatus::NONBLOCK);
+            file_flags.insert(FileStatus::O_NONBLOCK);
         }
 
         if flags & libc::SOCK_CLOEXEC != 0 {
@@ -765,7 +765,7 @@ impl SyscallHandler {
 
         // if the syscall would block and it's a blocking descriptor
         if result.as_ref().err() == Some(&Errno::EWOULDBLOCK.into())
-            && !file_status.contains(FileStatus::NONBLOCK)
+            && !file_status.contains(FileStatus::O_NONBLOCK)
         {
             return Err(SyscallError::new_blocked_on_file(
                 file.clone(),
@@ -796,7 +796,7 @@ impl SyscallHandler {
             new_socket
                 .inner_file()
                 .borrow_mut()
-                .set_status(FileStatus::NONBLOCK);
+                .set_status(FileStatus::O_NONBLOCK);
         }
 
         let mut new_desc = Descriptor::new(CompatFile::New(new_socket));
@@ -951,7 +951,7 @@ impl SyscallHandler {
         let mut descriptor_flags = DescriptorFlags::empty();
 
         if flags & libc::SOCK_NONBLOCK != 0 {
-            file_flags.insert(FileStatus::NONBLOCK);
+            file_flags.insert(FileStatus::O_NONBLOCK);
         }
 
         if flags & libc::SOCK_CLOEXEC != 0 {

--- a/src/main/host/syscall/handler/timerfd.rs
+++ b/src/main/host/syscall/handler/timerfd.rs
@@ -49,7 +49,7 @@ impl SyscallHandler {
         let mut desc_flags = DescriptorFlags::empty();
 
         if flags.contains(TimerFlags::TFD_NONBLOCK) {
-            file_flags.insert(FileStatus::NONBLOCK);
+            file_flags.insert(FileStatus::O_NONBLOCK);
         }
 
         if flags.contains(TimerFlags::TFD_CLOEXEC) {

--- a/src/main/host/syscall/handler/uio.c
+++ b/src/main/host/syscall/handler/uio.c
@@ -189,7 +189,7 @@ static SyscallReturn _syscallhandler_readvHelper(SyscallHandler* sys, int fd,
 
     free(iov);
 
-    if (result == -EWOULDBLOCK && !(legacyfile_getFlags(desc) & O_NONBLOCK)) {
+    if (result == -EWOULDBLOCK && !(legacyfile_getFileStatusFlags(desc) & O_NONBLOCK)) {
         /* Blocking for file io will lock up the plugin because we don't
          * yet have a way to wait on file descriptors. */
         if (dType == DT_FILE) {
@@ -320,7 +320,7 @@ static SyscallReturn _syscallhandler_writevHelper(SyscallHandler* sys, int fd,
 
     free(iov);
 
-    if (result == -EWOULDBLOCK && !(legacyfile_getFlags(desc) & O_NONBLOCK)) {
+    if (result == -EWOULDBLOCK && !(legacyfile_getFileStatusFlags(desc) & O_NONBLOCK)) {
         /* Blocking for file io will lock up the plugin because we don't
          * yet have a way to wait on file descriptors. */
         if (dType == DT_FILE) {

--- a/src/main/host/syscall/handler/uio.rs
+++ b/src/main/host/syscall/handler/uio.rs
@@ -278,7 +278,8 @@ impl SyscallHandler {
             });
 
         // if the syscall would block and it's a blocking descriptor
-        if result == Err(Errno::EWOULDBLOCK.into()) && !file_status.contains(FileStatus::NONBLOCK) {
+        if result == Err(Errno::EWOULDBLOCK.into()) && !file_status.contains(FileStatus::O_NONBLOCK)
+        {
             // TODO: should we block on the READABLE, HUP, and RDHUP states?
             // https://github.com/shadow/shadow/issues/2181
             let wait_for = FileState::READABLE;
@@ -558,7 +559,8 @@ impl SyscallHandler {
             });
 
         // if the syscall would block and it's a blocking descriptor
-        if result == Err(Errno::EWOULDBLOCK.into()) && !file_status.contains(FileStatus::NONBLOCK) {
+        if result == Err(Errno::EWOULDBLOCK.into()) && !file_status.contains(FileStatus::O_NONBLOCK)
+        {
             // TODO: should we block on the WRITABLE and HUP states?
             // https://github.com/shadow/shadow/issues/2181
             let wait_for = FileState::WRITABLE;

--- a/src/main/host/syscall/handler/unistd.c
+++ b/src/main/host/syscall/handler/unistd.c
@@ -84,7 +84,7 @@ SyscallReturn _syscallhandler_readHelper(SyscallHandler* sys, int fd, UntypedFor
             break;
     }
 
-    if (result == -EWOULDBLOCK && !(legacyfile_getFlags(desc) & O_NONBLOCK)) {
+    if (result == -EWOULDBLOCK && !(legacyfile_getFileStatusFlags(desc) & O_NONBLOCK)) {
         /* Blocking for file io will lock up the plugin because we don't
          * yet have a way to wait on file descriptors. */
         if (dType == DT_FILE) {
@@ -165,7 +165,7 @@ SyscallReturn _syscallhandler_writeHelper(SyscallHandler* sys, int fd, UntypedFo
             break;
     }
 
-    if (result == -EWOULDBLOCK && !(legacyfile_getFlags(desc) & O_NONBLOCK)) {
+    if (result == -EWOULDBLOCK && !(legacyfile_getFileStatusFlags(desc) & O_NONBLOCK)) {
         /* Blocking for file io will lock up the plugin because we don't
          * yet have a way to wait on file descriptors. */
         if (dType == DT_FILE) {

--- a/src/main/host/syscall/handler/unistd.rs
+++ b/src/main/host/syscall/handler/unistd.rs
@@ -471,8 +471,8 @@ impl SyscallHandler {
 
         for flag in flags.iter() {
             match flag {
-                OFlag::O_NONBLOCK => file_flags.insert(FileStatus::NONBLOCK),
-                OFlag::O_DIRECT => file_flags.insert(FileStatus::DIRECT),
+                OFlag::O_NONBLOCK => file_flags.insert(FileStatus::O_NONBLOCK),
+                OFlag::O_DIRECT => file_flags.insert(FileStatus::O_DIRECT),
                 OFlag::O_CLOEXEC => descriptor_flags.insert(DescriptorFlags::FD_CLOEXEC),
                 x if x == OFlag::empty() => {
                     // The "empty" flag is always present. Ignore.


### PR DESCRIPTION
Split from #3774

This started as wanting to be able to get the access-mode of regular files from Rust in #3774, but pulling that thread ended up becoming a wider cleanup.

Broadly, this:

* adds linux-api support for handling open flags, particularly distinguishing between "access mode", "creation", and "file status" flags
* updates legacyfile and regularfile code to be more careful about these distinctions.
* expose related functionality in CompatFile
* updates the fcntl F_SETFL and F_GETFL handling, ultimately unifying it into the rust handler
