### PR TITLE
Attempt at improving the flaky epoll tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,8 +24,6 @@ jobs:
           - 'ubuntu:22.04'
           # End of standard support: June 2029 https://wiki.ubuntu.com/Releases
           - 'ubuntu:24.04'
-          # EOL ~June 2026 https://wiki.debian.org/LTS
-          - 'debian:11-slim'
           # EOL June 2028 https://wiki.debian.org/LTS
           - 'debian:12-slim'
           # EOL June 2030 https://wiki.debian.org/LTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes since v3.3.0:
 
 Documentation / policy updates:
 
-*
+* Ended support for Debian 11 (the LTS support ended 31 Aug 2026: https://endoflife.date/debian)
 
 MAJOR changes (breaking):
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@
 ## requests that we don't get new behaviors introduced since that lowest version.
 ##
 ## We use the oldest version provided in our supported platforms, which
-## is currently 3.18.4 on debian 11.
-cmake_minimum_required(VERSION 3.18.4...3.18.4 FATAL_ERROR)
+## is currently 3.22.1 on Ubuntu 22.04.
+cmake_minimum_required(VERSION 3.22.1...3.22.1 FATAL_ERROR)
 
 ## set build parameters
 project(Shadow)

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -5,7 +5,7 @@
 We support the following Linux x86-64 distributions:
 
 - Ubuntu 22.04, 24.04
-- Debian 11, 12, 13
+- Debian 12, 13
 - Fedora 42
 
 We do not provide official support for other platforms. This means that we do
@@ -25,8 +25,8 @@ distribution (the GA kernel). However,
 we are currently only able to regularly test on the latest Ubuntu kernel,
 since that's what GitHub Actions provides.
 
-By these criteria, Shadow's oldest supported kernel version is currently 5.10
-(the default kernel in Debian 11).
+By these criteria, Shadow's oldest supported kernel version is currently 5.15
+(the default kernel in Ubuntu 22.04).
 
 ## Docker
 

--- a/shadowtools/pyproject.toml
+++ b/shadowtools/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "shadowtools"
 version = "0.0.1"
 description = "Libraries and tools for use with the shadow network simulator"
-# Oldest python version on a supported platform (debian 11).
-requires-python = ">=3.9.2"
+# Oldest python version on a supported platform (Ubuntu 22.04).
+requires-python = ">=3.10"
 # Strings from https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 1 - Planning",

--- a/src/test/epoll/test_epoll.rs
+++ b/src/test/epoll/test_epoll.rs
@@ -7,43 +7,9 @@ use nix::unistd;
 
 use test_utils::{ShadowTest, TestEnvironment, ensure_ord, set};
 
-#[derive(Debug)]
-struct WaiterResult {
-    duration: Duration,
-    epoll_res: nix::Result<usize>,
-    events: Vec<epoll::EpollEvent>,
-}
+use crate::util::*;
 
-fn do_epoll_wait(epoll_fd: i32, timeout: Duration, do_read: bool) -> WaiterResult {
-    let mut events = Vec::new();
-    events.resize(10, epoll::EpollEvent::empty());
-
-    let t0 = std::time::Instant::now();
-
-    let res = epoll::epoll_wait(
-        epoll_fd,
-        &mut events,
-        timeout.as_millis().try_into().unwrap(),
-    );
-
-    let t1 = std::time::Instant::now();
-
-    events.resize(res.unwrap_or(0), epoll::EpollEvent::empty());
-
-    if do_read {
-        for ev in &events {
-            let fd = ev.data() as i32;
-            // we don't care if the read is successful or not (another thread may have already read)
-            let _ = unistd::read(fd, &mut [0]);
-        }
-    }
-
-    WaiterResult {
-        duration: t1.duration_since(t0),
-        epoll_res: res,
-        events,
-    }
-}
+mod util;
 
 fn test_threads_edge() -> anyhow::Result<()> {
     let (readfd, writefd) = unistd::pipe()?;
@@ -58,15 +24,17 @@ fn test_threads_edge() -> anyhow::Result<()> {
             Some(&mut event),
         )?;
 
-        let timeout = Duration::from_millis(100);
+        let (waiter1, block1) = init(epollfd, SHORT_DUR);
+        let (waiter2, block2) = init(epollfd, SHORT_DUR);
 
         let threads = [
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
+            std::thread::spawn(move || waiter1.wait()),
+            std::thread::spawn(move || waiter2.wait()),
         ];
 
         // Wait for readers to block.
-        std::thread::sleep(timeout / 2);
+        block1.wait();
+        block2.wait();
 
         // Make the read-end readable.
         unistd::write(writefd, &[0])?;
@@ -79,12 +47,12 @@ fn test_threads_edge() -> anyhow::Result<()> {
 
         // One thread should have timed out with no events received.
         ensure_ord!(results[0].epoll_res, ==, Ok(0));
-        ensure_ord!(results[0].duration, >=, timeout);
+        ensure_ord!(results[0].duration, >=, SHORT_DUR);
 
         // The other should have gotten a single event.
         ensure_ord!(results[1].epoll_res, ==, Ok(1));
-        ensure_ord!(results[1].duration, <, timeout);
-        ensure_ord!(results[1].events[0], ==, epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0));
+        ensure_ord!(results[1].duration, <, SHORT_DUR);
+        ensure_ord!(results[1].events[0], ==, readable_zero());
 
         Ok(())
     })
@@ -173,10 +141,12 @@ fn test_threads_eof(
         }
         unistd::close(writefd)?;
 
-        let timeout = Duration::from_millis(100);
+        let (waiter1, _block1) = init(epollfd, SHORT_DUR);
+        let (waiter2, _block2) = init(epollfd, SHORT_DUR);
+
         let threads = [
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
+            std::thread::spawn(move || waiter1.wait()),
+            std::thread::spawn(move || waiter2.wait()),
         ];
 
         let mut results = threads.map(|t| t.join().unwrap());
@@ -199,19 +169,19 @@ fn test_threads_eof(
             UseEPOLLET::No => {
                 // Both threads get the event
                 ensure_ord!(results[0].epoll_res, ==, Ok(1));
-                ensure_ord!(results[0].duration, <, timeout);
+                ensure_ord!(results[0].duration, <, SHORT_DUR);
                 ensure_ord!(results[0].events[0], ==, epoll::EpollEvent::new(expected_mask, 0));
             }
             UseEPOLLET::Yes => {
                 // One thread should have timed out with no events received.
                 ensure_ord!(results[0].epoll_res, ==, Ok(0));
-                ensure_ord!(results[0].duration, >=, timeout);
+                ensure_ord!(results[0].duration, >=, SHORT_DUR);
             }
         }
 
         // The other should have gotten a single event.
         ensure_ord!(results[1].epoll_res, ==, Ok(1));
-        ensure_ord!(results[1].duration, <, timeout);
+        ensure_ord!(results[1].duration, <, SHORT_DUR);
         ensure_ord!(results[1].events[0], ==, epoll::EpollEvent::new(expected_mask, 0));
         Ok(())
     })
@@ -222,7 +192,7 @@ fn test_threads_level() -> anyhow::Result<()> {
     let epollfd = epoll::epoll_create()?;
 
     test_utils::run_and_close_fds(&[epollfd, readfd, writefd], || {
-        let mut event = epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0);
+        let mut event = readable_zero();
         epoll::epoll_ctl(
             epollfd,
             epoll::EpollOp::EpollCtlAdd,
@@ -230,15 +200,17 @@ fn test_threads_level() -> anyhow::Result<()> {
             Some(&mut event),
         )?;
 
-        let timeout = Duration::from_millis(100);
+        let (waiter1, block1) = init(epollfd, SHORT_DUR);
+        let (waiter2, block2) = init(epollfd, SHORT_DUR);
 
         let threads = [
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
+            std::thread::spawn(move || waiter1.wait()),
+            std::thread::spawn(move || waiter2.wait()),
         ];
 
         // Wait for readers to block.
-        std::thread::sleep(timeout / 2);
+        block1.wait();
+        block2.wait();
 
         // Make the read-end readable.
         unistd::write(writefd, &[0])?;
@@ -248,8 +220,8 @@ fn test_threads_level() -> anyhow::Result<()> {
         // Both waiters should have received the event
         for res in results {
             ensure_ord!(res.epoll_res, ==, Ok(1));
-            ensure_ord!(res.duration, <, timeout);
-            ensure_ord!(res.events[0], ==, epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0));
+            ensure_ord!(res.duration, <, SHORT_DUR);
+            ensure_ord!(res.events[0], ==, readable_zero());
         }
 
         Ok(())
@@ -280,15 +252,17 @@ fn test_threads_level_with_late_read() -> anyhow::Result<()> {
             Some(&mut event),
         )?;
 
-        let timeout = Duration::from_millis(100);
+        let (waiter1, block1) = init(epollfd, SHORT_DUR);
+        let (waiter2, block2) = init(epollfd, SHORT_DUR);
 
         let threads = [
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ true)),
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ true)),
+            std::thread::spawn(move || waiter1.wait_then_read()),
+            std::thread::spawn(move || waiter2.wait_then_read()),
         ];
 
         // Wait for readers to block.
-        std::thread::sleep(timeout / 2);
+        block1.wait();
+        block2.wait();
 
         // Make the read-end readable.
         unistd::write(writefd, &[0])?;
@@ -301,11 +275,11 @@ fn test_threads_level_with_late_read() -> anyhow::Result<()> {
 
         // One thread should have timed out with no events received.
         ensure_ord!(results[0].epoll_res, ==, Ok(0));
-        ensure_ord!(results[0].duration, >=, timeout);
+        ensure_ord!(results[0].duration, >=, SHORT_DUR);
 
         // The other should have gotten a single event.
         ensure_ord!(results[1].epoll_res, ==, Ok(1));
-        ensure_ord!(results[1].duration, <, timeout);
+        ensure_ord!(results[1].duration, <, SHORT_DUR);
         ensure_ord!(results[1].events[0].events(), ==, EpollFlags::EPOLLIN);
 
         Ok(())
@@ -337,15 +311,17 @@ fn test_threads_level_with_early_read() -> anyhow::Result<()> {
             Some(&mut event),
         )?;
 
-        let timeout = Duration::from_millis(100);
+        let (waiter1, block1) = init(epollfd, SHORT_DUR);
+        let (waiter2, block2) = init(epollfd, SHORT_DUR);
 
         let threads = [
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
+            std::thread::spawn(move || waiter1.wait()),
+            std::thread::spawn(move || waiter2.wait()),
         ];
 
         // Wait for readers to block.
-        std::thread::sleep(timeout / 2);
+        block1.wait();
+        block2.wait();
 
         // Make the read-end readable.
         unistd::write(writefd, &[0])?;
@@ -358,7 +334,7 @@ fn test_threads_level_with_early_read() -> anyhow::Result<()> {
         // Neither waiter should have received the event
         for res in results {
             ensure_ord!(res.epoll_res, ==, Ok(0));
-            ensure_ord!(res.duration, >=, timeout);
+            ensure_ord!(res.duration, >=, SHORT_DUR);
         }
 
         Ok(())

--- a/src/test/epoll/test_epoll_edge.rs
+++ b/src/test/epoll/test_epoll_edge.rs
@@ -1,5 +1,5 @@
 use std::io::Cursor;
-use std::time::Duration;
+use std::sync::mpsc;
 
 use neli::ToBytes;
 use neli::consts::nl::NlmF;
@@ -13,43 +13,9 @@ use nix::unistd;
 use test_utils::socket_utils::{SocketInitMethod, socket_init_helper};
 use test_utils::{ShadowTest, TestEnvironment, ensure_ord, set};
 
-#[derive(Debug)]
-struct WaiterResult {
-    duration: Duration,
-    epoll_res: nix::Result<usize>,
-    events: Vec<epoll::EpollEvent>,
-}
+use crate::util::*;
 
-fn do_epoll_wait(epoll_fd: i32, timeout: Duration, do_read: bool) -> WaiterResult {
-    let mut events = Vec::new();
-    events.resize(10, epoll::EpollEvent::empty());
-
-    let t0 = std::time::Instant::now();
-
-    let res = epoll::epoll_wait(
-        epoll_fd,
-        &mut events,
-        timeout.as_millis().try_into().unwrap(),
-    );
-
-    let t1 = std::time::Instant::now();
-
-    events.resize(res.unwrap_or(0), epoll::EpollEvent::empty());
-
-    if do_read {
-        for ev in &events {
-            let fd = ev.data() as i32;
-            // we don't care if the read is successful or not (another thread may have already read)
-            let _ = unistd::read(fd, &mut [0]);
-        }
-    }
-
-    WaiterResult {
-        duration: t1.duration_since(t0),
-        epoll_res: res,
-        events,
-    }
-}
+mod util;
 
 fn test_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow::Result<()> {
     let epollfd = epoll::epoll_create()?;
@@ -63,39 +29,37 @@ fn test_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow::Result
             Some(&mut event),
         )?;
 
-        let timeout = Duration::from_millis(200);
+        // We expect the first two will not reach the timeout, use LONG_DUR.
+        let (waiter1, block1) = init(epollfd, LONG_DUR);
+        let (waiter2, block2) = init(epollfd, LONG_DUR);
+        // We expect the last one will reach the timeout, use SHORT_DUR.
+        let (waiter3, block3) = init(epollfd, SHORT_DUR);
 
-        let thread = std::thread::spawn(move || {
-            vec![
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                // The last one is supposed to timeout.
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-            ]
-        });
+        let thread =
+            std::thread::spawn(move || vec![waiter1.wait(), waiter2.wait(), waiter3.wait()]);
 
-        // Wait for readers to block.
-        std::thread::sleep(timeout / 3);
-
-        // Make the read-end readable.
+        // Wait for the thread to start and execute the first epoll_wait,
+        // then write to the write end so the read end becomes readable.
+        block1.wait();
         unistd::write(writefd, &[0])?;
 
-        // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 3);
+        // Wait until inside the next epoll_wait, make the read-end readable again.
+        block2.wait();
         unistd::write(writefd, &[0])?;
 
+        block3.wait();
         let results = thread.join().unwrap();
 
         // The first two waits should have received the event
         for res in &results[..2] {
             ensure_ord!(res.epoll_res, ==, Ok(1));
-            ensure_ord!(res.duration, <, timeout);
-            ensure_ord!(res.events[0], ==, epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0));
+            ensure_ord!(res.duration, <, LONG_DUR);
+            ensure_ord!(res.events[0], ==, readable_zero());
         }
 
         // The last wait should have timed out with no events received.
         ensure_ord!(results[2].epoll_res, ==, Ok(0));
-        ensure_ord!(results[2].duration, >=, timeout);
+        ensure_ord!(results[2].duration, >=, SHORT_DUR);
 
         Ok(())
     })
@@ -113,36 +77,31 @@ fn test_write_then_partial_read(readfd: libc::c_int, writefd: libc::c_int) -> an
             Some(&mut event),
         )?;
 
-        let timeout = Duration::from_millis(200);
+        // We expect the first one will not reach the timeout, use LONG_DUR.
+        let (waiter1, block1) = init(epollfd, LONG_DUR);
+        // We expect the second one will reach the timeout, use SHORT_DUR.
+        let (waiter2, block2) = init(epollfd, SHORT_DUR);
 
-        let thread = std::thread::spawn(move || {
-            vec![
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                // The second one is supposed to timeout.
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-            ]
-        });
-
-        // Wait for readers to block.
-        std::thread::sleep(timeout / 3);
+        let thread = std::thread::spawn(move || vec![waiter1.wait(), waiter2.wait()]);
 
         // Make the read-end readable.
+        block1.wait();
         unistd::write(writefd, &[0, 0])?;
 
         // Wait and read some, but not all, from the buffer.
-        std::thread::sleep(timeout / 3);
+        block2.wait();
         unistd::read(readfd, &mut [0])?;
 
         let results = thread.join().unwrap();
 
         // The first wait should have received the event
         ensure_ord!(results[0].epoll_res, ==, Ok(1));
-        ensure_ord!(results[0].duration, <, timeout);
-        ensure_ord!(results[0].events[0], ==, epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0));
+        ensure_ord!(results[0].duration, <, LONG_DUR);
+        ensure_ord!(results[0].events[0], ==, readable_zero());
 
         // The second wait should have timed out with no events received.
         ensure_ord!(results[1].epoll_res, ==, Ok(0));
-        ensure_ord!(results[1].duration, >=, timeout);
+        ensure_ord!(results[1].duration, >=, SHORT_DUR);
 
         Ok(())
     })
@@ -160,25 +119,38 @@ fn test_threads_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
             Some(&mut event),
         )?;
 
-        let timeout = Duration::from_millis(200);
+        // For communicating results from the spawned threads to the main thread.
+        let (tx1, rx) = mpsc::sync_channel(3);
+        let (tx2, tx3) = (tx1.clone(), tx1.clone());
+
+        let (waiter1, block1) = init(epollfd, SHORT_DUR);
+        let (waiter2, _block2) = init(epollfd, SHORT_DUR);
+        let (waiter3, _block3) = init(epollfd, SHORT_DUR);
 
         let threads = [
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
-            std::thread::spawn(move || do_epoll_wait(epollfd, timeout, /* do_read= */ false)),
+            std::thread::spawn(move || tx1.send(waiter1.wait()).unwrap()),
+            std::thread::spawn(move || tx2.send(waiter2.wait()).unwrap()),
+            std::thread::spawn(move || tx3.send(waiter3.wait()).unwrap()),
         ];
 
-        // Wait for readers to block.
-        std::thread::sleep(timeout / 3);
+        // Wait for at least one thread to be ready.
+        block1.wait();
 
         // Make the read-end readable.
         unistd::write(writefd, &[0])?;
 
-        // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 3);
-        unistd::write(writefd, &[0])?;
+        // Wait for the event to be collected.
+        let result1 = rx.recv().unwrap();
 
-        let mut results = threads.map(|t| t.join().unwrap());
+        // Make the read-end readable again and collect the result.
+        unistd::write(writefd, &[0])?;
+        let result2 = rx.recv().unwrap();
+
+        // Collect the final event (probably the timeout).
+        let result3 = rx.recv().unwrap();
+
+        let _ = threads.map(|t| t.join().unwrap());
+        let mut results = [result1, result2, result3];
 
         // Two of the threads should have gotten an event, but we don't know which one.
         // Sort results by number of events received.
@@ -186,13 +158,13 @@ fn test_threads_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
 
         // One thread should have timed out with no events received.
         ensure_ord!(results[0].epoll_res, ==, Ok(0));
-        ensure_ord!(results[0].duration, >=, timeout);
+        ensure_ord!(results[0].duration, >=, SHORT_DUR);
 
         // The rest should have received the event
         for res in &results[1..] {
             ensure_ord!(res.epoll_res, ==, Ok(1));
-            ensure_ord!(res.duration, <, timeout);
-            ensure_ord!(res.events[0], ==, epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0));
+            ensure_ord!(res.duration, <, SHORT_DUR);
+            ensure_ord!(res.events[0], ==, readable_zero());
         }
 
         Ok(())
@@ -214,28 +186,26 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
             Some(&mut event),
         )?;
 
-        let timeout = Duration::from_millis(200);
+        // We expect the first and last will not reach the timeout, use LONG_DUR.
+        let (waiter1, block1) = init(epollfd, LONG_DUR);
+        let (waiter2, block2) = init(epollfd, SHORT_DUR);
+        let (waiter3, block3) = init(epollfd, LONG_DUR);
 
-        let thread = std::thread::spawn(move || {
-            vec![
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-            ]
-        });
+        let thread =
+            std::thread::spawn(move || vec![waiter1.wait(), waiter2.wait(), waiter3.wait()]);
 
         // Wait for readers to block.
-        std::thread::sleep(timeout / 3);
+        block1.wait();
 
         // Make the read-end readable.
         unistd::write(writefd, &[0])?;
 
         // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 3);
+        block2.wait();
         unistd::write(writefd, &[0])?;
 
         // Wait for the second wait to time out.
-        std::thread::sleep(timeout);
+        block3.wait();
 
         epoll::epoll_ctl(
             epollfd,
@@ -251,17 +221,17 @@ fn test_oneshot_multi_write(readfd: libc::c_int, writefd: libc::c_int) -> anyhow
 
         // The first wait should have received the event
         ensure_ord!(results[0].epoll_res, ==, Ok(1));
-        ensure_ord!(results[0].duration, <, timeout);
-        ensure_ord!(results[0].events[0], ==, epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0));
+        ensure_ord!(results[0].duration, <, LONG_DUR);
+        ensure_ord!(results[0].events[0], ==, readable_zero());
 
         // The second wait should have timed out with no events received.
         ensure_ord!(results[1].epoll_res, ==, Ok(0));
-        ensure_ord!(results[1].duration, >=, timeout);
+        ensure_ord!(results[1].duration, >=, SHORT_DUR);
 
         // The third wait should have received the event
         ensure_ord!(results[2].epoll_res, ==, Ok(1));
-        ensure_ord!(results[2].duration, <, timeout);
-        ensure_ord!(results[2].events[0], ==, epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0));
+        ensure_ord!(results[2].duration, <, LONG_DUR);
+        ensure_ord!(results[2].events[0], ==, readable_zero());
 
         Ok(())
     })
@@ -277,44 +247,48 @@ fn test_eventfd_multi_write() -> anyhow::Result<()> {
         let mut event = epoll::EpollEvent::new(EpollFlags::EPOLLET | EpollFlags::EPOLLIN, 0);
         epoll::epoll_ctl(epollfd, epoll::EpollOp::EpollCtlAdd, efd, Some(&mut event))?;
 
-        let timeout = Duration::from_millis(200);
+        // We expect the first three will not reach the timeout, use LONG_DUR.
+        let (waiter1, block1) = init(epollfd, LONG_DUR);
+        let (waiter2, block2) = init(epollfd, LONG_DUR);
+        let (waiter3, block3) = init(epollfd, LONG_DUR);
+        let (waiter4, block4) = init(epollfd, SHORT_DUR);
 
         let thread = std::thread::spawn(move || {
             vec![
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                // The last one is supposed to timeout.
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
+                waiter1.wait(),
+                waiter2.wait(),
+                waiter3.wait(),
+                waiter4.wait(),
             ]
         });
 
         // Wait for readers to block.
-        std::thread::sleep(timeout / 4);
+        block1.wait();
 
         // Make the read-end readable.
         unistd::write(efd, &1u64.to_le_bytes())?;
 
         // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 4);
+        block2.wait();
         unistd::write(efd, &1u64.to_le_bytes())?;
 
         // Wait again and make the read-end readable again, but with zero value this time.
-        std::thread::sleep(timeout / 4);
+        block3.wait();
         unistd::write(efd, &0u64.to_le_bytes())?;
 
+        block4.wait();
         let results = thread.join().unwrap();
 
         // The first three waits should have received the event
         for res in &results[..3] {
             ensure_ord!(res.epoll_res, ==, Ok(1));
-            ensure_ord!(res.duration, <, timeout);
-            ensure_ord!(res.events[0], ==, epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0));
+            ensure_ord!(res.duration, <, LONG_DUR);
+            ensure_ord!(res.events[0], ==, readable_zero());
         }
 
         // The last wait should have timed out with no events received.
         ensure_ord!(results[3].epoll_res, ==, Ok(0));
-        ensure_ord!(results[3].duration, >=, timeout);
+        ensure_ord!(results[3].duration, >=, SHORT_DUR);
 
         Ok(())
     })
@@ -355,39 +329,38 @@ fn test_netlink_multi_write() -> anyhow::Result<()> {
         let mut event = epoll::EpollEvent::new(EpollFlags::EPOLLET | EpollFlags::EPOLLIN, 0);
         epoll::epoll_ctl(epollfd, epoll::EpollOp::EpollCtlAdd, fd, Some(&mut event))?;
 
-        let timeout = Duration::from_millis(200);
+        // We expect the first two will not reach the timeout, use LONG_DUR.
+        let (waiter1, block1) = init(epollfd, LONG_DUR);
+        let (waiter2, block2) = init(epollfd, LONG_DUR);
+        // We expect the last one will reach the timeout, use SHORT_DUR.
+        let (waiter3, block3) = init(epollfd, SHORT_DUR);
 
-        let thread = std::thread::spawn(move || {
-            vec![
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-                // The last one is supposed to timeout.
-                do_epoll_wait(epollfd, timeout, /* do_read= */ false),
-            ]
-        });
+        let thread =
+            std::thread::spawn(move || vec![waiter1.wait(), waiter2.wait(), waiter3.wait()]);
 
         // Wait for readers to block.
-        std::thread::sleep(timeout / 3);
+        block1.wait();
 
         // Make the read-end readable.
         unistd::write(fd, buffer.as_slice())?;
 
         // Wait again and make the read-end readable again.
-        std::thread::sleep(timeout / 3);
+        block2.wait();
         unistd::write(fd, buffer.as_slice())?;
 
+        block3.wait();
         let results = thread.join().unwrap();
 
         // The first two waits should have received the event
         for res in &results[..2] {
             ensure_ord!(res.epoll_res, ==, Ok(1));
-            ensure_ord!(res.duration, <, timeout);
-            ensure_ord!(res.events[0], ==, epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0));
+            ensure_ord!(res.duration, <, LONG_DUR);
+            ensure_ord!(res.events[0], ==, readable_zero());
         }
 
         // The last wait should have timed out with no events received.
         ensure_ord!(results[2].epoll_res, ==, Ok(0));
-        ensure_ord!(results[2].duration, >=, timeout);
+        ensure_ord!(results[2].duration, >=, SHORT_DUR);
 
         Ok(())
     })

--- a/src/test/epoll/util.rs
+++ b/src/test/epoll/util.rs
@@ -1,0 +1,110 @@
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+use nix::sys::epoll::{self, EpollFlags};
+use nix::unistd;
+
+/// When we expect an event to be ready quickly, use a long timeout that
+/// shouldn't normally trigger but provides an upper bound on error.
+pub const LONG_DUR: Duration = Duration::from_secs(10);
+
+/// When we expect that the timeout will be reached, use a shorter one to
+/// prevent the test from consuming too much runtime.
+pub const SHORT_DUR: Duration = Duration::from_millis(200);
+
+#[derive(Debug, Clone)]
+pub struct Notify {
+    state: Arc<(Mutex<bool>, Condvar)>,
+}
+
+impl Notify {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new((Mutex::new(false), Condvar::new())),
+        }
+    }
+
+    /// Waits for a notify signal to be sent by another thread.
+    pub fn wait(&self) {
+        let (lock, cvar) = self.state.as_ref();
+        let mut value = lock.lock().unwrap();
+        while !*value {
+            value = cvar.wait(value).unwrap();
+        }
+    }
+
+    /// Sets the value to true and notifies the condition variable if the value
+    /// changed from false to true.
+    pub fn notify(&self) {
+        let (lock, cvar) = self.state.as_ref();
+        let mut value = lock.lock().unwrap();
+        if !*value {
+            *value = true;
+            cvar.notify_one();
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct WaiterResult {
+    pub duration: Duration,
+    pub epoll_res: nix::Result<usize>,
+    pub events: Vec<epoll::EpollEvent>,
+}
+
+pub struct EpollWaiter {
+    epoll_fd: i32,
+    timeout_ms: isize,
+    notify: Notify,
+}
+
+impl EpollWaiter {
+    pub fn new(epoll_fd: i32, timeout: Duration, notify: Notify) -> Self {
+        Self {
+            epoll_fd,
+            timeout_ms: timeout.as_millis().try_into().unwrap(),
+            notify,
+        }
+    }
+
+    pub fn wait(&self) -> WaiterResult {
+        let mut events = Vec::new();
+        events.resize(1, epoll::EpollEvent::empty());
+
+        let t0 = std::time::Instant::now();
+        self.notify.notify();
+        let res = epoll::epoll_wait(self.epoll_fd, &mut events, self.timeout_ms);
+        let t1 = std::time::Instant::now();
+
+        events.resize(res.unwrap_or(0), epoll::EpollEvent::empty());
+
+        WaiterResult {
+            duration: t1.duration_since(t0),
+            epoll_res: res,
+            events,
+        }
+    }
+
+    pub fn wait_then_read(&self) -> WaiterResult {
+        let result = self.wait();
+
+        for ev in &result.events {
+            let fd = ev.data() as i32;
+            // we don't care if the read is successful or not (another thread may have already read)
+            let _ = unistd::read(fd, &mut [0]);
+        }
+
+        result
+    }
+}
+
+/// Create epoll_wait state that can be run inside a thread, with linked sync
+/// primitives that give the main thread some semblence of control.
+pub fn init(epoll_fd: i32, timeout: Duration) -> (EpollWaiter, Notify) {
+    let notify = Notify::new();
+    (EpollWaiter::new(epoll_fd, timeout, notify.clone()), notify)
+}
+
+pub fn readable_zero() -> epoll::EpollEvent {
+    epoll::EpollEvent::new(EpollFlags::EPOLLIN, 0)
+}

--- a/src/test/epoll/util.rs
+++ b/src/test/epoll/util.rs
@@ -6,6 +6,7 @@ use nix::unistd;
 
 /// When we expect an event to be ready quickly, use a long timeout that
 /// shouldn't normally trigger but provides an upper bound on error.
+#[allow(dead_code)]
 pub const LONG_DUR: Duration = Duration::from_secs(10);
 
 /// When we expect that the timeout will be reached, use a shorter one to
@@ -85,6 +86,7 @@ impl EpollWaiter {
         }
     }
 
+    #[allow(dead_code)]
     pub fn wait_then_read(&self) -> WaiterResult {
         let result = self.wait();
 


### PR DESCRIPTION
My attempt at improving the stability of the flaky epoll tests (some minimal discussion [here](https://github.com/shadow/shadow/pull/3768#discussion_r3567874827)).

Tried to as much as possible remove any dependency on sleeping a certain period of time and then assuming that a thread has already started after waking up.

Was able to reproduce a failing test case (epoll-edge-rs-linux) using `stress-ng` to eat up all CPUs while running the test. With my new code, that test now passes even when running stress-ng.

Also useful was separating our timeouts into two different ones: a long timeout (10s) which is used only in cases where we expect that the `epoll_wait` call should not reach the timeout, and a short timeout (100ms) which is used only in cases where we expect the `epoll_wait` call should exceed the timeout. (The short duration timeout keeps the test runtime lower.)