### PR TITLE
End support for Debian 11

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,8 +24,6 @@ jobs:
           - 'ubuntu:22.04'
           # End of standard support: June 2029 https://wiki.ubuntu.com/Releases
           - 'ubuntu:24.04'
-          # EOL ~June 2026 https://wiki.debian.org/LTS
-          - 'debian:11-slim'
           # EOL June 2028 https://wiki.debian.org/LTS
           - 'debian:12-slim'
           # EOL June 2030 https://wiki.debian.org/LTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes since v3.3.0:
 
 Documentation / policy updates:
 
-*
+* Ended support for Debian 11 (the LTS support ended 31 Aug 2026: https://endoflife.date/debian)
 
 MAJOR changes (breaking):
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@
 ## requests that we don't get new behaviors introduced since that lowest version.
 ##
 ## We use the oldest version provided in our supported platforms, which
-## is currently 3.18.4 on debian 11.
-cmake_minimum_required(VERSION 3.18.4...3.18.4 FATAL_ERROR)
+## is currently 3.22.1 on Ubuntu 22.04.
+cmake_minimum_required(VERSION 3.22.1...3.22.1 FATAL_ERROR)
 
 ## set build parameters
 project(Shadow)

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -5,7 +5,7 @@
 We support the following Linux x86-64 distributions:
 
 - Ubuntu 22.04, 24.04
-- Debian 11, 12, 13
+- Debian 12, 13
 - Fedora 42
 
 We do not provide official support for other platforms. This means that we do
@@ -25,8 +25,8 @@ distribution (the GA kernel). However,
 we are currently only able to regularly test on the latest Ubuntu kernel,
 since that's what GitHub Actions provides.
 
-By these criteria, Shadow's oldest supported kernel version is currently 5.10
-(the default kernel in Debian 11).
+By these criteria, Shadow's oldest supported kernel version is currently 5.15
+(the default kernel in Ubuntu 22.04).
 
 ## Docker
 

--- a/shadowtools/pyproject.toml
+++ b/shadowtools/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "shadowtools"
 version = "0.0.1"
 description = "Libraries and tools for use with the shadow network simulator"
-# Oldest python version on a supported platform (debian 11).
-requires-python = ">=3.9.2"
+# Oldest python version on a supported platform (Ubuntu 22.04).
+requires-python = ">=3.10"
 # Strings from https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 1 - Planning",


### PR DESCRIPTION
Debian 11 LTS support ended 31 Aug 2026: https://endoflife.date/debian

Stale package mirrors are causing test failures in #3768 and #3786.